### PR TITLE
feat(recipes,shell): add URL input for recipe import (US-010)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -71,6 +71,18 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "welcome": "Willkommen bei Yumney!"
+    "welcome": "Willkommen bei Yumney!",
+    "import": {
+      "title": "Rezept importieren",
+      "subtitle": "Füge eine URL von einer beliebigen Rezept-Website ein",
+      "placeholder": "https://example.com/rezept/...",
+      "submit": "Rezept importieren",
+      "submitting": "Wird importiert...",
+      "errors": {
+        "urlRequired": "Bitte gib eine URL ein.",
+        "urlInvalid": "Bitte gib eine gültige HTTP- oder HTTPS-URL ein.",
+        "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
+      }
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -71,6 +71,18 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "welcome": "Welcome to Yumney!"
+    "welcome": "Welcome to Yumney!",
+    "import": {
+      "title": "Import a Recipe",
+      "subtitle": "Paste a URL from any recipe website",
+      "placeholder": "https://example.com/recipe/...",
+      "submit": "Import Recipe",
+      "submitting": "Importing...",
+      "errors": {
+        "urlRequired": "Please enter a URL.",
+        "urlInvalid": "Please enter a valid HTTP or HTTPS URL.",
+        "generic": "An unexpected error occurred. Please try again later."
+      }
+    }
   }
 }

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -112,4 +112,21 @@ describe('i18n keys', () => {
       expect(enKeys).toContain(key);
     }
   });
+
+  it('should contain required dashboard.import keys', () => {
+    const requiredKeys = [
+      'dashboard.import.title',
+      'dashboard.import.subtitle',
+      'dashboard.import.placeholder',
+      'dashboard.import.submit',
+      'dashboard.import.submitting',
+      'dashboard.import.errors.urlRequired',
+      'dashboard.import.errors.urlInvalid',
+      'dashboard.import.errors.generic',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,40 @@
 <div class="dashboard-container" *transloco="let t">
   <h1>{{ t('dashboard.title') }}</h1>
   <p>{{ t('dashboard.welcome') }}</p>
+
+  <section class="url-import">
+    <h2>{{ t('dashboard.import.title') }}</h2>
+    <p class="subtitle">{{ t('dashboard.import.subtitle') }}</p>
+
+    <form [formGroup]="form" (ngSubmit)="onImport()">
+      @if (serverError()) {
+      <div class="error-banner">{{ t(serverError()!) }}</div>
+      }
+
+      <div class="import-row">
+        <div class="form-field">
+          <input
+            id="url"
+            type="url"
+            formControlName="url"
+            [placeholder]="t('dashboard.import.placeholder')"
+          />
+          @if (hasError('url', 'required')) {
+          <span class="field-error">{{ t('dashboard.import.errors.urlRequired') }}</span>
+          } @if (hasError('url', 'invalidUrl')) {
+          <span class="field-error">{{ t('dashboard.import.errors.urlInvalid') }}</span>
+          }
+        </div>
+
+        <button type="submit" [disabled]="isLoading()">
+          @if (isLoading()) {
+          <span class="spinner"></span>
+          <span>{{ t('dashboard.import.submitting') }}</span>
+          } @else {
+          <span>{{ t('dashboard.import.submit') }}</span>
+          }
+        </button>
+      </div>
+    </form>
+  </section>
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -9,8 +9,109 @@
     font-weight: 600;
   }
 
-  p {
+  > p {
     color: #666;
     font-size: 1rem;
+  }
+}
+
+.url-import {
+  margin-top: 2rem;
+  padding: 2rem;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+
+  h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    margin: 0 0 1.5rem;
+    color: #666;
+    font-size: 0.875rem;
+  }
+}
+
+.error-banner {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+  background: #fef2f2;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.import-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.form-field {
+  flex: 1;
+
+  input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 1rem;
+    outline: none;
+    box-sizing: border-box;
+
+    &:focus {
+      border-color: #f97316;
+      box-shadow: 0 0 0 3px rgb(249 115 22 / 15%);
+    }
+  }
+
+  .field-error {
+    display: block;
+    margin-top: 0.25rem;
+    color: #dc2626;
+    font-size: 0.8125rem;
+  }
+}
+
+button[type='submit'] {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  background: #f97316;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:hover:not(:disabled) {
+    background: #ea580c;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgb(255 255 255 / 30%);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -150,9 +150,7 @@ describe('DashboardComponent', () => {
     component.isLoading.set(true);
     fixture.detectChanges();
 
-    const button = fixture.nativeElement.querySelector(
-      'button[type="submit"]',
-    );
+    const button = fixture.nativeElement.querySelector('button[type="submit"]');
     expect(button.disabled).toBe(true);
   });
 
