### PR TITLE
feat(recipes): add recipe detail view (US-031)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -93,6 +93,28 @@
       "errors": {
         "generic": "Rezepte konnten nicht geladen werden. Bitte versuche es später erneut."
       }
+    },
+    "detail": {
+      "back": "Zurück zu Rezepten",
+      "servings": "{{count}} Portionen",
+      "prepTime": "Vorbereitung",
+      "cookTime": "Kochen",
+      "totalTime": "Gesamt",
+      "minutes": "{{minutes}} Min.",
+      "difficulty": "Schwierigkeit",
+      "ingredients": "Zutaten",
+      "steps": "Schritte",
+      "sourceUrl": "Originalrezept",
+      "actions": {
+        "edit": "Bearbeiten",
+        "delete": "Löschen",
+        "shoppingList": "Einkaufsliste"
+      },
+      "loading": "Rezept wird geladen...",
+      "notFound": "Rezept nicht gefunden.",
+      "errors": {
+        "generic": "Rezept konnte nicht geladen werden. Bitte versuche es später erneut."
+      }
     }
   },
   "dashboard": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -93,6 +93,28 @@
       "errors": {
         "generic": "Failed to load recipes. Please try again later."
       }
+    },
+    "detail": {
+      "back": "Back to Recipes",
+      "servings": "{{count}} servings",
+      "prepTime": "Prep",
+      "cookTime": "Cook",
+      "totalTime": "Total",
+      "minutes": "{{minutes}} min",
+      "difficulty": "Difficulty",
+      "ingredients": "Ingredients",
+      "steps": "Steps",
+      "sourceUrl": "Original Recipe",
+      "actions": {
+        "edit": "Edit",
+        "delete": "Delete",
+        "shoppingList": "Shopping List"
+      },
+      "loading": "Loading recipe...",
+      "notFound": "Recipe not found.",
+      "errors": {
+        "generic": "Failed to load recipe. Please try again later."
+      }
     }
   },
   "dashboard": {

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -13,6 +13,14 @@ export const appRoutes: Route[] = [
       import('./dashboard/dashboard.component').then((m) => m.DashboardComponent),
   },
   {
+    path: 'recipes/:identifier',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./recipes/recipe-detail/recipe-detail.component').then(
+        (m) => m.RecipeDetailComponent,
+      ),
+  },
+  {
     path: 'recipes',
     canActivate: [authGuard],
     loadComponent: () =>

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
@@ -1,0 +1,107 @@
+<div class="recipe-detail-container" *transloco="let t">
+  <a routerLink="/recipes" class="back-link">
+    &larr; {{ t('recipes.detail.back') }}
+  </a>
+
+  @if (isLoading()) {
+    <div class="loading">
+      <span class="spinner"></span>
+      <span>{{ t('recipes.detail.loading') }}</span>
+    </div>
+  }
+
+  @if (error()) {
+    <div class="error-banner">{{ t(error()!) }}</div>
+  }
+
+  @if (recipe(); as recipe) {
+    <div class="recipe-hero">
+      @if (recipe.imageUrl) {
+        <img [src]="recipe.imageUrl" [alt]="recipe.title" class="hero-image" />
+      } @else {
+        <div class="hero-placeholder"></div>
+      }
+    </div>
+
+    <h1 class="recipe-title">{{ recipe.title }}</h1>
+
+    @if (recipe.description) {
+      <p class="recipe-description">{{ recipe.description }}</p>
+    }
+
+    <div class="meta-bar">
+      @if (recipe.servings) {
+        <div class="meta-item">
+          <span class="meta-label">{{ t('recipes.detail.servings', { count: recipe.servings }) }}</span>
+        </div>
+      }
+      @if (recipe.prepTimeMinutes) {
+        <div class="meta-item">
+          <span class="meta-label">{{ t('recipes.detail.prepTime') }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.prepTimeMinutes }) }}</span>
+        </div>
+      }
+      @if (recipe.cookTimeMinutes) {
+        <div class="meta-item">
+          <span class="meta-label">{{ t('recipes.detail.cookTime') }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.cookTimeMinutes }) }}</span>
+        </div>
+      }
+      @if (totalTime()) {
+        <div class="meta-item">
+          <span class="meta-label">{{ t('recipes.detail.totalTime') }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: totalTime() }) }}</span>
+        </div>
+      }
+      @if (recipe.difficulty) {
+        <div class="meta-item">
+          <span class="meta-label">{{ t('recipes.detail.difficulty') }}</span>
+          <span class="meta-value">{{ recipe.difficulty }}</span>
+        </div>
+      }
+    </div>
+
+    <div class="actions-bar">
+      <button class="action-button" disabled>{{ t('recipes.detail.actions.edit') }}</button>
+      <button class="action-button action-button--danger" disabled>{{ t('recipes.detail.actions.delete') }}</button>
+      <button class="action-button action-button--secondary" disabled>{{ t('recipes.detail.actions.shoppingList') }}</button>
+    </div>
+
+    <section class="ingredients-section">
+      <h2>{{ t('recipes.detail.ingredients') }}</h2>
+      <ul class="ingredients-list">
+        @for (ingredient of recipe.ingredients; track ingredient.name) {
+          <li>
+            @if (ingredient.amount) {
+              <span class="ingredient-amount">{{ ingredient.amount }}</span>
+            }
+            @if (ingredient.unit) {
+              <span class="ingredient-unit">{{ ingredient.unit }}</span>
+            }
+            <span class="ingredient-name">{{ ingredient.name }}</span>
+          </li>
+        }
+      </ul>
+    </section>
+
+    <section class="steps-section">
+      <h2>{{ t('recipes.detail.steps') }}</h2>
+      <ol class="steps-list">
+        @for (step of recipe.steps; track step.number) {
+          <li>
+            <span class="step-number">{{ step.number }}</span>
+            <span class="step-description">{{ step.description }}</span>
+          </li>
+        }
+      </ol>
+    </section>
+
+    @if (recipe.sourceUrl) {
+      <div class="source-link">
+        <a [href]="recipe.sourceUrl" target="_blank" rel="noopener noreferrer">
+          {{ t('recipes.detail.sourceUrl') }}
+        </a>
+      </div>
+    }
+  }
+</div>

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
@@ -1,7 +1,5 @@
 <div class="recipe-detail-container" *transloco="let t">
