### PR TITLE
feat(users): add resend verification email and complete test coverage (US-001)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -13,7 +13,8 @@
       "submitting": "Konto wird erstellt...",
       "success": {
         "title": "Überprüfe deine E-Mails",
-        "message": "Wir haben dir einen Bestätigungslink an deine E-Mail-Adresse gesendet. Bitte klicke darauf, um dein Konto zu aktivieren."
+        "message": "Wir haben dir einen Bestätigungslink an deine E-Mail-Adresse gesendet. Bitte klicke darauf, um dein Konto zu aktivieren.",
+        "resendLink": "Keine E-Mail erhalten? Bestätigungsmail erneut senden"
       },
       "errors": {
         "emailRequired": "E-Mail ist erforderlich.",
@@ -28,6 +29,26 @@
         "passwordsMismatch": "Passwörter stimmen nicht überein.",
         "emailAlreadyExists": "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits.",
         "validationFailed": "Bitte überprüfe deine Eingaben und versuche es erneut.",
+        "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
+      }
+    },
+    "resendVerification": {
+      "title": "Bestätigungsmail erneut senden",
+      "subtitle": "Gib deine E-Mail-Adresse ein und wir senden dir einen neuen Bestätigungslink",
+      "email": "E-Mail",
+      "emailPlaceholder": "du@beispiel.de",
+      "submit": "Bestätigungsmail erneut senden",
+      "submitting": "Wird gesendet...",
+      "backToRegister": "Zurück zur Registrierung",
+      "success": {
+        "title": "E-Mail gesendet",
+        "message": "Wenn diese E-Mail-Adresse registriert ist, wurde eine Bestätigungsmail gesendet. Bitte überprüfe deinen Posteingang."
+      },
+      "errors": {
+        "emailRequired": "E-Mail ist erforderlich.",
+        "emailInvalid": "Bitte gib eine gültige E-Mail-Adresse ein.",
+        "emailMaxLength": "E-Mail darf maximal 254 Zeichen lang sein.",
+        "serviceUnavailable": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.",
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
       }
     }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -13,7 +13,8 @@
       "submitting": "Creating account...",
       "success": {
         "title": "Check your email",
-        "message": "We've sent a verification link to your email address. Please click it to activate your account."
+        "message": "We've sent a verification link to your email address. Please click it to activate your account.",
+        "resendLink": "Didn't receive the email? Resend verification email"
       },
       "errors": {
         "emailRequired": "Email is required.",
@@ -28,6 +29,26 @@
         "passwordsMismatch": "Passwords do not match.",
         "emailAlreadyExists": "A user with this email address already exists.",
         "validationFailed": "Please check your input and try again.",
+        "generic": "An unexpected error occurred. Please try again later."
+      }
+    },
+    "resendVerification": {
+      "title": "Resend Verification Email",
+      "subtitle": "Enter your email address and we'll send you a new verification link",
+      "email": "Email",
+      "emailPlaceholder": "you@example.com",
+      "submit": "Resend Verification Email",
+      "submitting": "Sending...",
+      "backToRegister": "Back to registration",
+      "success": {
+        "title": "Email sent",
+        "message": "If this email is registered, a verification email has been sent. Please check your inbox."
+      },
+      "errors": {
+        "emailRequired": "Email is required.",
+        "emailInvalid": "Please enter a valid email address.",
+        "emailMaxLength": "Email must not exceed 254 characters.",
+        "serviceUnavailable": "The service is temporarily unavailable. Please try again later.",
         "generic": "An unexpected error occurred. Please try again later."
       }
     }

--- a/client/apps/shell/src/app/auth/auth.routes.ts
+++ b/client/apps/shell/src/app/auth/auth.routes.ts
@@ -5,4 +5,11 @@ export const authRoutes: Route[] = [
     path: 'register',
     loadComponent: () => import('./register/register.component').then((m) => m.RegisterComponent),
   },
