### PR TITLE
feat(recipes): add manual recipe creation (US-020)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -89,6 +89,12 @@
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
       }
     },
+    "create": {
+      "title": "Rezept erstellen",
+      "subtitle": "Erstelle ein eigenes Rezept von Grund auf",
+      "submit": "Rezept erstellen",
+      "previewTitle": "Neues Rezept"
+    },
     "save": {
       "success": "Rezept \"{{title}}\" erfolgreich gespeichert!",
       "saving": "Wird gespeichert...",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -89,6 +89,12 @@
         "generic": "An unexpected error occurred. Please try again later."
       }
     },
+    "create": {
+      "title": "Create a Recipe",
+      "subtitle": "Start from scratch and enter your own recipe",
+      "submit": "Create Recipe",
+      "previewTitle": "New Recipe"
+    },
     "save": {
       "success": "Recipe \"{{title}}\" saved successfully!",
       "saving": "Saving...",

--- a/client/apps/shell/src/app/auth/i18n-keys.spec.ts
+++ b/client/apps/shell/src/app/auth/i18n-keys.spec.ts
@@ -113,6 +113,19 @@ describe('i18n keys', () => {
     }
   });
 
+  it('should contain required dashboard.create keys', () => {
+    const requiredKeys = [
+      'dashboard.create.title',
+      'dashboard.create.subtitle',
+      'dashboard.create.submit',
+      'dashboard.create.previewTitle',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(enKeys).toContain(key);
+    }
+  });
+
   it('should contain required dashboard.import keys', () => {
     const requiredKeys = [
       'dashboard.import.title',

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -42,6 +42,19 @@
     </form>
   </section>
 
+  <section class="manual-create">
+    <h2>{{ t('dashboard.create.title') }}</h2>
+    <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
+    <button
+      type="button"
+      class="create-btn"
+      [disabled]="isLoading() || isSaving() || extractedRecipe()"
+      (click)="onCreateManually()"
+    >
+      {{ t('dashboard.create.submit') }}
+    </button>
+  </section>
+
   @if (saveSuccess()) {
     <div class="success-banner">
       {{ t('dashboard.save.success', { title: saveSuccess() }) }}
@@ -51,6 +64,7 @@
     <yn-recipe-preview
       [recipe]="extractedRecipe()!"
       [isSaving]="isSaving()"
+      [previewTitle]="isManualEntry() ? t('dashboard.create.previewTitle') : undefined"
       (save)="onSaveRecipe($event)"
       (discard)="onDiscardRecipe()"
     />

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -35,6 +35,46 @@
   }
 }
 
+.manual-create {
+  margin-top: 1.5rem;
+  padding: 2rem;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+
+  h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    margin: 0 0 1.5rem;
+    color: #666;
+    font-size: 0.875rem;
+  }
+}
+
+.create-btn {
+  padding: 0.75rem 1.5rem;
+  border: 2px dashed #f97316;
+  border-radius: 8px;
+  background: transparent;
+  color: #f97316;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: #fff7ed;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
 .error-banner {
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -458,7 +458,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -477,7 +477,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -540,7 +540,7 @@ describe('DashboardComponent', () => {
     subject.next({
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     });
     subject.complete();
     tick();
@@ -548,17 +548,28 @@ describe('DashboardComponent', () => {
     expect(component.isSaving()).toBe(false);
   }));
 
-  it('should not call saveRecipe when sourceUrl is null', () => {
-    component.onSaveRecipe(mockRecipe);
+  it('should call saveRecipe without sourceUrl when sourceUrl is null', fakeAsync(() => {
+    const savedResponse: SavedRecipeResponse = {
+      identifier: '123',
+      title: 'Pasta Carbonara',
+      createdAt: '2026-03-10T00:00:00Z',
+    };
+    recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    expect(recipeApiMock.saveRecipe).not.toHaveBeenCalled();
-  });
+    component.extractedRecipe.set(mockRecipe);
+    component.onSaveRecipe(mockRecipe);
+    tick();
+
+    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
+      expect.not.objectContaining({ sourceUrl: expect.anything() }),
+    );
+  }));
 
   it('should clear saveSuccess on new import', fakeAsync(() => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -582,7 +593,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -603,7 +614,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -668,7 +679,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
     component.onSaveRecipe(mockRecipe);
@@ -695,7 +706,7 @@ describe('DashboardComponent', () => {
     subject.next({
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     });
     subject.complete();
     tick();
@@ -724,7 +735,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
@@ -751,7 +762,7 @@ describe('DashboardComponent', () => {
     const savedResponse: SavedRecipeResponse = {
       identifier: '123',
       title: 'Pasta Carbonara',
-      importedAt: '2026-03-10T00:00:00Z',
+      createdAt: '2026-03-10T00:00:00Z',
     };
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -48,6 +48,12 @@ const en = {
         generic: 'An unexpected error occurred. Please try again later.',
       },
     },
+    create: {
+      title: 'Create a Recipe',
+      subtitle: 'Start from scratch and enter your own recipe',
+      submit: 'Create Recipe',
+      previewTitle: 'New Recipe',
+    },
     save: {
       success: 'Recipe "{{title}}" saved successfully!',
       saving: 'Saving...',
@@ -778,5 +784,119 @@ describe('DashboardComponent', () => {
     const banner = fixture.nativeElement.querySelector('.success-banner');
     expect(banner).toBeTruthy();
     expect(banner.textContent).toContain('Pasta Carbonara');
+  }));
+
+  it('should render create recipe button', () => {
+    const btn = fixture.nativeElement.querySelector('.create-btn');
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toContain('Create Recipe');
+  });
+
+  it('should show recipe preview when create button is clicked', () => {
+    const btn = fixture.nativeElement.querySelector('.create-btn');
+    btn.click();
+    fixture.detectChanges();
+
+    const preview = fixture.nativeElement.querySelector('yn-recipe-preview');
+    expect(preview).toBeTruthy();
+  });
+
+  it('should set empty recipe template on create manually', () => {
+    component.onCreateManually();
+
+    const recipe = component.extractedRecipe();
+    expect(recipe).toBeTruthy();
+    expect(recipe!.title).toBe('');
+    expect(recipe!.ingredients).toHaveLength(1);
+    expect(recipe!.steps).toHaveLength(1);
+  });
+
+  it('should set isManualEntry on create manually', () => {
+    component.onCreateManually();
+
+    expect(component.isManualEntry()).toBe(true);
+  });
+
+  it('should save manual recipe without sourceUrl', fakeAsync(() => {
+    const savedResponse: SavedRecipeResponse = {
+      identifier: '456',
+      title: 'My Recipe',
+      createdAt: '2026-03-10T00:00:00Z',
+    };
+    recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
+
+    component.onCreateManually();
+    const recipe = component.extractedRecipe()!;
+    component.onSaveRecipe({ ...recipe, title: 'My Recipe' });
+    tick();
+
+    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
+      expect.not.objectContaining({ sourceUrl: expect.anything() }),
+    );
+    expect(component.saveSuccess()).toBe('My Recipe');
+  }));
+
+  it('should reset isManualEntry after successful save', fakeAsync(() => {
+    const savedResponse: SavedRecipeResponse = {
+      identifier: '456',
+      title: 'My Recipe',
+      createdAt: '2026-03-10T00:00:00Z',
+    };
+    recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
+
+    component.onCreateManually();
+    component.onSaveRecipe(component.extractedRecipe()!);
+    tick();
+
+    expect(component.isManualEntry()).toBe(false);
+  }));
+
+  it('should reset isManualEntry on discard', () => {
+    component.onCreateManually();
+    expect(component.isManualEntry()).toBe(true);
+
+    component.onDiscardRecipe();
+
+    expect(component.isManualEntry()).toBe(false);
+  });
+
+  it('should disable create button while loading', () => {
+    component.isLoading.set(true);
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector('.create-btn');
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('should disable create button while saving', fakeAsync(() => {
+    const subject = new Subject<SavedRecipeResponse>();
+    recipeApiMock.saveRecipe.mockReturnValue(subject);
+
+    component.onCreateManually();
+    component.onSaveRecipe(component.extractedRecipe()!);
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector('.create-btn');
+    expect(btn.disabled).toBe(true);
+
+    subject.next({
+      identifier: '123',
+      title: 'Test',
+      createdAt: '2026-03-10T00:00:00Z',
+    });
+    subject.complete();
+    tick();
+  }));
+
+  it('should disable create button when recipe preview is shown', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector('.create-btn');
+    expect(btn.disabled).toBe(true);
   }));
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -888,6 +888,59 @@ describe('DashboardComponent', () => {
     tick();
   }));
 
+  it('should clear sourceUrl when creating manually after import', fakeAsync(() => {
+    const savedResponse: SavedRecipeResponse = {
+      identifier: '123',
+      title: 'Pasta Carbonara',
+      createdAt: '2026-03-10T00:00:00Z',
+    };
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+    recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    component.onSaveRecipe(mockRecipe);
+    tick();
+    expect(component.sourceUrl()).toBe('https://example.com/recipe');
+
+    component.onCreateManually();
+
+    expect(component.sourceUrl()).toBeNull();
+  }));
+
+  it('should reset isManualEntry when starting import', () => {
+    component.onCreateManually();
+    expect(component.isManualEntry()).toBe(true);
+
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+
+    expect(component.isManualEntry()).toBe(false);
+  });
+
+  it('should clear serverError and saveSuccess on create manually', fakeAsync(() => {
+    recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
+    recipeApiMock.saveRecipe.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.form.controls.url.setValue('https://example.com/recipe');
+    component.onImport();
+    tick();
+
+    component.onSaveRecipe(mockRecipe);
+    tick();
+    expect(component.serverError()).toBe('dashboard.save.errors.generic');
+
+    component.onCreateManually();
+
+    expect(component.serverError()).toBeNull();
+    expect(component.saveSuccess()).toBeNull();
+  }));
+
   it('should disable create button when recipe preview is shown', fakeAsync(() => {
     recipeApiMock.importRecipe.mockReturnValue(of(mockRecipe));
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -80,6 +80,7 @@ export class DashboardComponent {
     this.serverError.set(null);
     this.extractedRecipe.set(null);
     this.saveSuccess.set(null);
+    this.isManualEntry.set(false);
 
     const { url } = this.form.getRawValue();
 
@@ -105,6 +106,7 @@ export class DashboardComponent {
   onCreateManually(): void {
     this.serverError.set(null);
     this.saveSuccess.set(null);
+    this.sourceUrl.set(null);
     this.isManualEntry.set(true);
     this.extractedRecipe.set({
       title: '',

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -61,6 +61,7 @@ export class DashboardComponent {
   extractedRecipe = signal<ImportRecipeResponse | null>(null);
   sourceUrl = signal<string | null>(null);
   saveSuccess = signal<string | null>(null);
+  isManualEntry = signal(false);
 
   form = this.fb.nonNullable.group({
     url: [
@@ -101,11 +102,25 @@ export class DashboardComponent {
       });
   }
 
+  onCreateManually(): void {
+    this.serverError.set(null);
+    this.saveSuccess.set(null);
+    this.isManualEntry.set(true);
+    this.extractedRecipe.set({
+      title: '',
+      description: null,
+      ingredients: [{ name: '', amount: null, unit: null }],
+      steps: [{ number: 1, description: '' }],
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      imageUrl: null,
+    });
+  }
+
   onSaveRecipe(recipe: ImportRecipeResponse): void {
     const sourceUrl = this.sourceUrl();
-    if (!sourceUrl) {
-      return;
-    }
 
     const request: SaveRecipeRequest = {
       title: recipe.title,
@@ -124,7 +139,7 @@ export class DashboardComponent {
       cookTimeMinutes: recipe.cookTimeMinutes,
       difficulty: recipe.difficulty,
       imageUrl: recipe.imageUrl,
-      sourceUrl,
+      sourceUrl: sourceUrl ?? undefined,
     };
 
     this.isSaving.set(true);
@@ -138,6 +153,7 @@ export class DashboardComponent {
         next: (saved) => {
           this.isSaving.set(false);
           this.extractedRecipe.set(null);
+          this.isManualEntry.set(false);
           this.saveSuccess.set(saved.title);
         },
         error: (err: HttpErrorResponse) => {
@@ -154,6 +170,7 @@ export class DashboardComponent {
   onDiscardRecipe(): void {
     this.extractedRecipe.set(null);
     this.sourceUrl.set(null);
+    this.isManualEntry.set(false);
     this.serverError.set(null);
   }
 

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.html
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.html
@@ -1,5 +1,5 @@
 <section class="recipe-preview" *transloco="let t">
-  <h2>{{ t('dashboard.preview.title') }}</h2>
+  <h2>{{ previewTitle() ?? t('dashboard.preview.title') }}</h2>
 
   @if (recipe().imageUrl) {
     <div class="preview-image">

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.spec.ts
@@ -54,12 +54,18 @@ const en = {
 
 @Component({
   template: `
-    <yn-recipe-preview [recipe]="recipe" (save)="onSave($event)" (discard)="onDiscard()" />
+    <yn-recipe-preview
+      [recipe]="recipe"
+      [previewTitle]="previewTitle"
+      (save)="onSave($event)"
+      (discard)="onDiscard()"
+    />
   `,
   imports: [RecipePreviewComponent],
 })
 class TestHostComponent {
   recipe = mockRecipe;
+  previewTitle: string | undefined;
   onSave = vi.fn();
   onDiscard = vi.fn();
   preview = viewChild(RecipePreviewComponent);
@@ -383,5 +389,46 @@ describe('RecipePreviewComponent', () => {
     const img = fixture.nativeElement.querySelector('.preview-image img');
     expect(img).toBeTruthy();
     expect(img.src).toContain('https://example.com/image.jpg');
+  });
+
+  it('should render custom previewTitle when provided', () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.previewTitle = 'New Recipe';
+    fixture.detectChanges();
+
+    const heading = fixture.nativeElement.querySelector('h2');
+    expect(heading.textContent).toContain('New Recipe');
+  });
+
+  it('should render default title when previewTitle is not provided', () => {
+    const heading = fixture.nativeElement.querySelector('h2');
+    expect(heading.textContent).toContain('Review Extracted Recipe');
+  });
+
+  it('should render empty recipe correctly', () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.recipe = {
+      title: '',
+      description: null,
+      ingredients: [{ name: '', amount: null, unit: null }],
+      steps: [{ number: 1, description: '' }],
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      imageUrl: null,
+    };
+    fixture.detectChanges();
+
+    const titleInput = fixture.nativeElement.querySelector('#preview-title') as HTMLInputElement;
+    expect(titleInput.value).toBe('');
+
+    const ingredients = fixture.nativeElement.querySelectorAll('.ingredient-fields');
+    expect(ingredients.length).toBe(1);
+
+    const steps = fixture.nativeElement.querySelectorAll('.step-fields');
+    expect(steps.length).toBe(1);
   });
 });

--- a/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.ts
+++ b/client/apps/shell/src/app/dashboard/recipe-preview/recipe-preview.component.ts
@@ -37,6 +37,7 @@ export class RecipePreviewComponent implements OnInit {
 
   recipe = input.required<ImportRecipeResponse>();
   isSaving = input(false);
+  previewTitle = input<string | undefined>();
 
   save = output<ImportRecipeResponse>();
   discard = output<void>();

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -39,13 +39,13 @@ export interface SaveRecipeRequest {
   cookTimeMinutes: number | null;
   difficulty: string | null;
   imageUrl: string | null;
-  sourceUrl: string;
+  sourceUrl?: string;
 }
 
 export interface SavedRecipeResponse {
   identifier: string;
   title: string;
-  importedAt: string;
+  createdAt: string;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -51,7 +51,6 @@ public static class RecipesEndpoints
 
         var command = new SaveRecipeCommand(
             new RecipeTitle(request.Title),
-            new RecipeUrl(request.SourceUrl),
             request.Ingredients.Select(i => new SaveRecipeIngredientCommand(
                 new IngredientName(i.Name),
                 Amount.FromNullable(i.Amount),
@@ -64,7 +63,8 @@ public static class RecipesEndpoints
             PreparationTime.FromNullable(request.PrepTimeMinutes),
             CookingTime.FromNullable(request.CookTimeMinutes),
             Difficulty.FromNullable(request.Difficulty),
-            ImageUrl.FromNullable(request.ImageUrl));
+            ImageUrl.FromNullable(request.ImageUrl),
+            SourceUrl: RecipeUrl.FromNullable(request.SourceUrl));
 
         var result = await handler.HandleAsync(command, cancellationToken);
 

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeCommand.cs
@@ -7,7 +7,6 @@ namespace Yumney.Recipes.Application.Commands;
 
 public sealed record SaveRecipeCommand(
     RecipeTitle Title,
-    RecipeUrl SourceUrl,
     IReadOnlyList<SaveRecipeIngredientCommand> Ingredients,
     IReadOnlyList<SaveRecipeStepCommand> Steps,
     RecipeDescription? Description = null,
@@ -15,7 +14,8 @@ public sealed record SaveRecipeCommand(
     PreparationTime? PreparationTime = null,
     CookingTime? CookingTime = null,
     Difficulty? Difficulty = null,
-    ImageUrl? ImageUrl = null) : ICommand<Result<SavedRecipeDto>>;
+    ImageUrl? ImageUrl = null,
+    RecipeUrl? SourceUrl = null) : ICommand<Result<SavedRecipeDto>>;
 
 public sealed record SaveRecipeIngredientCommand(IngredientName Name, Amount? Amount, Unit? Unit);
 

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeCommandHandler.cs
@@ -15,11 +15,11 @@ public sealed partial class SaveRecipeCommandHandler(
 {
     public async Task<Result<SavedRecipeDto>> HandleAsync(SaveRecipeCommand command, CancellationToken cancellationToken = default)
     {
-        var (title, sourceUrl, ingredientCommands, stepCommands, description, servings, preparationTime, cookingTime, difficulty, imageUrl) = command;
+        var (title, ingredientCommands, stepCommands, description, servings, preparationTime, cookingTime, difficulty, imageUrl, sourceUrl) = command;
 
         var owner = new OwnerIdentifier(currentUser.UserId);
 
-        if (await recipes.ExistsBySourceUrlAsync(sourceUrl, owner, cancellationToken))
+        if (sourceUrl is not null && await recipes.ExistsBySourceUrlAsync(sourceUrl, owner, cancellationToken))
         {
             LogDuplicateImport(sourceUrl.Value, owner.Value);
             return Result<SavedRecipeDto>.Failure(SaveRecipeErrors.AlreadyImported);
@@ -35,7 +35,6 @@ public sealed partial class SaveRecipeCommandHandler(
 
         var recipe = Recipe.Create(
             title,
-            sourceUrl,
             owner,
             ingredients,
             steps,
@@ -44,14 +43,15 @@ public sealed partial class SaveRecipeCommandHandler(
             preparationTime,
             cookingTime,
             difficulty,
-            imageUrl);
+            imageUrl,
+            sourceUrl);
 
         await recipes.AddAsync(recipe, cancellationToken);
 
         LogRecipeSaved(recipe.Id, title.Value);
 
         return Result<SavedRecipeDto>.Success(
-            new SavedRecipeDto(recipe.Id, title.Value, recipe.ImportedAt));
+            new SavedRecipeDto(recipe.Id, title.Value, recipe.CreatedAt));
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Duplicate import attempt for URL {SourceUrl} by owner {Owner}")]

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeRequest.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeRequest.cs
@@ -10,7 +10,7 @@ public sealed record SaveRecipeRequest(
     int? CookTimeMinutes,
     string? Difficulty,
     string? ImageUrl,
-    string SourceUrl);
+    string? SourceUrl = null);
 
 public sealed record SaveRecipeIngredientRequest(string Name, decimal? Amount, string? Unit);
 

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeRequestValidator.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeRequestValidator.cs
@@ -12,11 +12,11 @@ public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeReq
             .MaximumLength(RecipeTitle.MaxLength);
 
         RuleFor(x => x.SourceUrl)
-            .NotEmpty()
             .MaximumLength(RecipeUrl.MaxLength)
             .Must(url => Uri.TryCreate(url, UriKind.Absolute, out var uri)
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
-            .WithMessage("A valid HTTP or HTTPS URL is required.");
+            .WithMessage("A valid HTTP or HTTPS URL is required.")
+            .When(x => !string.IsNullOrWhiteSpace(x.SourceUrl));
 
         RuleFor(x => x.Description)
             .MaximumLength(RecipeDescription.MaxLength)

--- a/src/Yumney.Recipes.Application/DTOs/SavedRecipeDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/SavedRecipeDto.cs
@@ -1,3 +1,3 @@
 namespace Yumney.Recipes.Application.DTOs;
 
-public sealed record SavedRecipeDto(Guid Identifier, string Title, DateTime ImportedAt);
+public sealed record SavedRecipeDto(Guid Identifier, string Title, DateTime CreatedAt);

--- a/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
@@ -23,11 +23,11 @@ public sealed class Recipe : AggregateRoot<Guid>
 
     public ImageUrl? ImageUrl { get; private set; }
 
-    public RecipeUrl SourceUrl { get; private set; } = default!;
+    public RecipeUrl? SourceUrl { get; private set; }
 
     public OwnerIdentifier Owner { get; private set; } = default!;
 
-    public DateTime ImportedAt { get; private set; }
+    public DateTime CreatedAt { get; private set; }
 
     public IReadOnlyList<Ingredient> Ingredients => ingredients.AsReadOnly();
 
@@ -39,7 +39,6 @@ public sealed class Recipe : AggregateRoot<Guid>
 
     public static Recipe Create(
         RecipeTitle title,
-        RecipeUrl sourceUrl,
         OwnerIdentifier owner,
         IReadOnlyList<Ingredient> ingredients,
         IReadOnlyList<Step> steps,
@@ -48,7 +47,8 @@ public sealed class Recipe : AggregateRoot<Guid>
         PreparationTime? preparationTime = null,
         CookingTime? cookingTime = null,
         Difficulty? difficulty = null,
-        ImageUrl? imageUrl = null)
+        ImageUrl? imageUrl = null,
+        RecipeUrl? sourceUrl = null)
     {
         Ensure.That((IReadOnlyCollection<Ingredient>)ingredients).IsNotEmpty();
         Ensure.That((IReadOnlyCollection<Step>)steps).IsNotEmpty();
@@ -65,7 +65,7 @@ public sealed class Recipe : AggregateRoot<Guid>
             CookingTime = cookingTime,
             Difficulty = difficulty,
             ImageUrl = imageUrl,
-            ImportedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
         };
 
         recipe.ingredients.AddRange(ingredients);

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeUrl.cs
@@ -18,5 +18,8 @@ public sealed record RecipeUrl
         Value = validated.Trim();
     }
 
+    public static RecipeUrl? FromNullable(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : new RecipeUrl(value);
+
     public override string ToString() => Value;
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDbContext.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDbContext.cs
@@ -54,14 +54,16 @@ public sealed class RecipesDbContext(DbContextOptions<RecipesDbContext> options)
                 .HasMaxLength(ImageUrl.MaxLength);
 
             entity.Property(e => e.SourceUrl)
-                .HasConversion(v => v.Value, v => new RecipeUrl(v))
-                .HasMaxLength(RecipeUrl.MaxLength).IsRequired();
+                .HasConversion(
+                    v => v != null ? v.Value : null,
+                    v => RecipeUrl.FromNullable(v))
+                .HasMaxLength(RecipeUrl.MaxLength);
 
             entity.Property(e => e.Owner)
                 .HasConversion(v => v.Value, v => new OwnerIdentifier(v))
                 .HasMaxLength(OwnerIdentifier.MaxLength).IsRequired();
 
-            entity.Property(e => e.ImportedAt).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
 
             entity.OwnsMany(e => e.Ingredients, ingredient =>
             {
@@ -100,7 +102,9 @@ public sealed class RecipesDbContext(DbContextOptions<RecipesDbContext> options)
                     .HasMaxLength(StepDescription.MaxLength).IsRequired();
             });
 
-            entity.HasIndex(e => new { e.SourceUrl, e.Owner }).IsUnique();
+            entity.HasIndex(e => new { e.SourceUrl, e.Owner })
+                .IsUnique()
+                .HasFilter("\"SourceUrl\" IS NOT NULL");
             entity.Ignore(e => e.DomainEvents);
         });
     }

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -235,6 +235,23 @@ public class SaveRecipeCommandHandlerTests
         await recipes.Received(1).AddAsync(Arg.Any<Recipe>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task HandleAsync_NullSourceUrl_CreatesRecipeWithNullSourceUrl()
+    {
+        Recipe? capturedRecipe = null;
+        await recipes.AddAsync(Arg.Do<Recipe>(r => capturedRecipe = r), Arg.Any<CancellationToken>());
+
+        var command = new SaveRecipeCommand(
+            new RecipeTitle("Manual Recipe"),
+            [new SaveRecipeIngredientCommand(new IngredientName("Flour"), null, null)],
+            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))]);
+
+        await handler.HandleAsync(command);
+
+        capturedRecipe.Should().NotBeNull();
+        capturedRecipe!.SourceUrl.Should().BeNull();
+    }
+
     private static SaveRecipeCommand CreateValidCommand()
     {
         return new SaveRecipeCommand(

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -40,7 +40,7 @@ public class SaveRecipeCommandHandlerTests
 
         result.Value.Title.Should().Be("Pasta Carbonara");
         result.Value.Identifier.Should().NotBeEmpty();
-        result.Value.ImportedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        result.Value.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
     }
 
     [Fact]
@@ -104,12 +104,12 @@ public class SaveRecipeCommandHandlerTests
 
         var command = new SaveRecipeCommand(
             new RecipeTitle("Test"),
-            new RecipeUrl("https://example.com/recipe"),
             [
                 new SaveRecipeIngredientCommand(new IngredientName("Flour"), new Amount(500), new Unit("g")),
                 new SaveRecipeIngredientCommand(new IngredientName("Sugar"), new Amount(100), null),
             ],
-            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))]);
+            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))],
+            SourceUrl: new RecipeUrl("https://example.com/recipe"));
 
         await handler.HandleAsync(command);
 
@@ -128,12 +128,12 @@ public class SaveRecipeCommandHandlerTests
 
         var command = new SaveRecipeCommand(
             new RecipeTitle("Test"),
-            new RecipeUrl("https://example.com/recipe"),
             [new SaveRecipeIngredientCommand(new IngredientName("Flour"), null, null)],
             [
                 new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Preheat oven")),
                 new SaveRecipeStepCommand(new StepNumber(2), new StepDescription("Mix ingredients")),
-            ]);
+            ],
+            SourceUrl: new RecipeUrl("https://example.com/recipe"));
 
         await handler.HandleAsync(command);
 
@@ -151,7 +151,6 @@ public class SaveRecipeCommandHandlerTests
 
         var command = new SaveRecipeCommand(
             new RecipeTitle("Test"),
-            new RecipeUrl("https://example.com/recipe"),
             [new SaveRecipeIngredientCommand(new IngredientName("Flour"), null, null)],
             [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))],
             new RecipeDescription("A test recipe"),
@@ -159,7 +158,8 @@ public class SaveRecipeCommandHandlerTests
             new PreparationTime(10),
             new CookingTime(20),
             new Difficulty("easy"),
-            new ImageUrl("https://example.com/image.jpg"));
+            new ImageUrl("https://example.com/image.jpg"),
+            new RecipeUrl("https://example.com/recipe"));
 
         await handler.HandleAsync(command);
 
@@ -204,12 +204,43 @@ public class SaveRecipeCommandHandlerTests
             cts.Token);
     }
 
+    [Fact]
+    public async Task HandleAsync_NullSourceUrl_SkipsDuplicateCheck()
+    {
+        var command = new SaveRecipeCommand(
+            new RecipeTitle("Manual Recipe"),
+            [new SaveRecipeIngredientCommand(new IngredientName("Flour"), null, null)],
+            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))]);
+
+        await handler.HandleAsync(command);
+
+        await recipes.DidNotReceive().ExistsBySourceUrlAsync(
+            Arg.Any<RecipeUrl>(),
+            Arg.Any<OwnerIdentifier>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NullSourceUrl_SavesSuccessfully()
+    {
+        var command = new SaveRecipeCommand(
+            new RecipeTitle("Manual Recipe"),
+            [new SaveRecipeIngredientCommand(new IngredientName("Flour"), null, null)],
+            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Mix"))]);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Manual Recipe");
+        await recipes.Received(1).AddAsync(Arg.Any<Recipe>(), Arg.Any<CancellationToken>());
+    }
+
     private static SaveRecipeCommand CreateValidCommand()
     {
         return new SaveRecipeCommand(
             new RecipeTitle("Pasta Carbonara"),
-            new RecipeUrl("https://example.com/recipe"),
             [new SaveRecipeIngredientCommand(new IngredientName("Spaghetti"), new Amount(400), new Unit("g"))],
-            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Cook pasta"))]);
+            [new SaveRecipeStepCommand(new StepNumber(1), new StepDescription("Cook pasta"))],
+            SourceUrl: new RecipeUrl("https://example.com/recipe"));
     }
 }

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeRequestValidatorTests.cs
@@ -62,6 +62,16 @@ public class SaveRecipeRequestValidatorTests
         result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
     }
 
+    [Fact]
+    public void Validate_ValidRequestWithNullSourceUrl_HasNoErrors()
+    {
+        var request = CreateValidRequest() with { SourceUrl = null };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
     [Theory]
     [InlineData("not-a-url")]
     [InlineData("ftp://example.com")]

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeRequestValidatorTests.cs
@@ -42,17 +42,24 @@ public class SaveRecipeRequestValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Title);
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void Validate_EmptySourceUrl_HasError(string? sourceUrl)
+    [Fact]
+    public void Validate_NullSourceUrl_HasNoError()
     {
-        var request = CreateValidRequest() with { SourceUrl = sourceUrl! };
+        var request = CreateValidRequest() with { SourceUrl = null };
 
         var result = validator.TestValidate(request);
 
-        result.ShouldHaveValidationErrorFor(x => x.SourceUrl);
+        result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
+    }
+
+    [Fact]
+    public void Validate_EmptySourceUrl_HasNoError()
+    {
+        var request = CreateValidRequest() with { SourceUrl = string.Empty };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
     }
 
     [Theory]

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -27,7 +27,7 @@ public class RecipeTests
     }
 
     [Fact]
-    public void Create_ValidInput_SetsSourceUrl()
+    public void Create_WithSourceUrl_SetsSourceUrl()
     {
         var sourceUrl = new RecipeUrl("https://example.com/recipe");
 
@@ -47,14 +47,22 @@ public class RecipeTests
     }
 
     [Fact]
-    public void Create_ValidInput_SetsImportedAt()
+    public void Create_ValidInput_SetsCreatedAt()
     {
         var before = DateTime.UtcNow;
 
         var recipe = CreateValidRecipe();
 
-        recipe.ImportedAt.Should().BeOnOrAfter(before);
-        recipe.ImportedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+        recipe.CreatedAt.Should().BeOnOrAfter(before);
+        recipe.CreatedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Create_WithoutSourceUrl_SourceUrlIsNull()
+    {
+        var recipe = CreateValidRecipe();
+
+        recipe.SourceUrl.Should().BeNull();
     }
 
     [Fact]
@@ -187,7 +195,6 @@ public class RecipeTests
     {
         return Domain.Recipe.Recipe.Create(
             title ?? new RecipeTitle("Test Recipe"),
-            sourceUrl ?? new RecipeUrl("https://example.com/recipe"),
             owner ?? new OwnerIdentifier("user-123"),
             ingredients ?? [Ingredient.Create(new IngredientName("Flour"), new Amount(500), new Unit("g"))],
             steps ?? [Step.Create(new StepNumber(1), new StepDescription("Mix ingredients"))],
@@ -196,6 +203,7 @@ public class RecipeTests
             preparationTime,
             cookingTime,
             difficulty,
-            imageUrl);
+            imageUrl,
+            sourceUrl);
     }
 }

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeUrlTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeUrlTests.cs
@@ -126,4 +126,24 @@ public class RecipeUrlTests
 
         url.ToString().Should().Be("https://example.com/recipe");
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FromNullable_NullOrWhitespace_ReturnsNull(string? value)
+    {
+        var result = RecipeUrl.FromNullable(value);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromNullable_ValidUrl_ReturnsRecipeUrl()
+    {
+        var result = RecipeUrl.FromNullable("https://example.com/recipe");
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be("https://example.com/recipe");
+    }
 }


### PR DESCRIPTION
## Summary
- Make `SourceUrl` optional across domain, application, API, and frontend to support manual recipe creation without a source URL
- Add "Create Recipe" button on dashboard that opens the recipe preview form with an empty template
- Rename `ImportedAt` to `CreatedAt` for semantic correctness
- Use filtered unique index (`SourceUrl IS NOT NULL`) to allow multiple manual recipes while enforcing uniqueness on imported ones

## Changes
- **Domain:** `RecipeUrl.FromNullable()`, `Recipe.SourceUrl` nullable, `ImportedAt` → `CreatedAt`
- **Infrastructure:** `RecipesDbContext` updated with nullable conversion, filtered unique index
- **Application:** `SaveRecipeCommand` / `SaveRecipeRequest` SourceUrl optional, conditional duplicate check in handler, validator gated with `.When()`
- **API:** `RecipesEndpoints` uses `RecipeUrl.FromNullable()`
- **Frontend:** `sourceUrl` optional in API service, `isManualEntry` signal, `onCreateManually()`, `previewTitle` input on preview component, i18n keys (EN/DE)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 455 backend tests pass
- [x] `yarn nx test shell --run` — 202 frontend tests pass
- [x] `yarn nx lint shell` — clean
- [x] `yarn prettier --check` — formatted
- [x] `yarn nx run shell:build --configuration=production` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)