-  <a routerLink="/recipes" class="back-link">
-    &larr; {{ t('recipes.detail.back') }}
-  </a>
+  <a routerLink="/recipes" class="back-link"> &larr; {{ t('recipes.detail.back') }} </a>
 
   @if (isLoading()) {
     <div class="loading">
@@ -32,25 +30,33 @@
     <div class="meta-bar">
       @if (recipe.servings) {
         <div class="meta-item">
-          <span class="meta-label">{{ t('recipes.detail.servings', { count: recipe.servings }) }}</span>
+          <span class="meta-label">{{
+            t('recipes.detail.servings', { count: recipe.servings })
+          }}</span>
         </div>
       }
       @if (recipe.prepTimeMinutes) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.prepTime') }}</span>
-          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.prepTimeMinutes }) }}</span>
+          <span class="meta-value">{{
+            t('recipes.detail.minutes', { minutes: recipe.prepTimeMinutes })
+          }}</span>
         </div>
       }
       @if (recipe.cookTimeMinutes) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.cookTime') }}</span>
-          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.cookTimeMinutes }) }}</span>
+          <span class="meta-value">{{
+            t('recipes.detail.minutes', { minutes: recipe.cookTimeMinutes })
+          }}</span>
         </div>
       }
       @if (totalTime()) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.totalTime') }}</span>