+  {
+    path: 'resend-verification',
+    loadComponent: () =>
+      import('./resend-verification/resend-verification.component').then(
+        (m) => m.ResendVerificationComponent,
+      ),
+  },
 ];

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function flattenKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      return flattenKeys(value as Record<string, unknown>, fullKey);
+    }
+    return [fullKey];
+  });
+}
+
+function loadTranslations(lang: string): Record<string, unknown> {
+  const filePath = resolve(process.cwd(), `apps/shell/public/assets/i18n/${lang}.json`);
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+describe('i18n keys', () => {
+  const en = loadTranslations('en');
+  const de = loadTranslations('de');
+  const enKeys = flattenKeys(en).sort();
+  const deKeys = flattenKeys(de).sort();
+
+  it('should have matching keys between en.json and de.json', () => {
+    expect(enKeys).toEqual(deKeys);
+  });
+
+  it('should contain required auth.register keys', () => {
+    const requiredKeys = [
+      'auth.register.title',
+      'auth.register.subtitle',
+      'auth.register.email',
+      'auth.register.password',
+      'auth.register.confirmPassword',
+      'auth.register.displayName',
+      'auth.register.submit',
+      'auth.register.submitting',
+      'auth.register.success.title',
+      'auth.register.success.message',
+      'auth.register.success.resendLink',
+      'auth.register.errors.emailRequired',
+      'auth.register.errors.emailInvalid',
+      'auth.register.errors.emailMaxLength',
+      'auth.register.errors.displayNameRequired',
+      'auth.register.errors.displayNameMaxLength',
+      'auth.register.errors.passwordRequired',
+      'auth.register.errors.passwordMinLength',
+      'auth.register.errors.passwordPattern',
+      'auth.register.errors.confirmPasswordRequired',
+      'auth.register.errors.passwordsMismatch',
+      'auth.register.errors.emailAlreadyExists',
+      'auth.register.errors.validationFailed',
+      'auth.register.errors.generic',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
+
+  it('should contain required auth.resendVerification keys', () => {
+    const requiredKeys = [
+      'auth.resendVerification.title',
+      'auth.resendVerification.subtitle',
+      'auth.resendVerification.email',
+      'auth.resendVerification.submit',
+      'auth.resendVerification.submitting',
+      'auth.resendVerification.backToRegister',
+      'auth.resendVerification.success.title',
+      'auth.resendVerification.success.message',
+      'auth.resendVerification.errors.emailRequired',
+      'auth.resendVerification.errors.emailInvalid',
+      'auth.resendVerification.errors.emailMaxLength',
+      'auth.resendVerification.errors.serviceUnavailable',
+      'auth.resendVerification.errors.generic',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
+});

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -7,6 +7,9 @@
     <div class="success-message">
       <h2>{{ t('auth.register.success.title') }}</h2>
       <p>{{ t('auth.register.success.message') }}</p>
+      <p class="resend-link">
+        <a routerLink="/auth/resend-verification">{{ t('auth.register.success.resendLink') }}</a>
+      </p>
     </div>
     } @else {
     <form [formGroup]="form" (ngSubmit)="onSubmit()">

--- a/client/apps/shell/src/app/auth/register/register.component.spec.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoTestingModule } from '@jsverse/transloco';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { RegisterComponent } from './register.component';
 import { AuthApiService } from '@yumney/shared/api-client';
 
@@ -172,16 +172,18 @@ describe('RegisterComponent', () => {
       expect(component.form.controls.password.touched).toBe(true);
     });
 
-    it('should set isLoading during submission', fakeAsync(() => {
+    it('should set isLoading to true during submission', () => {
       fillValidForm();
-      authApiMock.register.mockReturnValue(of({ message: 'ok' }));
+      const subject = new Subject();
+      authApiMock.register.mockReturnValue(subject);
 
-      expect(component.isLoading()).toBe(false);
       component.onSubmit();
-      tick();
+      expect(component.isLoading()).toBe(true);
+
+      subject.next({ message: 'ok' });
+      subject.complete();
       expect(component.isLoading()).toBe(false);
-      expect(component.isSuccess()).toBe(true);
-    }));
+    });
 
     it('should set isSuccess on successful registration', fakeAsync(() => {
       fillValidForm();

--- a/client/apps/shell/src/app/auth/register/register.component.spec.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.spec.ts
@@ -193,6 +193,32 @@ describe('RegisterComponent', () => {
       expect(component.isSuccess()).toBe(true);
     }));
 
+    it('should reset form on successful registration', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(of({ message: 'ok' }));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.form.controls.email.value).toBe('');
+      expect(component.form.controls.password.value).toBe('');
+    }));
+
+    it('should clear serverError on new submission', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500 })),
+      );
+
+      component.onSubmit();
+      tick();
+      expect(component.serverError()).toBe('auth.register.errors.generic');
+
+      authApiMock.register.mockReturnValue(of({ message: 'ok' }));
+      component.onSubmit();
+      expect(component.serverError()).toBeNull();
+    }));
+
     it('should set serverError for 409 conflict', fakeAsync(() => {
       fillValidForm();
       authApiMock.register.mockReturnValue(

--- a/client/apps/shell/src/app/auth/register/register.component.spec.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.spec.ts
@@ -1,0 +1,232 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, throwError } from 'rxjs';
+import { RegisterComponent } from './register.component';
+import { AuthApiService } from '@yumney/shared/api-client';
+
+const en = {
+  auth: {
+    register: {
+      title: 'Create Account',
+      subtitle: 'Join Yumney',
+      email: 'Email',
+      emailPlaceholder: 'you@example.com',
+      displayName: 'Display Name',
+      displayNamePlaceholder: 'Your name',
+      password: 'Password',
+      confirmPassword: 'Confirm Password',
+      submit: 'Create Account',
+      submitting: 'Creating account...',
+      success: {
+        title: 'Check your email',
+        message: 'Verification link sent.',
+        resendLink: 'Resend verification email',
+      },
+      errors: {
+        emailRequired: 'Email is required.',
+        emailInvalid: 'Please enter a valid email.',
+        emailMaxLength: 'Email too long.',
+        displayNameRequired: 'Display name is required.',
+        displayNameMaxLength: 'Display name too long.',
+        passwordRequired: 'Password is required.',
+        passwordMinLength: 'Password too short.',
+        passwordPattern: 'Password needs pattern.',
+        confirmPasswordRequired: 'Confirm password.',
+        passwordsMismatch: 'Passwords do not match.',
+        emailAlreadyExists: 'Email already exists.',
+        validationFailed: 'Validation failed.',
+        generic: 'Unexpected error.',
+      },
+    },
+  },
+};
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let fixture: ComponentFixture<RegisterComponent>;
+  let authApiMock: { register: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    authApiMock = { register: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RegisterComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [provideRouter([]), { provide: AuthApiService, useValue: authApiMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('form validation', () => {
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have an invalid form when empty', () => {
+      expect(component.form.valid).toBe(false);
+    });
+
+    it('should require email', () => {
+      const email = component.form.controls.email;
+      expect(email.hasError('required')).toBe(true);
+    });
+
+    it('should reject invalid email format', () => {
+      component.form.controls.email.setValue('not-an-email');
+      expect(component.form.controls.email.hasError('email')).toBe(true);
+    });
+
+    it('should accept valid email', () => {
+      component.form.controls.email.setValue('test@example.com');
+      expect(component.form.controls.email.valid).toBe(true);
+    });
+
+    it('should reject email exceeding max length', () => {
+      const longEmail = 'a'.repeat(243) + '@example.com';
+      component.form.controls.email.setValue(longEmail);
+      expect(component.form.controls.email.hasError('maxlength')).toBe(true);
+    });
+
+    it('should require password', () => {
+      expect(component.form.controls.password.hasError('required')).toBe(true);
+    });
+
+    it('should reject short password', () => {
+      component.form.controls.password.setValue('Ab1');
+      expect(component.form.controls.password.hasError('minlength')).toBe(true);
+    });
+
+    it('should reject password without pattern match', () => {
+      component.form.controls.password.setValue('alllowercase1');
+      expect(component.form.controls.password.hasError('pattern')).toBe(true);
+    });
+
+    it('should require display name', () => {
+      expect(component.form.controls.displayName.hasError('required')).toBe(true);
+    });
+
+    it('should reject display name exceeding max length', () => {
+      component.form.controls.displayName.setValue('A'.repeat(201));
+      expect(component.form.controls.displayName.hasError('maxlength')).toBe(true);
+    });
+
+    it('should require confirm password', () => {
+      expect(component.form.controls.confirmPassword.hasError('required')).toBe(true);
+    });
+
+    it('should detect password mismatch', () => {
+      component.form.controls.password.setValue('Password1');
+      component.form.controls.confirmPassword.setValue('Different1');
+      expect(component.form.hasError('passwordsMismatch')).toBe(true);
+    });
+
+    it('should accept matching passwords', () => {
+      component.form.controls.password.setValue('Password1');
+      component.form.controls.confirmPassword.setValue('Password1');
+      expect(component.form.hasError('passwordsMismatch')).toBe(false);
+    });
+  });
+
+  describe('hasError helper', () => {
+    it('should return false when control is not touched', () => {
+      component.form.controls.email.setValue('');
+      expect(component.hasError('email', 'required')).toBe(false);
+    });
+
+    it('should return true when control is touched and has error', () => {
+      component.form.controls.email.setValue('');
+      component.form.controls.email.markAsTouched();
+      expect(component.hasError('email', 'required')).toBe(true);
+    });
+  });
+
+  describe('submission flow', () => {
+    function fillValidForm(): void {
+      component.form.controls.email.setValue('test@example.com');
+      component.form.controls.password.setValue('Password1');
+      component.form.controls.confirmPassword.setValue('Password1');
+      component.form.controls.displayName.setValue('Test User');
+    }
+
+    it('should not submit when form is invalid', () => {
+      component.onSubmit();
+      expect(authApiMock.register).not.toHaveBeenCalled();
+    });
+
+    it('should mark all fields as touched on invalid submit', () => {
+      component.onSubmit();
+      expect(component.form.controls.email.touched).toBe(true);
+      expect(component.form.controls.password.touched).toBe(true);
+    });
+
+    it('should set isLoading during submission', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(of({ message: 'ok' }));
+
+      expect(component.isLoading()).toBe(false);
+      component.onSubmit();
+      tick();
+      expect(component.isLoading()).toBe(false);
+      expect(component.isSuccess()).toBe(true);
+    }));
+
+    it('should set isSuccess on successful registration', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(of({ message: 'ok' }));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.isSuccess()).toBe(true);
+    }));
+
+    it('should set serverError for 409 conflict', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 409 })),
+      );
+
+      component.onSubmit();
+      tick();
+
+      expect(component.serverError()).toBe('auth.register.errors.emailAlreadyExists');
+    }));
+
+    it('should set serverError for 422 validation error', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 422 })),
+      );
+
+      component.onSubmit();
+      tick();
+
+      expect(component.serverError()).toBe('auth.register.errors.validationFailed');
+    }));
+
+    it('should set generic serverError for 500', fakeAsync(() => {
+      fillValidForm();
+      authApiMock.register.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500 })),
+      );
+
+      component.onSubmit();
+      tick();
+
+      expect(component.serverError()).toBe('auth.register.errors.generic');
+    }));
+  });
+});

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -8,12 +8,13 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
+import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthApiService } from '@yumney/shared/api-client';
 
 @Component({
   selector: 'yn-register',
-  imports: [ReactiveFormsModule, TranslocoModule],
+  imports: [ReactiveFormsModule, TranslocoModule, RouterLink],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
@@ -1,0 +1,49 @@
+<div class="resend-container" *transloco="let t">
+  <div class="resend-card">
+    <h1>{{ t('auth.resendVerification.title') }}</h1>
+    <p class="subtitle">{{ t('auth.resendVerification.subtitle') }}</p>
+
+    @if (isSuccess()) {
+    <div class="success-message">
+      <h2>{{ t('auth.resendVerification.success.title') }}</h2>
+      <p>{{ t('auth.resendVerification.success.message') }}</p>
+    </div>
+    } @else {
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      @if (serverError()) {
+      <div class="error-banner">{{ t(serverError()!) }}</div>
+      }
+
+      <div class="form-field">
+        <label for="email">{{ t('auth.resendVerification.email') }}</label>
+        <input
+          id="email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          [placeholder]="t('auth.resendVerification.emailPlaceholder')"
+        />
+        @if (hasError('email', 'required')) {
+        <span class="field-error">{{ t('auth.resendVerification.errors.emailRequired') }}</span>
+        } @if (hasError('email', 'email')) {
+        <span class="field-error">{{ t('auth.resendVerification.errors.emailInvalid') }}</span>
+        } @if (hasError('email', 'maxlength')) {
+        <span class="field-error">{{ t('auth.resendVerification.errors.emailMaxLength') }}</span>
+        }
+      </div>
+
+      <button type="submit" [disabled]="isLoading()">
+        @if (isLoading()) {
+        <span>{{ t('auth.resendVerification.submitting') }}</span>
+        } @else {
+        <span>{{ t('auth.resendVerification.submit') }}</span>
+        }
+      </button>
+    </form>
+    }
+
+    <p class="back-link">
+      <a routerLink="/auth/register">{{ t('auth.resendVerification.backToRegister') }}</a>
+    </p>
+  </div>
+</div>

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
@@ -1,0 +1,122 @@
+.resend-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.resend-card {
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+  background: #fff;
+
+  h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.5rem;
+  }
+
+  .subtitle {
+    margin: 0 0 1.5rem;
+    color: #666;
+    font-size: 0.9rem;
+  }
+}
+
+.form-field {
+  margin-bottom: 1rem;
+
+  label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
+  input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: #4a90d9;
+      box-shadow: 0 0 0 2px rgb(74 144 217 / 20%);
+    }
+
+    &.ng-invalid.ng-touched {
+      border-color: #dc3545;
+    }
+  }
+
+  .field-error {
+    display: block;
+    margin-top: 0.25rem;
+    color: #dc3545;
+    font-size: 0.8rem;
+  }
+}
+
+.error-banner {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border-radius: 4px;
+  background: #fef2f2;
+  color: #dc3545;
+  font-size: 0.9rem;
+}
+
+.success-message {
+  text-align: center;
+  color: #059669;
+
+  h2 {
+    margin: 0 0 0.5rem;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+button[type='submit'] {
+  width: 100%;
+  padding: 0.75rem;
+  margin-top: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  background: #4a90d9;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: #3a7bc8;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.back-link {
+  margin-top: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+
+  a {
+    color: #4a90d9;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoTestingModule } from '@jsverse/transloco';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { ResendVerificationComponent } from './resend-verification.component';
 import { AuthApiService } from '@yumney/shared/api-client';
 
@@ -106,6 +106,39 @@ describe('ResendVerificationComponent', () => {
       component.onSubmit();
       expect(authApiMock.resendVerificationEmail).not.toHaveBeenCalled();
     });
+
+    it('should mark email as touched on invalid submit', () => {
+      component.onSubmit();
+      expect(component.form.controls.email.touched).toBe(true);
+    });
+
+    it('should set isLoading to true during submission', () => {
+      component.form.controls.email.setValue('test@example.com');
+      const subject = new Subject();
+      authApiMock.resendVerificationEmail.mockReturnValue(subject);
+
+      component.onSubmit();
+      expect(component.isLoading()).toBe(true);
+
+      subject.next({ message: 'ok' });
+      subject.complete();
+      expect(component.isLoading()).toBe(false);
+    });
+
+    it('should clear serverError on new submission', fakeAsync(() => {
+      component.form.controls.email.setValue('test@example.com');
+      authApiMock.resendVerificationEmail.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500 })),
+      );
+
+      component.onSubmit();
+      tick();
+      expect(component.serverError()).toBe('auth.resendVerification.errors.generic');
+
+      authApiMock.resendVerificationEmail.mockReturnValue(of({ message: 'ok' }));
+      component.onSubmit();
+      expect(component.serverError()).toBeNull();
+    }));
 
     it('should set isSuccess on successful submission', fakeAsync(() => {
       component.form.controls.email.setValue('test@example.com');

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, throwError } from 'rxjs';
+import { ResendVerificationComponent } from './resend-verification.component';
+import { AuthApiService } from '@yumney/shared/api-client';
+
+const en = {
+  auth: {
+    resendVerification: {
+      title: 'Resend Verification Email',
+      subtitle: 'Enter your email',
+      email: 'Email',
+      emailPlaceholder: 'you@example.com',
+      submit: 'Resend',
+      submitting: 'Sending...',
+      backToRegister: 'Back to registration',
+      success: {
+        title: 'Email sent',
+        message: 'Check your inbox.',
+      },
+      errors: {
+        emailRequired: 'Email is required.',
+        emailInvalid: 'Invalid email.',
+        emailMaxLength: 'Email too long.',
+        serviceUnavailable: 'Service unavailable.',
+        generic: 'Unexpected error.',
+      },
+    },
+  },
+};
+
+describe('ResendVerificationComponent', () => {
+  let component: ResendVerificationComponent;
+  let fixture: ComponentFixture<ResendVerificationComponent>;
+  let authApiMock: { resendVerificationEmail: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    authApiMock = { resendVerificationEmail: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ResendVerificationComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [provideRouter([]), { provide: AuthApiService, useValue: authApiMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResendVerificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('form validation', () => {
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have an invalid form when empty', () => {
+      expect(component.form.valid).toBe(false);
+    });
+
+    it('should require email', () => {
+      expect(component.form.controls.email.hasError('required')).toBe(true);
+    });
+
+    it('should reject invalid email format', () => {
+      component.form.controls.email.setValue('not-an-email');
+      expect(component.form.controls.email.hasError('email')).toBe(true);
+    });
+
+    it('should accept valid email', () => {
+      component.form.controls.email.setValue('test@example.com');
+      expect(component.form.controls.email.valid).toBe(true);
+    });
+
+    it('should reject email exceeding max length', () => {
+      const longEmail = 'a'.repeat(243) + '@example.com';
+      component.form.controls.email.setValue(longEmail);
+      expect(component.form.controls.email.hasError('maxlength')).toBe(true);
+    });
+  });
+
+  describe('hasError helper', () => {
+    it('should return false when control is not touched', () => {
+      component.form.controls.email.setValue('');
+      expect(component.hasError('email', 'required')).toBe(false);
+    });
+
+    it('should return true when control is touched and has error', () => {
+      component.form.controls.email.setValue('');
+      component.form.controls.email.markAsTouched();
+      expect(component.hasError('email', 'required')).toBe(true);
+    });
+  });
+
+  describe('submission flow', () => {
+    it('should not submit when form is invalid', () => {
+      component.onSubmit();
+      expect(authApiMock.resendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('should set isSuccess on successful submission', fakeAsync(() => {
+      component.form.controls.email.setValue('test@example.com');
+      authApiMock.resendVerificationEmail.mockReturnValue(of({ message: 'ok' }));
+
+      component.onSubmit();
+      tick();
+
+      expect(component.isSuccess()).toBe(true);
+    }));
+
+    it('should set serverError for 503 service unavailable', fakeAsync(() => {
+      component.form.controls.email.setValue('test@example.com');
+      authApiMock.resendVerificationEmail.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 503 })),
+      );
+
+      component.onSubmit();
+      tick();
+
+      expect(component.serverError()).toBe('auth.resendVerification.errors.serviceUnavailable');
+    }));
+
+    it('should set generic serverError for other errors', fakeAsync(() => {
+      component.form.controls.email.setValue('test@example.com');
+      authApiMock.resendVerificationEmail.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500 })),
+      );
+
+      component.onSubmit();
+      tick();
+
+      expect(component.serverError()).toBe('auth.resendVerification.errors.generic');
+    }));
+  });
+});

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
@@ -1,0 +1,64 @@
+import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AuthApiService } from '@yumney/shared/api-client';
+
+@Component({
+  selector: 'yn-resend-verification',
+  imports: [ReactiveFormsModule, TranslocoModule, RouterLink],
+  templateUrl: './resend-verification.component.html',
+  styleUrl: './resend-verification.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ResendVerificationComponent {
+  private fb = inject(FormBuilder);
+  private authApi = inject(AuthApiService);
+  private destroyRef = inject(DestroyRef);
+
+  isLoading = signal(false);
+  isSuccess = signal(false);
+  serverError = signal<string | null>(null);
+
+  form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email, Validators.maxLength(254)]],
+  });
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.serverError.set(null);
+
+    const { email } = this.form.getRawValue();
+
+    this.authApi
+      .resendVerificationEmail({ email })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isLoading.set(false);
+          this.isSuccess.set(true);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading.set(false);
+
+          if (err.status === 503) {
+            this.serverError.set('auth.resendVerification.errors.serviceUnavailable');
+          } else {
+            this.serverError.set('auth.resendVerification.errors.generic');
+          }
+        },
+      });
+  }
+
+  hasError(field: string, error: string): boolean {
+    const control = this.form.get(field);
+    return !!control?.hasError(error) && !!control?.touched;
+  }
+}

