### PR TITLE
feat(recipes,shell): add LLM recipe extraction pipeline (US-011)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ yarn-error.log*
 *.pfx
 *.key
 *.pem
+
+# Claude Code
+.claude/
+
+# Docs (local only)
+Yumney-Spezifikation.docx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,9 +31,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.1" />
     <!-- DI & Logging Abstractions -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <!-- Logging -->
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <!-- Analyzers -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <!-- Aspire -->
 <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.2-preview.1.26125.13" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.2" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.1.2-preview.1.26125.13" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-<PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.2-preview.1.26125.13" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.2-preview.1.26125.13" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.2" />
@@ -30,7 +30,7 @@
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.2" />
     <!-- DI & Logging Abstractions -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
@@ -42,8 +42,8 @@
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -26,6 +26,7 @@
     <Project Path="tests/Yumney.Shopping.Application.Tests/Yumney.Shopping.Application.Tests.csproj" />
     <Project Path="tests/Yumney.Users.Domain.Tests/Yumney.Users.Domain.Tests.csproj" />
     <Project Path="tests/Yumney.Users.Application.Tests/Yumney.Users.Application.Tests.csproj" />
+    <Project Path="tests/Yumney.Recipes.Infrastructure.Tests/Yumney.Recipes.Infrastructure.Tests.csproj" />
     <Project Path="tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj" />
     <Project Path="tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj" />
   </Folder>

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -78,9 +78,13 @@
       "placeholder": "https://example.com/rezept/...",
       "submit": "Rezept importieren",
       "submitting": "Wird importiert...",
+      "success": "Rezept \"{{title}}\" erfolgreich extrahiert!",
       "errors": {
         "urlRequired": "Bitte gib eine URL ein.",
         "urlInvalid": "Bitte gib eine gültige HTTP- oder HTTPS-URL ein.",
+        "unreachable": "Die Website konnte nicht erreicht werden. Bitte überprüfe die URL.",
+        "timeout": "Die Extraktion hat zu lange gedauert. Bitte versuche es erneut.",
+        "noRecipe": "Auf dieser Seite wurde kein Rezept gefunden.",
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
       }
     }

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -82,6 +82,7 @@
       "errors": {
         "urlRequired": "Bitte gib eine URL ein.",
         "urlInvalid": "Bitte gib eine gültige HTTP- oder HTTPS-URL ein.",
+        "urlTooLong": "URL darf maximal 2048 Zeichen lang sein.",
         "unreachable": "Die Website konnte nicht erreicht werden. Bitte überprüfe die URL.",
         "timeout": "Die Extraktion hat zu lange gedauert. Bitte versuche es erneut.",
         "noRecipe": "Auf dieser Seite wurde kein Rezept gefunden.",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -78,9 +78,13 @@
       "placeholder": "https://example.com/recipe/...",
       "submit": "Import Recipe",
       "submitting": "Importing...",
+      "success": "Recipe \"{{title}}\" extracted successfully!",
       "errors": {
         "urlRequired": "Please enter a URL.",
         "urlInvalid": "Please enter a valid HTTP or HTTPS URL.",
+        "unreachable": "Could not reach the website. Please check the URL.",
+        "timeout": "Extraction timed out. Please try again.",
+        "noRecipe": "No recipe found on this page.",
         "generic": "An unexpected error occurred. Please try again later."
       }
     }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -82,6 +82,7 @@
       "errors": {
         "urlRequired": "Please enter a URL.",
         "urlInvalid": "Please enter a valid HTTP or HTTPS URL.",
+        "urlTooLong": "URL must not exceed 2048 characters.",
         "unreachable": "Could not reach the website. Please check the URL.",
         "timeout": "Extraction timed out. Please try again.",
         "noRecipe": "No recipe found on this page.",

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -123,6 +123,7 @@ describe('i18n keys', () => {
       'dashboard.import.success',
       'dashboard.import.errors.urlRequired',
       'dashboard.import.errors.urlInvalid',
+      'dashboard.import.errors.urlTooLong',
       'dashboard.import.errors.unreachable',
       'dashboard.import.errors.timeout',
       'dashboard.import.errors.noRecipe',

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -120,8 +120,12 @@ describe('i18n keys', () => {
       'dashboard.import.placeholder',
       'dashboard.import.submit',
       'dashboard.import.submitting',
+      'dashboard.import.success',
       'dashboard.import.errors.urlRequired',
       'dashboard.import.errors.urlInvalid',
+      'dashboard.import.errors.unreachable',
+      'dashboard.import.errors.timeout',
+      'dashboard.import.errors.noRecipe',
       'dashboard.import.errors.generic',
     ];
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -7,7 +7,11 @@
     <p class="subtitle">{{ t('dashboard.import.subtitle') }}</p>
 
     <form [formGroup]="form" (ngSubmit)="onImport()">
-      @if (serverError()) {
+      @if (extractedRecipe()) {
+      <div class="success-banner">
+        {{ t('dashboard.import.success', { title: extractedRecipe()!.title }) }}
+      </div>
+      } @if (serverError()) {
       <div class="error-banner">{{ t(serverError()!) }}</div>
       }
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -25,6 +25,8 @@
           />
           @if (hasError('url', 'required')) {
           <span class="field-error">{{ t('dashboard.import.errors.urlRequired') }}</span>
+          } @if (hasError('url', 'maxlength')) {
+          <span class="field-error">{{ t('dashboard.import.errors.urlTooLong') }}</span>
           } @if (hasError('url', 'invalidUrl')) {
           <span class="field-error">{{ t('dashboard.import.errors.urlInvalid') }}</span>
           }

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -35,6 +35,15 @@
   }
 }
 
+.success-banner {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+  background: #f0fdf4;
+  color: #16a34a;
+  font-size: 0.875rem;
+}
+
 .error-banner {
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -37,6 +37,7 @@ const en = {
       errors: {
         urlRequired: 'Please enter a URL.',
         urlInvalid: 'Please enter a valid HTTP or HTTPS URL.',
+        urlTooLong: 'URL must not exceed 2048 characters.',
         unreachable: 'Could not reach the website. Please check the URL.',
         timeout: 'Extraction timed out. Please try again.',
         noRecipe: 'No recipe found on this page.',
@@ -125,6 +126,23 @@ describe('DashboardComponent', () => {
     component.form.controls.url.setValue('https://example.com/recipe?id=123&lang=en');
 
     expect(component.form.valid).toBe(true);
+  });
+
+  it('should reject URL exceeding 2048 characters', () => {
+    const longUrl = 'https://example.com/' + 'a'.repeat(2048);
+    component.form.controls.url.setValue(longUrl);
+
+    expect(component.form.valid).toBe(false);
+  });
+
+  it('should show validation error for URL exceeding max length', () => {
+    const longUrl = 'https://example.com/' + 'a'.repeat(2048);
+    component.form.controls.url.setValue(longUrl);
+    component.onImport();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.field-error');
+    expect(error.textContent).toContain('URL must not exceed 2048 characters.');
   });
 
   it('should call recipeApi.importRecipe on valid submit', fakeAsync(() => {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -3,7 +3,25 @@ import { TranslocoTestingModule } from '@jsverse/transloco';
 import { HttpErrorResponse } from '@angular/common/http';
 import { of, Subject, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
-import { RecipeApiService } from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
+
+const mockRecipe: ImportRecipeResponse = {
+  title: 'Pasta Carbonara',
+  description: 'A classic Italian pasta dish',
+  ingredients: [
+    { name: 'Spaghetti', amount: 400, unit: 'g' },
+    { name: 'Pancetta', amount: 200, unit: 'g' },
+  ],
+  steps: [
+    { number: 1, description: 'Cook pasta' },
+    { number: 2, description: 'Fry pancetta' },
+  ],
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: 'medium',
+  imageUrl: null,
+};
 
 const en = {
   dashboard: {
@@ -15,9 +33,13 @@ const en = {
       placeholder: 'https://example.com/recipe/...',
       submit: 'Import Recipe',
       submitting: 'Importing...',
+      success: 'Recipe "{{title}}" extracted successfully!',
       errors: {
         urlRequired: 'Please enter a URL.',
         urlInvalid: 'Please enter a valid HTTP or HTTPS URL.',
+        unreachable: 'Could not reach the website. Please check the URL.',
+        timeout: 'Extraction timed out. Please try again.',
+        noRecipe: 'No recipe found on this page.',
         generic: 'An unexpected error occurred. Please try again later.',
       },
     },
@@ -106,7 +128,7 @@ describe('DashboardComponent', () => {
   });
 
   it('should call recipeApi.importRecipe on valid submit', fakeAsync(() => {
-    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
 
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
@@ -128,7 +150,7 @@ describe('DashboardComponent', () => {
     const button = fixture.nativeElement.querySelector('button[type="submit"]');
     expect(button.textContent).toContain('Importing...');
 
-    subject.next({ message: 'OK' });
+    subject.next(mockRecipe);
     subject.complete();
   });
 
@@ -167,7 +189,7 @@ describe('DashboardComponent', () => {
   });
 
   it('should reset form after successful import', fakeAsync(() => {
-    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
 
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
@@ -186,22 +208,10 @@ describe('DashboardComponent', () => {
     tick();
     expect(component.serverError()).toBe('dashboard.import.errors.generic');
 
-    recipeApiMock.importRecipe.mockReturnValue(of({ message: 'OK' }));
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onImport();
     expect(component.serverError()).toBeNull();
-  }));
-
-  it('should show url invalid error on 422 response', fakeAsync(() => {
-    recipeApiMock.importRecipe.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 422 })),
-    );
-
-    component.form.controls.url.setValue('https://example.com/recipe');
-    component.onImport();
-    tick();
-
-    expect(component.serverError()).toBe('dashboard.import.errors.urlInvalid');
   }));
 
   it('should reject ftp URL', () => {
@@ -231,5 +241,125 @@ describe('DashboardComponent', () => {
     tick();
 
     expect(component.isLoading()).toBe(false);
+  }));
+
+  it('should show success banner with recipe title after extraction', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    fixture.detectChanges();
+
+    const successBanner = fixture.nativeElement.querySelector('.success-banner');
+    expect(successBanner).toBeTruthy();
+    expect(successBanner.textContent).toContain('Pasta Carbonara');
+  }));
+
+  it('should store extracted recipe data', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.extractedRecipe()).toEqual(mockRecipe);
+  }));
+
+  it('should show unreachable error on 502 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 502 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.import.errors.unreachable');
+  }));
+
+  it('should show timeout error on 504 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 504 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.import.errors.timeout');
+  }));
+
+  it('should show no recipe error on 404 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.import.errors.noRecipe');
+  }));
+
+  it('should clear extracted recipe before new import', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    expect(component.extractedRecipe()).toEqual(mockRecipe);
+
+    const subject = new Subject();
+    recipeApiMock.importRecipe.mockReturnValue(subject);
+    component.form.controls.url.setValue('https://example.com/other');
+    component.onImport();
+
+    expect(component.extractedRecipe()).toBeNull();
+
+    subject.next(mockRecipe);
+    subject.complete();
+  }));
+
+  it('should clear extracted recipe on error', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    expect(component.extractedRecipe()).toEqual(mockRecipe);
+
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+    component.form.controls.url.setValue('https://example.com/other');
+    component.onImport();
+    tick();
+
+    expect(component.extractedRecipe()).toBeNull();
+  }));
+
+  it('should show generic error on 400 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 400 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.import.errors.generic');
+  }));
+
+  it('should show generic error on 422 response', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 422 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.import.errors.generic');
   }));
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,12 @@
 import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ReactiveFormsModule, FormBuilder, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
