### PR TITLE
feat(recipes): replace load-more button with infinite scroll (US-030)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -91,7 +91,6 @@
       "prepTime": "Vorbereitung {{minutes}} Min.",
       "cookTime": "Kochen {{minutes}} Min.",
       "loading": "Rezepte werden geladen...",
-      "loadMore": "Mehr laden",
       "empty": {
         "title": "Noch keine Rezepte",
         "message": "Importiere dein erstes Rezept von einer beliebigen Website oder erstelle eines von Grund auf.",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -91,7 +91,6 @@
       "prepTime": "Prep {{minutes}} min",
       "cookTime": "Cook {{minutes}} min",
       "loading": "Loading recipes...",
-      "loadMore": "Load more",
       "empty": {
         "title": "No recipes yet",
         "message": "Import your first recipe from any website or create one from scratch.",

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
@@ -67,6 +67,8 @@
     </div>
   }
 
+  <div #scrollSentinel class="scroll-sentinel"></div>
+
   @if (isLoading()) {
     <div class="loading">
       <span class="spinner"></span>
@@ -74,11 +76,4 @@
     </div>
   }
 
-  @if (hasMore() && !isLoading()) {
-    <div class="load-more">
-      <button class="load-more-button" (click)="onLoadMore()">
-        {{ t('recipes.list.loadMore') }}
-      </button>
-    </div>
-  }
 </div>

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.scss
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.scss
@@ -139,23 +139,6 @@
   border-radius: 4px;
 }
 