--- a/client/libs/shared/api-client/src/lib/auth-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/auth-api.service.ts
@@ -12,11 +12,28 @@ export interface RegisterResponse {
   message: string;
 }
 
+export interface ResendVerificationRequest {
+  email: string;
+}
+
+export interface ResendVerificationResponse {
+  message: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthApiService {
   private http = inject(HttpClient);
 
   register(request: RegisterRequest): Observable<RegisterResponse> {
     return this.http.post<RegisterResponse>('/api/v1/auth/register', request);
+  }
+
+  resendVerificationEmail(
+    request: ResendVerificationRequest,
+  ): Observable<ResendVerificationResponse> {
+    return this.http.post<ResendVerificationResponse>(
+      '/api/v1/auth/resend-verification-email',
+      request,
+    );
   }
 }

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>(
 
 builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserCommandValidator>();
 builder.Services.AddScoped<ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>, RegisterUserCommandHandler>();
+builder.Services.AddScoped<ICommandHandler<ResendVerificationEmailCommand, Result>, ResendVerificationEmailCommandHandler>();
 
 builder.Services.AddHttpClient<IKeycloakAdminService, KeycloakAdminService>(client => { client.BaseAddress = new Uri("https+http://keycloak"); })
 .AddStandardResilienceHandler();

--- a/src/Yumney.Users.Api/AuthEndpoints.cs
+++ b/src/Yumney.Users.Api/AuthEndpoints.cs
@@ -18,6 +18,10 @@ public static class AuthEndpoints
             .AllowAnonymous()
             .WithName("RegisterUser");
 
+        group.MapPost("/resend-verification-email", ResendVerificationEmailAsync)
+            .AllowAnonymous()
+            .WithName("ResendVerificationEmail");
+
         return app;
     }
 
@@ -50,5 +54,34 @@ public static class AuthEndpoints
         }
 
         return Results.Created("/auth/register", result.Value);
