### PR TITLE
feat(auth,users): add login/logout and replace primitives with value objects (US-001, US-002, US-003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,32 @@ public Quantity(decimal amount, string unit) { }
 public Quantity(Amount amount, Unit unit) { }
 ```
 
+### Value Objects in Commands, Events, and Service Interfaces
+
+Commands, events, and service/repository interfaces MUST use value object types
+for all business-meaningful parameters. No primitive types (`string`, `int`, etc.)
+for concepts that carry domain meaning.
+
+API endpoints receive request DTOs (primitives), validate via FluentValidation,
+then map to commands with value objects.
+
+```csharp
+// ❌ FORBIDDEN – Primitives in commands
+public sealed record RegisterUserCommand(string Email, string Password, string DisplayName);
+
+// ✅ REQUIRED – Value objects in commands
+public sealed record RegisterUserRequest(string Email, string Password, string DisplayName); // API DTO
+public sealed record RegisterUserCommand(Email Email, Password Password, DisplayName DisplayName); // Command
+```
+
+```csharp
+// ❌ FORBIDDEN – Primitives in service interfaces
+Task<Result<string>> CreateUserAsync(string email, string password, string displayName);
+
+// ✅ REQUIRED – Value objects in service interfaces
+Task<Result<KeycloakUserId>> CreateUserAsync(Email email, Password password, DisplayName displayName);
+```
+
 ### Domain Model Structure – by Aggregate, NOT by type
 
 ```

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -1,5 +1,13 @@
 {
   "auth": {
+    "login": {
+      "title": "Willkommen zurück",
+      "subtitle": "Melde dich bei deinem Yumney-Konto an",
+      "submit": "Über Keycloak anmelden",
+      "rememberMe": "Angemeldet bleiben",
+      "noAccount": "Noch kein Konto?",
+      "registerLink": "Jetzt erstellen"
+    },
     "register": {
       "title": "Konto erstellen",
       "subtitle": "Tritt Yumney bei und beginne Rezepte zu sammeln",
@@ -52,5 +60,16 @@
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
       }
     }
+  },
+  "layout": {
+    "header": {
+      "greeting": "Hallo, {{name}}",
+      "logout": "Abmelden",
+      "login": "Anmelden"
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "welcome": "Willkommen bei Yumney!"
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -1,5 +1,13 @@
 {
   "auth": {
+    "login": {
+      "title": "Welcome back",
+      "subtitle": "Sign in to your Yumney account",
+      "submit": "Sign in with Keycloak",
+      "rememberMe": "Stay logged in",
+      "noAccount": "Don't have an account?",
+      "registerLink": "Create one"
+    },
     "register": {
       "title": "Create Account",
       "subtitle": "Join Yumney and start collecting recipes",
@@ -52,5 +60,16 @@
         "generic": "An unexpected error occurred. Please try again later."
       }
     }
+  },
+  "layout": {
+    "header": {
+      "greeting": "Hi, {{name}}",
+      "logout": "Sign out",
+      "login": "Sign in"
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "welcome": "Welcome to Yumney!"
   }
 }

--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -5,8 +5,9 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideTransloco } from '@jsverse/transloco';
+import { authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { appRoutes } from './app.routes';
 import { TranslocoHttpLoader } from './transloco-loader';
 
@@ -15,7 +16,8 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
+    provideAuth(),
     provideTransloco({
       config: {
         availableLangs: ['en', 'de'],

--- a/client/apps/shell/src/app/app.html
+++ b/client/apps/shell/src/app/app.html
@@ -1,1 +1,4 @@
-<router-outlet></router-outlet>
+<yn-header />
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Route } from '@angular/router';
+import { authGuard } from '@yumney/shared/auth';
 
 export const appRoutes: Route[] = [
   {
@@ -6,8 +7,14 @@ export const appRoutes: Route[] = [
     loadChildren: () => import('./auth/auth.routes').then((m) => m.authRoutes),
   },
   {
+    path: 'dashboard',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./dashboard/dashboard.component').then((m) => m.DashboardComponent),
+  },
+  {
     path: '',
-    redirectTo: 'auth/register',
+    redirectTo: 'dashboard',
     pathMatch: 'full',
   },
 ];

--- a/client/apps/shell/src/app/app.scss
+++ b/client/apps/shell/src/app/app.scss
@@ -2,3 +2,7 @@
   display: block;
   min-height: 100vh;
 }
+
+main {
+  flex: 1;
+}

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -1,8 +1,9 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { HeaderComponent } from './layout/header/header.component';
 
 @Component({
-  imports: [RouterModule],
+  imports: [RouterModule, HeaderComponent],
   selector: 'yn-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -9,6 +9,4 @@ import { HeaderComponent } from './layout/header/header.component';
   styleUrl: './app.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class App {
-  protected title = 'Yumney';
-}
+export class App {}

--- a/client/apps/shell/src/app/auth/auth.routes.ts
+++ b/client/apps/shell/src/app/auth/auth.routes.ts
@@ -2,6 +2,10 @@ import { Route } from '@angular/router';
 
 export const authRoutes: Route[] = [
   {
+    path: 'login',
+    loadComponent: () => import('./login/login.component').then((m) => m.LoginComponent),
+  },
+  {
     path: 'register',
     loadComponent: () => import('./register/register.component').then((m) => m.RegisterComponent),
   },

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -80,4 +80,35 @@ describe('i18n keys', () => {
       expect(enKeys).toContain(key);
     }
   });
+
+  it('should contain required auth.login keys', () => {
+    const requiredKeys = [
+      'auth.login.title',
+      'auth.login.subtitle',
+      'auth.login.submit',
+      'auth.login.rememberMe',
+      'auth.login.noAccount',
+      'auth.login.registerLink',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
+
+  it('should contain required layout.header keys', () => {
+    const requiredKeys = ['layout.header.greeting', 'layout.header.logout', 'layout.header.login'];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
+
+  it('should contain required dashboard keys', () => {
+    const requiredKeys = ['dashboard.title', 'dashboard.welcome'];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
 });

--- a/client/apps/shell/src/app/auth/login/login.component.html
+++ b/client/apps/shell/src/app/auth/login/login.component.html
@@ -1,0 +1,22 @@
+<div class="login-container" *transloco="let t">
+  <div class="login-card">
+    <h1>{{ t('auth.login.title') }}</h1>
+    <p class="subtitle">{{ t('auth.login.subtitle') }}</p>
+
+    <div class="login-form">
+      <label class="remember-me">
+        <input type="checkbox" [(ngModel)]="rememberMe" />
+        {{ t('auth.login.rememberMe') }}
+      </label>
+
+      <button type="button" (click)="onLogin()">
+        {{ t('auth.login.submit') }}
+      </button>
+
+      <p class="register-link">
+        {{ t('auth.login.noAccount') }}
+        <a routerLink="/auth/register">{{ t('auth.login.registerLink') }}</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/client/apps/shell/src/app/auth/login/login.component.scss
+++ b/client/apps/shell/src/app/auth/login/login.component.scss
@@ -1,0 +1,76 @@
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+
+  h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    margin: 0 0 1.5rem;
+    color: #666;
+    font-size: 0.875rem;
+  }
+}
+
+.remember-me {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+  }
+}
+
+button {
+  width: 100%;
+  padding: 0.625rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #4a90d9;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #357abd;
+  }
+}
+
+.register-link {
+  margin-top: 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #666;
+
+  a {
+    color: #4a90d9;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/client/apps/shell/src/app/auth/login/login.component.spec.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.spec.ts
@@ -74,4 +74,20 @@ describe('LoginComponent', () => {
     const link = fixture.nativeElement.querySelector('a[href="/auth/register"]');
     expect(link).toBeTruthy();
   });
+
+  it('should render the subtitle', () => {
+    const subtitle = fixture.nativeElement.querySelector('.subtitle');
+    expect(subtitle.textContent).toContain('Sign in to your Yumney account');
+  });
+
+  it('should have rememberMe unchecked by default', () => {
+    expect(component.rememberMe).toBe(false);
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('should render the remember me label', () => {
+    const label = fixture.nativeElement.querySelector('.remember-me');
+    expect(label.textContent).toContain('Stay logged in');
+  });
 });

--- a/client/apps/shell/src/app/auth/login/login.component.spec.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { LoginComponent } from './login.component';
+import { AuthService } from '@yumney/shared/auth';
+
+const en = {
+  auth: {
+    login: {
+      title: 'Welcome back',
+      subtitle: 'Sign in to your Yumney account',
+      submit: 'Sign in with Keycloak',
+      rememberMe: 'Stay logged in',
+      noAccount: "Don't have an account?",
+      registerLink: 'Create one',
+    },
+  },
+};
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+  let authServiceMock: { login: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    authServiceMock = { login: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        LoginComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [provideRouter([]), { provide: AuthService, useValue: authServiceMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the login title', () => {
+    const heading = fixture.nativeElement.querySelector('h1');
+    expect(heading.textContent).toContain('Welcome back');
+  });
+
+  it('should call authService.login on button click', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(authServiceMock.login).toHaveBeenCalledWith(false);
+  });
+
+  it('should pass rememberMe=true when checkbox is checked', () => {
+    component.rememberMe = true;
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(authServiceMock.login).toHaveBeenCalledWith(true);
+  });
+
+  it('should contain a link to the register page', () => {
+    const link = fixture.nativeElement.querySelector('a[href="/auth/register"]');
+    expect(link).toBeTruthy();
+  });
+});

--- a/client/apps/shell/src/app/auth/login/login.component.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.ts
@@ -1,0 +1,22 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AuthService } from '@yumney/shared/auth';
+
+@Component({
+  selector: 'yn-login',
+  imports: [FormsModule, TranslocoModule, RouterLink],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LoginComponent {
+  private authService = inject(AuthService);
+
+  rememberMe = false;
+
+  onLogin(): void {
+    this.authService.login(this.rememberMe);
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,4 @@
+<div class="dashboard-container" *transloco="let t">
+  <h1>{{ t('dashboard.title') }}</h1>
+  <p>{{ t('dashboard.welcome') }}</p>
+</div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -1,0 +1,16 @@
+.dashboard-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+
+  h1 {
+    margin: 0 0 0.5rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  p {
+    color: #666;
+    font-size: 1rem;
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { DashboardComponent } from './dashboard.component';
+
+const en = {
+  dashboard: {
+    title: 'Dashboard',
+    welcome: 'Welcome to Yumney!',
+  },
+};
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DashboardComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the welcome message', () => {
+    const element = fixture.nativeElement;
+    expect(element.textContent).toContain('Welcome to Yumney!');
+  });
+
+  it('should render the dashboard title', () => {
+    const heading = fixture.nativeElement.querySelector('h1');
+    expect(heading.textContent).toContain('Dashboard');
+  });
+});

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,11 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'yn-dashboard',
+  imports: [TranslocoModule],
+  templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardComponent {}

--- a/client/apps/shell/src/app/layout/header/header.component.html
+++ b/client/apps/shell/src/app/layout/header/header.component.html
@@ -1,4 +1,4 @@
-<header *transloco="let t; params: { name: authService.displayName() }">
+<header *transloco="let t">
   <div class="header-content">
     <a class="brand" routerLink="/">Yumney</a>
     <nav>

--- a/client/apps/shell/src/app/layout/header/header.component.html
+++ b/client/apps/shell/src/app/layout/header/header.component.html
@@ -1,0 +1,19 @@
+<header *transloco="let t; params: { name: authService.displayName() }">
+  <div class="header-content">
+    <a class="brand" routerLink="/">Yumney</a>
+    <nav>
+      @if (authService.isAuthenticated()) {
+      <span class="greeting">{{
+        t('layout.header.greeting', { name: authService.displayName() })
+      }}</span>
+      <button class="logout-button" (click)="onLogout()">
+        {{ t('layout.header.logout') }}
+      </button>
+      } @else {
+      <a routerLink="/auth/login" class="login-link">
+        {{ t('layout.header.login') }}
+      </a>
+      }
+    </nav>
+  </div>
+</header>

--- a/client/apps/shell/src/app/layout/header/header.component.scss
+++ b/client/apps/shell/src/app/layout/header/header.component.scss
@@ -1,0 +1,59 @@
+header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: #fff;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 10%);
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #4a90d9;
+  text-decoration: none;
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.greeting {
+  font-size: 0.875rem;
+  color: #333;
+}
+
+.logout-button {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: none;
+  font-size: 0.875rem;
+  color: #666;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5f5f5;
+    border-color: #ccc;
+  }
+}
+
+.login-link {
+  font-size: 0.875rem;
+  color: #4a90d9;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/client/apps/shell/src/app/layout/header/header.component.spec.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.spec.ts
@@ -94,4 +94,23 @@ describe('HeaderComponent', () => {
     const brand = fixture.nativeElement.querySelector('.brand');
     expect(brand.textContent).toContain('Yumney');
   });
+
+  it('should not show logout button when not authenticated', () => {
+    const logoutButton = fixture.nativeElement.querySelector('.logout-button');
+    expect(logoutButton).toBeNull();
+  });
+
+  it('should not show login link when authenticated', () => {
+    authServiceMock.isAuthenticated.set(true);
+    authServiceMock.displayName.set('testuser');
+    fixture.detectChanges();
+
+    const loginLink = fixture.nativeElement.querySelector('.login-link');
+    expect(loginLink).toBeNull();
+  });
+
+  it('should not show greeting when not authenticated', () => {
+    const greeting = fixture.nativeElement.querySelector('.greeting');
+    expect(greeting).toBeNull();
+  });
 });

--- a/client/apps/shell/src/app/layout/header/header.component.spec.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.spec.ts
@@ -1,0 +1,97 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { HeaderComponent } from './header.component';
+import { AuthService } from '@yumney/shared/auth';
+
+const en = {
+  layout: {
+    header: {
+      greeting: 'Hi, {{name}}',
+      logout: 'Sign out',
+      login: 'Sign in',
+    },
+  },
+};
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let authServiceMock: {
+    isAuthenticated: ReturnType<typeof signal<boolean>>;
+    displayName: ReturnType<typeof signal<string | null>>;
+    logout: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    authServiceMock = {
+      isAuthenticated: signal(false),
+      displayName: signal<string | null>(null),
+      logout: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HeaderComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [provideRouter([]), { provide: AuthService, useValue: authServiceMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show login link when not authenticated', () => {
+    const loginLink = fixture.nativeElement.querySelector('.login-link');
+    expect(loginLink).toBeTruthy();
+    expect(loginLink.textContent).toContain('Sign in');
+  });
+
+  it('should show logout button when authenticated', () => {
+    authServiceMock.isAuthenticated.set(true);
+    authServiceMock.displayName.set('testuser');
+    fixture.detectChanges();
+
+    const logoutButton = fixture.nativeElement.querySelector('.logout-button');
+    expect(logoutButton).toBeTruthy();
+    expect(logoutButton.textContent).toContain('Sign out');
+  });
+
+  it('should show greeting with display name when authenticated', () => {
+    authServiceMock.isAuthenticated.set(true);
+    authServiceMock.displayName.set('testuser');
+    fixture.detectChanges();
+
+    const greeting = fixture.nativeElement.querySelector('.greeting');
+    expect(greeting.textContent).toContain('Hi, testuser');
+  });
+
+  it('should call logout on logout button click', () => {
+    authServiceMock.isAuthenticated.set(true);
+    authServiceMock.displayName.set('testuser');
+    fixture.detectChanges();
+
+    const logoutButton = fixture.nativeElement.querySelector('.logout-button');
+    logoutButton.click();
+
+    expect(authServiceMock.logout).toHaveBeenCalled();
+  });
+
+  it('should show brand text', () => {
+    const brand = fixture.nativeElement.querySelector('.brand');
+    expect(brand.textContent).toContain('Yumney');
+  });
+});

--- a/client/apps/shell/src/app/layout/header/header.component.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.ts
@@ -1,0 +1,19 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AuthService } from '@yumney/shared/auth';
+
+@Component({
+  selector: 'yn-header',
+  imports: [TranslocoModule, RouterLink],
+  templateUrl: './header.component.html',
+  styleUrl: './header.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HeaderComponent {
+  protected authService = inject(AuthService);
+
+  onLogout(): void {
+    this.authService.logout();
+  }
+}

--- a/client/apps/shell/src/app/shared-auth/auth-storage.factory.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth-storage.factory.spec.ts
@@ -1,0 +1,21 @@
+import { authStorageFactory } from '@yumney/shared/auth';
+
+describe('authStorageFactory', () => {
+  afterEach(() => {
+    localStorage.removeItem('yn_remember_me');
+  });
+
+  it('should return localStorage when remember-me is true', () => {
+    localStorage.setItem('yn_remember_me', 'true');
+
+    const storage = authStorageFactory();
+
+    expect(storage).toBe(localStorage);
+  });
+
+  it('should return sessionStorage when remember-me is not set', () => {
+    const storage = authStorageFactory();
+
+    expect(storage).toBe(sessionStorage);
+  });
+});

--- a/client/apps/shell/src/app/shared-auth/auth-storage.factory.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth-storage.factory.spec.ts
@@ -18,4 +18,12 @@ describe('authStorageFactory', () => {
 
     expect(storage).toBe(sessionStorage);
   });
+
+  it('should return sessionStorage when remember-me is set to false', () => {
+    localStorage.setItem('yn_remember_me', 'false');
+
+    const storage = authStorageFactory();
+
+    expect(storage).toBe(sessionStorage);
+  });
 });

--- a/client/apps/shell/src/app/shared-auth/auth.guard.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.guard.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { AuthService, authGuard } from '@yumney/shared/auth';
+
+describe('authGuard', () => {
+  let authServiceMock: {
+    isAuthenticated: ReturnType<typeof vi.fn>;
+    login: ReturnType<typeof vi.fn>;
+  };
+
+  const route = {} as ActivatedRouteSnapshot;
+  const state = {} as RouterStateSnapshot;
+
+  beforeEach(() => {
+    authServiceMock = {
+      isAuthenticated: vi.fn(),
+      login: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: authServiceMock }],
+    });
+  });
+
+  it('should return true when authenticated', () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true);
+
+    const result = TestBed.runInInjectionContext(() => authGuard(route, state));
+
+    expect(result).toBe(true);
+  });
+
+  it('should call login when not authenticated', () => {
+    authServiceMock.isAuthenticated.mockReturnValue(false);
+
+    TestBed.runInInjectionContext(() => authGuard(route, state));
+
+    expect(authServiceMock.login).toHaveBeenCalled();
+  });
+
+  it('should return false when not authenticated', () => {
+    authServiceMock.isAuthenticated.mockReturnValue(false);
+
+    const result = TestBed.runInInjectionContext(() => authGuard(route, state));
+
+    expect(result).toBe(false);
+  });
+});