@@ -169,9 +167,7 @@ describe('DashboardComponent', () => {
   });
 
   it('should reset form after successful import', fakeAsync(() => {
-    recipeApiMock.importRecipe.mockReturnValue(
-      of({ message: 'OK' }),
-    );
+    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
 
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
@@ -188,13 +184,9 @@ describe('DashboardComponent', () => {
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
     tick();
-    expect(component.serverError()).toBe(
-      'dashboard.import.errors.generic',
-    );
+    expect(component.serverError()).toBe('dashboard.import.errors.generic');
 
-    recipeApiMock.importRecipe.mockReturnValue(
-      of({ message: 'OK' }),
-    );
+    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
     expect(component.serverError()).toBeNull();
@@ -209,9 +201,7 @@ describe('DashboardComponent', () => {
     component.onImport();
     tick();
 
-    expect(component.serverError()).toBe(
-      'dashboard.import.errors.urlInvalid',
-    );
+    expect(component.serverError()).toBe('dashboard.import.errors.urlInvalid');
   }));
 
   it('should reject ftp URL', () => {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -1,19 +1,37 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslocoTestingModule } from '@jsverse/transloco';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, Subject, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
+import { RecipeApiService } from '@yumney/shared/api-client';
 
 const en = {
   dashboard: {
     title: 'Dashboard',
     welcome: 'Welcome to Yumney!',
+    import: {
+      title: 'Import a Recipe',
+      subtitle: 'Paste a URL from any recipe website',
+      placeholder: 'https://example.com/recipe/...',
+      submit: 'Import Recipe',
+      submitting: 'Importing...',
+      errors: {
+        urlRequired: 'Please enter a URL.',
+        urlInvalid: 'Please enter a valid HTTP or HTTPS URL.',
+        generic: 'An unexpected error occurred. Please try again later.',
+      },
+    },
   },
 };
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let recipeApiMock: { importRecipe: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
+    recipeApiMock = { importRecipe: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [
         DashboardComponent,
@@ -25,6 +43,7 @@ describe('DashboardComponent', () => {
           },
         }),
       ],
+      providers: [{ provide: RecipeApiService, useValue: recipeApiMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);
@@ -45,4 +64,182 @@ describe('DashboardComponent', () => {
     const heading = fixture.nativeElement.querySelector('h1');
     expect(heading.textContent).toContain('Dashboard');
   });
+
+  it('should render the URL import input', () => {
+    const input = fixture.nativeElement.querySelector('input#url');
+    expect(input).toBeTruthy();
+  });
+
+  it('should show validation error when submitting empty URL', () => {
+    component.onImport();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.field-error');
+    expect(error.textContent).toContain('Please enter a URL.');
+  });
+
+  it('should show validation error for invalid URL format', () => {
+    component.form.controls.url.setValue('not-a-url');
+    component.onImport();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.field-error');
+    expect(error.textContent).toContain('Please enter a valid HTTP or HTTPS URL.');
+  });
+
+  it('should accept valid HTTP URL', () => {
+    component.form.controls.url.setValue('http://example.com/recipe');
+
+    expect(component.form.valid).toBe(true);
+  });
+
+  it('should accept valid HTTPS URL', () => {
+    component.form.controls.url.setValue('https://example.com/recipe');
+
+    expect(component.form.valid).toBe(true);
+  });
+
+  it('should accept URL with query parameters', () => {
+    component.form.controls.url.setValue('https://example.com/recipe?id=123&lang=en');
+
+    expect(component.form.valid).toBe(true);
+  });
+
+  it('should call recipeApi.importRecipe on valid submit', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(recipeApiMock.importRecipe).toHaveBeenCalledWith({
+      url: 'https://example.com/recipe',
+    });
+  }));
+
+  it('should show loading indicator during import', () => {
+    const subject = new Subject();
+    recipeApiMock.importRecipe.mockReturnValue(subject);
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button[type="submit"]');
+    expect(button.textContent).toContain('Importing...');
+
+    subject.next({ message: 'OK' });
+    subject.complete();
+  });
+
+  it('should show server error on API failure', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    fixture.detectChanges();
+
+    const errorBanner = fixture.nativeElement.querySelector('.error-banner');
+    expect(errorBanner.textContent).toContain('An unexpected error occurred.');
+  }));
+
+  it('should disable submit button while loading', () => {
+    component.isLoading.set(true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector(
+      'button[type="submit"]',
+    );
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should not call API when form is invalid', () => {
+    component.onImport();
+
+    expect(recipeApiMock.importRecipe).not.toHaveBeenCalled();
+  });
+
+  it('should mark fields as touched on invalid submit', () => {
+    component.onImport();
+
+    expect(component.form.controls.url.touched).toBe(true);
+  });
+
+  it('should reset form after successful import', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      of({ message: 'OK' }),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.form.controls.url.value).toBe('');
+  }));
+
+  it('should clear server error on new submission', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    expect(component.serverError()).toBe(
+      'dashboard.import.errors.generic',
+    );
+
+    recipeApiMock.importRecipe.mockReturnValue(
+      of({ message: 'OK' }),
+    );
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    expect(component.serverError()).toBeNull();
+  }));
+
+  it('should show url invalid error on 422 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 422 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe(
+      'dashboard.import.errors.urlInvalid',
+    );
+  }));
+
+  it('should reject ftp URL', () => {
+    component.form.controls.url.setValue('ftp://example.com/file');
+
+    expect(component.form.valid).toBe(false);
+  });
+
+  it('should return false from hasError when control is not touched', () => {
+    component.form.controls.url.setValue('');
+    expect(component.hasError('url', 'required')).toBe(false);
+  });
+
+  it('should return true from hasError when control is touched and has error', () => {
+    component.form.controls.url.setValue('');
+    component.form.controls.url.markAsTouched();
+    expect(component.hasError('url', 'required')).toBe(true);
+  });
+
+  it('should set isLoading to false after error', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.isLoading()).toBe(false);
+  }));
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,11 +1,86 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule } from '@jsverse/transloco';
+import { RecipeApiService } from '@yumney/shared/api-client';
+
+function urlValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return null;
+    }
+  } catch {
+    // invalid URL
+  }
+
+  return { invalidUrl: true };
+}
 
 @Component({
   selector: 'yn-dashboard',
-  imports: [TranslocoModule],
+  imports: [ReactiveFormsModule, TranslocoModule],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent {}
+export class DashboardComponent {
+  private fb = inject(FormBuilder);
+  private recipeApi = inject(RecipeApiService);
+  private destroyRef = inject(DestroyRef);
+
+  isLoading = signal(false);
+  serverError = signal<string | null>(null);
+
+  form = this.fb.nonNullable.group({
+    url: ['', [Validators.required, urlValidator]],
+  });
+
+  onImport(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.serverError.set(null);
+
+    const { url } = this.form.getRawValue();
+
+    this.recipeApi
+      .importRecipe({ url })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isLoading.set(false);
+          this.form.reset();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading.set(false);
+
+          if (err.status === 422) {
+            this.serverError.set('dashboard.import.errors.urlInvalid');
+          } else {
+            this.serverError.set('dashboard.import.errors.generic');
+          }
+        },
+      });
+  }
+
+  hasError(field: string, error: string): boolean {
+    const control = this.form.get(field);
+    return !!control?.hasError(error) && !!control?.touched;
+  }
+}

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -1,1 +1,2 @@
 export { AuthApiService } from './lib/auth-api.service';