+    }
+
+    private static async Task<IResult> ResendVerificationEmailAsync(
+        ResendVerificationEmailCommand command,
+        IValidator<ResendVerificationEmailCommand> validator,
+        ICommandHandler<ResendVerificationEmailCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await validator.ValidateAsync(command, cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            return Results.ValidationProblem(validationResult.ToDictionary());
+        }
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.Error switch
+            {
+                VerificationErrors.IdentityProviderUnavailable =>
+                    Results.Problem("Identity provider is unavailable.", statusCode: 503),
+                _ =>
+                    Results.Ok(new { message = "If this email is registered, a verification email has been sent." }),
+            };
+        }
+
+        return Results.Ok(new { message = "If this email is registered, a verification email has been sent." });
     }
 }

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommand.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommand.cs
@@ -1,0 +1,6 @@
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+
+namespace Yumney.Users.Application.Commands;
+
+public sealed record ResendVerificationEmailCommand(string Email) : ICommand<Result>;

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandHandler.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+using Yumney.Users.Application.Interfaces;
+
+namespace Yumney.Users.Application.Commands;
+
+#pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
+public sealed partial class ResendVerificationEmailCommandHandler(
+    IKeycloakAdminService keycloakAdmin,
+    ILogger<ResendVerificationEmailCommandHandler> logger)
+    : ICommandHandler<ResendVerificationEmailCommand, Result>
+{
+    public async Task<Result> HandleAsync(ResendVerificationEmailCommand command, CancellationToken cancellationToken = default)
+    {
+        var email = command.Email;
+
+        var findResult = await keycloakAdmin.FindUserByEmailAsync(email, cancellationToken);
+
+        if (findResult.IsFailure)
+        {
+            if (findResult.Error == VerificationErrors.UserNotFound)
+            {
+                LogUserNotFoundSilent(email);
+                return Result.Success();
+            }
+
+            return Result.Failure(findResult.Error!);
+        }
+
+        var keycloakUserId = findResult.Value;
+
+        var sendResult = await keycloakAdmin.SendVerificationEmailAsync(keycloakUserId, cancellationToken);
+
+        if (sendResult.IsFailure)
+        {
+            return Result.Failure(sendResult.Error!);
+        }
+
+        LogVerificationEmailSent(email);
+
+        return Result.Success();
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Resend verification requested for unknown email {Email}, returning success to prevent enumeration")]
+    private partial void LogUserNotFoundSilent(string email);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Verification email resent for {Email}")]
+    private partial void LogVerificationEmailSent(string email);
+}

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandValidator.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Yumney.Users.Application.Commands;
+
+public sealed class ResendVerificationEmailCommandValidator : AbstractValidator<ResendVerificationEmailCommand>
+{
+    public ResendVerificationEmailCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .MaximumLength(254)
+            .EmailAddress();
+    }
+}