--- a/client/apps/shell/src/app/shared-auth/auth.interceptor.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.interceptor.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { authInterceptor } from '@yumney/shared/auth';
+
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpTesting: HttpTestingController;
+  let oauthMock: {
+    hasValidAccessToken: ReturnType<typeof vi.fn>;
+    getAccessToken: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    oauthMock = {
+      hasValidAccessToken: vi.fn().mockReturnValue(false),
+      getAccessToken: vi.fn().mockReturnValue('test-token'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: OAuthService, useValue: oauthMock },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('should add Bearer token to /api/ requests when authenticated', () => {
+    oauthMock.hasValidAccessToken.mockReturnValue(true);
+
+    http.get('/api/v1/recipes').subscribe();
+
+    const req = httpTesting.expectOne('/api/v1/recipes');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush([]);
+  });
+
+  it('should not add token to /api/ requests when not authenticated', () => {
+    oauthMock.hasValidAccessToken.mockReturnValue(false);
+
+    http.get('/api/v1/recipes').subscribe();
+
+    const req = httpTesting.expectOne('/api/v1/recipes');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush([]);
+  });
+
+  it('should not add token to non-api requests', () => {
+    oauthMock.hasValidAccessToken.mockReturnValue(true);
+
+    http.get('/assets/i18n/en.json').subscribe();
+
+    const req = httpTesting.expectOne('/assets/i18n/en.json');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+});

--- a/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
@@ -93,6 +93,16 @@ describe('AuthService', () => {
       expect(service.isLoading()).toBe(false);
     });
 
+    it('should not update currentUser when token is valid but claims are null', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue(null);
+
+      await service.initialize();
+
+      expect(service.isAuthenticated()).toBe(true);
+      expect(service.currentUser()).toBeNull();
+    });
+
     it('should default roles to empty array when realm_access is missing', async () => {
       oauthMock.hasValidAccessToken.mockReturnValue(true);
       oauthMock.getIdentityClaims.mockReturnValue({

--- a/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
@@ -1,0 +1,140 @@
+import { TestBed } from '@angular/core/testing';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { Subject } from 'rxjs';
+import { AuthService } from '@yumney/shared/auth';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let oauthMock: {
+    configure: ReturnType<typeof vi.fn>;
+    setupAutomaticSilentRefresh: ReturnType<typeof vi.fn>;
+    loadDiscoveryDocumentAndTryLogin: ReturnType<typeof vi.fn>;
+    hasValidAccessToken: ReturnType<typeof vi.fn>;
+    getIdentityClaims: ReturnType<typeof vi.fn>;
+    initCodeFlow: ReturnType<typeof vi.fn>;
+    logOut: ReturnType<typeof vi.fn>;
+    events: Subject<unknown>;
+  };
+
+  beforeEach(() => {
+    oauthMock = {
+      configure: vi.fn(),
+      setupAutomaticSilentRefresh: vi.fn(),
+      loadDiscoveryDocumentAndTryLogin: vi.fn().mockResolvedValue(true),
+      hasValidAccessToken: vi.fn().mockReturnValue(false),
+      getIdentityClaims: vi.fn().mockReturnValue(null),
+      initCodeFlow: vi.fn(),
+      logOut: vi.fn(),
+      events: new Subject(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [AuthService, { provide: OAuthService, useValue: oauthMock }],
+    });
+
+    service = TestBed.inject(AuthService);
+  });
+
+  describe('initialize', () => {
+    it('should set isAuthenticated to true when token is valid', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+        realm_access: { roles: ['user'] },
+      });
+
+      await service.initialize();
+
+      expect(service.isAuthenticated()).toBe(true);
+    });
+
+    it('should set isAuthenticated to false when no valid token', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(false);
+
+      await service.initialize();
+
+      expect(service.isAuthenticated()).toBe(false);
+    });
+
+    it('should extract user claims into currentUser signal', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+        realm_access: { roles: ['user', 'admin'] },
+      });
+
+      await service.initialize();
+
+      expect(service.currentUser()).toEqual({
+        sub: '123',
+        email: 'test@example.com',
+        preferredUsername: 'testuser',
+        roles: ['user', 'admin'],
+      });
+    });
+
+    it('should set isLoading to false after initialization', async () => {
+      expect(service.isLoading()).toBe(true);
+
+      await service.initialize();
+
+      expect(service.isLoading()).toBe(false);
+    });
+  });
+
+  describe('login', () => {
+    it('should call initCodeFlow on login', () => {
+      service.login();
+
+      expect(oauthMock.initCodeFlow).toHaveBeenCalled();
+    });
+
+    it('should store remember-me preference on login with rememberMe=true', () => {
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+      service.login(true);
+
+      expect(setItemSpy).toHaveBeenCalledWith('yn_remember_me', 'true');
+      setItemSpy.mockRestore();
+    });
+  });
+
+  describe('logout', () => {
+    it('should call logOut on logout', () => {
+      service.logout();
+
+      expect(oauthMock.logOut).toHaveBeenCalled();
+    });
+
+    it('should clear currentUser and isAuthenticated on logout', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+        realm_access: { roles: ['user'] },
+      });
+
+      await service.initialize();
+      expect(service.isAuthenticated()).toBe(true);
+
+      service.logout();
+
+      expect(service.isAuthenticated()).toBe(false);
+      expect(service.currentUser()).toBeNull();
+    });
+
+    it('should remove remember-me preference on logout', () => {
+      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
+      service.logout();
+
+      expect(removeItemSpy).toHaveBeenCalledWith('yn_remember_me');
+      removeItemSpy.mockRestore();
+    });
+  });
+});