-          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: totalTime() }) }}</span>
+          <span class="meta-value">{{
+            t('recipes.detail.minutes', { minutes: totalTime() })
+          }}</span>
         </div>
       }
       @if (recipe.difficulty) {
@@ -63,8 +69,12 @@
 
     <div class="actions-bar">
       <button class="action-button" disabled>{{ t('recipes.detail.actions.edit') }}</button>
-      <button class="action-button action-button--danger" disabled>{{ t('recipes.detail.actions.delete') }}</button>
-      <button class="action-button action-button--secondary" disabled>{{ t('recipes.detail.actions.shoppingList') }}</button>
+      <button class="action-button action-button--danger" disabled>
+        {{ t('recipes.detail.actions.delete') }}
+      </button>
+      <button class="action-button action-button--secondary" disabled>
+        {{ t('recipes.detail.actions.shoppingList') }}
+      </button>
     </div>
 
     <section class="ingredients-section">

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.scss
@@ -1,0 +1,252 @@
+.recipe-detail-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 1.5rem;
+  color: #f97316;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  &:hover {
+    color: #ea580c;
+  }
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 4rem 0;
+  color: #666;
+  font-size: 0.875rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgb(249 115 22 / 30%);
+  border-top-color: #f97316;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-banner {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+  background: #fef2f2;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.recipe-hero {
+  margin-bottom: 1.5rem;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.hero-image {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+}
+
+.hero-placeholder {
+  width: 100%;
+  height: 240px;
+  background: linear-gradient(135deg, #fff7ed, #fed7aa);
+}
+
+.recipe-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.recipe-description {
+  margin: 0 0 1.5rem;
+  color: #555;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.meta-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 80px;
+  text-align: center;
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.meta-value {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.actions-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.action-button {
+  padding: 0.5rem 1.25rem;
+  border: 2px solid #f97316;
+  border-radius: 8px;
+  background: #f97316;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &--danger {
+    background: transparent;
+    border-color: #dc2626;
+    color: #dc2626;
+  }
+
+  &--secondary {
+    background: transparent;
+    border-color: #f97316;
+    color: #f97316;
+  }
+}
+
+.ingredients-section,
+.steps-section {
+  margin-bottom: 2rem;
+
+  h2 {
+    margin: 0 0 1rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+}
+
+.ingredients-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9375rem;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.ingredient-amount {
+  font-weight: 600;
+  color: #f97316;
+  min-width: 2.5rem;
+}
+
+.ingredient-unit {
+  color: #888;
+  min-width: 2rem;
+}
+
+.ingredient-name {
+  color: #333;
+}
+
+.steps-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: step-counter;
+
+  li {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 0;
+    border-bottom: 1px solid #f3f4f6;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.step-number {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: #f97316;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.step-description {
+  padding-top: 0.25rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: #333;
+}
+
+.source-link {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+
+  a {
+    color: #f97316;
+    text-decoration: none;
+    font-size: 0.875rem;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
@@ -63,7 +63,7 @@ describe('RecipeDetailComponent', () => {
 
   function setupTestBed(
     getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
-    identifier: string = 'abc-123',
+    identifier = 'abc-123',
   ) {
     recipeApiMock = {
       getRecipeById: getRecipeByIdReturn,

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
@@ -297,4 +297,68 @@ describe('RecipeDetailComponent', () => {
 
     expect(recipeApiMock.getRecipeById).toHaveBeenCalledWith('my-recipe-id');
   }));
+
+  it('should show not-found when route has no identifier', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), null as unknown as string);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(recipeApiMock.getRecipeById).not.toHaveBeenCalled();
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Recipe not found.');
+  }));
+
+  it('should return null totalTime when both times are null', fakeAsync(() => {
+    const noTimes = { ...mockRecipe, prepTimeMinutes: null, cookTimeMinutes: null };
+    setupTestBed(vi.fn().mockReturnValue(of(noTimes)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.totalTime()).toBeNull();
+  }));
+
+  it('should compute totalTime as sum of prep and cook', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.totalTime()).toBe(30);
+  }));
+
+  it('should compute totalTime with only prep time', fakeAsync(() => {
+    const prepOnly = { ...mockRecipe, cookTimeMinutes: null };
+    setupTestBed(vi.fn().mockReturnValue(of(prepOnly)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.totalTime()).toBe(10);
+  }));
+
+  it('should compute totalTime with only cook time', fakeAsync(() => {
+    const cookOnly = { ...mockRecipe, prepTimeMinutes: null };
+    setupTestBed(vi.fn().mockReturnValue(of(cookOnly)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.totalTime()).toBe(20);
+  }));
+
+  it('should set isLoading to false after successful load', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.isLoading()).toBe(false);
+  }));
+
+  it('should set isLoading to false after error', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 500 });
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => httpError)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.isLoading()).toBe(false);
+  }));
 });

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
@@ -1,0 +1,300 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter, ActivatedRoute } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, Subject, throwError } from 'rxjs';
+import { RecipeDetailComponent } from './recipe-detail.component';
+import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
+import { HttpErrorResponse } from '@angular/common/http';
+
+const mockRecipe: RecipeDetail = {
+  identifier: 'abc-123',
+  title: 'Pasta Carbonara',
+  description: 'A classic Italian dish with eggs and bacon',
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: 'medium',
+  imageUrl: 'https://example.com/image.jpg',
+  sourceUrl: 'https://example.com/recipe',
+  createdAt: '2026-03-10T00:00:00Z',
+  ingredients: [
+    { name: 'Spaghetti', amount: 400, unit: 'g' },
+    { name: 'Eggs', amount: 4, unit: null },
+    { name: 'Parmesan', amount: null, unit: null },
+  ],
+  steps: [
+    { number: 1, description: 'Cook pasta' },
+    { number: 2, description: 'Mix eggs and cheese' },
+    { number: 3, description: 'Combine everything' },
+  ],
+};
+
+const en = {
+  recipes: {
+    detail: {
+      back: 'Back to Recipes',
+      servings: '{{count}} servings',
+      prepTime: 'Prep',
+      cookTime: 'Cook',
+      totalTime: 'Total',
+      minutes: '{{minutes}} min',
+      difficulty: 'Difficulty',
+      ingredients: 'Ingredients',
+      steps: 'Steps',
+      sourceUrl: 'Original Recipe',
+      actions: {
+        edit: 'Edit',
+        delete: 'Delete',
+        shoppingList: 'Shopping List',
+      },
+      loading: 'Loading recipe...',
+      notFound: 'Recipe not found.',
+      errors: {
+        generic: 'Failed to load recipe. Please try again later.',
+      },
+    },
+  },
+};
+
+describe('RecipeDetailComponent', () => {
+  let component: RecipeDetailComponent;
+  let fixture: ComponentFixture<RecipeDetailComponent>;
+  let recipeApiMock: { getRecipeById: ReturnType<typeof vi.fn> };
+
+  function setupTestBed(
+    getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
+    identifier: string = 'abc-123',
+  ) {
+    recipeApiMock = {
+      getRecipeById: getRecipeByIdReturn,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        RecipeDetailComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [
+        provideRouter([]),
+        { provide: RecipeApiService, useValue: recipeApiMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => (key === 'identifier' ? identifier : null),
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(RecipeDetailComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('should create the component', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component).toBeTruthy();
+  }));
+
+  it('should render recipe title', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const title = fixture.nativeElement.querySelector('.recipe-title');
+    expect(title.textContent).toContain('Pasta Carbonara');
+  }));
+
+  it('should render recipe description', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const desc = fixture.nativeElement.querySelector('.recipe-description');
+    expect(desc.textContent).toContain('A classic Italian dish');
+  }));
+
+  it('should render recipe image', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('.hero-image');
+    expect(img).toBeTruthy();
+    expect(img.src).toContain('example.com/image.jpg');
+  }));
+
+  it('should show placeholder when no image', fakeAsync(() => {
+    const noImage = { ...mockRecipe, imageUrl: null };
+    setupTestBed(vi.fn().mockReturnValue(of(noImage)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const placeholder = fixture.nativeElement.querySelector('.hero-placeholder');
+    expect(placeholder).toBeTruthy();
+  }));
+
+  it('should render ingredients list', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.ingredients-list li');
+    expect(items.length).toBe(3);
+  }));
+
+  it('should render ingredient with amount and unit', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const firstItem = fixture.nativeElement.querySelector('.ingredients-list li');
+    expect(firstItem.textContent).toContain('400');
+    expect(firstItem.textContent).toContain('g');
+    expect(firstItem.textContent).toContain('Spaghetti');
+  }));
+
+  it('should render steps in order', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const steps = fixture.nativeElement.querySelectorAll('.steps-list li');
+    expect(steps.length).toBe(3);
+    expect(steps[0].textContent).toContain('Cook pasta');
+    expect(steps[1].textContent).toContain('Mix eggs and cheese');
+    expect(steps[2].textContent).toContain('Combine everything');
+  }));
+
+  it('should show meta bar with servings', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const meta = fixture.nativeElement.querySelector('.meta-bar');
+    expect(meta.textContent).toContain('4 servings');
+  }));
+
+  it('should hide optional fields when null', fakeAsync(() => {
+    const minimal: RecipeDetail = {
+      ...mockRecipe,
+      description: null,
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      sourceUrl: null,
+    };
+    setupTestBed(vi.fn().mockReturnValue(of(minimal)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.recipe-description')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.source-link')).toBeNull();
+    const metaItems = fixture.nativeElement.querySelectorAll('.meta-item');
+    expect(metaItems.length).toBe(0);
+  }));
+
+  it('should show loading state', fakeAsync(() => {
+    const subject = new Subject<RecipeDetail>();
+    setupTestBed(vi.fn().mockReturnValue(subject));
+    fixture.detectChanges();
+
+    const loading = fixture.nativeElement.querySelector('.loading');
+    expect(loading).toBeTruthy();
+    expect(loading.textContent).toContain('Loading recipe...');
+
+    subject.next(mockRecipe);
+    subject.complete();
+    tick();
+  }));
+
+  it('should show error state on API failure', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 500 });
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => httpError)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Failed to load recipe.');
+  }));
+
+  it('should show not-found message on 404', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 404 });
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => httpError)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Recipe not found.');
+  }));
+
+  it('should render back link', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const backLink = fixture.nativeElement.querySelector('.back-link');
+    expect(backLink).toBeTruthy();
+    expect(backLink.textContent).toContain('Back to Recipes');
+  }));
+
+  it('should render source URL as link', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const sourceLink = fixture.nativeElement.querySelector('.source-link a');
+    expect(sourceLink).toBeTruthy();
+    expect(sourceLink.href).toContain('example.com/recipe');
+    expect(sourceLink.textContent).toContain('Original Recipe');
+  }));
+
+  it('should render action buttons as disabled', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const buttons = fixture.nativeElement.querySelectorAll('.action-button');
+    expect(buttons.length).toBe(3);
+    buttons.forEach((btn: HTMLButtonElement) => {
+      expect(btn.disabled).toBe(true);
+    });
+  }));
+
+  it('should call getRecipeById with correct identifier', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), 'my-recipe-id');
+    fixture.detectChanges();
+    tick();
+
+    expect(recipeApiMock.getRecipeById).toHaveBeenCalledWith('my-recipe-id');
+  }));
+});

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.ts
@@ -1,0 +1,71 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  OnInit,
+  DestroyRef,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslocoModule } from '@jsverse/transloco';
+import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
+
+@Component({
+  selector: 'yn-recipe-detail',
+  imports: [TranslocoModule, RouterLink],
+  templateUrl: './recipe-detail.component.html',
+  styleUrl: './recipe-detail.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecipeDetailComponent implements OnInit {
+  private recipeApi = inject(RecipeApiService);
+  private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
+
+  recipe = signal<RecipeDetail | null>(null);
+  isLoading = signal(false);
+  error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    const identifier = this.route.snapshot.paramMap.get('identifier');
+    if (!identifier) {
+      this.error.set('recipes.detail.notFound');
+      return;
+    }
+
+    this.isLoading.set(true);
+
+    this.recipeApi
+      .getRecipeById(identifier)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (recipe) => {
+          this.recipe.set(recipe);
+          this.isLoading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading.set(false);
+          if (err.status === 404) {
+            this.error.set('recipes.detail.notFound');
+          } else {
+            this.error.set('recipes.detail.errors.generic');
+          }
+        },
+      });
+  }
+
+  totalTime(): number | null {
+    const recipe = this.recipe();
+    if (!recipe) {
+      return null;
+    }
+    const prep = recipe.prepTimeMinutes ?? 0;
+    const cook = recipe.cookTimeMinutes ?? 0;
+    if (prep === 0 && cook === 0) {
+      return null;
+    }
+    return prep + cook;
+  }
+}

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
@@ -30,7 +30,7 @@
   @if (recipes().length > 0) {
     <div class="recipe-grid">
       @for (recipe of recipes(); track recipe.identifier) {
-        <div class="recipe-card">
+        <a class="recipe-card" [routerLink]="['/recipes', recipe.identifier]">
           @if (recipe.imageUrl) {
             <img [src]="recipe.imageUrl" [alt]="recipe.title" class="recipe-image" />
           } @else {
@@ -62,7 +62,7 @@
               }
             </div>
           </div>
-        </div>
+        </a>
       }
     </div>
   }

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.scss
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.scss
@@ -83,11 +83,15 @@
 }
 
 .recipe-card {
+  display: block;
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
   overflow: hidden;
   transition: box-shadow 0.2s ease;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 
   &:hover {
     box-shadow: 0 4px 16px rgb(0 0 0 / 12%);

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -10,4 +10,7 @@ export {
   type RecipeListItem,
   type RecipeListResponse,
   type GetRecipesParams,
+  type RecipeDetail,
+  type RecipeIngredient,
+  type RecipeStep,
 } from './lib/recipe-api.service';

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -74,6 +74,32 @@ export interface GetRecipesParams {
   sortDirection?: 'Ascending' | 'Descending';
 }
 
+export interface RecipeIngredient {
+  name: string;
+  amount: number | null;
+  unit: string | null;
+}
+
+export interface RecipeStep {
+  number: number;
+  description: string;
+}
+
+export interface RecipeDetail {
+  identifier: string;
+  title: string;
+  description: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  difficulty: string | null;
+  imageUrl: string | null;
+  sourceUrl: string | null;
+  createdAt: string;
+  ingredients: RecipeIngredient[];
+  steps: RecipeStep[];
+}
+
 @Injectable({ providedIn: 'root' })
 export class RecipeApiService {
   private http = inject(HttpClient);
@@ -84,6 +110,10 @@ export class RecipeApiService {
 
   saveRecipe(request: SaveRecipeRequest): Observable<SavedRecipeResponse> {
     return this.http.post<SavedRecipeResponse>('/api/v1/recipes', request);
+  }
+
+  getRecipeById(identifier: string): Observable<RecipeDetail> {
+    return this.http.get<RecipeDetail>(`/api/v1/recipes/${identifier}`);
   }
 
   getRecipes(params: GetRecipesParams = {}): Observable<RecipeListResponse> {

--- a/src/Yumney.Api/Program.cs
+++ b/src/Yumney.Api/Program.cs
@@ -68,6 +68,7 @@ builder.Services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidato
 builder.Services.AddScoped<ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>, ImportRecipeCommandHandler>();
 builder.Services.AddScoped<ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>>, SaveRecipeCommandHandler>();
 builder.Services.AddScoped<IQueryHandler<GetRecipesQuery, Result<RecipeListDto>>, GetRecipesQueryHandler>();
+builder.Services.AddScoped<IQueryHandler<GetRecipeByIdQuery, Result<RecipeDetailDto>>, GetRecipeByIdQueryHandler>();
 
 builder.Services.AddHttpClient<IWebScraper, WebScraper>().AddStandardResilienceHandler();
 builder.Services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -22,6 +22,12 @@ public static class RecipesEndpoints
             .WithTags("Recipes")
             .Produces<RecipeListDto>();
 
+        group.MapGet("/{identifier:guid}", GetByIdAsync)
+            .WithName("GetRecipeById")
+            .WithTags("Recipes")
+            .Produces<RecipeDetailDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         group.MapPost("/import", ImportAsync)
             .WithName("ImportRecipe")
             .WithTags("Recipes")
@@ -106,6 +112,22 @@ public static class RecipesEndpoints
         }
 
         return Results.Created($"/api/v1/recipes/{result.Value.Identifier}", result.Value);
+    }
+
+    private static async Task<IResult> GetByIdAsync(
+        Guid identifier,
+        IQueryHandler<GetRecipeByIdQuery, Result<RecipeDetailDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetRecipeByIdQuery(identifier);
+        var result = await handler.HandleAsync(query, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return Results.Problem("Recipe not found.", statusCode: 404);
+        }
+
+        return Results.Ok(result.Value);
     }
 
     private static async Task<IResult> ImportAsync(

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -124,7 +124,12 @@ public static class RecipesEndpoints
 
         if (result.IsFailure)
         {
-            return Results.Problem("Recipe not found.", statusCode: 404);
+            return result.Error switch
+            {
+                GetRecipeByIdErrors.NotFound => Results.Problem("Recipe not found.", statusCode: 404),
+                GetRecipeByIdErrors.AccessDenied => Results.Problem("Recipe not found.", statusCode: 404),
+                _ => Results.Problem("Failed to fetch recipe.", statusCode: 500),
+            };
         }
 
         return Results.Ok(result.Value);

--- a/src/Yumney.Recipes.Application/DTOs/RecipeDetailDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/RecipeDetailDto.cs
@@ -1,0 +1,19 @@
+namespace Yumney.Recipes.Application.DTOs;
+
+public sealed record RecipeDetailDto(
+    Guid Identifier,
+    string Title,
+    string? Description,
+    int? Servings,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    string? Difficulty,
+    string? ImageUrl,
+    string? SourceUrl,
+    DateTime CreatedAt,
+    IReadOnlyList<RecipeIngredientDto> Ingredients,
+    IReadOnlyList<RecipeStepDto> Steps);
+
+public sealed record RecipeIngredientDto(string Name, decimal? Amount, string? Unit);
+
+public sealed record RecipeStepDto(int Number, string Description);

--- a/src/Yumney.Recipes.Application/Queries/GetRecipeByIdErrors.cs
+++ b/src/Yumney.Recipes.Application/Queries/GetRecipeByIdErrors.cs
@@ -1,0 +1,7 @@
+namespace Yumney.Recipes.Application.Queries;
+
+public static class GetRecipeByIdErrors
+{
+    public const string NotFound = "RECIPE_NOT_FOUND";
+    public const string AccessDenied = "RECIPE_ACCESS_DENIED";
+}

--- a/src/Yumney.Recipes.Application/Queries/GetRecipeByIdQuery.cs
+++ b/src/Yumney.Recipes.Application/Queries/GetRecipeByIdQuery.cs
@@ -1,0 +1,7 @@
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+
+namespace Yumney.Recipes.Application.Queries;
+
+public sealed record GetRecipeByIdQuery(Guid Identifier) : IQuery<Result<RecipeDetailDto>>;

--- a/src/Yumney.Recipes.Application/Queries/GetRecipeByIdQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/GetRecipeByIdQueryHandler.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+using Yumney.Shared.CQRS;
+
+namespace Yumney.Recipes.Application.Queries;
+
+#pragma warning disable SA1601 // Partial elements should be documented (required for LoggerMessage source generation)
+public sealed partial class GetRecipeByIdQueryHandler(
+    IRecipeRepository recipes,
+    ICurrentUser currentUser,
+    ILogger<GetRecipeByIdQueryHandler> logger)
+    : IQueryHandler<GetRecipeByIdQuery, Result<RecipeDetailDto>>
+{
+    public async Task<Result<RecipeDetailDto>> HandleAsync(GetRecipeByIdQuery query, CancellationToken cancellationToken = default)
+    {
+        var identifier = query.Identifier;
+        var owner = new OwnerIdentifier(currentUser.UserId);
+
+        LogGetRecipeById(identifier, owner.Value);
+
+        var recipe = await recipes.GetByIdAsync(identifier, cancellationToken);
+
+        if (recipe is null)
+        {
+            LogRecipeNotFound(identifier);
+            return Result<RecipeDetailDto>.Failure(GetRecipeByIdErrors.NotFound);
+        }
+
+        if (recipe.Owner != owner)
+        {
+            LogRecipeAccessDenied(identifier, owner.Value);
+            return Result<RecipeDetailDto>.Failure(GetRecipeByIdErrors.AccessDenied);
+        }
+
+        var dto = new RecipeDetailDto(
+            recipe.Id,
+            recipe.Title.Value,
+            recipe.Description?.Value,
+            recipe.Servings?.Value,
+            recipe.PreparationTime?.Value,
+            recipe.CookingTime?.Value,
+            recipe.Difficulty?.Value,
+            recipe.ImageUrl?.Value,
+            recipe.SourceUrl?.Value,
+            recipe.CreatedAt,
+            recipe.Ingredients.Select(i => new RecipeIngredientDto(
+                i.Name.Value,
+                i.Amount?.Value,
+                i.Unit?.Value)).ToList(),
+            recipe.Steps.Select(s => new RecipeStepDto(
+                s.Number.Value,
+                s.Description.Value)).ToList());
+
+        return Result<RecipeDetailDto>.Success(dto);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Fetching recipe {RecipeId} for owner {OwnerId}")]
+    private partial void LogGetRecipeById(Guid recipeId, string ownerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recipe {RecipeId} not found")]
+    private partial void LogRecipeNotFound(Guid recipeId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Access denied to recipe {RecipeId} for owner {OwnerId}")]
+    private partial void LogRecipeAccessDenied(Guid recipeId, string ownerId);
+}

--- a/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
@@ -6,6 +6,8 @@ public interface IRecipeRepository
 
     Task<bool> ExistsBySourceUrlAsync(RecipeUrl sourceUrl, OwnerIdentifier owner, CancellationToken cancellationToken = default);
 
+    Task<Recipe?> GetByIdAsync(Guid identifier, CancellationToken cancellationToken = default);
+
     Task<(IReadOnlyList<Recipe> Items, int TotalCount)> GetByOwnerAsync(
         OwnerIdentifier owner,
         int skip,

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -11,6 +11,14 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
         await context.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<Recipe?> GetByIdAsync(Guid identifier, CancellationToken cancellationToken = default)
+    {
+        return await context.Recipes
+            .Include(r => r.Ingredients)
+            .Include(r => r.Steps)
+            .FirstOrDefaultAsync(r => r.Id == identifier, cancellationToken);
+    }
+
     public async Task<bool> ExistsBySourceUrlAsync(RecipeUrl sourceUrl, OwnerIdentifier owner, CancellationToken cancellationToken = default)
     {
         return await context.Recipes.AnyAsync(

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
@@ -1,0 +1,221 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Yumney.Recipes.Application.DTOs;
+using Yumney.Recipes.Application.Queries;
+using Yumney.Recipes.Domain.Recipe;
+using Yumney.Shared.Common;
+
+namespace Yumney.Recipes.Application.Tests.Queries;
+
+public class GetRecipeByIdQueryHandlerTests
+{
+    private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ILogger<GetRecipeByIdQueryHandler> logger = Substitute.For<ILogger<GetRecipeByIdQueryHandler>>();
+    private readonly GetRecipeByIdQueryHandler handler;
+
+    public GetRecipeByIdQueryHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new GetRecipeByIdQueryHandler(recipes, currentUser, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeExists_ReturnsSuccessResult()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeExists_ReturnsMappedTitle()
+    {
+        var recipe = CreateTestRecipe("user-123", "Pasta Carbonara");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.Value.Title.Should().Be("Pasta Carbonara");
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeExists_ReturnsMappedIdentifier()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.Value.Identifier.Should().Be(recipe.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeNotFound_ReturnsFailure()
+    {
+        var id = Guid.NewGuid();
+        recipes.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((Recipe?)null);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(id));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(GetRecipeByIdErrors.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongOwner_ReturnsAccessDeniedFailure()
+    {
+        var recipe = CreateTestRecipe("other-user");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(GetRecipeByIdErrors.AccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeWithAllFields_MapsOptionalFieldsCorrectly()
+    {
+        var recipe = CreateTestRecipeWithOptionals("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        var dto = result.Value;
+        dto.Description.Should().Be("A test recipe");
+        dto.Servings.Should().Be(4);
+        dto.PrepTimeMinutes.Should().Be(10);
+        dto.CookTimeMinutes.Should().Be(20);
+        dto.Difficulty.Should().Be("easy");
+        dto.ImageUrl.Should().Be("https://example.com/image.jpg");
+        dto.SourceUrl.Should().Be("https://example.com/recipe");
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeWithoutOptionals_MapsNullFields()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        var dto = result.Value;
+        dto.Description.Should().BeNull();
+        dto.Servings.Should().BeNull();
+        dto.PrepTimeMinutes.Should().BeNull();
+        dto.CookTimeMinutes.Should().BeNull();
+        dto.Difficulty.Should().BeNull();
+        dto.ImageUrl.Should().BeNull();
+        dto.SourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeWithIngredients_MapsIngredientsCorrectly()
+    {
+        var recipe = CreateTestRecipeWithIngredients("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.Value.Ingredients.Should().HaveCount(2);
+        result.Value.Ingredients[0].Name.Should().Be("Flour");
+        result.Value.Ingredients[0].Amount.Should().Be(500m);
+        result.Value.Ingredients[0].Unit.Should().Be("g");
+        result.Value.Ingredients[1].Name.Should().Be("Eggs");
+        result.Value.Ingredients[1].Amount.Should().BeNull();
+        result.Value.Ingredients[1].Unit.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeWithSteps_MapsStepsCorrectly()
+    {
+        var recipe = CreateTestRecipeWithSteps("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.Value.Steps.Should().HaveCount(2);
+        result.Value.Steps[0].Number.Should().Be(1);
+        result.Value.Steps[0].Description.Should().Be("Mix flour");
+        result.Value.Steps[1].Number.Should().Be(2);
+        result.Value.Steps[1].Description.Should().Be("Add eggs");
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeExists_MapsCreatedAt()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var result = await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        result.Value.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithCancellationToken_ForwardsToRepository()
+    {
+        var id = Guid.NewGuid();
+        var cts = new CancellationTokenSource();
+        recipes.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((Recipe?)null);
+
+        await handler.HandleAsync(new GetRecipeByIdQuery(id), cts.Token);
+
+        await recipes.Received(1).GetByIdAsync(id, cts.Token);
+    }
+
+    private static Recipe CreateTestRecipe(string ownerId, string title = "Test Recipe")
+    {
+        return Recipe.Create(
+            new RecipeTitle(title),
+            new OwnerIdentifier(ownerId),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+    }
+
+    private static Recipe CreateTestRecipeWithOptionals(string ownerId)
+    {
+        return Recipe.Create(
+            new RecipeTitle("Full Recipe"),
+            new OwnerIdentifier(ownerId),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))],
+            new RecipeDescription("A test recipe"),
+            new Servings(4),
+            new PreparationTime(10),
+            new CookingTime(20),
+            new Difficulty("easy"),
+            new ImageUrl("https://example.com/image.jpg"),
+            new RecipeUrl("https://example.com/recipe"));
+    }
+
+    private static Recipe CreateTestRecipeWithIngredients(string ownerId)
+    {
+        return Recipe.Create(
+            new RecipeTitle("Recipe With Ingredients"),
+            new OwnerIdentifier(ownerId),
+            [
+                Ingredient.Create(new IngredientName("Flour"), new Amount(500m), new Unit("g")),
+                Ingredient.Create(new IngredientName("Eggs"), null, null),
+            ],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+    }
+
+    private static Recipe CreateTestRecipeWithSteps(string ownerId)
+    {
+        return Recipe.Create(
+            new RecipeTitle("Recipe With Steps"),
+            new OwnerIdentifier(ownerId),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [
+                Step.Create(new StepNumber(1), new StepDescription("Mix flour")),
+                Step.Create(new StepNumber(2), new StepDescription("Add eggs")),
+            ]);
+    }
+}

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
@@ -148,6 +148,17 @@ public class GetRecipeByIdQueryHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_Always_CallsRepositoryWithCorrectIdentifier()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        await handler.HandleAsync(new GetRecipeByIdQuery(recipe.Id));
+
+        await recipes.Received(1).GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task HandleAsync_RecipeExists_MapsCreatedAt()
     {
         var recipe = CreateTestRecipe("user-123");


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/recipes/{identifier}` endpoint with ownership validation (returns 404 for not-found and access-denied to avoid leaking existence)
- Add `RecipeDetailComponent` displaying title, image, description, meta bar (servings, prep/cook/total time, difficulty), ingredients list, numbered steps, source URL, and disabled action button placeholders (Edit, Delete, Shopping List)
- Recipe list cards now navigate to `/recipes/:identifier` on click
- i18n support for EN and DE

## Test plan

- [x] Backend: `GetRecipeByIdQueryHandler` — 12 tests covering success, not-found, wrong owner, field mapping (all/null/ingredients/steps), repository call verification, cancellation token forwarding
- [x] Backend: All 482 tests pass (including architecture tests)
- [x] Frontend: `RecipeDetailComponent` — 23 tests covering rendering, loading/error/404 states, back link, source URL, action buttons, totalTime() logic, null identifier edge case, isLoading transitions
- [x] Frontend: All 263 tests pass across 14 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)