### PR TITLE
feat(auth): add password reset via Keycloak (US-004)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -6,7 +6,8 @@
       "submit": "Über Keycloak anmelden",
       "rememberMe": "Angemeldet bleiben",
       "noAccount": "Noch kein Konto?",
-      "registerLink": "Jetzt erstellen"
+      "registerLink": "Jetzt erstellen",
+      "forgotPassword": "Passwort vergessen?"
     },
     "register": {
       "title": "Konto erstellen",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -6,7 +6,8 @@
       "submit": "Sign in with Keycloak",
       "rememberMe": "Stay logged in",
       "noAccount": "Don't have an account?",
-      "registerLink": "Create one"
+      "registerLink": "Create one",
+      "forgotPassword": "Forgot your password?"
     },
     "register": {
       "title": "Create Account",

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -89,6 +89,7 @@ describe('i18n keys', () => {
       'auth.login.rememberMe',
       'auth.login.noAccount',
       'auth.login.registerLink',
+      'auth.login.forgotPassword',
     ];
 
     for (const key of requiredKeys) {

--- a/client/apps/shell/src/app/auth/login/login.component.html
+++ b/client/apps/shell/src/app/auth/login/login.component.html
@@ -13,6 +13,12 @@
         {{ t('auth.login.submit') }}
       </button>
 
+      <p class="forgot-password">
+        <a (click)="onForgotPassword()" (keydown.enter)="onForgotPassword()" tabindex="0">
+          {{ t('auth.login.forgotPassword') }}
+        </a>
+      </p>
+
       <p class="register-link">
         {{ t('auth.login.noAccount') }}
         <a routerLink="/auth/register">{{ t('auth.login.registerLink') }}</a>

--- a/client/apps/shell/src/app/auth/login/login.component.scss
+++ b/client/apps/shell/src/app/auth/login/login.component.scss
@@ -59,6 +59,22 @@ button {
   }
 }
 
+.forgot-password {
+  margin-top: 0.75rem;
+  text-align: center;
+  font-size: 0.875rem;
+
+  a {
+    color: #4a90d9;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 .register-link {
   margin-top: 1rem;
   text-align: center;

--- a/client/apps/shell/src/app/auth/login/login.component.spec.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.spec.ts
@@ -13,6 +13,7 @@ const en = {
       rememberMe: 'Stay logged in',
       noAccount: "Don't have an account?",
       registerLink: 'Create one',
+      forgotPassword: 'Forgot your password?',
     },
   },
 };
@@ -20,10 +21,13 @@ const en = {
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
-  let authServiceMock: { login: ReturnType<typeof vi.fn> };
+  let authServiceMock: {
+    login: ReturnType<typeof vi.fn>;
+    forgotPassword: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
-    authServiceMock = { login: vi.fn() };
+    authServiceMock = { login: vi.fn(), forgotPassword: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [
@@ -89,5 +93,18 @@ describe('LoginComponent', () => {
   it('should render the remember me label', () => {
     const label = fixture.nativeElement.querySelector('.remember-me');
     expect(label.textContent).toContain('Stay logged in');
+  });
+
+  it('should render forgot password link', () => {
+    const link = fixture.nativeElement.querySelector('.forgot-password a');
+    expect(link).toBeTruthy();
+    expect(link.textContent).toContain('Forgot your password?');
+  });
+
+  it('should call authService.forgotPassword on forgot password click', () => {
+    const link = fixture.nativeElement.querySelector('.forgot-password a');
+    link.click();
+
+    expect(authServiceMock.forgotPassword).toHaveBeenCalled();
   });
 });

--- a/client/apps/shell/src/app/auth/login/login.component.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.ts
@@ -19,4 +19,8 @@ export class LoginComponent {
   onLogin(): void {
     this.authService.login(this.rememberMe);
   }
+
+  onForgotPassword(): void {
+    this.authService.forgotPassword();
+  }
 }

--- a/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
@@ -216,6 +216,16 @@ describe('AuthService', () => {
     });
   });
 
+  describe('forgotPassword', () => {
+    it('should initiate code flow with UPDATE_PASSWORD action', () => {
+      service.forgotPassword();
+
+      expect(oauthMock.initCodeFlow).toHaveBeenCalledWith('', {
+        kc_action: 'UPDATE_PASSWORD',
+      });
+    });
+  });
+
   describe('logout', () => {
     it('should call logOut on logout', () => {
       service.logout();

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -55,6 +55,10 @@ export class AuthService {
     localStorage.removeItem(REMEMBER_ME_KEY);
   }
 
+  forgotPassword(): void {
+    this.oauthService.initCodeFlow('', { kc_action: 'UPDATE_PASSWORD' });
+  }
+
   private updateAuthState(): void {
     const hasValidToken = this.oauthService.hasValidAccessToken();
     this.isAuthenticated.set(hasValidToken);

--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -11,6 +11,7 @@
   "failureFactor": 5,
   "verifyEmail": true,
   "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1)",
+  "actionTokenGeneratedByUserLifespan": 3600,
   "smtpServer": {
     "host": "mailpit",
     "port": "1025",


### PR DESCRIPTION
## Summary
- Configure Keycloak `actionTokenGeneratedByUserLifespan` to 3600s (1 hour) for password reset link expiry
- Add `forgotPassword()` method to `AuthService` using `initCodeFlow` with `kc_action: UPDATE_PASSWORD`
- Add "Forgot your password?" link on the login page (i18n: EN + DE) with keyboard accessibility

## Test plan
- [x] All 96 shell tests pass (`nx test shell`)
- [ ] Start Aspire, navigate to login page, verify "Forgot your password?" link renders
- [ ] Click link → redirected to Keycloak login → password reset form shown
- [ ] Complete reset flow via mailpit → verify login works with new password
- [ ] Verify reset link expires after 1 hour (Keycloak admin console)

Closes #4