--- a/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
@@ -84,6 +84,65 @@ describe('AuthService', () => {
 
       expect(service.isLoading()).toBe(false);
     });
+
+    it('should set isLoading to false even when discovery document fails', async () => {
+      oauthMock.loadDiscoveryDocumentAndTryLogin.mockRejectedValue(new Error('Network error'));
+
+      await service.initialize();
+
+      expect(service.isLoading()).toBe(false);
+    });
+
+    it('should default roles to empty array when realm_access is missing', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+      });
+
+      await service.initialize();
+
+      expect(service.currentUser()?.roles).toEqual([]);
+    });
+
+    it('should update auth state when oauth events are emitted', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(false);
+
+      await service.initialize();
+      expect(service.isAuthenticated()).toBe(false);
+
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '456',
+        email: 'new@example.com',
+        preferred_username: 'newuser',
+        realm_access: { roles: ['user'] },
+      });
+
+      oauthMock.events.next({});
+
+      expect(service.isAuthenticated()).toBe(true);
+      expect(service.currentUser()?.preferredUsername).toBe('newuser');
+    });
+
+    it('should set currentUser to null when token becomes invalid via event', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+        realm_access: { roles: ['user'] },
+      });
+
+      await service.initialize();
+      expect(service.currentUser()).not.toBeNull();
+
+      oauthMock.hasValidAccessToken.mockReturnValue(false);
+      oauthMock.events.next({});
+
+      expect(service.currentUser()).toBeNull();
+    });
   });
 
   describe('login', () => {
@@ -100,6 +159,50 @@ describe('AuthService', () => {
 
       expect(setItemSpy).toHaveBeenCalledWith('yn_remember_me', 'true');
       setItemSpy.mockRestore();
+    });
+
+    it('should remove remember-me preference on login with rememberMe=false', () => {
+      localStorage.setItem('yn_remember_me', 'true');
+      const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
+      service.login(false);
+
+      expect(removeItemSpy).toHaveBeenCalledWith('yn_remember_me');
+      removeItemSpy.mockRestore();
+    });
+  });
+
+  describe('displayName', () => {
+    it('should return preferredUsername when available', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: 'testuser',
+        realm_access: { roles: [] },
+      });
+
+      await service.initialize();
+
+      expect(service.displayName()).toBe('testuser');
+    });
+
+    it('should fall back to email when preferredUsername is undefined', async () => {
+      oauthMock.hasValidAccessToken.mockReturnValue(true);
+      oauthMock.getIdentityClaims.mockReturnValue({
+        sub: '123',
+        email: 'test@example.com',
+        preferred_username: undefined,
+        realm_access: { roles: [] },
+      });
+
+      await service.initialize();
+
+      expect(service.displayName()).toBe('test@example.com');
+    });
+
+    it('should return null when no user is authenticated', () => {
+      expect(service.displayName()).toBeNull();
     });
   });
 

--- a/client/libs/shared/auth/src/index.ts
+++ b/client/libs/shared/auth/src/index.ts
@@ -1,0 +1,6 @@
+export { AuthService } from './lib/auth.service';
+export type { AuthUser } from './lib/auth.service';
+export { authGuard } from './lib/auth.guard';
+export { authInterceptor } from './lib/auth.interceptor';
+export { provideAuth } from './lib/provide-auth';
+export { authStorageFactory } from './lib/auth-storage.factory';

--- a/client/libs/shared/auth/src/lib/auth-config.ts
+++ b/client/libs/shared/auth/src/lib/auth-config.ts
@@ -1,0 +1,12 @@
+import { AuthConfig } from 'angular-oauth2-oidc';
+
+export const authConfig: AuthConfig = {
+  issuer: 'http://localhost:8080/realms/yumney',
+  clientId: 'yumney-web',
+  responseType: 'code',
+  scope: 'openid profile email roles',
+  redirectUri: typeof window !== 'undefined' ? window.location.origin : '',
+  postLogoutRedirectUri: typeof window !== 'undefined' ? window.location.origin : '',
+  requireHttps: false,
+  strictDiscoveryDocumentValidation: false,
+};

--- a/client/libs/shared/auth/src/lib/auth-storage.factory.ts
+++ b/client/libs/shared/auth/src/lib/auth-storage.factory.ts
@@ -1,0 +1,10 @@
+import { OAuthStorage } from 'angular-oauth2-oidc';
+
+const REMEMBER_ME_KEY = 'yn_remember_me';
+
+export function authStorageFactory(): OAuthStorage {
+  if (typeof localStorage !== 'undefined' && localStorage.getItem(REMEMBER_ME_KEY) === 'true') {
+    return localStorage;
+  }
+  return sessionStorage;
+}

--- a/client/libs/shared/auth/src/lib/auth-storage.factory.ts
+++ b/client/libs/shared/auth/src/lib/auth-storage.factory.ts
@@ -1,6 +1,6 @@
 import { OAuthStorage } from 'angular-oauth2-oidc';
 