@@ -49,7 +55,10 @@ export class DashboardComponent {
   extractedRecipe = signal<ImportRecipeResponse | null>(null);
 
   form = this.fb.nonNullable.group({
-    url: ['', [Validators.required, Validators.maxLength(DashboardComponent.urlMaxLength), urlValidator]],
+    url: [
+      '',
+      [Validators.required, Validators.maxLength(DashboardComponent.urlMaxLength), urlValidator],
+    ],
   });
 
   onImport(): void {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule } from '@jsverse/transloco';
-import { RecipeApiService } from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
 
 function urlValidator(control: AbstractControl): ValidationErrors | null {
   const value = control.value;
@@ -43,6 +43,7 @@ export class DashboardComponent {
 
   isLoading = signal(false);
   serverError = signal<string | null>(null);
+  extractedRecipe = signal<ImportRecipeResponse | null>(null);
 
   form = this.fb.nonNullable.group({
     url: ['', [Validators.required, urlValidator]],
@@ -56,6 +57,7 @@ export class DashboardComponent {
 
     this.isLoading.set(true);
     this.serverError.set(null);
+    this.extractedRecipe.set(null);
 
     const { url } = this.form.getRawValue();
 
@@ -63,15 +65,20 @@ export class DashboardComponent {
       .importRecipe({ url })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: () => {
+        next: (response) => {
           this.isLoading.set(false);
+          this.extractedRecipe.set(response);
           this.form.reset();
         },
         error: (err: HttpErrorResponse) => {
           this.isLoading.set(false);
 
-          if (err.status === 422) {
-            this.serverError.set('dashboard.import.errors.urlInvalid');
+          if (err.status === 502) {
+            this.serverError.set('dashboard.import.errors.unreachable');
+          } else if (err.status === 504) {
+            this.serverError.set('dashboard.import.errors.timeout');
+          } else if (err.status === 404) {
+            this.serverError.set('dashboard.import.errors.noRecipe');
           } else {
             this.serverError.set('dashboard.import.errors.generic');
           }

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -46,7 +46,7 @@ export class DashboardComponent {
   extractedRecipe = signal<ImportRecipeResponse | null>(null);
 
   form = this.fb.nonNullable.group({
-    url: ['', [Validators.required, urlValidator]],
+    url: ['', [Validators.required, Validators.maxLength(2048), urlValidator]],
   });
 
   onImport(): void {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,12 +1,6 @@
 import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  ReactiveFormsModule,
-  FormBuilder,
-  Validators,
-  AbstractControl,
-  ValidationErrors,
-} from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
@@ -37,6 +31,15 @@ function urlValidator(control: AbstractControl): ValidationErrors | null {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardComponent {
+  private static readonly importErrorMap: Record<number, string> = {
+    502: 'dashboard.import.errors.unreachable',
+    504: 'dashboard.import.errors.timeout',
+    404: 'dashboard.import.errors.noRecipe',
+  };
+
+  private static readonly defaultImportError = 'dashboard.import.errors.generic';
+  private static readonly urlMaxLength = 2048;
+
   private fb = inject(FormBuilder);
   private recipeApi = inject(RecipeApiService);
   private destroyRef = inject(DestroyRef);
@@ -46,7 +49,7 @@ export class DashboardComponent {
   extractedRecipe = signal<ImportRecipeResponse | null>(null);
 
   form = this.fb.nonNullable.group({
-    url: ['', [Validators.required, Validators.maxLength(2048), urlValidator]],
+    url: ['', [Validators.required, Validators.maxLength(DashboardComponent.urlMaxLength), urlValidator]],
   });
 
   onImport(): void {
@@ -72,16 +75,9 @@ export class DashboardComponent {
         },
         error: (err: HttpErrorResponse) => {
           this.isLoading.set(false);
-
-          if (err.status === 502) {
-            this.serverError.set('dashboard.import.errors.unreachable');
-          } else if (err.status === 504) {
-            this.serverError.set('dashboard.import.errors.timeout');
-          } else if (err.status === 404) {
-            this.serverError.set('dashboard.import.errors.noRecipe');
-          } else {
-            this.serverError.set('dashboard.import.errors.generic');
-          }
+          this.serverError.set(
+            DashboardComponent.importErrorMap[err.status] ?? DashboardComponent.defaultImportError,
+          );
         },
       });
   }

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -1,2 +1,8 @@
 export { AuthApiService } from './lib/auth-api.service';
-export { RecipeApiService } from './lib/recipe-api.service';
+export {
+  RecipeApiService,
+  type ImportRecipeRequest,
+  type ImportRecipeResponse,
+  type ExtractedIngredient,
+  type ExtractedStep,
+} from './lib/recipe-api.service';

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -6,8 +6,27 @@ export interface ImportRecipeRequest {
   url: string;
 }
 
+export interface ExtractedIngredient {
+  name: string;
+  amount: number | null;
+  unit: string | null;
+}
+
+export interface ExtractedStep {
+  number: number;
+  description: string;
+}
+
 export interface ImportRecipeResponse {
-  message: string;
+  title: string;
+  description: string | null;
+  ingredients: ExtractedIngredient[];
+  steps: ExtractedStep[];
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  difficulty: string | null;
+  imageUrl: string | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/client/nx.json
+++ b/client/nx.json
@@ -105,6 +105,5 @@
     "@nx/angular:component": {
       "style": "css"
     }
-  },
-  "nxCloudId": "69aa6bda37b18dac26833553"
+  }
 }

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.SemanticKernel;
 using Scalar.AspNetCore;
 using Serilog;
+using Yumney.Api;
 using Yumney.Api.Middleware;
 using Yumney.Recipes.Api;
 using Yumney.Recipes.Application.Commands;
@@ -28,10 +29,17 @@ builder.Host.UseSerilog((context, configuration) => configuration.ReadFrom.Confi
 
 builder.AddServiceDefaults();
 
+var keycloakOptions = builder.Configuration
+    .GetSection(KeycloakOptions.SectionName)
+    .Get<KeycloakOptions>() ?? new KeycloakOptions();
+
+builder.Services.Configure<KeycloakOptions>(
+    builder.Configuration.GetSection(KeycloakOptions.SectionName));
+
 builder.Services.AddAuthentication()
     .AddKeycloakJwtBearer(
         serviceName: "keycloak",
-        realm: "yumney",
+        realm: keycloakOptions.Realm,
         configureOptions: options =>
         {
             options.RequireHttpsMetadata = false;
@@ -53,25 +61,24 @@ builder.Services.AddHttpClient<IWebScraper, WebScraper>()
     .AddStandardResilienceHandler();
 builder.Services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
 
-var skConfig = builder.Configuration.GetSection("SemanticKernel");
+var skOptions = builder.Configuration
+    .GetSection(SemanticKernelOptions.SectionName)
+    .Get<SemanticKernelOptions>() ?? new SemanticKernelOptions();
+
 var kernelBuilder = builder.Services.AddKernel();
 
-var provider = skConfig["Provider"] ?? "OpenAI";
-var modelId = skConfig["ModelId"] ?? "gpt-4o-mini";
-var apiKey = skConfig["ApiKey"] ?? string.Empty;
-
-switch (provider)
+switch (skOptions.Provider)
 {
-    case "AzureOpenAI":
-        var endpoint = skConfig["Endpoint"] ?? string.Empty;
-        kernelBuilder.AddAzureOpenAIChatCompletion(modelId, endpoint, apiKey);
+    case SemanticKernelOptions.ProviderAzureOpenAI:
+        kernelBuilder.AddAzureOpenAIChatCompletion(
+            skOptions.ModelId, skOptions.Endpoint, skOptions.ApiKey);
         break;
-    case "Ollama":
-        var ollamaEndpoint = new Uri(skConfig["Endpoint"] ?? "http://localhost:11434/v1");
-        kernelBuilder.AddOpenAIChatCompletion(modelId, ollamaEndpoint, apiKey: null);
+    case SemanticKernelOptions.ProviderOllama:
+        kernelBuilder.AddOpenAIChatCompletion(
+            skOptions.ModelId, new Uri(skOptions.Endpoint), apiKey: null);
         break;
     default:
-        kernelBuilder.AddOpenAIChatCompletion(modelId, apiKey);
+        kernelBuilder.AddOpenAIChatCompletion(skOptions.ModelId, skOptions.ApiKey);
         break;
 }
 

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -1,11 +1,15 @@
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.SemanticKernel;
 using Scalar.AspNetCore;
 using Serilog;
 using Yumney.Api.Middleware;
 using Yumney.Recipes.Api;
 using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Interfaces;
+using Yumney.Recipes.Infrastructure.Services;
 using Yumney.ServiceDefaults;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
@@ -43,7 +47,33 @@ builder.Services.AddDbContext<UsersDbContext>(options => options.UseNpgsql(build
 builder.Services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
 
 builder.Services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidator>();
-builder.Services.AddScoped<ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>>, ImportRecipeCommandHandler>();
+builder.Services.AddScoped<ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>, ImportRecipeCommandHandler>();
+
+builder.Services.AddHttpClient<IWebScraper, WebScraper>()
+    .AddStandardResilienceHandler();
+builder.Services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
+
+var skConfig = builder.Configuration.GetSection("SemanticKernel");
+var kernelBuilder = builder.Services.AddKernel();
+
+var provider = skConfig["Provider"] ?? "OpenAI";
+var modelId = skConfig["ModelId"] ?? "gpt-4o-mini";
+var apiKey = skConfig["ApiKey"] ?? string.Empty;
+
+switch (provider)
+{
+    case "AzureOpenAI":
+        var endpoint = skConfig["Endpoint"] ?? string.Empty;
+        kernelBuilder.AddAzureOpenAIChatCompletion(modelId, endpoint, apiKey);
+        break;
+    case "Ollama":
+        var ollamaEndpoint = new Uri(skConfig["Endpoint"] ?? "http://localhost:11434/v1");
+        kernelBuilder.AddOpenAIChatCompletion(modelId, ollamaEndpoint, apiKey: null);
+        break;
+    default:
+        kernelBuilder.AddOpenAIChatCompletion(modelId, apiKey);
+        break;
+}
 
 builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserRequestValidator>();
 builder.Services.AddScoped<ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>, RegisterUserCommandHandler>();

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -30,12 +30,9 @@ builder.Host.UseSerilog((context, configuration) => configuration.ReadFrom.Confi
 
 builder.AddServiceDefaults();
 
-var keycloakOptions = builder.Configuration
-    .GetSection(KeycloakOptions.SectionName)
-    .Get<KeycloakOptions>() ?? new KeycloakOptions();
+var keycloakOptions = builder.Configuration.GetSection(KeycloakOptions.SectionName).Get<KeycloakOptions>() ?? new KeycloakOptions();
 
-builder.Services.Configure<KeycloakOptions>(
-    builder.Configuration.GetSection(KeycloakOptions.SectionName));
+builder.Services.Configure<KeycloakOptions>(builder.Configuration.GetSection(KeycloakOptions.SectionName));
 
 builder.Services.AddAuthentication()
     .AddKeycloakJwtBearer(
@@ -58,25 +55,20 @@ builder.Services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>(
 builder.Services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidator>();
 builder.Services.AddScoped<ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>, ImportRecipeCommandHandler>();
 
-builder.Services.AddHttpClient<IWebScraper, WebScraper>()
-    .AddStandardResilienceHandler();
+builder.Services.AddHttpClient<IWebScraper, WebScraper>().AddStandardResilienceHandler();
 builder.Services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
 
-var skOptions = builder.Configuration
-    .GetSection(SemanticKernelOptions.SectionName)
-    .Get<SemanticKernelOptions>() ?? new SemanticKernelOptions();
+var skOptions = builder.Configuration.GetSection(SemanticKernelOptions.SectionName).Get<SemanticKernelOptions>() ?? new SemanticKernelOptions();
 
 var kernelBuilder = builder.Services.AddKernel();
 
 switch (skOptions.Provider)
 {
     case SemanticKernelOptions.ProviderAzureOpenAI:
-        kernelBuilder.AddAzureOpenAIChatCompletion(
-            skOptions.ModelId, skOptions.Endpoint, skOptions.ApiKey);
+        kernelBuilder.AddAzureOpenAIChatCompletion(skOptions.ModelId, skOptions.Endpoint, skOptions.ApiKey);
         break;
     case SemanticKernelOptions.ProviderOllama:
-        kernelBuilder.AddOpenAIChatCompletion(
-            skOptions.ModelId, new Uri(skOptions.Endpoint), apiKey: null);
+        kernelBuilder.AddOpenAIChatCompletion(skOptions.ModelId, new Uri(skOptions.Endpoint), apiKey: null);
         break;
     default:
         kernelBuilder.AddOpenAIChatCompletion(skOptions.ModelId, skOptions.ApiKey);

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -19,6 +19,7 @@ using Yumney.Shopping.Api;
 using Yumney.Users.Api;
 using Yumney.Users.Application.Commands;
 using Yumney.Users.Application.Interfaces;
+using Yumney.Users.Domain.AppUserProfile;
 using Yumney.Users.Infrastructure;
 using Yumney.Users.Infrastructure.Persistence;
 using Yumney.Users.Infrastructure.Services;

--- a/src/Yumney.Api/SemanticKernelOptions.cs
+++ b/src/Yumney.Api/SemanticKernelOptions.cs
@@ -1,0 +1,20 @@
+namespace Yumney.Api;
+
+public sealed class SemanticKernelOptions
+{
+    public const string SectionName = "SemanticKernel";
+
+    public const string ProviderOpenAI = "OpenAI";
+
+    public const string ProviderAzureOpenAI = "AzureOpenAI";
+
+    public const string ProviderOllama = "Ollama";
+
+    public string Provider { get; init; } = ProviderOpenAI;
+
+    public string ModelId { get; init; } = "gpt-4o-mini";
+
+    public string ApiKey { get; init; } = string.Empty;
+
+    public string Endpoint { get; init; } = string.Empty;
+}

--- a/src/Yumney.Api/appsettings.json
+++ b/src/Yumney.Api/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Keycloak": {
+    "Realm": "yumney",
+    "ClientId": "yumney-api",
+    "ClientSecret": "from-user-secrets"
+  },
   "SemanticKernel": {
     "Provider": "OpenAI",
     "ModelId": "gpt-4o-mini",

--- a/src/Yumney.Api/appsettings.json
+++ b/src/Yumney.Api/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "SemanticKernel": {
+    "Provider": "OpenAI",
+    "ModelId": "gpt-4o-mini",
+    "ApiKey": "from-user-secrets"
+  },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -18,13 +18,18 @@ var yumneyDb = postgres.AddDatabase("yumneydb");
 var redis = builder.AddRedis("redis")
     .WithDataVolume();
 
+var ollama = builder.AddOllama("ollama")
+    .WithDataVolume();
+
 var yumneyApi = builder.AddProject<Projects.Yumney_Api>("yumney-api")
     .WithReference(keycloak)
     .WithReference(yumneyDb)
     .WithReference(redis)
+    .WithReference(ollama)
     .WaitFor(keycloak)
     .WaitFor(yumneyDb)
-    .WaitFor(redis);
+    .WaitFor(redis)
+    .WaitFor(ollama);
 
 builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
     .WithReference(yumneyApi)

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Aspire.Hosting.Keycloak" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.Redis" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" />
   </ItemGroup>
 
 </Project>

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -17,7 +17,14 @@ public static class RecipesEndpoints
         var group = app.MapGroup("/recipes");
 
         group.MapPost("/import", ImportAsync)
-            .WithName("ImportRecipe");
+            .WithName("ImportRecipe")
+            .WithTags("Recipes")
+            .Produces<ExtractedRecipeDto>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
+            .ProducesProblem(StatusCodes.Status502BadGateway)
+            .ProducesProblem(StatusCodes.Status504GatewayTimeout);
 
         return app;
     }

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -50,16 +50,11 @@ public static class RecipesEndpoints
         {
             return result.Error switch
             {
-                ImportRecipeErrors.PageUnreachable =>
-                    Results.Problem("Could not reach the website.", statusCode: 502),
-                ImportRecipeErrors.ScrapeTimeout =>
-                    Results.Problem("Extraction timed out.", statusCode: 504),
-                ImportRecipeErrors.NoRecipeFound =>
-                    Results.Problem("No recipe found on this page.", statusCode: 404),
-                ImportRecipeErrors.ExtractionFailed =>
-                    Results.Problem("Recipe extraction failed.", statusCode: 500),
-                _ =>
-                    Results.Problem("Failed to import recipe.", statusCode: 500),
+                ImportRecipeErrors.PageUnreachable => Results.Problem("Could not reach the website.", statusCode: 502),
+                ImportRecipeErrors.ScrapeTimeout => Results.Problem("Extraction timed out.", statusCode: 504),
+                ImportRecipeErrors.NoRecipeFound => Results.Problem("No recipe found on this page.", statusCode: 404),
+                ImportRecipeErrors.ExtractionFailed => Results.Problem("Recipe extraction failed.", statusCode: 500),
+                _ => Results.Problem("Failed to import recipe.", statusCode: 500),
             };
         }
 

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
 using Yumney.Recipes.Domain.Recipe;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
@@ -24,7 +25,7 @@ public static class RecipesEndpoints
     private static async Task<IResult> ImportAsync(
         ImportRecipeRequest request,
         IValidator<ImportRecipeRequest> validator,
-        ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>> handler,
+        ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>> handler,
         CancellationToken cancellationToken)
     {
         var validationResult = await validator.ValidateAsync(request, cancellationToken);
@@ -42,8 +43,14 @@ public static class RecipesEndpoints
         {
             return result.Error switch
             {
-                ImportRecipeErrors.InvalidUrl =>
-                    Results.Problem("The provided URL is not valid.", statusCode: 400),
+                ImportRecipeErrors.PageUnreachable =>
+                    Results.Problem("Could not reach the website.", statusCode: 502),
+                ImportRecipeErrors.ScrapeTimeout =>
+                    Results.Problem("Extraction timed out.", statusCode: 504),
+                ImportRecipeErrors.NoRecipeFound =>
+                    Results.Problem("No recipe found on this page.", statusCode: 404),
+                ImportRecipeErrors.ExtractionFailed =>
+                    Results.Problem("Recipe extraction failed.", statusCode: 500),
                 _ =>
                     Results.Problem("Failed to import recipe.", statusCode: 500),
             };

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
@@ -1,9 +1,9 @@
+using Yumney.Recipes.Application.DTOs;
 using Yumney.Recipes.Domain.Recipe;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
 
 namespace Yumney.Recipes.Application.Commands;
 
-public sealed record ImportRecipeCommand(RecipeUrl Url) : ICommand<Result<ImportRecipeResultDto>>;
-
-public sealed record ImportRecipeResultDto(string Message);
+public sealed record ImportRecipeCommand(RecipeUrl Url)
+    : ICommand<Result<ExtractedRecipeDto>>;

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
@@ -7,15 +7,10 @@ using Yumney.Shared.CQRS;
 namespace Yumney.Recipes.Application.Commands;
 
 #pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
-public sealed partial class ImportRecipeCommandHandler(
-    IWebScraper scraper,
-    IRecipeExtractionService extraction,
-    ILogger<ImportRecipeCommandHandler> logger)
+public sealed partial class ImportRecipeCommandHandler(IWebScraper scraper, IRecipeExtractionService extraction, ILogger<ImportRecipeCommandHandler> logger)
     : ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>
 {
-    public async Task<Result<ExtractedRecipeDto>> HandleAsync(
-        ImportRecipeCommand command,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<ExtractedRecipeDto>> HandleAsync(ImportRecipeCommand command, CancellationToken cancellationToken = default)
     {
         var url = command.Url;
         LogImportAttempt(url.Value);
@@ -38,19 +33,15 @@ public sealed partial class ImportRecipeCommandHandler(
         return extractResult;
     }
 
-    [LoggerMessage(Level = LogLevel.Information,
-        Message = "Recipe import requested for URL {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe import requested for URL {SourceUrl}")]
     private partial void LogImportAttempt(string sourceUrl);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "Scraping failed for URL {SourceUrl}: {Error}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Scraping failed for URL {SourceUrl}: {Error}")]
     private partial void LogScrapeFailed(string sourceUrl, string error);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "Extraction failed for URL {SourceUrl}: {Error}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Extraction failed for URL {SourceUrl}: {Error}")]
     private partial void LogExtractionFailed(string sourceUrl, string error);
 
-    [LoggerMessage(Level = LogLevel.Information,
-        Message = "Recipe '{Title}' extracted from {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe '{Title}' extracted from {SourceUrl}")]
     private partial void LogImportSuccess(string sourceUrl, string title);
 }

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommandHandler.cs
@@ -1,27 +1,56 @@
 using Microsoft.Extensions.Logging;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Interfaces;
 using Yumney.Shared.Common;
 using Yumney.Shared.CQRS;
 
 namespace Yumney.Recipes.Application.Commands;
 
 #pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
-public sealed partial class ImportRecipeCommandHandler(ILogger<ImportRecipeCommandHandler> logger)
-    : ICommandHandler<ImportRecipeCommand, Result<ImportRecipeResultDto>>
+public sealed partial class ImportRecipeCommandHandler(
+    IWebScraper scraper,
+    IRecipeExtractionService extraction,
+    ILogger<ImportRecipeCommandHandler> logger)
+    : ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>
 {
-    public Task<Result<ImportRecipeResultDto>> HandleAsync(
+    public async Task<Result<ExtractedRecipeDto>> HandleAsync(
         ImportRecipeCommand command,
         CancellationToken cancellationToken = default)
     {
         var url = command.Url;
-
         LogImportAttempt(url.Value);
 
-        var result = Result<ImportRecipeResultDto>.Success(
-            new ImportRecipeResultDto("Recipe URL accepted. Extraction will be available in a future release."));
+        var scrapeResult = await scraper.ScrapeAsync(url, cancellationToken);
+        if (scrapeResult.IsFailure)
+        {
+            LogScrapeFailed(url.Value, scrapeResult.Error!);
+            return Result<ExtractedRecipeDto>.Failure(scrapeResult.Error!);
+        }
 
-        return Task.FromResult(result);
+        var extractResult = await extraction.ExtractAsync(scrapeResult.Value, cancellationToken);
+        if (extractResult.IsFailure)
+        {
+            LogExtractionFailed(url.Value, extractResult.Error!);
+            return Result<ExtractedRecipeDto>.Failure(extractResult.Error!);
+        }
+
+        LogImportSuccess(url.Value, extractResult.Value.Title);
+        return extractResult;
     }
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe import requested for URL {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Recipe import requested for URL {SourceUrl}")]
     private partial void LogImportAttempt(string sourceUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Scraping failed for URL {SourceUrl}: {Error}")]
+    private partial void LogScrapeFailed(string sourceUrl, string error);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Extraction failed for URL {SourceUrl}: {Error}")]
+    private partial void LogExtractionFailed(string sourceUrl, string error);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Recipe '{Title}' extracted from {SourceUrl}")]
+    private partial void LogImportSuccess(string sourceUrl, string title);
 }

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeErrors.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeErrors.cs
@@ -2,5 +2,8 @@ namespace Yumney.Recipes.Application.Commands;
 
 public static class ImportRecipeErrors
 {
-    public const string InvalidUrl = "IMPORT_INVALID_URL";
+    public const string PageUnreachable = "IMPORT_PAGE_UNREACHABLE";
+    public const string ScrapeTimeout = "IMPORT_SCRAPE_TIMEOUT";
+    public const string NoRecipeFound = "IMPORT_NO_RECIPE_FOUND";
+    public const string ExtractionFailed = "IMPORT_EXTRACTION_FAILED";
 }

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeRequestValidator.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeRequestValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Yumney.Recipes.Domain.Recipe;
 
 namespace Yumney.Recipes.Application.Commands;
 
@@ -8,7 +9,7 @@ public sealed class ImportRecipeRequestValidator : AbstractValidator<ImportRecip
     {
         RuleFor(x => x.Url)
             .NotEmpty()
-            .MaximumLength(2048)
+            .MaximumLength(RecipeUrl.MaxLength)
             .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var uri)
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
             .WithMessage("A valid HTTP or HTTPS URL is required.");

--- a/src/Yumney.Recipes.Application/DTOs/ExtractedIngredientDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ExtractedIngredientDto.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Recipes.Application.DTOs;
+
+public sealed record ExtractedIngredientDto(string Name, decimal? Amount, string? Unit);

--- a/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
@@ -1,0 +1,26 @@
+namespace Yumney.Recipes.Application.DTOs;
+
+public sealed record ExtractedRecipeDto
+{
+    public required string Title { get; init; }
+
+    public string? Description { get; init; }
+
+    public required IReadOnlyList<ExtractedIngredientDto> Ingredients { get; init; }
+
+    public required IReadOnlyList<ExtractedStepDto> Steps { get; init; }
+
+    public int? Servings { get; init; }
+
+    public int? PrepTimeMinutes { get; init; }
+
+    public int? CookTimeMinutes { get; init; }
+
+    public string? Difficulty { get; init; }
+
+    public string? ImageUrl { get; init; }
+}
+
+public sealed record ExtractedIngredientDto(string Name, decimal? Amount, string? Unit);
+
+public sealed record ExtractedStepDto(int Number, string Description);

--- a/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
@@ -1,26 +1,12 @@
 namespace Yumney.Recipes.Application.DTOs;
 
-public sealed record ExtractedRecipeDto
-{
-    public required string Title { get; init; }
-
-    public string? Description { get; init; }
-
-    public required IReadOnlyList<ExtractedIngredientDto> Ingredients { get; init; }
-
-    public required IReadOnlyList<ExtractedStepDto> Steps { get; init; }
-
-    public int? Servings { get; init; }
-
-    public int? PrepTimeMinutes { get; init; }
-
-    public int? CookTimeMinutes { get; init; }
-
-    public string? Difficulty { get; init; }
-
-    public string? ImageUrl { get; init; }
-}
-
-public sealed record ExtractedIngredientDto(string Name, decimal? Amount, string? Unit);
-
-public sealed record ExtractedStepDto(int Number, string Description);
+public sealed record ExtractedRecipeDto(
+    string Title,
+    IReadOnlyList<ExtractedIngredientDto> Ingredients,
+    IReadOnlyList<ExtractedStepDto> Steps,
+    string? Description = null,
+    int? Servings = null,
+    int? PrepTimeMinutes = null,
+    int? CookTimeMinutes = null,
+    string? Difficulty = null,
+    string? ImageUrl = null);

--- a/src/Yumney.Recipes.Application/DTOs/ExtractedStepDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ExtractedStepDto.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Recipes.Application.DTOs;
+
+public sealed record ExtractedStepDto(int Number, string Description);

--- a/src/Yumney.Recipes.Application/DTOs/ScrapedContent.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ScrapedContent.cs
@@ -1,0 +1,3 @@
+namespace Yumney.Recipes.Application.DTOs;
+
+public sealed record ScrapedContent(string CleanedText, string SourceUrl);

--- a/src/Yumney.Recipes.Application/Interfaces/IRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IRecipeExtractionService.cs
@@ -1,5 +1,9 @@
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Shared.Common;
+
 namespace Yumney.Recipes.Application.Interfaces;
 
 public interface IRecipeExtractionService
 {
+    Task<Result<ExtractedRecipeDto>> ExtractAsync(ScrapedContent content, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Recipes.Application/Interfaces/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IRecipeRepository.cs
@@ -1,5 +1,0 @@
-namespace Yumney.Recipes.Application.Interfaces;
-
-public interface IRecipeRepository
-{
-}

--- a/src/Yumney.Recipes.Application/Interfaces/IWebScraper.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IWebScraper.cs
@@ -1,5 +1,10 @@
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+
 namespace Yumney.Recipes.Application.Interfaces;
 
 public interface IWebScraper
 {
+    Task<Result<ScrapedContent>> ScrapeAsync(RecipeUrl url, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
@@ -1,0 +1,5 @@
+namespace Yumney.Recipes.Domain.Recipe;
+
+public interface IRecipeRepository
+{
+}

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
@@ -4,13 +4,15 @@ namespace Yumney.Recipes.Domain.Recipe;
 
 public sealed record RecipeUrl
 {
+    public const int MaxLength = 2048;
+
     public string Value { get; }
 
     public RecipeUrl(string value)
     {
         string validated = Ensure.That(value)
             .IsNotNullOrWhiteSpace()
-            .HasMaxLength(2048)
+            .HasMaxLength(MaxLength)
             .IsValidUrl()
             .AndReturn();
         Value = validated.Trim();

--- a/src/Yumney.Recipes.Infrastructure/Placeholder.cs
+++ b/src/Yumney.Recipes.Infrastructure/Placeholder.cs
@@ -1,3 +1,0 @@
-namespace Yumney.Recipes.Infrastructure;
-
-// Placeholder — EF Core, Semantic Kernel, and web scraping implementations will be added in feat/US-004

--- a/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
@@ -11,13 +11,16 @@ using Yumney.Shared.Common;
 namespace Yumney.Recipes.Infrastructure.Services;
 
 #pragma warning disable SA1601
-#pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
-public sealed partial class SemanticKernelRecipeExtractionService(
-    Kernel kernel,
-    ILogger<SemanticKernelRecipeExtractionService> logger)
+#pragma warning disable SA1311
+public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel, ILogger<SemanticKernelRecipeExtractionService> logger)
     : IRecipeExtractionService
 {
-    private const string SystemPrompt = """
+    private const string LlmNoRecipeErrorCode = "NO_RECIPE_FOUND";
+    private const string ErrorPropertyName = "error";
+    private const string JsonFencePrefix = "```json";
+    private const string FenceMarker = "```";
+
+    private const string SystemPrompt = $$"""
         You are a recipe extraction assistant. Extract structured recipe data
         from the provided webpage content. Respond ONLY with valid JSON matching this schema:
         {
@@ -31,7 +34,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(
           "difficulty": "easy" | "medium" | "hard" or null,
           "imageUrl": "string or null"
         }
-        If the content does not contain a recipe, respond with: { "error": "NO_RECIPE_FOUND" }
+        If the content does not contain a recipe, respond with: { "{{ErrorPropertyName}}": "{{LlmNoRecipeErrorCode}}" }
         """;
 
     private static readonly JsonSerializerOptions jsonOptions = new()
@@ -40,8 +43,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    public async Task<Result<ExtractedRecipeDto>> ExtractAsync(
-        ScrapedContent content, CancellationToken cancellationToken = default)
+    public async Task<Result<ExtractedRecipeDto>> ExtractAsync(ScrapedContent content, CancellationToken cancellationToken = default)
     {
         var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
 
@@ -52,8 +54,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(
         string response;
         try
         {
-            var result = await chatCompletion.GetChatMessageContentAsync(
-                chatHistory, cancellationToken: cancellationToken);
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
             response = result.Content ?? string.Empty;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -73,18 +74,18 @@ public sealed partial class SemanticKernelRecipeExtractionService(
     {
         var trimmed = response.Trim();
 
-        if (trimmed.StartsWith("```json", StringComparison.OrdinalIgnoreCase))
+        if (trimmed.StartsWith(JsonFencePrefix, StringComparison.OrdinalIgnoreCase))
         {
-            trimmed = trimmed["```json".Length..];
+            trimmed = trimmed[JsonFencePrefix.Length..];
         }
-        else if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        else if (trimmed.StartsWith(FenceMarker, StringComparison.Ordinal))
         {
-            trimmed = trimmed["```".Length..];
+            trimmed = trimmed[FenceMarker.Length..];
         }
 
-        if (trimmed.EndsWith("```", StringComparison.Ordinal))
+        if (trimmed.EndsWith(FenceMarker, StringComparison.Ordinal))
         {
-            trimmed = trimmed[..^"```".Length];
+            trimmed = trimmed[..^FenceMarker.Length];
         }
 
         return trimmed.Trim();
@@ -99,14 +100,14 @@ public sealed partial class SemanticKernelRecipeExtractionService(
             using var document = JsonDocument.Parse(json);
             var root = document.RootElement;
 
-            if (root.TryGetProperty("error", out var errorElement)
-                && errorElement.GetString() == "NO_RECIPE_FOUND")
+            if (root.TryGetProperty(ErrorPropertyName, out var errorElement)
+                && errorElement.GetString() == LlmNoRecipeErrorCode)
             {
                 LogNoRecipeFound(sourceUrl);
                 return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.NoRecipeFound);
             }
 
-            var recipe = JsonSerializer.Deserialize<ExtractedRecipeDto>(json, jsonOptions);
+            var recipe = root.Deserialize<ExtractedRecipeDto>(jsonOptions);
             if (recipe is null)
             {
                 LogParsingFailed(sourceUrl, "Deserialization returned null");
@@ -122,15 +123,12 @@ public sealed partial class SemanticKernelRecipeExtractionService(
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "LLM call failed for URL {SourceUrl}: {Reason}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "LLM call failed for URL {SourceUrl}: {Reason}")]
     private partial void LogLlmCallFailed(string sourceUrl, string reason);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "No recipe found in content from URL {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No recipe found in content from URL {SourceUrl}")]
     private partial void LogNoRecipeFound(string sourceUrl);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "Failed to parse LLM response for URL {SourceUrl}: {Reason}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse LLM response for URL {SourceUrl}: {Reason}")]
     private partial void LogParsingFailed(string sourceUrl, string reason);
 }

--- a/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Interfaces;
+using Yumney.Shared.Common;
+
+namespace Yumney.Recipes.Infrastructure.Services;
+
+#pragma warning disable SA1601
+#pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
+public sealed partial class SemanticKernelRecipeExtractionService(
+    Kernel kernel,
+    ILogger<SemanticKernelRecipeExtractionService> logger)
+    : IRecipeExtractionService
+{
+    private const string SystemPrompt = """
+        You are a recipe extraction assistant. Extract structured recipe data
+        from the provided webpage content. Respond ONLY with valid JSON matching this schema:
+        {
+          "title": "string (required)",
+          "description": "string or null",
+          "ingredients": [{ "name": "string", "amount": number or null, "unit": "string or null" }],
+          "steps": [{ "number": integer, "description": "string" }],
+          "servings": integer or null,
+          "prepTimeMinutes": integer or null,
+          "cookTimeMinutes": integer or null,
+          "difficulty": "easy" | "medium" | "hard" or null,
+          "imageUrl": "string or null"
+        }
+        If the content does not contain a recipe, respond with: { "error": "NO_RECIPE_FOUND" }
+        """;
+
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public async Task<Result<ExtractedRecipeDto>> ExtractAsync(
+        ScrapedContent content, CancellationToken cancellationToken = default)
+    {
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage(SystemPrompt);
+        chatHistory.AddUserMessage(content.CleanedText);
+
+        string response;
+        try
+        {
+            var result = await chatCompletion.GetChatMessageContentAsync(
+                chatHistory, cancellationToken: cancellationToken);
+            response = result.Content ?? string.Empty;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogLlmCallFailed(content.SourceUrl, ex.Message);
+            return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
+        }
+
+        return ParseResponse(response, content.SourceUrl);
+    }
+
+    private static string ExtractJson(string response)
+    {
+        var trimmed = response.Trim();
+
+        if (trimmed.StartsWith("```json", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed["```json".Length..];
+        }
+        else if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            trimmed = trimmed["```".Length..];
+        }
+
+        if (trimmed.EndsWith("```", StringComparison.Ordinal))
+        {
+            trimmed = trimmed[..^"```".Length];
+        }
+
+        return trimmed.Trim();
+    }
+
+    private Result<ExtractedRecipeDto> ParseResponse(string response, string sourceUrl)
+    {
+        try
+        {
+            var json = ExtractJson(response);
+
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+
+            if (root.TryGetProperty("error", out var errorElement)
+                && errorElement.GetString() == "NO_RECIPE_FOUND")
+            {
+                LogNoRecipeFound(sourceUrl);
+                return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.NoRecipeFound);
+            }
+
+            var recipe = JsonSerializer.Deserialize<ExtractedRecipeDto>(json, jsonOptions);
+            if (recipe is null)
+            {
+                LogParsingFailed(sourceUrl, "Deserialization returned null");
+                return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
+            }
+
+            return Result<ExtractedRecipeDto>.Success(recipe);
+        }
+        catch (JsonException ex)
+        {
+            LogParsingFailed(sourceUrl, ex.Message);
+            return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "LLM call failed for URL {SourceUrl}: {Reason}")]
+    private partial void LogLlmCallFailed(string sourceUrl, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "No recipe found in content from URL {SourceUrl}")]
+    private partial void LogNoRecipeFound(string sourceUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Failed to parse LLM response for URL {SourceUrl}: {Reason}")]
+    private partial void LogParsingFailed(string sourceUrl, string reason);
+}

--- a/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/SemanticKernelRecipeExtractionService.cs
@@ -11,16 +11,17 @@ using Yumney.Shared.Common;
 namespace Yumney.Recipes.Infrastructure.Services;
 
 #pragma warning disable SA1601
+#pragma warning disable SA1303
 #pragma warning disable SA1311
 public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel, ILogger<SemanticKernelRecipeExtractionService> logger)
     : IRecipeExtractionService
 {
-    private const string LlmNoRecipeErrorCode = "NO_RECIPE_FOUND";
-    private const string ErrorPropertyName = "error";
-    private const string JsonFencePrefix = "```json";
-    private const string FenceMarker = "```";
+    private const string llmNoRecipeErrorCode = "NO_RECIPE_FOUND";
+    private const string errorPropertyName = "error";
+    private const string jsonFencePrefix = "```json";
+    private const string fenceMarker = "```";
 
-    private const string SystemPrompt = $$"""
+    private const string systemPrompt = $$"""
         You are a recipe extraction assistant. Extract structured recipe data
         from the provided webpage content. Respond ONLY with valid JSON matching this schema:
         {
@@ -34,7 +35,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
           "difficulty": "easy" | "medium" | "hard" or null,
           "imageUrl": "string or null"
         }
-        If the content does not contain a recipe, respond with: { "{{ErrorPropertyName}}": "{{LlmNoRecipeErrorCode}}" }
+        If the content does not contain a recipe, respond with: { "{{errorPropertyName}}": "{{llmNoRecipeErrorCode}}" }
         """;
 
     private static readonly JsonSerializerOptions jsonOptions = new()
@@ -48,7 +49,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
         var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
 
         var chatHistory = new ChatHistory();
-        chatHistory.AddSystemMessage(SystemPrompt);
+        chatHistory.AddSystemMessage(systemPrompt);
         chatHistory.AddUserMessage(content.CleanedText);
 
         string response;
@@ -74,18 +75,18 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
     {
         var trimmed = response.Trim();
 
-        if (trimmed.StartsWith(JsonFencePrefix, StringComparison.OrdinalIgnoreCase))
+        if (trimmed.StartsWith(jsonFencePrefix, StringComparison.OrdinalIgnoreCase))
         {
-            trimmed = trimmed[JsonFencePrefix.Length..];
+            trimmed = trimmed[jsonFencePrefix.Length..];
         }
-        else if (trimmed.StartsWith(FenceMarker, StringComparison.Ordinal))
+        else if (trimmed.StartsWith(fenceMarker, StringComparison.Ordinal))
         {
-            trimmed = trimmed[FenceMarker.Length..];
+            trimmed = trimmed[fenceMarker.Length..];
         }
 
-        if (trimmed.EndsWith(FenceMarker, StringComparison.Ordinal))
+        if (trimmed.EndsWith(fenceMarker, StringComparison.Ordinal))
         {
-            trimmed = trimmed[..^FenceMarker.Length];
+            trimmed = trimmed[..^fenceMarker.Length];
         }
 
         return trimmed.Trim();
@@ -100,8 +101,8 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
             using var document = JsonDocument.Parse(json);
             var root = document.RootElement;
 
-            if (root.TryGetProperty(ErrorPropertyName, out var errorElement)
-                && errorElement.GetString() == LlmNoRecipeErrorCode)
+            if (root.TryGetProperty(errorPropertyName, out var errorElement)
+                && errorElement.GetString() == llmNoRecipeErrorCode)
             {
                 LogNoRecipeFound(sourceUrl);
                 return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.NoRecipeFound);

--- a/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
@@ -1,0 +1,81 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using Microsoft.Extensions.Logging;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Interfaces;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+
+namespace Yumney.Recipes.Infrastructure.Services;
+
+#pragma warning disable SA1601
+#pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
+public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper> logger)
+    : IWebScraper
+{
+    private static readonly string[] tagsToRemove =
+        ["script", "style", "nav", "footer", "header", "aside", "iframe", "noscript"];
+
+    public async Task<Result<ScrapedContent>> ScrapeAsync(RecipeUrl url, CancellationToken cancellationToken = default)
+    {
+        string html;
+        try
+        {
+            html = await httpClient.GetStringAsync(url.Value, cancellationToken);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            LogScrapeTimeout(url.Value);
+            return Result<ScrapedContent>.Failure(ImportRecipeErrors.ScrapeTimeout);
+        }
+        catch (HttpRequestException ex)
+        {
+            LogPageUnreachable(url.Value, ex.Message);
+            return Result<ScrapedContent>.Failure(ImportRecipeErrors.PageUnreachable);
+        }
+
+        var cleanedText = await CleanHtmlAsync(html, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(cleanedText))
+        {
+            LogEmptyContent(url.Value);
+            return Result<ScrapedContent>.Failure(ImportRecipeErrors.NoRecipeFound);
+        }
+
+        return Result<ScrapedContent>.Success(new ScrapedContent(cleanedText, url.Value));
+    }
+
+    private static async Task<string> CleanHtmlAsync(string html, CancellationToken cancellationToken)
+    {
+        var config = Configuration.Default;
+        using var context = BrowsingContext.New(config);
+        using var document = await context.OpenAsync(req => req.Content(html), cancellationToken);
+
+        foreach (var tag in tagsToRemove)
+        {
+            foreach (var element in document.QuerySelectorAll(tag).ToList())
+            {
+                element.Remove();
+            }
+        }
+
+        var contentElement = document.QuerySelector("main")
+            ?? document.QuerySelector("article")
+            ?? document.QuerySelector("body");
+
+        return contentElement?.TextContent.Trim() ?? string.Empty;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Scrape timed out for URL {SourceUrl}")]
+    private partial void LogScrapeTimeout(string sourceUrl);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Page unreachable at URL {SourceUrl}: {Reason}")]
+    private partial void LogPageUnreachable(string sourceUrl, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "No content extracted from URL {SourceUrl}")]
+    private partial void LogEmptyContent(string sourceUrl);
+}

--- a/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
@@ -1,5 +1,4 @@
 using AngleSharp;
-using AngleSharp.Dom;
 using Microsoft.Extensions.Logging;
 using Yumney.Recipes.Application.Commands;
 using Yumney.Recipes.Application.DTOs;
@@ -10,12 +9,10 @@ using Yumney.Shared.Common;
 namespace Yumney.Recipes.Infrastructure.Services;
 
 #pragma warning disable SA1601
-#pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
 public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper> logger)
     : IWebScraper
 {
-    private static readonly string[] tagsToRemove =
-        ["script", "style", "nav", "footer", "header", "aside", "iframe", "noscript"];
+    private const string RemoveSelector = "script, style, nav, footer, header, aside, iframe, noscript";
 
     public async Task<Result<ScrapedContent>> ScrapeAsync(RecipeUrl url, CancellationToken cancellationToken = default)
     {
@@ -52,12 +49,9 @@ public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper
         using var context = BrowsingContext.New(config);
         using var document = await context.OpenAsync(req => req.Content(html), cancellationToken);
 
-        foreach (var tag in tagsToRemove)
+        foreach (var element in document.QuerySelectorAll(RemoveSelector).ToList())
         {
-            foreach (var element in document.QuerySelectorAll(tag).ToList())
-            {
-                element.Remove();
-            }
+            element.Remove();
         }
 
         var contentElement = document.QuerySelector("main")
@@ -67,15 +61,12 @@ public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper
         return contentElement?.TextContent.Trim() ?? string.Empty;
     }
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "Scrape timed out for URL {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Scrape timed out for URL {SourceUrl}")]
     private partial void LogScrapeTimeout(string sourceUrl);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "Page unreachable at URL {SourceUrl}: {Reason}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Page unreachable at URL {SourceUrl}: {Reason}")]
     private partial void LogPageUnreachable(string sourceUrl, string reason);
 
-    [LoggerMessage(Level = LogLevel.Warning,
-        Message = "No content extracted from URL {SourceUrl}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No content extracted from URL {SourceUrl}")]
     private partial void LogEmptyContent(string sourceUrl);
 }

--- a/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/WebScraper.cs
@@ -9,10 +9,11 @@ using Yumney.Shared.Common;
 namespace Yumney.Recipes.Infrastructure.Services;
 
 #pragma warning disable SA1601
+#pragma warning disable SA1303
 public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper> logger)
     : IWebScraper
 {
-    private const string RemoveSelector = "script, style, nav, footer, header, aside, iframe, noscript";
+    private const string removeSelector = "script, style, nav, footer, header, aside, iframe, noscript";
 
     public async Task<Result<ScrapedContent>> ScrapeAsync(RecipeUrl url, CancellationToken cancellationToken = default)
     {
@@ -49,7 +50,7 @@ public sealed partial class WebScraper(HttpClient httpClient, ILogger<WebScraper
         using var context = BrowsingContext.New(config);
         using var document = await context.OpenAsync(req => req.Content(html), cancellationToken);
 
-        foreach (var element in document.QuerySelectorAll(RemoveSelector).ToList())
+        foreach (var element in document.QuerySelectorAll(removeSelector).ToList())
         {
             element.Remove();
         }

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListRepository.cs
@@ -1,5 +1,0 @@
-namespace Yumney.Shopping.Application.Interfaces;
-
-public interface IShoppingListRepository
-{
-}

--- a/src/Yumney.Shopping.Domain/IShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Domain/IShoppingListRepository.cs
@@ -1,0 +1,5 @@
+namespace Yumney.Shopping.Domain;
+
+public interface IShoppingListRepository
+{
+}

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -5,17 +5,9 @@ namespace Yumney.Users.Application.Interfaces;
 
 public interface IKeycloakAdminService
 {
-    Task<Result<KeycloakUserId>> CreateUserAsync(
-        Email email,
-        Password password,
-        DisplayName displayName,
-        CancellationToken cancellationToken = default);
+    Task<Result<KeycloakUserId>> CreateUserAsync(Email email, Password password, DisplayName displayName, CancellationToken cancellationToken = default);
 
-    Task<Result<KeycloakUserId>> FindUserByEmailAsync(
-        Email email,
-        CancellationToken cancellationToken = default);
+    Task<Result<KeycloakUserId>> FindUserByEmailAsync(Email email, CancellationToken cancellationToken = default);
 
-    Task<Result> SendVerificationEmailAsync(
-        KeycloakUserId keycloakUserId,
-        CancellationToken cancellationToken = default);
+    Task<Result> SendVerificationEmailAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
@@ -1,6 +1,4 @@
-using Yumney.Users.Domain.AppUserProfile;
-
-namespace Yumney.Users.Application.Interfaces;
+namespace Yumney.Users.Domain.AppUserProfile;
 
 public interface IAppUserProfileRepository
 {

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Yumney.Users.Application.Interfaces;
 using Yumney.Users.Domain.AppUserProfile;
 
 namespace Yumney.Users.Infrastructure.Persistence;

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Yumney.Shared.Common;
 using Yumney.Users.Application.Commands;
 using Yumney.Users.Application.Interfaces;
@@ -12,7 +13,10 @@ using Yumney.Users.Domain.AppUserProfile;
 namespace Yumney.Users.Infrastructure.Services;
 
 #pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
-public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<KeycloakAdminService> logger)
+public sealed class KeycloakAdminService(
+    HttpClient httpClient,
+    IOptions<KeycloakOptions> options,
+    ILogger<KeycloakAdminService> logger)
     : IKeycloakAdminService
 {
     private static readonly JsonSerializerOptions jsonOptions = new()
@@ -38,9 +42,7 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         return await CreateKeycloakUserAsync(email, password, displayName, token.Value, cancellationToken);
     }
 
-    public async Task<Result<KeycloakUserId>> FindUserByEmailAsync(
-        Email email,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<KeycloakUserId>> FindUserByEmailAsync(Email email, CancellationToken cancellationToken = default)
     {
         var token = await GetServiceAccountTokenAsync(cancellationToken);
         if (token.IsFailure)
@@ -49,8 +51,9 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         }
 
         var encodedEmail = Uri.EscapeDataString(email.Value);
+        var url = $"/admin/realms/{options.Value.Realm}/users?email={encodedEmail}&exact=true";
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/realms/yumney/users?email={encodedEmail}&exact=true");
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
 
         try
@@ -79,9 +82,7 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         }
     }
 
-    public async Task<Result> SendVerificationEmailAsync(
-        KeycloakUserId keycloakUserId,
-        CancellationToken cancellationToken = default)
+    public async Task<Result> SendVerificationEmailAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
     {
         var token = await GetServiceAccountTokenAsync(cancellationToken);
         if (token.IsFailure)
@@ -89,7 +90,9 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
             return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
         }
 
-        using var request = new HttpRequestMessage(HttpMethod.Put, $"/admin/realms/yumney/users/{keycloakUserId.Value}/execute-actions-email");
+        var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}/execute-actions-email";
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
         request.Content = JsonContent.Create(verifyEmailActions, options: jsonOptions);
 
@@ -118,13 +121,14 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["grant_type"] = "client_credentials",
-            ["client_id"] = "yumney-api",
-            ["client_secret"] = "yumney-api-secret",
+            ["client_id"] = options.Value.ClientId,
+            ["client_secret"] = options.Value.ClientSecret,
         });
 
         try
         {
-            var response = await httpClient.PostAsync("/realms/yumney/protocol/openid-connect/token", content, cancellationToken);
+            var tokenUrl = $"/realms/{options.Value.Realm}/protocol/openid-connect/token";
+            var response = await httpClient.PostAsync(tokenUrl, content, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -169,7 +173,9 @@ public sealed class KeycloakAdminService(HttpClient httpClient, ILogger<Keycloak
             },
         };
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/admin/realms/yumney/users");
+        var url = $"/admin/realms/{options.Value.Realm}/users";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         request.Content = JsonContent.Create(userPayload, options: jsonOptions);
 

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakOptions.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakOptions.cs
@@ -1,0 +1,12 @@
+namespace Yumney.Users.Infrastructure.Services;
+
+public sealed class KeycloakOptions
+{
+    public const string SectionName = "Keycloak";
+
+    public string Realm { get; init; } = "yumney";
+
+    public string ClientId { get; init; } = "yumney-api";
+
+    public string ClientSecret { get; init; } = string.Empty;
+}

--- a/tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj
+++ b/tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj
@@ -24,8 +24,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NetArchTest.Rules" />
   </ItemGroup>

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
@@ -14,8 +14,7 @@ public class ImportRecipeCommandHandlerTests
 {
     private readonly IWebScraper scraper = Substitute.For<IWebScraper>();
     private readonly IRecipeExtractionService extraction = Substitute.For<IRecipeExtractionService>();
-    private readonly ILogger<ImportRecipeCommandHandler> logger =
-        Substitute.For<ILogger<ImportRecipeCommandHandler>>();
+    private readonly ILogger<ImportRecipeCommandHandler> logger = Substitute.For<ILogger<ImportRecipeCommandHandler>>();
 
     [Fact]
     public async Task HandleAsync_ValidUrl_ReturnsExtractedRecipe()
@@ -178,12 +177,7 @@ public class ImportRecipeCommandHandlerTests
     {
         var url = new RecipeUrl("https://example.com/recipe");
         var scrapedContent = new ScrapedContent("Content", url.Value);
-        var minimalRecipe = new ExtractedRecipeDto
-        {
-            Title = "Simple Dish",
-            Ingredients = [],
-            Steps = [],
-        };
+        var minimalRecipe = new ExtractedRecipeDto("Simple Dish", [], []);
 
         scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
             .Returns(Result<ScrapedContent>.Success(scrapedContent));
@@ -207,8 +201,7 @@ public class ImportRecipeCommandHandlerTests
         await cts.CancelAsync();
 
         scraper.ScrapeAsync(url, cts.Token)
-            .Returns<Result<ScrapedContent>>(
-                _ => throw new OperationCanceledException(cts.Token));
+            .Returns<Result<ScrapedContent>>(_ => throw new OperationCanceledException(cts.Token));
 
         var sut = CreateSut();
         var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
@@ -228,8 +221,7 @@ public class ImportRecipeCommandHandlerTests
         scraper.ScrapeAsync(url, cts.Token)
             .Returns(Result<ScrapedContent>.Success(scrapedContent));
         extraction.ExtractAsync(scrapedContent, cts.Token)
-            .Returns<Result<ExtractedRecipeDto>>(
-                _ => throw new OperationCanceledException(cts.Token));
+            .Returns<Result<ExtractedRecipeDto>>(_ => throw new OperationCanceledException(cts.Token));
 
         var sut = CreateSut();
         var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
@@ -238,13 +230,7 @@ public class ImportRecipeCommandHandlerTests
     }
 
     private static ExtractedRecipeDto CreateExtractedRecipe(string title = "Test Recipe") =>
-        new()
-        {
-            Title = title,
-            Ingredients = [new ExtractedIngredientDto("Flour", 500, "g")],
-            Steps = [new ExtractedStepDto(1, "Mix ingredients")],
-            Servings = 4,
-        };
+        new(title, [new ExtractedIngredientDto("Flour", 500, "g")], [new ExtractedStepDto(1, "Mix ingredients")], Servings: 4);
 
     private ImportRecipeCommandHandler CreateSut() => new(scraper, extraction, logger);
 }

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
@@ -3,48 +3,248 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Interfaces;
 using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
 
 namespace Yumney.Recipes.Application.Tests.Commands;
 
 public class ImportRecipeCommandHandlerTests
 {
+    private readonly IWebScraper scraper = Substitute.For<IWebScraper>();
+    private readonly IRecipeExtractionService extraction = Substitute.For<IRecipeExtractionService>();
     private readonly ILogger<ImportRecipeCommandHandler> logger =
         Substitute.For<ILogger<ImportRecipeCommandHandler>>();
 
     [Fact]
-    public async Task HandleAsync_ValidCommand_ReturnsSuccess()
+    public async Task HandleAsync_ValidUrl_ReturnsExtractedRecipe()
     {
-        var sut = new ImportRecipeCommandHandler(logger);
-        var command = new ImportRecipeCommand(
-            new RecipeUrl("https://example.com/recipe"));
+        var url = new RecipeUrl("https://example.com/recipe");
+        var scrapedContent = new ScrapedContent("Recipe content", url.Value);
+        var expectedRecipe = CreateExtractedRecipe("Pasta Carbonara");
 
-        var result = await sut.HandleAsync(command);
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
 
         result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Pasta Carbonara");
     }
 
     [Fact]
-    public async Task HandleAsync_ValidCommand_ReturnsMessageDto()
+    public async Task HandleAsync_ScrapeFailure_ReturnsFailure()
     {
-        var sut = new ImportRecipeCommandHandler(logger);
-        var command = new ImportRecipeCommand(
-            new RecipeUrl("https://example.com/recipe"));
+        var url = new RecipeUrl("https://example.com/recipe");
 
-        var result = await sut.HandleAsync(command);
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.PageUnreachable));
 
-        result.Value.Message.Should().NotBeNullOrWhiteSpace();
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.PageUnreachable);
     }
 
     [Fact]
-    public async Task HandleAsync_ValidCommand_DoesNotReturnFailure()
+    public async Task HandleAsync_NoRecipeFound_ReturnsFailure()
     {
-        var sut = new ImportRecipeCommandHandler(logger);
-        var command = new ImportRecipeCommand(
-            new RecipeUrl("https://example.com/recipe/pasta"));
+        var url = new RecipeUrl("https://example.com/recipe");
+        var scrapedContent = new ScrapedContent("Some content", url.Value);
 
-        var result = await sut.HandleAsync(command);
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.NoRecipeFound));
 
-        result.IsFailure.Should().BeFalse();
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.NoRecipeFound);
     }
+
+    [Fact]
+    public async Task HandleAsync_ScrapeSucceeds_CallsExtraction()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var scrapedContent = new ScrapedContent("Recipe content", url.Value);
+        var expectedRecipe = CreateExtractedRecipe();
+
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+
+        var sut = CreateSut();
+        await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        await extraction.Received(1).ExtractAsync(scrapedContent, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ScrapeFailure_DoesNotCallExtraction()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.PageUnreachable));
+
+        var sut = CreateSut();
+        await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        await extraction.DidNotReceive().ExtractAsync(
+            Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ScrapeTimeout_PropagatesTimeoutError()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.ScrapeTimeout));
+
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ScrapeTimeout);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExtractionFailed_PropagatesExtractionError()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var scrapedContent = new ScrapedContent("Some content", url.Value);
+
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed));
+
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidUrl_PassesCancellationTokenToScraper()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var cts = new CancellationTokenSource();
+        var scrapedContent = new ScrapedContent("Content", url.Value);
+        var expectedRecipe = CreateExtractedRecipe();
+
+        scraper.ScrapeAsync(url, cts.Token)
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, cts.Token)
+            .Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+
+        var sut = CreateSut();
+        await sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+
+        await scraper.Received(1).ScrapeAsync(url, cts.Token);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidUrl_PassesCancellationTokenToExtraction()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var cts = new CancellationTokenSource();
+        var scrapedContent = new ScrapedContent("Content", url.Value);
+        var expectedRecipe = CreateExtractedRecipe();
+
+        scraper.ScrapeAsync(url, cts.Token)
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, cts.Token)
+            .Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+
+        var sut = CreateSut();
+        await sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+
+        await extraction.Received(1).ExtractAsync(scrapedContent, cts.Token);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MinimalRecipeData_ReturnsSuccess()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var scrapedContent = new ScrapedContent("Content", url.Value);
+        var minimalRecipe = new ExtractedRecipeDto
+        {
+            Title = "Simple Dish",
+            Ingredients = [],
+            Steps = [],
+        };
+
+        scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Success(minimalRecipe));
+
+        var sut = CreateSut();
+        var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Simple Dish");
+        result.Value.Description.Should().BeNull();
+        result.Value.Servings.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ScraperThrowsOperationCanceledException_PropagatesException()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        scraper.ScrapeAsync(url, cts.Token)
+            .Returns<Result<ScrapedContent>>(
+                _ => throw new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+        var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExtractionThrowsOperationCanceledException_PropagatesException()
+    {
+        var url = new RecipeUrl("https://example.com/recipe");
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var scrapedContent = new ScrapedContent("Content", url.Value);
+
+        scraper.ScrapeAsync(url, cts.Token)
+            .Returns(Result<ScrapedContent>.Success(scrapedContent));
+        extraction.ExtractAsync(scrapedContent, cts.Token)
+            .Returns<Result<ExtractedRecipeDto>>(
+                _ => throw new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+        var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static ExtractedRecipeDto CreateExtractedRecipe(string title = "Test Recipe") =>
+        new()
+        {
+            Title = title,
+            Ingredients = [new ExtractedIngredientDto("Flour", 500, "g")],
+            Steps = [new ExtractedStepDto(1, "Mix ingredients")],
+            Servings = 4,
+        };
+
+    private ImportRecipeCommandHandler CreateSut() => new(scraper, extraction, logger);
 }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelRecipeExtractionServiceTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelRecipeExtractionServiceTests.cs
@@ -1,0 +1,255 @@
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using NSubstitute;
+using Xunit;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Infrastructure.Services;
+
+namespace Yumney.Recipes.Infrastructure.Tests.Services;
+
+#pragma warning disable SA1311
+public class SemanticKernelRecipeExtractionServiceTests
+{
+    private static readonly string validRecipeJson = """
+        {
+          "title": "Pasta Carbonara",
+          "description": "A classic Italian dish",
+          "ingredients": [
+            { "name": "Spaghetti", "amount": 400, "unit": "g" },
+            { "name": "Eggs", "amount": 3, "unit": null }
+          ],
+          "steps": [
+            { "number": 1, "description": "Cook pasta" },
+            { "number": 2, "description": "Mix eggs and cheese" }
+          ],
+          "servings": 4,
+          "prepTimeMinutes": 10,
+          "cookTimeMinutes": 15,
+          "difficulty": "medium",
+          "imageUrl": null
+        }
+        """;
+
+    private readonly ILogger<SemanticKernelRecipeExtractionService> logger = Substitute.For<ILogger<SemanticKernelRecipeExtractionService>>();
+
+    [Fact]
+    public async Task ExtractAsync_ValidRecipeJson_ReturnsExtractedRecipe()
+    {
+        var sut = CreateSut(validRecipeJson);
+        var content = new ScrapedContent("Some recipe text", "https://example.com/recipe");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Pasta Carbonara");
+        result.Value.Description.Should().Be("A classic Italian dish");
+        result.Value.Ingredients.Should().HaveCount(2);
+        result.Value.Ingredients[0].Name.Should().Be("Spaghetti");
+        result.Value.Ingredients[0].Amount.Should().Be(400);
+        result.Value.Ingredients[0].Unit.Should().Be("g");
+        result.Value.Steps.Should().HaveCount(2);
+        result.Value.Servings.Should().Be(4);
+        result.Value.Difficulty.Should().Be("medium");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_JsonWrappedInMarkdownFence_ReturnsExtractedRecipe()
+    {
+        var wrapped = $"```json\n{validRecipeJson}\n```";
+        var sut = CreateSut(wrapped);
+        var content = new ScrapedContent("Some recipe text", "https://example.com/recipe");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Pasta Carbonara");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_JsonWrappedInPlainFence_ReturnsExtractedRecipe()
+    {
+        var wrapped = $"```\n{validRecipeJson}\n```";
+        var sut = CreateSut(wrapped);
+        var content = new ScrapedContent("Some recipe text", "https://example.com/recipe");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Pasta Carbonara");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NoRecipeFoundResponse_ReturnsNoRecipeFound()
+    {
+        var sut = CreateSut("""{ "error": "NO_RECIPE_FOUND" }""");
+        var content = new ScrapedContent("Random page text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.NoRecipeFound);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InvalidJson_ReturnsExtractionFailed()
+    {
+        var sut = CreateSut("this is not valid JSON at all");
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LlmThrowsException_ReturnsExtractionFailed()
+    {
+        var sut = CreateSutWithException(new HttpRequestException("Service unavailable"));
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_UserCancellation_ThrowsOperationCanceledException()
+    {
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var sut = CreateSutWithException(new OperationCanceledException(cts.Token));
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var act = () => sut.ExtractAsync(content, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MinimalRecipe_ReturnsExtractedRecipe()
+    {
+        var json = """
+            {
+              "title": "Simple Toast",
+              "ingredients": [{ "name": "Bread", "amount": 2, "unit": "slices" }],
+              "steps": [{ "number": 1, "description": "Toast the bread" }]
+            }
+            """;
+        var sut = CreateSut(json);
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Simple Toast");
+        result.Value.Description.Should().BeNull();
+        result.Value.Servings.Should().BeNull();
+        result.Value.Difficulty.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyContent_ReturnsExtractionFailed()
+    {
+        var sut = CreateSut(string.Empty);
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NullLlmContent_ReturnsExtractionFailed()
+    {
+        var sut = CreateSutWithNullContent();
+        var content = new ScrapedContent("Some text", "https://example.com/page");
+
+        var result = await sut.ExtractAsync(content);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
+    }
+
+    private static Kernel CreateKernel(IChatCompletionService chatCompletionService)
+    {
+        var builder = Kernel.CreateBuilder();
+        builder.Services.AddSingleton(chatCompletionService);
+        return builder.Build();
+    }
+
+    private SemanticKernelRecipeExtractionService CreateSut(string llmResponse)
+    {
+        var fake = new FakeChatCompletionService(llmResponse);
+        var kernel = CreateKernel(fake);
+        return new SemanticKernelRecipeExtractionService(kernel, logger);
+    }
+
+    private SemanticKernelRecipeExtractionService CreateSutWithException(Exception exception)
+    {
+        var fake = new FakeChatCompletionService(exception);
+        var kernel = CreateKernel(fake);
+        return new SemanticKernelRecipeExtractionService(kernel, logger);
+    }
+
+    private SemanticKernelRecipeExtractionService CreateSutWithNullContent()
+    {
+        var fake = new FakeChatCompletionService();
+        var kernel = CreateKernel(fake);
+        return new SemanticKernelRecipeExtractionService(kernel, logger);
+    }
+
+    private sealed class FakeChatCompletionService(
+        string? response = null,
+        Exception? exception = null) : IChatCompletionService
+    {
+        public FakeChatCompletionService(string response)
+            : this(response, null)
+        {
+        }
+
+        public FakeChatCompletionService(Exception exception)
+            : this(null, exception)
+        {
+        }
+
+        public IReadOnlyDictionary<string, object?> Attributes { get; } =
+            new Dictionary<string, object?>();
+
+        public Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
+            ChatHistory chatHistory,
+            PromptExecutionSettings? executionSettings = null,
+            Kernel? kernel = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (exception is not null)
+            {
+                throw exception;
+            }
+
+            IReadOnlyList<ChatMessageContent> result =
+                [new ChatMessageContent(AuthorRole.Assistant, response)];
+            return Task.FromResult(result);
+        }
+
+        public async IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
+            ChatHistory chatHistory,
+            PromptExecutionSettings? executionSettings = null,
+            Kernel? kernel = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/WebScraperTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/WebScraperTests.cs
@@ -1,0 +1,233 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Yumney.Recipes.Application.Commands;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Recipes.Infrastructure.Services;
+
+namespace Yumney.Recipes.Infrastructure.Tests.Services;
+
+public class WebScraperTests
+{
+    private readonly ILogger<WebScraper> logger = Substitute.For<ILogger<WebScraper>>();
+
+    [Fact]
+    public async Task ScrapeAsync_ValidHtml_ReturnsCleanedText()
+    {
+        var html = "<html><body><main><h1>Recipe</h1><p>Delicious pasta</p></main></body></html>";
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().Contain("Recipe");
+        result.Value.CleanedText.Should().Contain("Delicious pasta");
+        result.Value.SourceUrl.Should().Be("https://example.com/recipe");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_RemovesScriptAndStyleTags()
+    {
+        var html = """
+            <html><body>
+            <script>alert('xss')</script>
+            <style>.hidden { display: none; }</style>
+            <main><p>Recipe content</p></main>
+            </body></html>
+            """;
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().NotContain("alert");
+        result.Value.CleanedText.Should().NotContain("display: none");
+        result.Value.CleanedText.Should().Contain("Recipe content");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_RemovesNavFooterHeaderAside()
+    {
+        var html = """
+            <html><body>
+            <nav>Menu items</nav>
+            <header>Site header</header>
+            <main><p>Recipe content</p></main>
+            <aside>Sidebar ads</aside>
+            <footer>Footer links</footer>
+            </body></html>
+            """;
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().NotContain("Menu items");
+        result.Value.CleanedText.Should().NotContain("Site header");
+        result.Value.CleanedText.Should().NotContain("Sidebar ads");
+        result.Value.CleanedText.Should().NotContain("Footer links");
+        result.Value.CleanedText.Should().Contain("Recipe content");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_PrefersMainOverArticleOverBody()
+    {
+        var html = """
+            <html><body>
+            <p>Body text</p>
+            <main><p>Main content</p></main>
+            </body></html>
+            """;
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().Contain("Main content");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_FallsBackToArticleWhenNoMain()
+    {
+        var html = """
+            <html><body>
+            <p>Body text</p>
+            <article><p>Article content</p></article>
+            </body></html>
+            """;
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().Contain("Article content");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_FallsBackToBodyWhenNoMainOrArticle()
+    {
+        var html = "<html><body><p>Body only content</p></body></html>";
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().Contain("Body only content");
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_EmptyBody_ReturnsNoRecipeFound()
+    {
+        var html = "<html><body><script>only scripts</script></body></html>";
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.NoRecipeFound);
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_HttpError_ReturnsPageUnreachable()
+    {
+        var httpClient = CreateHttpClient(statusCode: HttpStatusCode.InternalServerError);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.PageUnreachable);
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_Timeout_ReturnsScrapeTimeout()
+    {
+        var handler = new TimeoutHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ImportRecipeErrors.ScrapeTimeout);
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_UserCancellation_ThrowsOperationCanceledException()
+    {
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var httpClient = CreateHttpClient("<html><body>content</body></html>");
+        var sut = new WebScraper(httpClient, logger);
+
+        var act = () => sut.ScrapeAsync(
+            new RecipeUrl("https://example.com/recipe"), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ScrapeAsync_RemovesIframeAndNoscript()
+    {
+        var html = """
+            <html><body>
+            <iframe src="ad.html">Ad content</iframe>
+            <noscript>Enable JavaScript</noscript>
+            <main><p>Recipe text</p></main>
+            </body></html>
+            """;
+        var httpClient = CreateHttpClient(html);
+        var sut = new WebScraper(httpClient, logger);
+
+        var result = await sut.ScrapeAsync(new RecipeUrl("https://example.com/recipe"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CleanedText.Should().NotContain("Ad content");
+        result.Value.CleanedText.Should().NotContain("Enable JavaScript");
+    }
+
+    private static HttpClient CreateHttpClient(string content = "", HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new FakeHttpMessageHandler(content, statusCode);
+        return new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+    }
+
+    private sealed class FakeHttpMessageHandler(string content, HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content),
+            };
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException("Request failed", null, statusCode);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class TimeoutHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new TaskCanceledException("The request timed out.");
+        }
+    }
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Yumney.Recipes.Infrastructure.Tests.csproj
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Yumney.Recipes.Infrastructure.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Yumney.Recipes.Infrastructure.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.Recipes.Infrastructure\Yumney.Recipes.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- **LLM extraction pipeline**: Import recipes from any URL via Semantic Kernel — scrapes page content, sends to LLM, returns structured recipe data (title, ingredients, steps, metadata)
- **Aspire Ollama integration**: Added `CommunityToolkit.Aspire.Hosting.Ollama` for local LLM dev with persistent data volume
- **DDD alignment**: Moved repository interfaces (`IRecipeRepository`, `IAppUserProfileRepository`, `IShoppingListRepository`) from Application to Domain layer
- **Code quality**: Extracted Keycloak config into `IOptions<KeycloakOptions>`, converted DTOs to positional records, added URL maxLength validation with OpenAPI metadata, cleaned up formatting

## Test plan

- [ ] `dotnet build` compiles without warnings
- [ ] `dotnet test` — all 255 tests pass (including 27 architecture tests)
- [ ] Verify Aspire dashboard shows Ollama container alongside existing resources
- [ ] Import a recipe URL via `POST /api/v1/recipes/import` and verify structured response
- [ ] Verify error handling for unreachable URLs (502), timeouts (504), and no-recipe pages (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)