### PR TITLE
feat(shell): add editable recipe preview after extraction (US-012)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -88,6 +88,31 @@
         "noRecipe": "Auf dieser Seite wurde kein Rezept gefunden.",
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
       }
+    },
+    "preview": {
+      "title": "Extrahiertes Rezept überprüfen",
+      "recipeTitle": "Titel",
+      "description": "Beschreibung",
+      "servings": "Portionen",
+      "prepTime": "Vorbereitungszeit (Min.)",
+      "cookTime": "Kochzeit (Min.)",
+      "difficulty": "Schwierigkeit",
+      "ingredients": "Zutaten",
+      "ingredientName": "Zutat",
+      "amount": "Menge",
+      "unit": "Einheit",
+      "addIngredient": "Zutat hinzufügen",
+      "steps": "Schritte",
+      "stepDescription": "Beschreibung des Schritts",
+      "addStep": "Schritt hinzufügen",
+      "save": "Rezept speichern",
+      "discard": "Verwerfen",
+      "errors": {
+        "titleRequired": "Titel ist erforderlich.",
+        "titleMaxLength": "Titel darf maximal 200 Zeichen lang sein.",
+        "ingredientNameRequired": "Zutatname ist erforderlich.",
+        "stepDescriptionRequired": "Schrittbeschreibung ist erforderlich."
+      }
     }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -88,6 +88,31 @@
         "noRecipe": "No recipe found on this page.",
         "generic": "An unexpected error occurred. Please try again later."
       }
+    },
+    "preview": {
+      "title": "Review Extracted Recipe",
+      "recipeTitle": "Title",
+      "description": "Description",
+      "servings": "Servings",
+      "prepTime": "Prep Time (min)",
+      "cookTime": "Cook Time (min)",
+      "difficulty": "Difficulty",
+      "ingredients": "Ingredients",
+      "ingredientName": "Ingredient",
+      "amount": "Amount",
+      "unit": "Unit",
+      "addIngredient": "Add Ingredient",
+      "steps": "Steps",
+      "stepDescription": "Step Description",
+      "addStep": "Add Step",
+      "save": "Save Recipe",
+      "discard": "Discard",
+      "errors": {
+        "titleRequired": "Title is required.",
+        "titleMaxLength": "Title must not exceed 200 characters.",
+        "ingredientNameRequired": "Ingredient name is required.",
+        "stepDescriptionRequired": "Step description is required."
+      }
     }
   }
 }

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -134,4 +134,34 @@ describe('i18n keys', () => {
       expect(enKeys).toContain(key);
     }
   });
+
+  it('should contain required dashboard.preview keys', () => {
+    const requiredKeys = [
+      'dashboard.preview.title',
+      'dashboard.preview.recipeTitle',
+      'dashboard.preview.description',
+      'dashboard.preview.servings',
+      'dashboard.preview.prepTime',
+      'dashboard.preview.cookTime',
+      'dashboard.preview.difficulty',
+      'dashboard.preview.ingredients',
+      'dashboard.preview.ingredientName',
+      'dashboard.preview.amount',
+      'dashboard.preview.unit',
+      'dashboard.preview.addIngredient',
+      'dashboard.preview.steps',
+      'dashboard.preview.stepDescription',
+      'dashboard.preview.addStep',
+      'dashboard.preview.save',
+      'dashboard.preview.discard',
+      'dashboard.preview.errors.titleRequired',
+      'dashboard.preview.errors.titleMaxLength',
+      'dashboard.preview.errors.ingredientNameRequired',
+      'dashboard.preview.errors.stepDescriptionRequired',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -7,11 +7,7 @@
     <p class="subtitle">{{ t('dashboard.import.subtitle') }}</p>
 
     <form [formGroup]="form" (ngSubmit)="onImport()">
-      @if (extractedRecipe()) {
-      <div class="success-banner">
-        {{ t('dashboard.import.success', { title: extractedRecipe()!.title }) }}
-      </div>
-      } @if (serverError()) {
+      @if (serverError()) {
       <div class="error-banner">{{ t(serverError()!) }}</div>
       }
 
@@ -43,4 +39,12 @@
       </div>
     </form>
   </section>
+
+  @if (extractedRecipe()) {
+  <yn-recipe-preview
+    [recipe]="extractedRecipe()!"
+    (save)="onSaveRecipe($event)"
+    (discard)="onDiscardRecipe()"
+  />
+  }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -35,15 +35,6 @@
   }
 }
 
-.success-banner {
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
-  border-radius: 6px;
-  background: #f0fdf4;
-  color: #16a34a;
-  font-size: 0.875rem;
-}
-
 .error-banner {
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -44,6 +44,31 @@ const en = {
         generic: 'An unexpected error occurred. Please try again later.',
       },
     },
+    preview: {
+      title: 'Review Extracted Recipe',
+      recipeTitle: 'Title',
+      description: 'Description',
+      servings: 'Servings',
+      prepTime: 'Prep Time (min)',
+      cookTime: 'Cook Time (min)',
+      difficulty: 'Difficulty',
+      ingredients: 'Ingredients',
+      ingredientName: 'Ingredient',
+      amount: 'Amount',
+      unit: 'Unit',
+      addIngredient: 'Add Ingredient',
+      steps: 'Steps',
+      stepDescription: 'Step Description',
+      addStep: 'Add Step',
+      save: 'Save Recipe',
+      discard: 'Discard',
+      errors: {
+        titleRequired: 'Title is required.',
+        titleMaxLength: 'Title must not exceed 200 characters.',
+        ingredientNameRequired: 'Ingredient name is required.',
+        stepDescriptionRequired: 'Step description is required.',
+      },
+    },
   },
 };
 