-.load-more {
-  display: flex;
-  justify-content: center;
-  padding: 2rem 0;
-}
-
-.load-more-button {
-  padding: 0.75rem 2rem;
-  border: 2px solid #f97316;
-  border-radius: 8px;
-  background: transparent;
-  color: #f97316;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-
-  &:hover {
-    background: #fff7ed;
-  }
+.scroll-sentinel {
+  height: 1px;
 }

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.spec.ts
@@ -5,6 +5,33 @@ import { of, Subject, throwError } from 'rxjs';
 import { RecipeListComponent } from './recipe-list.component';
 import { RecipeApiService, RecipeListResponse } from '@yumney/shared/api-client';
 
+let intersectionCallback: IntersectionObserverCallback;
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+  observedElement: Element | null = null;
+
+  constructor(callback: IntersectionObserverCallback) {
+    intersectionCallback = callback;
+  }
+
+  observe(target: Element): void {
+    this.observedElement = target;
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.observedElement = null;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
 const mockResponse: RecipeListResponse = {
   items: [
     {
@@ -57,7 +84,6 @@ const en = {
       prepTime: 'Prep {{minutes}} min',
       cookTime: 'Cook {{minutes}} min',
       loading: 'Loading recipes...',
-      loadMore: 'Load more',
       empty: {
         title: 'No recipes yet',
         message: 'Import your first recipe from any website or create one from scratch.',
@@ -74,6 +100,14 @@ describe('RecipeListComponent', () => {
   let component: RecipeListComponent;
   let fixture: ComponentFixture<RecipeListComponent>;
   let recipeApiMock: { getRecipes: ReturnType<typeof vi.fn> };
+
+  beforeAll(() => {
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
 
   function setupTestBed(getRecipesReturn: ReturnType<typeof vi.fn> = vi.fn()) {
     recipeApiMock = {
@@ -100,6 +134,13 @@ describe('RecipeListComponent', () => {
 
   function mockSortEvent(value: string): Event {
     return { target: { value } } as unknown as Event;
+  }
+
+  function triggerIntersection(isIntersecting: boolean): void {
+    intersectionCallback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
   }
 
   it('should create the component', fakeAsync(() => {
@@ -227,29 +268,17 @@ describe('RecipeListComponent', () => {
     expect(component.currentPage()).toBe(1);
   }));
 
-  it('should show load more button when hasMore is true', fakeAsync(() => {
+  it('should render scroll sentinel element', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
 
-    const btn = fixture.nativeElement.querySelector('.load-more-button');
-    expect(btn).toBeTruthy();
-    expect(btn.textContent).toContain('Load more');
+    const sentinel = fixture.nativeElement.querySelector('.scroll-sentinel');
+    expect(sentinel).toBeTruthy();
   }));
 
-  it('should not show load more when all loaded', fakeAsync(() => {
-    const fullResponse: RecipeListResponse = { ...mockResponse, totalCount: 2 };
-    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
-    fixture.detectChanges();
-    tick();
-    fixture.detectChanges();
-
-    const btn = fixture.nativeElement.querySelector('.load-more-button');
-    expect(btn).toBeNull();
-  }));
-
-  it('should append recipes on load more', fakeAsync(() => {
+  it('should call loadMore when sentinel intersects and hasMore', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
@@ -273,11 +302,62 @@ describe('RecipeListComponent', () => {
       pageSize: 20,
     };
     recipeApiMock.getRecipes.mockReturnValue(of(moreResponse));
-    component.onLoadMore();
+    triggerIntersection(true);
     tick();
 
     expect(component.recipes().length).toBe(3);
     expect(component.currentPage()).toBe(2);
+  }));
+
+  it('should not call loadMore when sentinel intersects but no more items', fakeAsync(() => {
+    const fullResponse: RecipeListResponse = { ...mockResponse, totalCount: 2 };
+    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
+    fixture.detectChanges();
+    tick();
+
+    const callCount = recipeApiMock.getRecipes.mock.calls.length;
+    triggerIntersection(true);
+    tick();
+
+    expect(recipeApiMock.getRecipes.mock.calls.length).toBe(callCount);
+  }));
+
+  it('should not call loadMore when sentinel is not intersecting', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
+    fixture.detectChanges();
+    tick();
+
+    const callCount = recipeApiMock.getRecipes.mock.calls.length;
+    triggerIntersection(false);
+    tick();
+
+    expect(recipeApiMock.getRecipes.mock.calls.length).toBe(callCount);
+  }));
+
+  it('should not call loadMore when sentinel intersects but isLoading', fakeAsync(() => {
+    const subject = new Subject<RecipeListResponse>();
+    setupTestBed(vi.fn().mockReturnValue(subject));
+    fixture.detectChanges();
+
+    expect(component.isLoading()).toBe(true);
+    triggerIntersection(true);
+
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledTimes(1);
+
+    subject.next(mockResponse);
+    subject.complete();
+    tick();
+  }));
+
+  it('should disconnect observer on destroy', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
+    fixture.detectChanges();
+    tick();
+
+    const disconnectSpy = vi.spyOn(MockIntersectionObserver.prototype, 'disconnect');
+    fixture.destroy();
+    expect(disconnectSpy).toHaveBeenCalled();
+    disconnectSpy.mockRestore();
   }));
 
   it('should show recipe image when available', fakeAsync(() => {
@@ -339,22 +419,6 @@ describe('RecipeListComponent', () => {
     tick();
 
     expect(component.serverError()).toBeNull();
-  }));
-
-  it('should not show load more when items equal totalCount', fakeAsync(() => {
-    const exactResponse: RecipeListResponse = {
-      items: [mockResponse.items[0]],
-      totalCount: 1,
-      page: 1,
-      pageSize: 20,
-    };
-    setupTestBed(vi.fn().mockReturnValue(of(exactResponse)));
-    fixture.detectChanges();
-    tick();
-    fixture.detectChanges();
-
-    const btn = fixture.nativeElement.querySelector('.load-more-button');
-    expect(btn).toBeNull();
   }));
 
   it('should not show empty state while loading', fakeAsync(() => {

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.ts
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.ts
@@ -1,11 +1,14 @@
 import {
+  AfterViewInit,
   Component,
   ChangeDetectionStrategy,
   computed,
+  ElementRef,
   inject,
   OnInit,
   DestroyRef,
   signal,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -21,13 +24,16 @@ import { mapHttpError, HttpErrorMap } from '@yumney/shared/models';
   styleUrl: './recipe-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecipeListComponent implements OnInit {
+export class RecipeListComponent implements OnInit, AfterViewInit {
   private static readonly listErrorMap: HttpErrorMap = {
     default: 'recipes.list.errors.generic',
   };
 
   private recipeApi = inject(RecipeApiService);
   private destroyRef = inject(DestroyRef);
+  private observer: IntersectionObserver | null = null;
+
+  scrollSentinel = viewChild<ElementRef>('scrollSentinel');
 
   recipes = signal<RecipeListItem[]>([]);
   totalCount = signal(0);
@@ -70,7 +76,20 @@ export class RecipeListComponent implements OnInit {
     this.loadRecipes(false);
   }
 
-  onLoadMore(): void {
+  ngAfterViewInit(): void {
+    this.observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && this.hasMore() && !this.isLoading()) {
+        this.loadMore();
+      }
+    });
+    const sentinel = this.scrollSentinel()?.nativeElement;
+    if (sentinel) {
+      this.observer.observe(sentinel);
+    }
+    this.destroyRef.onDestroy(() => this.observer?.disconnect());
+  }
+
+  private loadMore(): void {
     this.currentPage.update((p) => p + 1);
     this.loadRecipes(true);
   }


### PR DESCRIPTION
## Summary
- Replace the manual "Load more" button with `IntersectionObserver`-based infinite scrolling on the recipe list
- Add a 1px scroll sentinel element that triggers auto-loading when the user scrolls near the bottom
- Remove unused `loadMore` i18n keys and button styles
- Update tests with `IntersectionObserver` mock and new scroll-specific test cases

## Test plan
- [x] All 26 recipe-list tests pass (sentinel renders, loads on intersect, guards against no-more/not-intersecting/still-loading, disconnects on destroy)
- [x] All 265 shell tests pass
- [x] Production build succeeds
- [ ] Manual: verify scroll triggers next page load in browser
- [ ] Manual: verify sort change resets and loads correctly
- [ ] Manual: verify empty state still displays when no recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)