--- a/src/Yumney.Users.Application/Commands/VerificationErrors.cs
+++ b/src/Yumney.Users.Application/Commands/VerificationErrors.cs
@@ -1,0 +1,10 @@
+namespace Yumney.Users.Application.Commands;
+
+public static class VerificationErrors
+{
+    public const string UserNotFound = "VERIFICATION_USER_NOT_FOUND";
+
+    public const string IdentityProviderUnavailable = "VERIFICATION_IDP_UNAVAILABLE";
+
+    public const string SendFailed = "VERIFICATION_SEND_FAILED";
+}

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -9,4 +9,12 @@ public interface IKeycloakAdminService
         string password,
         string displayName,
         CancellationToken cancellationToken = default);
+
+    Task<Result<string>> FindUserByEmailAsync(
+        string email,
+        CancellationToken cancellationToken = default);
+
+    Task<Result> SendVerificationEmailAsync(
+        string keycloakUserId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -20,6 +20,8 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
+    private static readonly string[] verifyEmailActions = ["VERIFY_EMAIL"];
+
     public async Task<Result<string>> CreateUserAsync(
         string email,
         string password,
@@ -33,6 +35,81 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         }
 
         return await CreateKeycloakUserAsync(email, password, displayName, token.Value, cancellationToken);
+    }
+
+    public async Task<Result<string>> FindUserByEmailAsync(
+        string email,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetServiceAccountTokenAsync(cancellationToken);
+        if (token.IsFailure)
+        {
+            return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+        }
+
+        var encodedEmail = Uri.EscapeDataString(email);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/realms/yumney/users?email={encodedEmail}&exact=true");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+
+        try
+        {
+            var response = await httpClient.SendAsync(request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Failed to search Keycloak users. Status: {StatusCode}", response.StatusCode);
+                return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+            }
+
+            var users = await response.Content.ReadFromJsonAsync<KeycloakUserRepresentation[]>(jsonOptions, cancellationToken);
+
+            if (users is null || users.Length == 0)
+            {
+                return Result<string>.Failure(VerificationErrors.UserNotFound);
+            }
+
+            return Result<string>.Success(users[0].Id);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "HTTP error while searching Keycloak users");
+            return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+        }
+    }
+
+    public async Task<Result> SendVerificationEmailAsync(
+        string keycloakUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var token = await GetServiceAccountTokenAsync(cancellationToken);
+        if (token.IsFailure)
+        {
+            return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"/admin/realms/yumney/users/{keycloakUserId}/execute-actions-email");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+        request.Content = JsonContent.Create(verifyEmailActions, options: jsonOptions);
+
+        try
+        {
+            var response = await httpClient.SendAsync(request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                logger.LogError("Failed to send verification email. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
+                return Result.Failure(VerificationErrors.SendFailed);
+            }
+
+            return Result.Success();
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "HTTP error while sending verification email");
+            return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
+        }
     }
 
     private async Task<Result<string>> GetServiceAccountTokenAsync(CancellationToken cancellationToken)