-const REMEMBER_ME_KEY = 'yn_remember_me';
+export const REMEMBER_ME_KEY = 'yn_remember_me';
 
 export function authStorageFactory(): OAuthStorage {
   if (typeof localStorage !== 'undefined' && localStorage.getItem(REMEMBER_ME_KEY) === 'true') {

--- a/client/libs/shared/auth/src/lib/auth.guard.ts
+++ b/client/libs/shared/auth/src/lib/auth.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  authService.login();
+  return false;
+};

--- a/client/libs/shared/auth/src/lib/auth.interceptor.ts
+++ b/client/libs/shared/auth/src/lib/auth.interceptor.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const oauthService = inject(OAuthService);
+
+  if (req.url.includes('/api/') && oauthService.hasValidAccessToken()) {
+    const cloned = req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${oauthService.getAccessToken()}`,
+      },
+    });
+    return next(cloned);
+  }
+
+  return next(req);
+};

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, signal, computed } from '@angular/core';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { authConfig } from './auth-config';
+
+export interface AuthUser {
+  sub: string;
+  email: string;
+  preferredUsername: string;
+  roles: string[];
+}
+
+const REMEMBER_ME_KEY = 'yn_remember_me';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  isLoading = signal(true);
+  isAuthenticated = signal(false);
+  currentUser = signal<AuthUser | null>(null);
+  displayName = computed(
+    () => this.currentUser()?.preferredUsername ?? this.currentUser()?.email ?? null,
+  );
+
+  constructor(private oauthService: OAuthService) {}
+
+  async initialize(): Promise<void> {
+    this.oauthService.configure(authConfig);
+    this.oauthService.setupAutomaticSilentRefresh();
+
+    try {
+      await this.oauthService.loadDiscoveryDocumentAndTryLogin();
+      this.updateAuthState();
+    } finally {
+      this.isLoading.set(false);
+    }
+
+    this.oauthService.events.subscribe(() => {
+      this.updateAuthState();
+    });
+  }
+
+  login(rememberMe = false): void {
+    if (rememberMe) {
+      localStorage.setItem(REMEMBER_ME_KEY, 'true');
+    } else {
+      localStorage.removeItem(REMEMBER_ME_KEY);
+    }
+    this.oauthService.initCodeFlow();
+  }
+
+  logout(): void {
+    this.oauthService.logOut();
+    this.isAuthenticated.set(false);
+    this.currentUser.set(null);
+    localStorage.removeItem(REMEMBER_ME_KEY);
+  }
+
+  private updateAuthState(): void {
+    const hasValidToken = this.oauthService.hasValidAccessToken();
+    this.isAuthenticated.set(hasValidToken);
+
+    if (hasValidToken) {
+      const claims = this.oauthService.getIdentityClaims();
+      if (claims) {
+        this.currentUser.set({
+          sub: claims['sub'],
+          email: claims['email'],
+          preferredUsername: claims['preferred_username'],
+          roles: claims['realm_access']?.['roles'] ?? [],
+        });
+      }
+    } else {
+      this.currentUser.set(null);
+    }
+  }
+}

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, signal, computed } from '@angular/core';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { authConfig } from './auth-config';
+import { REMEMBER_ME_KEY } from './auth-storage.factory';
 
 export interface AuthUser {
   sub: string;
@@ -8,8 +9,6 @@ export interface AuthUser {
   preferredUsername: string;
   roles: string[];
 }
-
-const REMEMBER_ME_KEY = 'yn_remember_me';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -26,6 +25,10 @@ export class AuthService {
     this.oauthService.configure(authConfig);
     this.oauthService.setupAutomaticSilentRefresh();
 
+    this.oauthService.events.subscribe(() => {
+      this.updateAuthState();
+    });
+
     try {
       await this.oauthService.loadDiscoveryDocumentAndTryLogin();
       this.updateAuthState();
@@ -34,10 +37,6 @@ export class AuthService {
     } finally {
       this.isLoading.set(false);
     }
-
-    this.oauthService.events.subscribe(() => {
-      this.updateAuthState();
-    });
   }
 
   login(rememberMe = false): void {

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -29,6 +29,8 @@ export class AuthService {
     try {
       await this.oauthService.loadDiscoveryDocumentAndTryLogin();
       this.updateAuthState();
+    } catch {
+      // Keycloak unreachable — app continues unauthenticated
     } finally {
       this.isLoading.set(false);
     }

--- a/client/libs/shared/auth/src/lib/provide-auth.ts
+++ b/client/libs/shared/auth/src/lib/provide-auth.ts
@@ -1,0 +1,21 @@
+import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { provideOAuthClient, OAuthStorage } from 'angular-oauth2-oidc';
+import { AuthService } from './auth.service';
+import { authStorageFactory } from './auth-storage.factory';
+
+function initializeAuth(authService: AuthService): () => Promise<void> {
+  return () => authService.initialize();
+}
+
+export function provideAuth(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    provideOAuthClient(),
+    { provide: OAuthStorage, useFactory: authStorageFactory },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAuth,
+      deps: [AuthService],
+      multi: true,
+    },
+  ]);
+}

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@angular/router": "21.1.1",
     "@angular/ssr": "21.1.1",
     "@jsverse/transloco": "^8.2.1",
+    "angular-oauth2-oidc": "^20.0.2",
     "express": "^4.21.2",
     "rxjs": "~7.8.0",
     "zone.js": "0.16.0"

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -17,7 +17,8 @@
     "paths": {
       "@yumney/shared/models": ["libs/shared/models/src/index.ts"],
       "@yumney/shared/api-client": ["libs/shared/api-client/src/index.ts"],
-      "@yumney/ui": ["libs/ui/src/index.ts"]
+      "@yumney/ui": ["libs/ui/src/index.ts"],
+      "@yumney/shared/auth": ["libs/shared/auth/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5430,6 +5430,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:4.0.9"
     "@vitest/ui": "npm:4.0.9"
     angular-eslint: "npm:21.1.0"
+    angular-oauth2-oidc: "npm:^20.0.2"
     esbuild: "npm:^0.19.2"
     eslint: "npm:^9.8.0"
     eslint-config-prettier: "npm:^10.0.0"
@@ -8040,6 +8041,18 @@ __metadata:
     typescript: "*"
     typescript-eslint: ^8.0.0
   checksum: 10c0/cd8291d345f601705aa3ecac242e43c2b8c743a4cfb282fd4d35971fe8065d64837038571c5dc31a4804daa665353b4841eac2a6e273af2b837278742bb5a6d2
+  languageName: node
+  linkType: hard
+
+"angular-oauth2-oidc@npm:^20.0.2":
+  version: 20.0.2
+  resolution: "angular-oauth2-oidc@npm:20.0.2"
+  dependencies:
+    tslib: "npm:^2.5.2"
+  peerDependencies:
+    "@angular/common": ">=20.0.0"
+    "@angular/core": ">=20.0.0"
+  checksum: 10c0/db22f23d4906dd6b413b2a01d832a35aa8f7e8db236eafc7d0c63fdf7e29e08ca3aea13241b16e7ca63d27f586d365dc6b1cce690a6fb6d6aaf3f88aeb89a21b
   languageName: node
   linkType: hard
 
@@ -17637,7 +17650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.2, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,7 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci'],
+      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci', 'auth'],
     ],
     'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
     'body-max-line-length': [1, 'always', 120],

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -41,7 +41,7 @@ builder.Services.AddInProcessEventBus();
 builder.Services.AddDbContext<UsersDbContext>(options => options.UseNpgsql(builder.Configuration.GetConnectionString("yumneydb")));
 builder.Services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
 
-builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserCommandValidator>();
+builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserRequestValidator>();
 builder.Services.AddScoped<ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>, RegisterUserCommandHandler>();
 builder.Services.AddScoped<ICommandHandler<ResendVerificationEmailCommand, Result>, ResendVerificationEmailCommandHandler>();
 

--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -8,6 +8,7 @@
   "resetPasswordAllowed": true,
   "editUsernameAllowed": false,
   "bruteForceProtected": true,
+  "failureFactor": 5,
   "verifyEmail": true,
   "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1)",
   "smtpServer": {
@@ -63,7 +64,8 @@
       ],
       "protocol": "openid-connect",
       "attributes": {
-        "pkce.code.challenge.method": "S256"
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:4200/*##https://localhost:4200/*"
       },
       "defaultClientScopes": [
         "openid",
@@ -77,6 +79,7 @@
     {
       "username": "testuser",
       "enabled": true,
+      "emailVerified": true,
       "email": "test@yumney.dev",
       "firstName": "Test",
       "lastName": "User",
@@ -92,6 +95,7 @@
     {
       "username": "admin",
       "enabled": true,
+      "emailVerified": true,
       "email": "admin@yumney.dev",
       "firstName": "Admin",
       "lastName": "User",

--- a/src/Yumney.Shared/Guards/GuardExtensions.cs
+++ b/src/Yumney.Shared/Guards/GuardExtensions.cs
@@ -1,3 +1,6 @@
+using System.Net.Mail;
+using System.Text.RegularExpressions;
+
 namespace Yumney.Shared.Guards;
 
 public static class GuardExtensions
@@ -33,6 +36,30 @@ public static class GuardExtensions
                 throw new GuardException(
                     guard.ParameterName,
                     $"{guard.ParameterName} must be at least {minLength} characters.");
+            }
+
+            return guard;
+        }
+
+        public GuardClause<string> IsValidEmail()
+        {
+            if (!MailAddress.TryCreate(guard.Value, out _))
+            {
+                throw new GuardException(
+                    guard.ParameterName,
+                    $"{guard.ParameterName} must be a valid email address.");
+            }
+
+            return guard;
+        }
+
+        public GuardClause<string> Matches(string pattern, string? message = null)
+        {
+            if (guard.Value is null || !Regex.IsMatch(guard.Value, pattern))
+            {
+                throw new GuardException(
+                    guard.ParameterName,
+                    message ?? $"{guard.ParameterName} must match the required pattern.");
             }
 
             return guard;

--- a/src/Yumney.Users.Api/AuthEndpoints.cs
+++ b/src/Yumney.Users.Api/AuthEndpoints.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Routing;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
 using Yumney.Users.Application.Commands;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Api;
 
@@ -26,17 +27,22 @@ public static class AuthEndpoints
     }
 
     private static async Task<IResult> RegisterAsync(
-        RegisterUserCommand command,
-        IValidator<RegisterUserCommand> validator,
+        RegisterUserRequest request,
+        IValidator<RegisterUserRequest> validator,
         ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>> handler,
         CancellationToken cancellationToken)
     {
-        var validationResult = await validator.ValidateAsync(command, cancellationToken);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
 
         if (!validationResult.IsValid)
         {
             return Results.ValidationProblem(validationResult.ToDictionary());
         }
+
+        var command = new RegisterUserCommand(
+            new Email(request.Email),
+            new Password(request.Password),
+            new DisplayName(request.DisplayName));
 
         var result = await handler.HandleAsync(command, cancellationToken);
 
@@ -57,17 +63,19 @@ public static class AuthEndpoints
     }
 
     private static async Task<IResult> ResendVerificationEmailAsync(
-        ResendVerificationEmailCommand command,
-        IValidator<ResendVerificationEmailCommand> validator,
+        ResendVerificationEmailRequest request,
+        IValidator<ResendVerificationEmailRequest> validator,
         ICommandHandler<ResendVerificationEmailCommand, Result> handler,
         CancellationToken cancellationToken)
     {
-        var validationResult = await validator.ValidateAsync(command, cancellationToken);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
 
         if (!validationResult.IsValid)
         {
             return Results.ValidationProblem(validationResult.ToDictionary());
         }
+
+        var command = new ResendVerificationEmailCommand(new Email(request.Email));
 
         var result = await handler.HandleAsync(command, cancellationToken);
 

--- a/src/Yumney.Users.Application/Commands/RegisterUserCommand.cs
+++ b/src/Yumney.Users.Application/Commands/RegisterUserCommand.cs
@@ -1,11 +1,12 @@
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Application.Commands;
 
 public sealed record RegisterUserCommand(
-    string Email,
-    string Password,
-    string DisplayName) : ICommand<Result<RegisterUserResultDto>>;
+    Email Email,
+    Password Password,
+    DisplayName DisplayName) : ICommand<Result<RegisterUserResultDto>>;
 
 public sealed record RegisterUserResultDto(string Message);

--- a/src/Yumney.Users.Application/Commands/RegisterUserCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/RegisterUserCommandHandler.cs
@@ -7,10 +7,7 @@ using Yumney.Users.Domain.AppUserProfile;
 namespace Yumney.Users.Application.Commands;
 
 #pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
-public sealed partial class RegisterUserCommandHandler(
-    IKeycloakAdminService keycloakAdmin,
-    IAppUserProfileRepository users,
-    ILogger<RegisterUserCommandHandler> logger)
+public sealed partial class RegisterUserCommandHandler(IKeycloakAdminService keycloakAdmin, IAppUserProfileRepository users, ILogger<RegisterUserCommandHandler> logger)
     : ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>
 {
     public async Task<Result<RegisterUserResultDto>> HandleAsync(RegisterUserCommand command, CancellationToken cancellationToken = default)
@@ -29,10 +26,9 @@ public sealed partial class RegisterUserCommandHandler(
         var profile = AppUserProfile.Create(keycloakUserId, displayName);
         await users.AddAsync(profile, cancellationToken);
 
-        LogUserRegistered(email, keycloakUserId);
+        LogUserRegistered(email.Value, keycloakUserId.Value);
 
-        return Result<RegisterUserResultDto>.Success(
-            new RegisterUserResultDto("Registration successful. Please check your email to verify your account."));
+        return Result<RegisterUserResultDto>.Success(new RegisterUserResultDto("Registration successful. Please check your email to verify your account."));
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "User {Email} registered with Keycloak ID {KeycloakUserId}")]

--- a/src/Yumney.Users.Application/Commands/RegisterUserRequest.cs
+++ b/src/Yumney.Users.Application/Commands/RegisterUserRequest.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Users.Application.Commands;
+
+public sealed record RegisterUserRequest(string Email, string Password, string DisplayName);

--- a/src/Yumney.Users.Application/Commands/RegisterUserRequestValidator.cs
+++ b/src/Yumney.Users.Application/Commands/RegisterUserRequestValidator.cs
@@ -2,9 +2,9 @@ using FluentValidation;
 
 namespace Yumney.Users.Application.Commands;
 
-public sealed class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+public sealed class RegisterUserRequestValidator : AbstractValidator<RegisterUserRequest>
 {
-    public RegisterUserCommandValidator()
+    public RegisterUserRequestValidator()
     {
         RuleFor(x => x.Email)
             .NotEmpty()

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommand.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommand.cs
@@ -1,6 +1,7 @@
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Application.Commands;
 
-public sealed record ResendVerificationEmailCommand(string Email) : ICommand<Result>;
+public sealed record ResendVerificationEmailCommand(Email Email) : ICommand<Result>;

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailCommandHandler.cs
@@ -6,9 +6,7 @@ using Yumney.Users.Application.Interfaces;
 namespace Yumney.Users.Application.Commands;
 
 #pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
-public sealed partial class ResendVerificationEmailCommandHandler(
-    IKeycloakAdminService keycloakAdmin,
-    ILogger<ResendVerificationEmailCommandHandler> logger)
+public sealed partial class ResendVerificationEmailCommandHandler(IKeycloakAdminService keycloakAdmin, ILogger<ResendVerificationEmailCommandHandler> logger)
     : ICommandHandler<ResendVerificationEmailCommand, Result>
 {
     public async Task<Result> HandleAsync(ResendVerificationEmailCommand command, CancellationToken cancellationToken = default)
@@ -21,7 +19,7 @@ public sealed partial class ResendVerificationEmailCommandHandler(
         {
             if (findResult.Error == VerificationErrors.UserNotFound)
             {
-                LogUserNotFoundSilent(email);
+                LogUserNotFoundSilent(email.Value);
                 return Result.Success();
             }
 
@@ -37,7 +35,7 @@ public sealed partial class ResendVerificationEmailCommandHandler(
             return Result.Failure(sendResult.Error!);
         }
 
-        LogVerificationEmailSent(email);
+        LogVerificationEmailSent(email.Value);
 
         return Result.Success();
     }

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailRequest.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailRequest.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Users.Application.Commands;
+
+public sealed record ResendVerificationEmailRequest(string Email);

--- a/src/Yumney.Users.Application/Commands/ResendVerificationEmailRequestValidator.cs
+++ b/src/Yumney.Users.Application/Commands/ResendVerificationEmailRequestValidator.cs
@@ -2,9 +2,9 @@ using FluentValidation;
 
 namespace Yumney.Users.Application.Commands;
 
-public sealed class ResendVerificationEmailCommandValidator : AbstractValidator<ResendVerificationEmailCommand>
+public sealed class ResendVerificationEmailRequestValidator : AbstractValidator<ResendVerificationEmailRequest>
 {
-    public ResendVerificationEmailCommandValidator()
+    public ResendVerificationEmailRequestValidator()
     {
         RuleFor(x => x.Email)
             .NotEmpty()

--- a/src/Yumney.Users.Application/Interfaces/IAppUserProfileRepository.cs
+++ b/src/Yumney.Users.Application/Interfaces/IAppUserProfileRepository.cs
@@ -4,7 +4,7 @@ namespace Yumney.Users.Application.Interfaces;
 
 public interface IAppUserProfileRepository
 {
-    Task<AppUserProfile?> FindByKeycloakUserIdAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+    Task<AppUserProfile?> FindByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 
     Task AddAsync(AppUserProfile profile, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -1,20 +1,21 @@
 using Yumney.Shared.Common;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Application.Interfaces;
 
 public interface IKeycloakAdminService
 {
-    Task<Result<string>> CreateUserAsync(
-        string email,
-        string password,
-        string displayName,
+    Task<Result<KeycloakUserId>> CreateUserAsync(
+        Email email,
+        Password password,
+        DisplayName displayName,
         CancellationToken cancellationToken = default);
 
-    Task<Result<string>> FindUserByEmailAsync(
-        string email,
+    Task<Result<KeycloakUserId>> FindUserByEmailAsync(
+        Email email,
         CancellationToken cancellationToken = default);
 
     Task<Result> SendVerificationEmailAsync(
-        string keycloakUserId,
+        KeycloakUserId keycloakUserId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
@@ -1,27 +1,23 @@
 using Yumney.Shared.Common;
-using Yumney.Shared.Guards;
 
 namespace Yumney.Users.Domain.AppUserProfile;
 
 public sealed class AppUserProfile : AggregateRoot<Guid>
 {
-    public string KeycloakUserId { get; private set; } = default!;
+    public KeycloakUserId KeycloakUserId { get; private set; } = default!;
 
-    public string DisplayName { get; private set; } = default!;
+    public DisplayName DisplayName { get; private set; } = default!;
 
-    public string PreferredLanguage { get; private set; } = "en";
+    public PreferredLanguage PreferredLanguage { get; private set; } = new("en");
 
-    public string PreferredUnitSystem { get; private set; } = "metric";
+    public PreferredUnitSystem PreferredUnitSystem { get; private set; } = new("metric");
 
     private AppUserProfile()
     {
     }
 
-    public static AppUserProfile Create(string keycloakUserId, string displayName)
+    public static AppUserProfile Create(KeycloakUserId keycloakUserId, DisplayName displayName)
     {
-        Ensure.That(keycloakUserId).IsNotNullOrWhiteSpace();
-        Ensure.That(displayName).IsNotNullOrWhiteSpace().HasMaxLength(200);
-
         return new AppUserProfile
         {
             Id = Guid.NewGuid(),
@@ -30,21 +26,18 @@ public sealed class AppUserProfile : AggregateRoot<Guid>
         };
     }
 
-    public void ChangePreferredLanguage(string language)
+    public void ChangePreferredLanguage(PreferredLanguage language)
     {
-        Ensure.That(language).IsNotNullOrWhiteSpace().HasMaxLength(10);
         PreferredLanguage = language;
     }
 
-    public void ChangePreferredUnitSystem(string unitSystem)
+    public void ChangePreferredUnitSystem(PreferredUnitSystem unitSystem)
     {
-        Ensure.That(unitSystem).IsNotNullOrWhiteSpace().HasMaxLength(20);
         PreferredUnitSystem = unitSystem;
     }
 
-    public void RenameAs(string displayName)
+    public void RenameAs(DisplayName displayName)
     {
-        Ensure.That(displayName).IsNotNullOrWhiteSpace().HasMaxLength(200);
         DisplayName = displayName;
     }
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/DisplayName.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DisplayName.cs
@@ -1,0 +1,19 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record DisplayName
+{
+    public string Value { get; }
+
+    public DisplayName(string value)
+    {
+        string validated = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(200)
+            .AndReturn();
+        Value = validated.Trim();
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/Email.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/Email.cs
@@ -1,0 +1,20 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record Email
+{
+    public string Value { get; }
+
+    public Email(string value)
+    {
+        string validated = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(254)
+            .IsValidEmail()
+            .AndReturn();
+        Value = validated.Trim().ToLowerInvariant();
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/KeycloakUserId.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/KeycloakUserId.cs
@@ -1,0 +1,17 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record KeycloakUserId
+{
+    public string Value { get; }
+
+    public KeycloakUserId(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .AndReturn();
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/Password.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/Password.cs
@@ -1,0 +1,21 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record Password
+{
+    public string Value { get; }
+
+    public Password(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMinLength(8)
+            .Matches("[A-Z]", "Password must contain at least one uppercase letter.")
+            .Matches("[a-z]", "Password must contain at least one lowercase letter.")
+            .Matches("[0-9]", "Password must contain at least one digit.")
+            .AndReturn();
+    }
+
+    public override string ToString() => "***";
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
@@ -1,0 +1,18 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record PreferredLanguage
+{
+    public string Value { get; }
+
+    public PreferredLanguage(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(10)
+            .AndReturn();
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
@@ -1,0 +1,18 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Users.Domain.AppUserProfile;
+
+public sealed record PreferredUnitSystem
+{
+    public string Value { get; }
+
+    public PreferredUnitSystem(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(20)
+            .AndReturn();
+    }
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -6,7 +6,7 @@ namespace Yumney.Users.Infrastructure.Persistence;
 
 public sealed class AppUserProfileRepository(UsersDbContext context) : IAppUserProfileRepository
 {
-    public async Task<AppUserProfile?> FindByKeycloakUserIdAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+    public async Task<AppUserProfile?> FindByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
     {
         return await context.AppUserProfiles.FirstOrDefaultAsync(p => p.KeycloakUserId == keycloakUserId, cancellationToken);
     }

--- a/src/Yumney.Users.Infrastructure/Persistence/UsersDbContext.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UsersDbContext.cs
@@ -13,10 +13,18 @@ public sealed class UsersDbContext(DbContextOptions<UsersDbContext> options) : D
         {
             entity.ToTable("AppUserProfiles");
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.KeycloakUserId).HasMaxLength(255).IsRequired();
-            entity.Property(e => e.DisplayName).HasMaxLength(200).IsRequired();
-            entity.Property(e => e.PreferredLanguage).HasMaxLength(10).IsRequired();
-            entity.Property(e => e.PreferredUnitSystem).HasMaxLength(20).IsRequired();
+            entity.Property(e => e.KeycloakUserId)
+                .HasConversion(v => v.Value, v => new KeycloakUserId(v))
+                .HasMaxLength(255).IsRequired();
+            entity.Property(e => e.DisplayName)
+                .HasConversion(v => v.Value, v => new DisplayName(v))
+                .HasMaxLength(200).IsRequired();
+            entity.Property(e => e.PreferredLanguage)
+                .HasConversion(v => v.Value, v => new PreferredLanguage(v))
+                .HasMaxLength(10).IsRequired();
+            entity.Property(e => e.PreferredUnitSystem)
+                .HasConversion(v => v.Value, v => new PreferredUnitSystem(v))
+                .HasMaxLength(20).IsRequired();
             entity.HasIndex(e => e.KeycloakUserId).IsUnique();
             entity.Ignore(e => e.DomainEvents);
         });

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Yumney.Shared.Common;
 using Yumney.Users.Application.Commands;
 using Yumney.Users.Application.Interfaces;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Infrastructure.Services;
 
@@ -22,32 +23,32 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
 
     private static readonly string[] verifyEmailActions = ["VERIFY_EMAIL"];
 
-    public async Task<Result<string>> CreateUserAsync(
-        string email,
-        string password,
-        string displayName,
+    public async Task<Result<KeycloakUserId>> CreateUserAsync(
+        Email email,
+        Password password,
+        DisplayName displayName,
         CancellationToken cancellationToken = default)
     {
         var token = await GetServiceAccountTokenAsync(cancellationToken);
         if (token.IsFailure)
         {
-            return Result<string>.Failure(token.Error!);
+            return Result<KeycloakUserId>.Failure(token.Error!);
         }
 
         return await CreateKeycloakUserAsync(email, password, displayName, token.Value, cancellationToken);
     }
 
-    public async Task<Result<string>> FindUserByEmailAsync(
-        string email,
+    public async Task<Result<KeycloakUserId>> FindUserByEmailAsync(
+        Email email,
         CancellationToken cancellationToken = default)
     {
         var token = await GetServiceAccountTokenAsync(cancellationToken);
         if (token.IsFailure)
         {
-            return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+            return Result<KeycloakUserId>.Failure(VerificationErrors.IdentityProviderUnavailable);
         }
 
-        var encodedEmail = Uri.EscapeDataString(email);
+        var encodedEmail = Uri.EscapeDataString(email.Value);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/realms/yumney/users?email={encodedEmail}&exact=true");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
@@ -59,27 +60,27 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogError("Failed to search Keycloak users. Status: {StatusCode}", response.StatusCode);
-                return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+                return Result<KeycloakUserId>.Failure(VerificationErrors.IdentityProviderUnavailable);
             }
 
             var users = await response.Content.ReadFromJsonAsync<KeycloakUserRepresentation[]>(jsonOptions, cancellationToken);
 
             if (users is null || users.Length == 0)
             {
-                return Result<string>.Failure(VerificationErrors.UserNotFound);
+                return Result<KeycloakUserId>.Failure(VerificationErrors.UserNotFound);
             }
 
-            return Result<string>.Success(users[0].Id);
+            return Result<KeycloakUserId>.Success(new KeycloakUserId(users[0].Id));
         }
         catch (HttpRequestException ex)
         {
             logger.LogError(ex, "HTTP error while searching Keycloak users");
-            return Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable);
+            return Result<KeycloakUserId>.Failure(VerificationErrors.IdentityProviderUnavailable);
         }
     }
 
     public async Task<Result> SendVerificationEmailAsync(
-        string keycloakUserId,
+        KeycloakUserId keycloakUserId,
         CancellationToken cancellationToken = default)
     {
         var token = await GetServiceAccountTokenAsync(cancellationToken);
@@ -88,7 +89,7 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
             return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
         }
 
-        using var request = new HttpRequestMessage(HttpMethod.Put, $"/admin/realms/yumney/users/{keycloakUserId}/execute-actions-email");
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"/admin/realms/yumney/users/{keycloakUserId.Value}/execute-actions-email");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
         request.Content = JsonContent.Create(verifyEmailActions, options: jsonOptions);
 
@@ -142,27 +143,27 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         }
     }
 
-    private async Task<Result<string>> CreateKeycloakUserAsync(
-        string email,
-        string password,
-        string displayName,
+    private async Task<Result<KeycloakUserId>> CreateKeycloakUserAsync(
+        Email email,
+        Password password,
+        DisplayName displayName,
         string accessToken,
         CancellationToken cancellationToken)
     {
         var userPayload = new
         {
-            username = email,
-            email,
+            username = email.Value,
+            email = email.Value,
             enabled = true,
             emailVerified = false,
-            firstName = displayName,
+            firstName = displayName.Value,
             requiredActions = new[] { "VERIFY_EMAIL" },
             credentials = new[]
             {
                 new
                 {
                     type = "password",
-                    value = password,
+                    value = password.Value,
                     temporary = false,
                 },
             },
@@ -178,30 +179,30 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
 
             if (response.StatusCode == HttpStatusCode.Conflict)
             {
-                return Result<string>.Failure(RegistrationErrors.EmailAlreadyExists);
+                return Result<KeycloakUserId>.Failure(RegistrationErrors.EmailAlreadyExists);
             }
 
             if (!response.IsSuccessStatusCode)
             {
                 var body = await response.Content.ReadAsStringAsync(cancellationToken);
                 logger.LogError("Failed to create Keycloak user. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
-                return Result<string>.Failure(RegistrationErrors.UserCreationFailed);
+                return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
             }
 
             var locationHeader = response.Headers.Location?.ToString();
             if (string.IsNullOrEmpty(locationHeader))
             {
                 logger.LogError("Keycloak did not return a Location header after user creation");
-                return Result<string>.Failure(RegistrationErrors.UserCreationFailed);
+                return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
             }
 
-            var keycloakUserId = locationHeader.Split('/').Last();
-            return Result<string>.Success(keycloakUserId);
+            var keycloakUserIdString = locationHeader.Split('/').Last();
+            return Result<KeycloakUserId>.Success(new KeycloakUserId(keycloakUserIdString));
         }
         catch (HttpRequestException ex)
         {
             logger.LogError(ex, "HTTP error while creating Keycloak user");
-            return Result<string>.Failure(RegistrationErrors.IdentityProviderUnavailable);
+            return Result<KeycloakUserId>.Failure(RegistrationErrors.IdentityProviderUnavailable);
         }
     }
 

--- a/tests/Yumney.Shared.Tests/Guards/EnsureTests.cs
+++ b/tests/Yumney.Shared.Tests/Guards/EnsureTests.cs
@@ -227,4 +227,60 @@ public class EnsureTests
 
         act.Should().Throw<GuardException>();
     }
+
+    [Theory]
+    [InlineData("test@example.com")]
+    [InlineData("user+tag@example.com")]
+    [InlineData("user.name@example.co.uk")]
+    public void IsValidEmail_ValidEmail_DoesNotThrow(string email)
+    {
+        var act = () => Ensure.That(email).IsValidEmail();
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("not-an-email")]
+    [InlineData("@missing-local.com")]
+    [InlineData("missing-domain@")]
+    public void IsValidEmail_InvalidEmail_ThrowsGuardException(string email)
+    {
+        var act = () => Ensure.That(email).IsValidEmail();
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Matches_MatchingPattern_DoesNotThrow()
+    {
+        var act = () => Ensure.That("Hello123").Matches("[A-Z]");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Matches_NonMatchingPattern_ThrowsGuardException()
+    {
+        var act = () => Ensure.That("hello").Matches("[0-9]");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Matches_WithCustomMessage_ThrowsWithMessage()
+    {
+        var act = () => Ensure.That("hello").Matches("[0-9]", "Must contain a digit.");
+
+        act.Should().Throw<GuardException>().WithMessage("Must contain a digit.");
+    }
+
+    [Fact]
+    public void Matches_NullValue_ThrowsGuardException()
+    {
+        string? value = null;
+
+        var act = () => Ensure.That(value!).Matches("[A-Z]");
+
+        act.Should().Throw<GuardException>();
+    }
 }

--- a/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
@@ -11,6 +11,10 @@ namespace Yumney.Users.Application.Tests.Commands;
 
 public class RegisterUserCommandHandlerTests
 {
+    private static readonly Email TestEmail = new("test@example.com");
+    private static readonly Password TestPassword = new("Password1");
+    private static readonly DisplayName TestDisplayName = new("Test User");
+
     private readonly IKeycloakAdminService keycloakAdmin = Substitute.For<IKeycloakAdminService>();
     private readonly IAppUserProfileRepository users = Substitute.For<IAppUserProfileRepository>();
     private readonly ILogger<RegisterUserCommandHandler> logger =
@@ -26,42 +30,36 @@ public class RegisterUserCommandHandlerTests
     [Fact]
     public async Task HandleAsync_ValidCommand_ReturnsSuccessAndCreatesProfile()
     {
-        // Arrange
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
-        var keycloakUserId = Guid.NewGuid().ToString();
+        var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
+        var keycloakUserId = new KeycloakUserId(Guid.NewGuid().ToString());
 
         keycloakAdmin
             .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Success(keycloakUserId));
+            .Returns(Result<KeycloakUserId>.Success(keycloakUserId));
 
-        // Act
         var result = await sut.HandleAsync(command);
 
-        // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.Message.Should().Contain("check your email");
 
         await users.Received(1).AddAsync(
             Arg.Is<AppUserProfile>(p =>
                 p.KeycloakUserId == keycloakUserId &&
-                p.DisplayName == "Test User"),
+                p.DisplayName == TestDisplayName),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task HandleAsync_KeycloakReturnsFailure_ReturnsFailureWithoutCreatingProfile()
     {
-        // Arrange
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+        var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
 
         keycloakAdmin
             .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(RegistrationErrors.EmailAlreadyExists));
+            .Returns(Result<KeycloakUserId>.Failure(RegistrationErrors.EmailAlreadyExists));
 
-        // Act
         var result = await sut.HandleAsync(command);
 
-        // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be(RegistrationErrors.EmailAlreadyExists);
 
@@ -73,11 +71,11 @@ public class RegisterUserCommandHandlerTests
     [Fact]
     public async Task HandleAsync_IdentityProviderUnavailable_ReturnsFailureWithCorrectError()
     {
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+        var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
 
         keycloakAdmin
             .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(RegistrationErrors.IdentityProviderUnavailable));
+            .Returns(Result<KeycloakUserId>.Failure(RegistrationErrors.IdentityProviderUnavailable));
 
         var result = await sut.HandleAsync(command);
 
@@ -88,11 +86,11 @@ public class RegisterUserCommandHandlerTests
     [Fact]
     public async Task HandleAsync_UserCreationFailed_ReturnsFailureWithCorrectError()
     {
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+        var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
 
         keycloakAdmin
             .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(RegistrationErrors.UserCreationFailed));
+            .Returns(Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed));
 
         var result = await sut.HandleAsync(command);
 
@@ -103,11 +101,11 @@ public class RegisterUserCommandHandlerTests
     [Fact]
     public async Task HandleAsync_KeycloakReturnsFailure_DoesNotCallAddAsync()
     {
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+        var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
 
         keycloakAdmin
             .CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(RegistrationErrors.IdentityProviderUnavailable));
+            .Returns(Result<KeycloakUserId>.Failure(RegistrationErrors.IdentityProviderUnavailable));
 
         await sut.HandleAsync(command);
 

--- a/tests/Yumney.Users.Application.Tests/Commands/RegisterUserRequestValidatorTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/RegisterUserRequestValidatorTests.cs
@@ -4,16 +4,16 @@ using Yumney.Users.Application.Commands;
 
 namespace Yumney.Users.Application.Tests.Commands;
 
-public class RegisterUserCommandValidatorTests
+public class RegisterUserRequestValidatorTests
 {
-    private readonly RegisterUserCommandValidator sut = new();
+    private readonly RegisterUserRequestValidator sut = new();
 
     [Fact]
-    public void Validate_ValidCommand_IsValid()
+    public void Validate_ValidRequest_IsValid()
     {
-        var command = new RegisterUserCommand("test@example.com", "Password1", "Test User");
+        var request = new RegisterUserRequest("test@example.com", "Password1", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeTrue();
     }
@@ -24,9 +24,9 @@ public class RegisterUserCommandValidatorTests
     [InlineData("not-an-email")]
     public void Validate_InvalidEmail_IsNotValid(string email)
     {
-        var command = new RegisterUserCommand(email, "Password1", "Test User");
+        var request = new RegisterUserRequest(email, "Password1", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Email");
@@ -39,9 +39,9 @@ public class RegisterUserCommandValidatorTests
     [InlineData("NoDigitsHere")]
     public void Validate_WeakPassword_IsNotValid(string password)
     {
-        var command = new RegisterUserCommand("test@example.com", password, "Test User");
+        var request = new RegisterUserRequest("test@example.com", password, "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Password");
@@ -52,9 +52,9 @@ public class RegisterUserCommandValidatorTests
     [InlineData("   ")]
     public void Validate_EmptyDisplayName_IsNotValid(string displayName)
     {
-        var command = new RegisterUserCommand("test@example.com", "Password1", displayName);
+        var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "DisplayName");
@@ -66,9 +66,9 @@ public class RegisterUserCommandValidatorTests
     [InlineData("user_name@example.co.uk")]
     public void Validate_EmailWithSpecialChars_IsValid(string email)
     {
-        var command = new RegisterUserCommand(email, "Password1", "Test User");
+        var request = new RegisterUserRequest(email, "Password1", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeTrue();
     }
@@ -79,9 +79,9 @@ public class RegisterUserCommandValidatorTests
         var localPart = new string('a', 242);
         var email = $"{localPart}@example.com";
 
-        var command = new RegisterUserCommand(email, "Password1", "Test User");
+        var request = new RegisterUserRequest(email, "Password1", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.Errors.Should().NotContain(e => e.PropertyName == "Email" && e.ErrorCode == "MaximumLengthValidator");
     }
@@ -92,9 +92,9 @@ public class RegisterUserCommandValidatorTests
         var localPart = new string('a', 243);
         var email = $"{localPart}@example.com";
 
-        var command = new RegisterUserCommand(email, "Password1", "Test User");
+        var request = new RegisterUserRequest(email, "Password1", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Email");
@@ -104,9 +104,9 @@ public class RegisterUserCommandValidatorTests
     public void Validate_DisplayNameAtMaxLength_IsValid()
     {
         var displayName = new string('A', 200);
-        var command = new RegisterUserCommand("test@example.com", "Password1", displayName);
+        var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeTrue();
     }
@@ -115,9 +115,9 @@ public class RegisterUserCommandValidatorTests
     public void Validate_DisplayNameExceedsMaxLength_IsNotValid()
     {
         var displayName = new string('A', 201);
-        var command = new RegisterUserCommand("test@example.com", "Password1", displayName);
+        var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "DisplayName");
@@ -126,9 +126,9 @@ public class RegisterUserCommandValidatorTests
     [Fact]
     public void Validate_PasswordAtMinLength_IsValid()
     {
-        var command = new RegisterUserCommand("test@example.com", "Abcdef1x", "Test User");
+        var request = new RegisterUserRequest("test@example.com", "Abcdef1x", "Test User");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeTrue();
     }

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
@@ -5,11 +5,15 @@ using Xunit;
 using Yumney.Shared.Common;
 using Yumney.Users.Application.Commands;
 using Yumney.Users.Application.Interfaces;
+using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Application.Tests.Commands;
 
 public class ResendVerificationEmailCommandHandlerTests
 {
+    private static readonly Email TestEmail = new("test@example.com");
+    private static readonly Email UnknownEmail = new("unknown@example.com");
+
     private readonly IKeycloakAdminService keycloakAdmin = Substitute.For<IKeycloakAdminService>();
     private readonly ILogger<ResendVerificationEmailCommandHandler> logger =
         Substitute.For<ILogger<ResendVerificationEmailCommandHandler>>();
@@ -24,12 +28,12 @@ public class ResendVerificationEmailCommandHandlerTests
     [Fact]
     public async Task HandleAsync_ValidEmail_ReturnsSuccessAndSendsEmail()
     {
-        var command = new ResendVerificationEmailCommand("test@example.com");
-        var keycloakUserId = Guid.NewGuid().ToString();
+        var command = new ResendVerificationEmailCommand(TestEmail);
+        var keycloakUserId = new KeycloakUserId(Guid.NewGuid().ToString());
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Success(keycloakUserId));
+            .Returns(Result<KeycloakUserId>.Success(keycloakUserId));
 
         keycloakAdmin
             .SendVerificationEmailAsync(keycloakUserId, Arg.Any<CancellationToken>())
@@ -47,11 +51,11 @@ public class ResendVerificationEmailCommandHandlerTests
     [Fact]
     public async Task HandleAsync_UserNotFound_ReturnsSuccessToPreventEnumeration()
     {
-        var command = new ResendVerificationEmailCommand("unknown@example.com");
+        var command = new ResendVerificationEmailCommand(UnknownEmail);
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(VerificationErrors.UserNotFound));
+            .Returns(Result<KeycloakUserId>.Failure(VerificationErrors.UserNotFound));
 
         var result = await sut.HandleAsync(command);
 
@@ -61,27 +65,27 @@ public class ResendVerificationEmailCommandHandlerTests
     [Fact]
     public async Task HandleAsync_UserNotFound_DoesNotAttemptToSendEmail()
     {
-        var command = new ResendVerificationEmailCommand("unknown@example.com");
+        var command = new ResendVerificationEmailCommand(UnknownEmail);
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(VerificationErrors.UserNotFound));
+            .Returns(Result<KeycloakUserId>.Failure(VerificationErrors.UserNotFound));
 
         await sut.HandleAsync(command);
 
         await keycloakAdmin.DidNotReceive().SendVerificationEmailAsync(
-            Arg.Any<string>(),
+            Arg.Any<KeycloakUserId>(),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task HandleAsync_IdentityProviderUnavailable_ReturnsFailure()
     {
-        var command = new ResendVerificationEmailCommand("test@example.com");
+        var command = new ResendVerificationEmailCommand(TestEmail);
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable));
+            .Returns(Result<KeycloakUserId>.Failure(VerificationErrors.IdentityProviderUnavailable));
 
         var result = await sut.HandleAsync(command);
 
@@ -92,28 +96,28 @@ public class ResendVerificationEmailCommandHandlerTests
     [Fact]
     public async Task HandleAsync_IdentityProviderUnavailable_DoesNotAttemptToSendEmail()
     {
-        var command = new ResendVerificationEmailCommand("test@example.com");
+        var command = new ResendVerificationEmailCommand(TestEmail);
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Failure(VerificationErrors.IdentityProviderUnavailable));
+            .Returns(Result<KeycloakUserId>.Failure(VerificationErrors.IdentityProviderUnavailable));
 
         await sut.HandleAsync(command);
 
         await keycloakAdmin.DidNotReceive().SendVerificationEmailAsync(
-            Arg.Any<string>(),
+            Arg.Any<KeycloakUserId>(),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task HandleAsync_SendFailed_ReturnsFailure()
     {
-        var command = new ResendVerificationEmailCommand("test@example.com");
-        var keycloakUserId = Guid.NewGuid().ToString();
+        var command = new ResendVerificationEmailCommand(TestEmail);
+        var keycloakUserId = new KeycloakUserId(Guid.NewGuid().ToString());
 
         keycloakAdmin
             .FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
-            .Returns(Result<string>.Success(keycloakUserId));
+            .Returns(Result<KeycloakUserId>.Success(keycloakUserId));
 
         keycloakAdmin
             .SendVerificationEmailAsync(keycloakUserId, Arg.Any<CancellationToken>())

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailRequestValidatorTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailRequestValidatorTests.cs
@@ -4,16 +4,16 @@ using Yumney.Users.Application.Commands;
 
 namespace Yumney.Users.Application.Tests.Commands;
 
-public class ResendVerificationEmailCommandValidatorTests
+public class ResendVerificationEmailRequestValidatorTests
 {
-    private readonly ResendVerificationEmailCommandValidator sut = new();
+    private readonly ResendVerificationEmailRequestValidator sut = new();
 
     [Fact]
-    public void Validate_ValidEmail_IsValid()
+    public void Validate_ValidRequest_IsValid()
     {
-        var command = new ResendVerificationEmailCommand("test@example.com");
+        var request = new ResendVerificationEmailRequest("test@example.com");
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeTrue();
     }
@@ -24,9 +24,9 @@ public class ResendVerificationEmailCommandValidatorTests
     [InlineData("not-an-email")]
     public void Validate_InvalidEmail_IsNotValid(string email)
     {
-        var command = new ResendVerificationEmailCommand(email);
+        var request = new ResendVerificationEmailRequest(email);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Email");
@@ -37,9 +37,9 @@ public class ResendVerificationEmailCommandValidatorTests
     {
         var localPart = new string('a', 242);
         var email = $"{localPart}@example.com";
-        var command = new ResendVerificationEmailCommand(email);
+        var request = new ResendVerificationEmailRequest(email);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.Errors.Should().NotContain(e => e.PropertyName == "Email" && e.ErrorCode == "MaximumLengthValidator");
     }
@@ -49,9 +49,9 @@ public class ResendVerificationEmailCommandValidatorTests
     {
         var localPart = new string('a', 243);
         var email = $"{localPart}@example.com";
-        var command = new ResendVerificationEmailCommand(email);
+        var request = new ResendVerificationEmailRequest(email);
 
-        var result = sut.Validate(command);
+        var result = sut.Validate(request);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Email");

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class AppUserProfileTests
+{
+    private static readonly KeycloakUserId TestKeycloakUserId = new("kc-user-123");
+    private static readonly DisplayName TestDisplayName = new("Test User");
+
+    [Fact]
+    public void Create_ValidParameters_ReturnsProfileWithCorrectValues()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.KeycloakUserId.Should().Be(TestKeycloakUserId);
+        profile.DisplayName.Should().Be(TestDisplayName);
+    }
+
+    [Fact]
+    public void Create_ValidParameters_GeneratesNonEmptyId()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.Id.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Create_ValidParameters_SetsDefaultPreferredLanguage()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.PreferredLanguage.Should().Be(new PreferredLanguage("en"));
+    }
+
+    [Fact]
+    public void Create_ValidParameters_SetsDefaultPreferredUnitSystem()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.PreferredUnitSystem.Should().Be(new PreferredUnitSystem("metric"));
+    }
+
+    [Fact]
+    public void Create_CalledTwice_GeneratesDifferentIds()
+    {
+        var profile1 = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var profile2 = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile1.Id.Should().NotBe(profile2.Id);
+    }
+
+    [Fact]
+    public void RenameAs_NewDisplayName_UpdatesDisplayName()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var newName = new DisplayName("New Name");
+
+        profile.RenameAs(newName);
+
+        profile.DisplayName.Should().Be(newName);
+    }
+
+    [Fact]
+    public void ChangePreferredLanguage_NewLanguage_UpdatesLanguage()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var german = new PreferredLanguage("de");
+
+        profile.ChangePreferredLanguage(german);
+
+        profile.PreferredLanguage.Should().Be(german);
+    }
+
+    [Fact]
+    public void ChangePreferredUnitSystem_NewUnitSystem_UpdatesUnitSystem()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var imperial = new PreferredUnitSystem("imperial");
+
+        profile.ChangePreferredUnitSystem(imperial);
+
+        profile.PreferredUnitSystem.Should().Be(imperial);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DisplayNameTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DisplayNameTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class DisplayNameTests
+{
+    [Fact]
+    public void Constructor_ValidName_CreatesInstance()
+    {
+        var name = new DisplayName("Test User");
+
+        name.Value.Should().Be("Test User");
+    }
+
+    [Fact]
+    public void Constructor_TrimsWhitespace()
+    {
+        var name = new DisplayName("  Test User  ");
+
+        name.Value.Should().Be("Test User");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new DisplayName(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    {
+        var act = () => new DisplayName(new string('A', 201));
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_AtMaxLength_CreatesInstance()
+    {
+        var name = new DisplayName(new string('A', 200));
+
+        name.Value.Should().HaveLength(200);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var name = new DisplayName("Test User");
+
+        name.ToString().Should().Be("Test User");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var name1 = new DisplayName("Test User");
+        var name2 = new DisplayName("Test User");
+
+        name1.Should().Be(name2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/EmailTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/EmailTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class EmailTests
+{
+    [Theory]
+    [InlineData("test@example.com")]
+    [InlineData("user+tag@example.com")]
+    [InlineData("user.name@example.co.uk")]
+    public void Constructor_ValidEmail_CreatesInstance(string value)
+    {
+        var email = new Email(value);
+
+        email.Value.Should().Be(value.Trim().ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Constructor_TrimsAndLowerCases()
+    {
+        var email = new Email("  Test@Example.COM  ");
+
+        email.Value.Should().Be("test@example.com");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new Email(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData("not-an-email")]
+    [InlineData("@missing-local.com")]
+    [InlineData("missing-domain@")]
+    public void Constructor_InvalidFormat_ThrowsGuardException(string value)
+    {
+        var act = () => new Email(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_AtMaxLength_CreatesInstance()
+    {
+        var localPart = new string('a', 242);
+        var email = $"{localPart}@example.com";
+
+        var result = new Email(email);
+
+        result.Value.Should().HaveLength(254);
+    }
+
+    [Fact]
+    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    {
+        var localPart = new string('a', 243);
+        var email = $"{localPart}@example.com";
+
+        var act = () => new Email(email);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_DifferentCasing_NormalizesToSameValue()
+    {
+        var email1 = new Email("User@Example.COM");
+        var email2 = new Email("user@example.com");
+
+        email1.Should().Be(email2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var email = new Email("test@example.com");
+
+        email.ToString().Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var email1 = new Email("test@example.com");
+        var email2 = new Email("test@example.com");
+
+        email1.Should().Be(email2);
+    }
+
+    [Fact]
+    public void Equality_DifferentValue_AreNotEqual()
+    {
+        var email1 = new Email("one@example.com");
+        var email2 = new Email("two@example.com");
+
+        email1.Should().NotBe(email2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/KeycloakUserIdTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/KeycloakUserIdTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class KeycloakUserIdTests
+{
+    [Fact]
+    public void Constructor_ValidValue_CreatesInstance()
+    {
+        var id = new KeycloakUserId("abc-123");
+
+        id.Value.Should().Be("abc-123");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new KeycloakUserId(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var id = new KeycloakUserId("abc-123");
+
+        id.ToString().Should().Be("abc-123");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var id1 = new KeycloakUserId("abc-123");
+        var id2 = new KeycloakUserId("abc-123");
+
+        id1.Should().Be(id2);
+    }
+
+    [Fact]
+    public void Equality_DifferentValue_AreNotEqual()
+    {
+        var id1 = new KeycloakUserId("abc-123");
+        var id2 = new KeycloakUserId("def-456");
+
+        id1.Should().NotBe(id2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/PasswordTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/PasswordTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class PasswordTests
+{
+    [Theory]
+    [InlineData("Password1")]
+    [InlineData("Abcdef1x")]
+    [InlineData("C0mpl3xP@ss")]
+    public void Constructor_ValidPassword_CreatesInstance(string value)
+    {
+        var password = new Password(value);
+
+        password.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new Password(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_TooShort_ThrowsGuardException()
+    {
+        var act = () => new Password("Short1A");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_NoUppercase_ThrowsGuardException()
+    {
+        var act = () => new Password("nouppercase1");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_NoLowercase_ThrowsGuardException()
+    {
+        var act = () => new Password("NOLOWERCASE1");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_NoDigit_ThrowsGuardException()
+    {
+        var act = () => new Password("NoDigitsHere");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void ToString_ReturnsMaskedValue()
+    {
+        var password = new Password("Password1");
+
+        password.ToString().Should().Be("***");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var password1 = new Password("Password1");
+        var password2 = new Password("Password1");
+
+        password1.Should().Be(password2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredLanguageTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredLanguageTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class PreferredLanguageTests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    [InlineData("fr")]
+    public void Constructor_ValidValue_CreatesInstance(string value)
+    {
+        var language = new PreferredLanguage(value);
+
+        language.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new PreferredLanguage(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_AtMaxLength_CreatesInstance()
+    {
+        var language = new PreferredLanguage(new string('a', 10));
+
+        language.Value.Should().HaveLength(10);
+    }
+
+    [Fact]
+    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    {
+        var act = () => new PreferredLanguage(new string('a', 11));
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var language = new PreferredLanguage("en");
+
+        language.ToString().Should().Be("en");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var lang1 = new PreferredLanguage("en");
+        var lang2 = new PreferredLanguage("en");
+
+        lang1.Should().Be(lang2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredUnitSystemTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredUnitSystemTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Shared.Guards;
+using Yumney.Users.Domain.AppUserProfile;
+
+namespace Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class PreferredUnitSystemTests
+{
+    [Theory]
+    [InlineData("metric")]
+    [InlineData("imperial")]
+    public void Constructor_ValidValue_CreatesInstance(string value)
+    {
+        var unitSystem = new PreferredUnitSystem(value);
+
+        unitSystem.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new PreferredUnitSystem(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_AtMaxLength_CreatesInstance()
+    {
+        var unitSystem = new PreferredUnitSystem(new string('a', 20));
+
+        unitSystem.Value.Should().HaveLength(20);
+    }
+
+    [Fact]
+    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    {
+        var act = () => new PreferredUnitSystem(new string('a', 21));
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var unitSystem = new PreferredUnitSystem("metric");
+
+        unitSystem.ToString().Should().Be("metric");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var us1 = new PreferredUnitSystem("metric");
+        var us2 = new PreferredUnitSystem("metric");
+
+        us1.Should().Be(us2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/Placeholder.cs
+++ b/tests/Yumney.Users.Domain.Tests/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Yumney.Users.Domain.Tests;
-
-// Placeholder — users domain tests will be added in Phase 6


### PR DESCRIPTION
## Summary

- **US-002 / US-003**: Add Angular login page with Keycloak OIDC redirect, header with logout button, dashboard placeholder, auth service/guard/interceptor, and i18n keys (DE + EN)
- **US-001**: Eliminate Primitive Obsession in the Users module — introduce 6 value objects (Email, Password, DisplayName, KeycloakUserId, PreferredLanguage, PreferredUnitSystem) and use them across commands, service interfaces, domain entity, infrastructure, and API endpoints
- Add `IsValidEmail()` and `Matches()` guard extensions, EF Core value conversions, request DTO / command separation with FluentValidation
- Add CLAUDE.md rule: commands, events, and service interfaces MUST use value objects

## Test plan

- [x] 71 domain tests (6 VO test files + AppUserProfile aggregate tests)
- [x] 35 application tests (handler + request validator tests updated for VOs)
- [x] 58 shared tests (guard extension tests for IsValidEmail, Matches)
- [x] Angular unit tests for auth service, guard, interceptor, header, login, dashboard
- [x] `dotnet build` — compiles clean (0 errors, 0 warnings)
- [x] `dotnet test` — all 164 backend tests pass
- [x] No EF Core migration changes needed (value conversions, columns unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)