@@ -261,7 +286,7 @@ describe('DashboardComponent', () => {
     expect(component.isLoading()).toBe(false);
   }));
 
-  it('should show success banner with recipe title after extraction', fakeAsync(() => {
+  it('should show recipe preview after successful extraction', fakeAsync(() => {
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
 
     component.form.controls.url.setValue('https://example.com/recipe');
@@ -269,10 +294,14 @@ describe('DashboardComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const successBanner = fixture.nativeElement.querySelector('.success-banner');
-    expect(successBanner).toBeTruthy();
-    expect(successBanner.textContent).toContain('Pasta Carbonara');
+    const preview = fixture.nativeElement.querySelector('yn-recipe-preview');
+    expect(preview).toBeTruthy();
   }));
+
+  it('should not show recipe preview when no recipe is extracted', () => {
+    const preview = fixture.nativeElement.querySelector('yn-recipe-preview');
+    expect(preview).toBeNull();
+  });
 
   it('should store extracted recipe data', fakeAsync(() => {
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
@@ -379,5 +408,44 @@ describe('DashboardComponent', () => {
     tick();
 
     expect(component.serverError()).toBe('dashboard.import.errors.generic');
+  }));
+
+  it('should clear extracted recipe on discard', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    expect(component.extractedRecipe()).toEqual(mockRecipe);
+
+    component.onDiscardRecipe();
+
+    expect(component.extractedRecipe()).toBeNull();
+  }));
+
+  it('should hide recipe preview after discard', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('yn-recipe-preview')).toBeTruthy();
+
+    component.onDiscardRecipe();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('yn-recipe-preview')).toBeNull();
+  }));
+
+  it('should log recipe on save (placeholder for US-013)', fakeAsync(() => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    component.onSaveRecipe(mockRecipe);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Save recipe (US-013):', mockRecipe);
+    consoleSpy.mockRestore();
   }));
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -10,6 +10,7 @@ import {
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
+import { RecipePreviewComponent } from './recipe-preview/recipe-preview.component';
 
 function urlValidator(control: AbstractControl): ValidationErrors | null {
   const value = control.value;
@@ -31,7 +32,7 @@ function urlValidator(control: AbstractControl): ValidationErrors | null {
 
 @Component({
   selector: 'yn-dashboard',
-  imports: [ReactiveFormsModule, TranslocoModule],
+  imports: [ReactiveFormsModule, TranslocoModule, RecipePreviewComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -89,6 +90,14 @@ export class DashboardComponent {
           );
         },
       });
+  }
+
+  onSaveRecipe(recipe: ImportRecipeResponse): void {
+    console.log('Save recipe (US-013):', recipe);
+  }
+
+  onDiscardRecipe(): void {
+    this.extractedRecipe.set(null);
   }
 
   hasError(field: string, error: string): boolean {

--- a/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.html
+++ b/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.html
@@ -1,0 +1,29 @@
+<div class="editable-list-item">
+  <div class="item-content">
+    <ng-content />
+  </div>
+
+  <div class="item-actions">
+    <button
+      type="button"
+      class="action-btn"
+      [disabled]="isFirst()"
+      (click)="moveUp.emit()"
+      aria-label="Move up"
+    >
+      &#9650;
+    </button>
+    <button
+      type="button"
+      class="action-btn"
+      [disabled]="isLast()"
+      (click)="moveDown.emit()"
+      aria-label="Move down"
+    >
+      &#9660;
+    </button>
+    <button type="button" class="action-btn remove-btn" (click)="remove.emit()" aria-label="Remove">
+      &times;
+    </button>
+  </div>
+</div>

--- a/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.scss
+++ b/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.scss
@@ -1,0 +1,55 @@
+.editable-list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.item-content {
+  flex: 1;
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.item-actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  padding-top: 0.25rem;
+}
+
+.action-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #fff;
+  color: #374151;
+  font-size: 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover:not(:disabled) {
+    background: #f3f4f6;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+}
+
+.remove-btn {
+  color: #dc2626;
+  font-size: 1rem;
+
+  &:hover:not(:disabled) {
+    background: #fef2f2;
+    border-color: #fca5a5;
+  }
+}

--- a/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.spec.ts
@@ -1,0 +1,99 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { EditableListItemComponent } from './editable-list-item.component';
+
+@Component({
+  template: `
+    <yn-editable-list-item
+      [index]="index()"
+      [total]="total()"
+      (moveUp)="onMoveUp()"
+      (moveDown)="onMoveDown()"
+      (remove)="onRemove()"
+    >
+      <span class="projected">Projected Content</span>
+    </yn-editable-list-item>
+  `,
+  imports: [EditableListItemComponent],
+})
+class TestHostComponent {
+  index = signal(1);
+  total = signal(3);
+  onMoveUp = vi.fn();
+  onMoveDown = vi.fn();
+  onRemove = vi.fn();
+}
+
+describe('EditableListItemComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    const component = fixture.debugElement.children[0].componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should project content', () => {
+    const projected = fixture.nativeElement.querySelector('.projected');
+    expect(projected.textContent).toBe('Projected Content');
+  });
+
+  it('should emit moveUp when up button is clicked', () => {
+    const upBtn = fixture.nativeElement.querySelector('[aria-label="Move up"]');
+    upBtn.click();
+
+    expect(host.onMoveUp).toHaveBeenCalled();
+  });
+
+  it('should emit moveDown when down button is clicked', () => {
+    const downBtn = fixture.nativeElement.querySelector('[aria-label="Move down"]');
+    downBtn.click();
+
+    expect(host.onMoveDown).toHaveBeenCalled();
+  });
+
+  it('should emit remove when remove button is clicked', () => {
+    const removeBtn = fixture.nativeElement.querySelector('[aria-label="Remove"]');
+    removeBtn.click();
+
+    expect(host.onRemove).toHaveBeenCalled();
+  });
+
+  it('should disable up button when index is 0', () => {
+    host.index.set(0);
+    fixture.detectChanges();
+
+    const upBtn = fixture.nativeElement.querySelector('[aria-label="Move up"]');
+    expect(upBtn.disabled).toBe(true);
+  });
+
+  it('should disable down button when index is last', () => {
+    host.index.set(2);
+    fixture.detectChanges();
+
+    const downBtn = fixture.nativeElement.querySelector('[aria-label="Move down"]');
+    expect(downBtn.disabled).toBe(true);
+  });
+
+  it('should enable both buttons for middle items', () => {
+    const upBtn = fixture.nativeElement.querySelector('[aria-label="Move up"]');
+    const downBtn = fixture.nativeElement.querySelector('[aria-label="Move down"]');
+    expect(upBtn.disabled).toBe(false);
+    expect(downBtn.disabled).toBe(false);
+  });
+
+  it('should never disable the remove button', () => {
+    const removeBtn = fixture.nativeElement.querySelector('[aria-label="Remove"]');
+    expect(removeBtn.disabled).toBe(false);
+  });
+});

--- a/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.ts
+++ b/client/apps/shell/src/app/dashboard/editable-list-item/editable-list-item.component.ts
@@ -1,0 +1,19 @@
+import { Component, ChangeDetectionStrategy, input, output, computed } from '@angular/core';
+
+@Component({
+  selector: 'yn-editable-list-item',
+  templateUrl: './editable-list-item.component.html',
+  styleUrl: './editable-list-item.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditableListItemComponent {
+  index = input.required<number>();
+  total = input.required<number>();
+
+  moveUp = output<void>();
+  moveDown = output<void>();
+  remove = output<void>();
+
+  isFirst = computed(() => this.index() === 0);
+  isLast = computed(() => this.index() === this.total() - 1);
+}

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.html
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.html
@@ -1,0 +1,141 @@
+<section class="recipe-preview" *transloco="let t">
+  <h2>{{ t('dashboard.preview.title') }}</h2>
+
+  @if (recipe().imageUrl) {
+  <div class="preview-image">
+    <img [src]="recipe().imageUrl!" [alt]="form.controls.title.value" />
+  </div>
+  }
+
+  <form [formGroup]="form" (ngSubmit)="onSave()">
+    <div class="metadata-section">
+      <div class="form-field">
+        <label for="preview-title">{{ t('dashboard.preview.recipeTitle') }}</label>
+        <input id="preview-title" type="text" formControlName="title" />
+        @if (hasFieldError('title', 'required')) {
+        <span class="field-error">{{ t('dashboard.preview.errors.titleRequired') }}</span>
+        } @if (hasFieldError('title', 'maxlength')) {
+        <span class="field-error">{{ t('dashboard.preview.errors.titleMaxLength') }}</span>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="preview-description">{{ t('dashboard.preview.description') }}</label>
+        <textarea id="preview-description" formControlName="description" rows="3"></textarea>
+      </div>
+
+      <div class="form-row">
+        <div class="form-field">
+          <label for="preview-servings">{{ t('dashboard.preview.servings') }}</label>
+          <input id="preview-servings" type="number" formControlName="servings" />
+        </div>
+        <div class="form-field">
+          <label for="preview-prepTime">{{ t('dashboard.preview.prepTime') }}</label>
+          <input id="preview-prepTime" type="number" formControlName="prepTimeMinutes" />
+        </div>
+        <div class="form-field">
+          <label for="preview-cookTime">{{ t('dashboard.preview.cookTime') }}</label>
+          <input id="preview-cookTime" type="number" formControlName="cookTimeMinutes" />
+        </div>
+        <div class="form-field">
+          <label for="preview-difficulty">{{ t('dashboard.preview.difficulty') }}</label>
+          <input id="preview-difficulty" type="text" formControlName="difficulty" />
+        </div>
+      </div>
+    </div>
+
+    <div class="list-section">
+      <h3>{{ t('dashboard.preview.ingredients') }}</h3>
+
+      <div formArrayName="ingredients">
+        @for (ingredient of ingredients.controls; track ingredient; let i = $index) {
+        <yn-editable-list-item
+          [index]="i"
+          [total]="ingredients.length"
+          (moveUp)="moveIngredientUp(i)"
+          (moveDown)="moveIngredientDown(i)"
+          (remove)="removeIngredient(i)"
+        >
+          <div class="ingredient-fields" [formGroupName]="i">
+            <div class="form-field ingredient-name">
+              <input
+                type="text"
+                formControlName="name"
+                [placeholder]="t('dashboard.preview.ingredientName')"
+              />
+              @if (hasIngredientError(i, 'name', 'required')) {
+              <span class="field-error">{{
+                t('dashboard.preview.errors.ingredientNameRequired')
+              }}</span>
+              }
+            </div>
+            <div class="form-field ingredient-amount">
+              <input
+                type="number"
+                formControlName="amount"
+                [placeholder]="t('dashboard.preview.amount')"
+              />
+            </div>
+            <div class="form-field ingredient-unit">
+              <input
+                type="text"
+                formControlName="unit"
+                [placeholder]="t('dashboard.preview.unit')"
+              />
+            </div>
+          </div>
+        </yn-editable-list-item>
+        }
+      </div>
+
+      <button type="button" class="add-btn" (click)="addIngredient()">
+        + {{ t('dashboard.preview.addIngredient') }}
+      </button>
+    </div>
+
+    <div class="list-section">
+      <h3>{{ t('dashboard.preview.steps') }}</h3>
+
+      <div formArrayName="steps">
+        @for (step of steps.controls; track step; let i = $index) {
+        <yn-editable-list-item
+          [index]="i"
+          [total]="steps.length"
+          (moveUp)="moveStepUp(i)"
+          (moveDown)="moveStepDown(i)"
+          (remove)="removeStep(i)"
+        >
+          <div class="step-fields" [formGroupName]="i">
+            <span class="step-number">{{ i + 1 }}.</span>
+            <div class="form-field step-description">
+              <textarea
+                formControlName="description"
+                [placeholder]="t('dashboard.preview.stepDescription')"
+                rows="2"
+              ></textarea>
+              @if (hasStepError(i, 'description', 'required')) {
+              <span class="field-error">{{
+                t('dashboard.preview.errors.stepDescriptionRequired')
+              }}</span>
+              }
+            </div>
+          </div>
+        </yn-editable-list-item>
+        }
+      </div>
+
+      <button type="button" class="add-btn" (click)="addStep()">
+        + {{ t('dashboard.preview.addStep') }}
+      </button>
+    </div>
+
+    <div class="action-buttons">
+      <button type="button" class="discard-btn" (click)="onDiscard()">
+        {{ t('dashboard.preview.discard') }}
+      </button>
+      <button type="submit" class="save-btn">
+        {{ t('dashboard.preview.save') }}
+      </button>
+    </div>
+  </form>
+</section>

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.scss
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.scss
@@ -1,0 +1,191 @@
+.recipe-preview {
+  margin-top: 2rem;
+  padding: 2rem;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+
+  h2 {
+    margin: 0 0 1.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+}
+
+.preview-image {
+  margin-bottom: 1.5rem;
+  border-radius: 8px;
+  overflow: hidden;
+  max-height: 300px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.metadata-section {
+  margin-bottom: 1.5rem;
+}
+
+.form-field {
+  margin-bottom: 0.75rem;
+
+  label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #374151;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    outline: none;
+    box-sizing: border-box;
+
+    &:focus {
+      border-color: #f97316;
+      box-shadow: 0 0 0 3px rgb(249 115 22 / 15%);
+    }
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  .field-error {
+    display: block;
+    margin-top: 0.25rem;
+    color: #dc2626;
+    font-size: 0.8125rem;
+  }
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  .form-field {
+    flex: 1;
+    min-width: 120px;
+  }
+}
+
+.list-section {
+  margin-bottom: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.ingredient-fields {
+  display: flex;
+  gap: 0.5rem;
+  flex: 1;
+  align-items: flex-start;
+
+  .ingredient-name {
+    flex: 3;
+    margin-bottom: 0;
+  }
+
+  .ingredient-amount {
+    flex: 1;
+    min-width: 80px;
+    margin-bottom: 0;
+  }
+
+  .ingredient-unit {
+    flex: 1;
+    min-width: 80px;
+    margin-bottom: 0;
+  }
+}
+
+.step-fields {
+  display: flex;
+  gap: 0.5rem;
+  flex: 1;
+  align-items: flex-start;
+
+  .step-number {
+    font-weight: 600;
+    color: #6b7280;
+    padding-top: 0.5rem;
+    min-width: 1.5rem;
+  }
+
+  .step-description {
+    flex: 1;
+    margin-bottom: 0;
+  }
+}
+
+.add-btn {
+  padding: 0.5rem 1rem;
+  border: 1px dashed #d1d5db;
+  border-radius: 6px;
+  background: transparent;
+  color: #6b7280;
+  font-size: 0.875rem;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 0.5rem;
+
+  &:hover {
+    border-color: #f97316;
+    color: #f97316;
+    background: #fff7ed;
+  }
+}
+
+.action-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.discard-btn {
+  padding: 0.75rem 1.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+  color: #374151;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: #f3f4f6;
+  }
+}
+
+.save-btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  background: #f97316;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: #ea580c;
+  }
+}

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.spec.ts
@@ -1,0 +1,387 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, viewChild } from '@angular/core';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { ImportRecipeResponse } from '@yumney/shared/api-client';
+import { RecipePreviewComponent } from './recipe-preview.component';
+
+const mockRecipe: ImportRecipeResponse = {
+  title: 'Pasta Carbonara',
+  description: 'A classic Italian pasta dish',
+  ingredients: [
+    { name: 'Spaghetti', amount: 400, unit: 'g' },
+    { name: 'Pancetta', amount: 200, unit: 'g' },
+  ],
+  steps: [
+    { number: 1, description: 'Cook pasta' },
+    { number: 2, description: 'Fry pancetta' },
+  ],
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: 'medium',
+  imageUrl: null,
+};
+
+const en = {
+  dashboard: {
+    preview: {
+      title: 'Review Extracted Recipe',
+      recipeTitle: 'Title',
+      description: 'Description',
+      servings: 'Servings',
+      prepTime: 'Prep Time (min)',
+      cookTime: 'Cook Time (min)',
+      difficulty: 'Difficulty',
+      ingredients: 'Ingredients',
+      ingredientName: 'Ingredient',
+      amount: 'Amount',
+      unit: 'Unit',
+      addIngredient: 'Add Ingredient',
+      steps: 'Steps',
+      stepDescription: 'Step Description',
+      addStep: 'Add Step',
+      save: 'Save Recipe',
+      discard: 'Discard',
+      errors: {
+        titleRequired: 'Title is required.',
+        titleMaxLength: 'Title must not exceed 200 characters.',
+        ingredientNameRequired: 'Ingredient name is required.',
+        stepDescriptionRequired: 'Step description is required.',
+      },
+    },
+  },
+};
+
+@Component({
+  template: `
+    <yn-recipe-preview [recipe]="recipe" (save)="onSave($event)" (discard)="onDiscard()" />
+  `,
+  imports: [RecipePreviewComponent],
+})
+class TestHostComponent {
+  recipe = mockRecipe;
+  onSave = vi.fn();
+  onDiscard = vi.fn();
+  preview = viewChild(RecipePreviewComponent);
+}
+
+describe('RecipePreviewComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let preview: RecipePreviewComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TestHostComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    preview = host.preview() as RecipePreviewComponent;
+  });
+
+  it('should create the component', () => {
+    expect(host.preview()).toBeTruthy();
+  });
+
+  it('should render the preview title', () => {
+    const heading = fixture.nativeElement.querySelector('h2');
+    expect(heading.textContent).toContain('Review Extracted Recipe');
+  });
+
+  it('should populate the title field from recipe input', () => {
+    const input = fixture.nativeElement.querySelector('#preview-title') as HTMLInputElement;
+    expect(input.value).toBe('Pasta Carbonara');
+  });
+
+  it('should populate the description field', () => {
+    const textarea = fixture.nativeElement.querySelector(
+      '#preview-description',
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('A classic Italian pasta dish');
+  });
+
+  it('should populate servings field', () => {
+    const input = fixture.nativeElement.querySelector('#preview-servings') as HTMLInputElement;
+    expect(input.value).toBe('4');
+  });
+
+  it('should render all ingredients', () => {
+    const items = fixture.nativeElement.querySelectorAll('.ingredient-fields');
+    expect(items.length).toBe(2);
+  });
+
+  it('should render all steps', () => {
+    const items = fixture.nativeElement.querySelectorAll('.step-fields');
+    expect(items.length).toBe(2);
+  });
+
+  it('should add a new ingredient when add button is clicked', () => {
+    const addBtn = fixture.nativeElement.querySelectorAll('.add-btn')[0];
+    addBtn.click();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.ingredient-fields');
+    expect(items.length).toBe(3);
+  });
+
+  it('should remove an ingredient', () => {
+    const removeBtn = fixture.nativeElement.querySelector(
+      '[formarrayname="ingredients"] [aria-label="Remove"]',
+    );
+    removeBtn.click();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.ingredient-fields');
+    expect(items.length).toBe(1);
+  });
+
+  it('should add a new step when add button is clicked', () => {
+    const addBtns = fixture.nativeElement.querySelectorAll('.add-btn');
+    const addStepBtn = addBtns[addBtns.length - 1];
+    addStepBtn.click();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.step-fields');
+    expect(items.length).toBe(3);
+  });
+
+  it('should remove a step', () => {
+    const removeBtn = fixture.nativeElement.querySelector(
+      '[formarrayname="steps"] [aria-label="Remove"]',
+    );
+    removeBtn.click();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.step-fields');
+    expect(items.length).toBe(1);
+  });
+
+  it('should emit save with edited recipe on valid submit', () => {
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(host.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Pasta Carbonara',
+        servings: 4,
+        ingredients: expect.arrayContaining([expect.objectContaining({ name: 'Spaghetti' })]),
+      }),
+    );
+  });
+
+  it('should emit discard when discard button is clicked', () => {
+    const discardBtn = fixture.nativeElement.querySelector('.discard-btn');
+    discardBtn.click();
+
+    expect(host.onDiscard).toHaveBeenCalled();
+  });
+
+  it('should not emit save when title is empty', () => {
+    preview.form.controls.title.setValue('');
+    fixture.detectChanges();
+
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(host.onSave).not.toHaveBeenCalled();
+  });
+
+  it('should show title required error when submitting with empty title', () => {
+    preview.form.controls.title.setValue('');
+    preview.onSave();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.metadata-section .field-error');
+    expect(error.textContent).toContain('Title is required.');
+  });
+
+  it('should show title max length error', () => {
+    preview.form.controls.title.setValue('a'.repeat(201));
+    preview.onSave();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.metadata-section .field-error');
+    expect(error.textContent).toContain('Title must not exceed 200 characters.');
+  });
+
+  it('should show ingredient name required error', () => {
+    preview.addIngredient();
+    preview.onSave();
+    fixture.detectChanges();
+
+    const errors = fixture.nativeElement.querySelectorAll('.ingredient-fields .field-error');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[errors.length - 1].textContent).toContain('Ingredient name is required.');
+  });
+
+  it('should show step description required error', () => {
+    preview.addStep();
+    preview.onSave();
+    fixture.detectChanges();
+
+    const errors = fixture.nativeElement.querySelectorAll('.step-fields .field-error');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[errors.length - 1].textContent).toContain('Step description is required.');
+  });
+
+  it('should preserve imageUrl from original recipe in save output', () => {
+    host.recipe = { ...mockRecipe, imageUrl: 'https://example.com/image.jpg' };
+    fixture.detectChanges();
+
+    // Re-create to pick up new recipe
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.recipe = { ...mockRecipe, imageUrl: 'https://example.com/image.jpg' };
+    fixture.detectChanges();
+
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(host.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ imageUrl: 'https://example.com/image.jpg' }),
+    );
+  });
+
+  it('should reorder ingredients up', () => {
+    preview.moveIngredientUp(1);
+    fixture.detectChanges();
+
+    const nameInputs = fixture.nativeElement.querySelectorAll(
+      '.ingredient-fields input[formcontrolname="name"]',
+    );
+    expect(nameInputs[0].value).toBe('Pancetta');
+    expect(nameInputs[1].value).toBe('Spaghetti');
+  });
+
+  it('should reorder ingredients down', () => {
+    preview.moveIngredientDown(0);
+    fixture.detectChanges();
+
+    const nameInputs = fixture.nativeElement.querySelectorAll(
+      '.ingredient-fields input[formcontrolname="name"]',
+    );
+    expect(nameInputs[0].value).toBe('Pancetta');
+    expect(nameInputs[1].value).toBe('Spaghetti');
+  });
+
+  it('should reorder steps up', () => {
+    preview.moveStepUp(1);
+    fixture.detectChanges();
+
+    const textareas = fixture.nativeElement.querySelectorAll(
+      '.step-fields textarea[formcontrolname="description"]',
+    );
+    expect(textareas[0].value).toBe('Fry pancetta');
+    expect(textareas[1].value).toBe('Cook pasta');
+  });
+
+  it('should reorder steps down', () => {
+    preview.moveStepDown(0);
+    fixture.detectChanges();
+
+    const textareas = fixture.nativeElement.querySelectorAll(
+      '.step-fields textarea[formcontrolname="description"]',
+    );
+    expect(textareas[0].value).toBe('Fry pancetta');
+    expect(textareas[1].value).toBe('Cook pasta');
+  });
+
+  it('should number steps sequentially in save output', () => {
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    const savedRecipe = host.onSave.mock.calls[0][0] as ImportRecipeResponse;
+    expect(savedRecipe.steps[0].number).toBe(1);
+    expect(savedRecipe.steps[1].number).toBe(2);
+  });
+
+  it('should not render image section when imageUrl is null', () => {
+    const img = fixture.nativeElement.querySelector('.preview-image');
+    expect(img).toBeNull();
+  });
+
+  it('should populate prepTime and cookTime fields', () => {
+    const prepInput = fixture.nativeElement.querySelector('#preview-prepTime') as HTMLInputElement;
+    const cookInput = fixture.nativeElement.querySelector('#preview-cookTime') as HTMLInputElement;
+    expect(prepInput.value).toBe('10');
+    expect(cookInput.value).toBe('20');
+  });
+
+  it('should populate difficulty field', () => {
+    const input = fixture.nativeElement.querySelector('#preview-difficulty') as HTMLInputElement;
+    expect(input.value).toBe('medium');
+  });
+
+  it('should emit edited values on save', () => {
+    preview.form.controls.title.setValue('Updated Title');
+    preview.form.controls.servings.setValue(2);
+
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(host.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Updated Title',
+        servings: 2,
+      }),
+    );
+  });
+
+  it('should handle recipe with null optional fields', () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.recipe = {
+      ...mockRecipe,
+      description: null,
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+    };
+    fixture.detectChanges();
+
+    const textarea = fixture.nativeElement.querySelector(
+      '#preview-description',
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
+
+    const form = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(host.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: null,
+        servings: null,
+        difficulty: null,
+      }),
+    );
+  });
+
+  it('should render image section when imageUrl is set', () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.recipe = { ...mockRecipe, imageUrl: 'https://example.com/image.jpg' };
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('.preview-image img');
+    expect(img).toBeTruthy();
+    expect(img.src).toContain('https://example.com/image.jpg');
+  });
+});

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.ts
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.ts
@@ -1,0 +1,186 @@
+import { Component, ChangeDetectionStrategy, input, output, OnInit } from '@angular/core';
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormArray,
+  FormGroup,
+  FormControl,
+  Validators,
+} from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  ImportRecipeResponse,
+  ExtractedIngredient,
+  ExtractedStep,
+} from '@yumney/shared/api-client';
+import { EditableListItemComponent } from '../editable-list-item/editable-list-item.component';
+
+interface IngredientFormGroup {
+  name: FormControl<string>;
+  amount: FormControl<number | null>;
+  unit: FormControl<string | null>;
+}
+
+interface StepFormGroup {
+  description: FormControl<string>;
+}
+
+@Component({
+  selector: 'yn-recipe-preview',
+  imports: [ReactiveFormsModule, TranslocoModule, EditableListItemComponent],
+  templateUrl: './recipe-preview.component.html',
+  styleUrl: './recipe-preview.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecipePreviewComponent implements OnInit {
+  private static readonly titleMaxLength = 200;
+
+  recipe = input.required<ImportRecipeResponse>();
+
+  save = output<ImportRecipeResponse>();
+  discard = output<void>();
+
+  private fb = new FormBuilder();
+
+  form = this.fb.nonNullable.group({
+    title: ['', [Validators.required, Validators.maxLength(RecipePreviewComponent.titleMaxLength)]],
+    description: [''],
+    servings: [null as number | null],
+    prepTimeMinutes: [null as number | null],
+    cookTimeMinutes: [null as number | null],
+    difficulty: [''],
+    ingredients: this.fb.array<FormGroup<IngredientFormGroup>>([]),
+    steps: this.fb.array<FormGroup<StepFormGroup>>([]),
+  });
+
+  get ingredients(): FormArray<FormGroup<IngredientFormGroup>> {
+    return this.form.controls.ingredients;
+  }
+
+  get steps(): FormArray<FormGroup<StepFormGroup>> {
+    return this.form.controls.steps;
+  }
+
+  ngOnInit(): void {
+    const recipe = this.recipe();
+    this.form.patchValue({
+      title: recipe.title,
+      description: recipe.description ?? '',
+      servings: recipe.servings,
+      prepTimeMinutes: recipe.prepTimeMinutes,
+      cookTimeMinutes: recipe.cookTimeMinutes,
+      difficulty: recipe.difficulty ?? '',
+    });
+
+    for (const ingredient of recipe.ingredients) {
+      this.ingredients.push(this.createIngredientGroup(ingredient));
+    }
+
+    for (const step of recipe.steps) {
+      this.steps.push(this.createStepGroup(step));
+    }
+  }
+
+  addIngredient(): void {
+    this.ingredients.push(this.createIngredientGroup({ name: '', amount: null, unit: null }));
+  }
+
+  removeIngredient(index: number): void {
+    this.ingredients.removeAt(index);
+  }
+
+  moveIngredientUp(index: number): void {
+    this.swapControls(this.ingredients, index, index - 1);
+  }
+
+  moveIngredientDown(index: number): void {
+    this.swapControls(this.ingredients, index, index + 1);
+  }
+
+  addStep(): void {
+    this.steps.push(this.createStepGroup({ number: this.steps.length + 1, description: '' }));
+  }
+
+  removeStep(index: number): void {
+    this.steps.removeAt(index);
+  }
+
+  moveStepUp(index: number): void {
+    this.swapControls(this.steps, index, index - 1);
+  }
+
+  moveStepDown(index: number): void {
+    this.swapControls(this.steps, index, index + 1);
+  }
+
+  onSave(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const value = this.form.getRawValue();
+    const result: ImportRecipeResponse = {
+      title: value.title,
+      description: value.description || null,
+      servings: value.servings,
+      prepTimeMinutes: value.prepTimeMinutes,
+      cookTimeMinutes: value.cookTimeMinutes,
+      difficulty: value.difficulty || null,
+      imageUrl: this.recipe().imageUrl,
+      ingredients: value.ingredients.map((i) => ({
+        name: i.name,
+        amount: i.amount,
+        unit: i.unit,
+      })),
+      steps: value.steps.map((s, index) => ({
+        number: index + 1,
+        description: s.description,
+      })),
+    };
+
+    this.save.emit(result);
+  }
+
+  onDiscard(): void {
+    this.discard.emit();
+  }
+
+  hasFieldError(field: string, error: string): boolean {
+    const control = this.form.get(field);
+    return !!control?.hasError(error) && !!control?.touched;
+  }
+
+  hasIngredientError(index: number, field: string, error: string): boolean {
+    const control = this.ingredients.at(index)?.get(field);
+    return !!control?.hasError(error) && !!control?.touched;
+  }
+
+  hasStepError(index: number, field: string, error: string): boolean {
+    const control = this.steps.at(index)?.get(field);
+    return !!control?.hasError(error) && !!control?.touched;
+  }
+
+  private createIngredientGroup(ingredient: ExtractedIngredient): FormGroup<IngredientFormGroup> {
+    return this.fb.group({
+      name: this.fb.nonNullable.control(ingredient.name, [Validators.required]),
+      amount: this.fb.control(ingredient.amount),
+      unit: this.fb.control(ingredient.unit),
+    }) as FormGroup<IngredientFormGroup>;
+  }
+
+  private createStepGroup(step: ExtractedStep): FormGroup<StepFormGroup> {
+    return this.fb.group({
+      description: this.fb.nonNullable.control(step.description, [Validators.required]),
+    }) as FormGroup<StepFormGroup>;
+  }
+
+  private swapControls<T extends FormGroup>(array: FormArray<T>, from: number, to: number): void {
+    const current = array.at(from);
+    const target = array.at(to);
+    const currentValue = current.getRawValue();
+    const targetValue = target.getRawValue();
+    current.patchValue(targetValue);
+    target.patchValue(currentValue);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `yn-recipe-preview` component with reactive form (FormArray for ingredients/steps), add/remove/reorder, and validation (title required/maxLength, ingredient name required, step description required)
- Add `yn-editable-list-item` presentational component with `<ng-content>` projection and up/down/remove buttons
- Replace success banner in dashboard with full editable preview; add `onSaveRecipe` placeholder (US-013) and `onDiscardRecipe` handler
- Add `dashboard.preview.*` i18n keys in both `en.json` and `de.json`

## Test plan
- [x] `yarn nx lint shell` — no errors
- [x] `yarn nx test shell` — 170 tests passing (30 recipe-preview, 9 editable-list-item, 36 dashboard, 8 i18n)
- [x] `yarn prettier --check` — all changed files formatted
- [x] `yarn nx run shell:build --configuration=production` — build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)