@@ -130,4 +207,8 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
 
     private sealed record TokenResponse(
         [property: JsonPropertyName("access_token")] string AccessToken);
+
+    private sealed record KeycloakUserRepresentation(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("email")] string Email);
 }

--- a/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
@@ -69,4 +69,50 @@ public class RegisterUserCommandHandlerTests
             Arg.Any<AppUserProfile>(),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task HandleAsync_IdentityProviderUnavailable_ReturnsFailureWithCorrectError()
+    {
+        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+
+        keycloakAdmin
+            .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(RegistrationErrors.IdentityProviderUnavailable));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(RegistrationErrors.IdentityProviderUnavailable);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserCreationFailed_ReturnsFailureWithCorrectError()
+    {
+        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+
+        keycloakAdmin
+            .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(RegistrationErrors.UserCreationFailed));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(RegistrationErrors.UserCreationFailed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_KeycloakReturnsFailure_DoesNotCallAddAsync()
+    {
+        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+
+        keycloakAdmin
+            .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(RegistrationErrors.IdentityProviderUnavailable));
+
+        await sut.HandleAsync(command);
+
+        await users.DidNotReceive().AddAsync(
+            Arg.Any<AppUserProfile>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandValidatorTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandValidatorTests.cs
@@ -59,4 +59,77 @@ public class RegisterUserCommandValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "DisplayName");
     }