+export { RecipeApiService } from './lib/recipe-api.service';

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface ImportRecipeRequest {
+  url: string;
+}
+
+export interface ImportRecipeResponse {
+  message: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RecipeApiService {
+  private http = inject(HttpClient);
+
+  importRecipe(request: ImportRecipeRequest): Observable<ImportRecipeResponse> {
+    return this.http.post<ImportRecipeResponse>(
+      '/api/v1/recipes/import',
+      request,
+    );
+  }
+}

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -15,9 +15,6 @@ export class RecipeApiService {
   private http = inject(HttpClient);
 
   importRecipe(request: ImportRecipeRequest): Observable<ImportRecipeResponse> {
-    return this.http.post<ImportRecipeResponse>(
-      '/api/v1/recipes/import',
-      request,
-    );
+    return this.http.post<ImportRecipeResponse>('/api/v1/recipes/import', request);
   }
 }

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -5,6 +5,7 @@ using Scalar.AspNetCore;
 using Serilog;
 using Yumney.Api.Middleware;
 using Yumney.Recipes.Api;
+using Yumney.Recipes.Application.Commands;
 using Yumney.ServiceDefaults;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
@@ -40,6 +41,9 @@ builder.Services.AddInProcessEventBus();
 
 builder.Services.AddDbContext<UsersDbContext>(options => options.UseNpgsql(builder.Configuration.GetConnectionString("yumneydb")));
 builder.Services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
+
+builder.Services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidator>();
+builder.Services.AddScoped<ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>>, ImportRecipeCommandHandler>();
 
 builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserRequestValidator>();
 builder.Services.AddScoped<ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>, RegisterUserCommandHandler>();

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -1,4 +1,11 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
 
 namespace Yumney.Recipes.Api;
 
@@ -6,7 +13,42 @@ public static class RecipesEndpoints
 {
     public static IEndpointRouteBuilder MapRecipesEndpoints(this IEndpointRouteBuilder app)
     {
-        // Endpoints will be added in feat/US-004
+        var group = app.MapGroup("/recipes");
+
+        group.MapPost("/import", ImportAsync)
+            .WithName("ImportRecipe");
+
         return app;
+    }
+
+    private static async Task<IResult> ImportAsync(
+        ImportRecipeRequest request,
+        IValidator<ImportRecipeRequest> validator,
+        ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            return Results.ValidationProblem(validationResult.ToDictionary());
+        }
+
+        var command = new ImportRecipeCommand(new RecipeUrl(request.Url));
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.Error switch
+            {
+                ImportRecipeErrors.InvalidUrl =>
+                    Results.Problem("The provided URL is not valid.", statusCode: 400),
+                _ =>
+                    Results.Problem("Failed to import recipe.", statusCode: 500),
+            };
+        }
+
+        return Results.Ok(result.Value);
     }
 }

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
@@ -1,0 +1,9 @@
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+
+namespace Yumney.Recipes.Application.Commands;
+
+public sealed record ImportRecipeCommand(RecipeUrl Url) : ICommand<Result<ImportRecipeResultDto>>;
+
+public sealed record ImportRecipeResultDto(string Message);

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+
+namespace Yumney.Recipes.Application.Commands;
+
+#pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
+public sealed partial class ImportRecipeCommandHandler(ILogger<ImportRecipeCommandHandler> logger)
+    : ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>>
+{
+    public Task<Result<ImportRecipeResultDto>> HandleAsync(
+        ImportRecipeCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var url = command.Url;
+
+        LogImportAttempt(url.Value);
+
+        var result = Result<ImportRecipeResultDto>.Success(
+            new ImportRecipeResultDto("Recipe URL accepted. Extraction will be available in a future release."));
+
+        return Task.FromResult(result);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe import requested for URL {SourceUrl}")]
+    private partial void LogImportAttempt(string sourceUrl);
+}

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeErrors.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeErrors.cs
@@ -1,0 +1,6 @@
+namespace Yumney.Recipes.Application.Commands;
+
+public static class ImportRecipeErrors
+{
+    public const string InvalidUrl = "IMPORT_INVALID_URL";
+}

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeRequest.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeRequest.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Recipes.Application.Commands;
+
+public sealed record ImportRecipeRequest(string Url);

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeRequestValidator.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeRequestValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Yumney.Recipes.Application.Commands;
+
+public sealed class ImportRecipeRequestValidator : AbstractValidator<ImportRecipeRequest>
+{
+    public ImportRecipeRequestValidator()
+    {
+        RuleFor(x => x.Url)
+            .NotEmpty()
+            .MaximumLength(2048)
+            .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            .WithMessage("A valid HTTP or HTTPS URL is required.");
+    }
+}

--- a/src/Yumney.Recipes.Domain/Placeholder.cs
+++ b/src/Yumney.Recipes.Domain/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Yumney.Recipes.Domain;
-
-// Placeholder — domain aggregates will be added in feat/US-002-recipes-domain

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
@@ -1,0 +1,20 @@
+using Yumney.Shared.Guards;
+
+namespace Yumney.Recipes.Domain.Recipe;
+
+public sealed record RecipeUrl
+{
+    public string Value { get; }
+
+    public RecipeUrl(string value)
+    {
+        string validated = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(2048)
+            .IsValidUrl()
+            .AndReturn();
+        Value = validated.Trim();
+    }
+
+    public override string ToString() => Value;
+}

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Domain.Recipe;
+
+namespace Yumney.Recipes.Application.Tests.Commands;
+
+public class ImportRecipeCommandHandlerTests
+{
+    private readonly ILogger<ImportRecipeCommandHandler> logger =
+        Substitute.For<ILogger<ImportRecipeCommandHandler>>();
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_ReturnsSuccess()
+    {
+        var sut = new ImportRecipeCommandHandler(logger);
+        var command = new ImportRecipeCommand(
+            new RecipeUrl("https://example.com/recipe"));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_ReturnsMessageDto()
+    {
+        var sut = new ImportRecipeCommandHandler(logger);
+        var command = new ImportRecipeCommand(
+            new RecipeUrl("https://example.com/recipe"));
+
+        var result = await sut.HandleAsync(command);
+
+        result.Value.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_DoesNotReturnFailure()
+    {
+        var sut = new ImportRecipeCommandHandler(logger);
+        var command = new ImportRecipeCommand(
+            new RecipeUrl("https://example.com/recipe/pasta"));
+
+        var result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeFalse();
+    }
+}

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeRequestValidatorTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Recipes.Application.Commands;
+
+namespace Yumney.Recipes.Application.Tests.Commands;
+
+public class ImportRecipeRequestValidatorTests
+{
+    private readonly ImportRecipeRequestValidator sut = new();
+
+    [Fact]
+    public void Validate_ValidHttpsUrl_IsValid()
+    {
+        var request = new ImportRecipeRequest("https://example.com/recipe/123");
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidHttpUrl_IsValid()
+    {
+        var request = new ImportRecipeRequest("http://example.com/recipe/123");
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_UrlWithQueryParams_IsValid()
+    {
+        var request = new ImportRecipeRequest("https://example.com/recipe?id=123&lang=en");
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_EmptyUrl_IsNotValid(string url)
+    {
+        var request = new ImportRecipeRequest(url);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Url");
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com/recipe")]
+    [InlineData("example.com/recipe")]
+    public void Validate_InvalidUrl_IsNotValid(string url)
+    {
+        var request = new ImportRecipeRequest(url);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Url");
+    }
+
+    [Fact]
+    public void Validate_UrlExceedsMaxLength_IsNotValid()
+    {
+        var path = new string('a', 2040);
+        var url = $"https://x.com/{path}";
+        var request = new ImportRecipeRequest(url);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Url");
+    }
+
+    [Fact]
+    public void Validate_UrlAtMaxLength_IsValid()
+    {
+        var prefix = "https://x.com/";
+        var path = new string('a', 2048 - prefix.Length);
+        var url = $"{prefix}{path}";
+        var request = new ImportRecipeRequest(url);
+
+        var result = sut.Validate(request);
+
+        result.Errors.Should().NotContain(
+            e => e.PropertyName == "Url"
+                && e.ErrorCode == "MaximumLengthValidator");
+    }
+
+    [Fact]
+    public void Validate_NullUrl_IsNotValid()
+    {
+        var request = new ImportRecipeRequest(null!);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Url");
+    }
+
+    [Fact]
+    public void Validate_UrlWithFragment_IsValid()
+    {
+        var request = new ImportRecipeRequest(
+            "https://example.com/recipe#ingredients");
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Yumney.Recipes.Application.Tests/Placeholder.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Yumney.Recipes.Application.Tests;
-
-// Placeholder — application tests will be added in feat/US-003-recipes-application

--- a/tests/Yumney.Recipes.Domain.Tests/Placeholder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Yumney.Recipes.Domain.Tests;
-
-// Placeholder — domain tests will be added in feat/US-002-recipes-domain

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeUrlTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeUrlTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Xunit;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Guards;
+
+namespace Yumney.Recipes.Domain.Tests.Recipe;
+
+public class RecipeUrlTests
+{
+    [Theory]
+    [InlineData("http://example.com/recipe")]
+    [InlineData("http://www.example.com/recipe/123")]
+    public void Constructor_ValidHttpUrl_CreatesInstance(string value)
+    {
+        var url = new RecipeUrl(value);
+
+        url.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/recipe")]
+    [InlineData("https://www.example.com/recipe/123")]
+    public void Constructor_ValidHttpsUrl_CreatesInstance(string value)
+    {
+        var url = new RecipeUrl(value);
+
+        url.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Constructor_UrlWithQueryParams_CreatesInstance()
+    {
+        var value = "https://example.com/recipe?id=123&lang=en";
+
+        var url = new RecipeUrl(value);
+
+        url.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Constructor_UrlWithFragment_CreatesInstance()
+    {
+        var value = "https://example.com/recipe#ingredients";
+
+        var url = new RecipeUrl(value);
+
+        url.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => new RecipeUrl(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData("ftp://example.com/recipe")]
+    [InlineData("example.com/recipe")]
+    [InlineData("not-a-url")]
+    [InlineData("javascript:alert(1)")]
+    public void Constructor_InvalidFormat_ThrowsGuardException(string value)
+    {
+        var act = () => new RecipeUrl(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    {
+        var path = new string('a', 2040);
+        var url = $"https://x.com/{path}";
+
+        var act = () => new RecipeUrl(url);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Constructor_AtMaxLength_CreatesInstance()
+    {
+        var prefix = "https://x.com/";
+        var path = new string('a', 2048 - prefix.Length);
+        var url = $"{prefix}{path}";
+
+        var result = new RecipeUrl(url);
+
+        result.Value.Should().HaveLength(2048);
+    }
+
+    [Fact]
+    public void Constructor_TrimsWhitespace()
+    {
+        var url = new RecipeUrl("  https://example.com/recipe  ");
+
+        url.Value.Should().Be("https://example.com/recipe");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var url1 = new RecipeUrl("https://example.com/recipe");
+        var url2 = new RecipeUrl("https://example.com/recipe");
+
+        url1.Should().Be(url2);
+    }
+
+    [Fact]
+    public void Equality_DifferentValue_AreNotEqual()
+    {
+        var url1 = new RecipeUrl("https://example.com/recipe1");
+        var url2 = new RecipeUrl("https://example.com/recipe2");
+
+        url1.Should().NotBe(url2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+
+        url.ToString().Should().Be("https://example.com/recipe");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RecipeUrl` value object with HTTP/HTTPS validation and 2048-char limit
- Add `ImportRecipeCommand` pipeline (command, request validator, stub handler, error constants)
- Add `POST /api/v1/recipes/import` endpoint with FluentValidation and Result pattern
- Add dashboard URL input form with client-side validation, loading state, and error handling
- Add `RecipeApiService` in shared API client library
- Add i18n keys (EN/DE) for the import section

## Test plan
- [x] `RecipeUrlTests` — 19 tests (guards, trim, equality, boundary lengths)
- [x] `ImportRecipeRequestValidatorTests` — 12 tests (null, empty, valid/invalid schemes, max length)
- [x] `ImportRecipeCommandHandlerTests` — 3 tests (success, message DTO, no failure)
- [x] `DashboardComponent` — 22 tests (form validation, API calls, loading, errors, hasError helper)
- [x] `i18n-keys.spec` — dashboard.import keys verified for en/de parity
- [x] `dotnet build` passes with zero warnings
- [x] `dotnet test` — all backend tests pass
- [x] `nx test shell` — all 116 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)