+
+    [Theory]
+    [InlineData("user+test@example.com")]
+    [InlineData("user.name@example.com")]
+    [InlineData("user_name@example.co.uk")]
+    public void Validate_EmailWithSpecialChars_IsValid(string email)
+    {
+        var command = new RegisterUserCommand(email, "Password1", "Test User");
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmailAtMaxLength_IsValid()
+    {
+        var localPart = new string('a', 242);
+        var email = $"{localPart}@example.com";
+
+        var command = new RegisterUserCommand(email, "Password1", "Test User");
+
+        var result = sut.Validate(command);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Email" && e.ErrorCode == "MaximumLengthValidator");
+    }
+
+    [Fact]
+    public void Validate_EmailExceedsMaxLength_IsNotValid()
+    {
+        var localPart = new string('a', 243);
+        var email = $"{localPart}@example.com";
+
+        var command = new RegisterUserCommand(email, "Password1", "Test User");
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Fact]
+    public void Validate_DisplayNameAtMaxLength_IsValid()
+    {
+        var displayName = new string('A', 200);
+        var command = new RegisterUserCommand("test@example.com", "Password1", displayName);
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_DisplayNameExceedsMaxLength_IsNotValid()
+    {
+        var displayName = new string('A', 201);
+        var command = new RegisterUserCommand("test@example.com", "Password1", displayName);
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "DisplayName");
+    }
+
+    [Fact]
+    public void Validate_PasswordAtMinLength_IsValid()
+    {
+        var command = new RegisterUserCommand("test@example.com", "Abcdef1x", "Test User");
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
 }

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
@@ -90,6 +90,22 @@ public class ResendVerificationEmailCommandHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_IdentityProviderUnavailable_DoesNotAttemptToSendEmail()
+    {
+        var command = new ResendVerificationEmailCommand("test@example.com");
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable));
+
+        await sut.HandleAsync(command);
+
+        await keycloakAdmin.DidNotReceive().SendVerificationEmailAsync(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task HandleAsync_SendFailed_ReturnsFailure()
     {
         var command = new ResendVerificationEmailCommand("test@example.com");

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Yumney.Shared.Common;
+using Yumney.Users.Application.Commands;
+using Yumney.Users.Application.Interfaces;
+
+namespace Yumney.Users.Application.Tests.Commands;
+
+public class ResendVerificationEmailCommandHandlerTests
+{
+    private readonly IKeycloakAdminService keycloakAdmin = Substitute.For<IKeycloakAdminService>();
+    private readonly ILogger<ResendVerificationEmailCommandHandler> logger =
+        Substitute.For<ILogger<ResendVerificationEmailCommandHandler>>();
+
+    private readonly ResendVerificationEmailCommandHandler sut;
+
+    public ResendVerificationEmailCommandHandlerTests()
+    {
+        sut = new ResendVerificationEmailCommandHandler(keycloakAdmin, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidEmail_ReturnsSuccessAndSendsEmail()
+    {
+        var command = new ResendVerificationEmailCommand("test@example.com");
+        var keycloakUserId = Guid.NewGuid().ToString();
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Success(keycloakUserId));
+
+        keycloakAdmin
+            .SendVerificationEmailAsync(keycloakUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+
+        await keycloakAdmin.Received(1).SendVerificationEmailAsync(
+            keycloakUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserNotFound_ReturnsSuccessToPreventEnumeration()
+    {
+        var command = new ResendVerificationEmailCommand("unknown@example.com");
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(VerificationErrors.UserNotFound));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserNotFound_DoesNotAttemptToSendEmail()
+    {
+        var command = new ResendVerificationEmailCommand("unknown@example.com");
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(VerificationErrors.UserNotFound));
+
+        await sut.HandleAsync(command);
+
+        await keycloakAdmin.DidNotReceive().SendVerificationEmailAsync(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_IdentityProviderUnavailable_ReturnsFailure()
+    {
+        var command = new ResendVerificationEmailCommand("test@example.com");
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(VerificationErrors.IdentityProviderUnavailable);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SendFailed_ReturnsFailure()
+    {
+        var command = new ResendVerificationEmailCommand("test@example.com");
+        var keycloakUserId = Guid.NewGuid().ToString();
+
+        keycloakAdmin
+            .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+            .Returns(Result<string>.Success(keycloakUserId));
+
+        keycloakAdmin
+            .SendVerificationEmailAsync(keycloakUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(VerificationErrors.SendFailed));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(VerificationErrors.SendFailed);
+    }
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandValidatorTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandValidatorTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Users.Application.Commands;
+
+namespace Yumney.Users.Application.Tests.Commands;
+
+public class ResendVerificationEmailCommandValidatorTests
+{
+    private readonly ResendVerificationEmailCommandValidator sut = new();
+
+    [Fact]
+    public void Validate_ValidEmail_IsValid()
+    {
+        var command = new ResendVerificationEmailCommand("test@example.com");
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    public void Validate_InvalidEmail_IsNotValid(string email)
+    {
+        var command = new ResendVerificationEmailCommand(email);
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Fact]
+    public void Validate_EmailExceedsMaxLength_IsNotValid()
+    {
+        var localPart = new string('a', 243);
+        var email = $"{localPart}@example.com";
+        var command = new ResendVerificationEmailCommand(email);
+
+        var result = sut.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandValidatorTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandValidatorTests.cs
@@ -33,6 +33,18 @@ public class ResendVerificationEmailCommandValidatorTests
     }
 
     [Fact]
+    public void Validate_EmailAtMaxLength_IsValid()
+    {
+        var localPart = new string('a', 242);
+        var email = $"{localPart}@example.com";
+        var command = new ResendVerificationEmailCommand(email);
+
+        var result = sut.Validate(command);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Email" && e.ErrorCode == "MaximumLengthValidator");
+    }
+
+    [Fact]
     public void Validate_EmailExceedsMaxLength_IsNotValid()
     {
         var localPart = new string('a', 243);


### PR DESCRIPTION
## Summary
- Add missing registration validator and handler edge-case tests (special-char emails, boundary lengths, password min-length, IDP/creation failure error codes)
- Implement resend verification email feature end-to-end: application command/handler/validator, Keycloak integration (FindUserByEmail + SendVerificationEmail), API endpoint, Angular component with i18n (EN/DE)
- Add comprehensive frontend tests for register and resend-verification components, plus i18n key parity checks

## Security
- Resend endpoint always returns 200 OK with generic message regardless of whether the user exists (prevents email enumeration)
- Backend handler returns `Result.Success()` for unknown emails, only fails for infrastructure errors

## Test plan
- [x] `dotnet test` — 35 backend tests pass (Users.Application.Tests)
- [x] `yarn nx test shell` — 43 frontend tests pass (register 25 + resend 15 + i18n 3)
- [x] `dotnet build Yumney.slnx` — compiles clean
- [x] `yarn nx lint shell` — no lint errors
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)