### PR TITLE
feat(recipes): add edit recipe functionality (US-032)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -100,6 +100,16 @@
         "generic": "Rezepte konnten nicht geladen werden. Bitte versuche es später erneut."
       }
     },
+    "edit": {
+      "title": "Rezept bearbeiten",
+      "back": "Zurück zum Rezept",
+      "loading": "Rezept wird geladen...",
+      "success": "Rezept \"{{title}}\" erfolgreich aktualisiert!",
+      "errors": {
+        "notFound": "Rezept nicht gefunden.",
+        "generic": "Rezept konnte nicht aktualisiert werden. Bitte versuche es später erneut."
+      }
+    },
     "detail": {
       "back": "Zurück zu Rezepten",
       "servings": "{{count}} Portionen",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -100,6 +100,16 @@
         "generic": "Failed to load recipes. Please try again later."
       }
     },
+    "edit": {
+      "title": "Edit Recipe",
+      "back": "Back to Recipe",
+      "loading": "Loading recipe...",
+      "success": "Recipe \"{{title}}\" updated successfully!",
+      "errors": {
+        "notFound": "Recipe not found.",
+        "generic": "Failed to update recipe. Please try again later."
+      }
+    },
     "detail": {
       "back": "Back to Recipes",
       "servings": "{{count}} servings",

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -13,6 +13,14 @@ export const appRoutes: Route[] = [
       import('./dashboard/dashboard.component').then((m) => m.DashboardComponent),
   },
   {
+    path: 'recipes/:identifier/edit',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./recipes/recipe-edit/recipe-edit.component').then(
+        (m) => m.RecipeEditComponent,
+      ),
+  },
+  {
     path: 'recipes/:identifier',
     canActivate: [authGuard],
     loadComponent: () =>

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -16,9 +16,7 @@ export const appRoutes: Route[] = [
     path: 'recipes/:identifier/edit',
     canActivate: [authGuard],
     loadComponent: () =>
-      import('./recipes/recipe-edit/recipe-edit.component').then(
-        (m) => m.RecipeEditComponent,
-      ),
+      import('./recipes/recipe-edit/recipe-edit.component').then((m) => m.RecipeEditComponent),
   },
   {
     path: 'recipes/:identifier',

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
@@ -68,7 +68,9 @@
     </div>
 
     <div class="actions-bar">
-      <button class="action-button" disabled>{{ t('recipes.detail.actions.edit') }}</button>
+      <a class="action-button" [routerLink]="['/recipes', recipe.identifier, 'edit']">
+        {{ t('recipes.detail.actions.edit') }}
+      </a>
       <button class="action-button action-button--danger" disabled>
         {{ t('recipes.detail.actions.delete') }}
       </button>

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
@@ -277,17 +277,27 @@ describe('RecipeDetailComponent', () => {
     expect(sourceLink.textContent).toContain('Original Recipe');
   }));
 
-  it('should render action buttons as disabled', fakeAsync(() => {
+  it('should render edit button as link with correct routerLink', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
 
-    const buttons = fixture.nativeElement.querySelectorAll('.action-button');
-    expect(buttons.length).toBe(3);
-    buttons.forEach((btn: HTMLButtonElement) => {
-      expect(btn.disabled).toBe(true);
-    });
+    const editLink = fixture.nativeElement.querySelector('.action-button[href]');
+    expect(editLink).toBeTruthy();
+    expect(editLink.tagName).toBe('A');
+    expect(editLink.getAttribute('href')).toBe('/recipes/abc-123/edit');
+    expect(editLink.textContent.trim()).toBe('Edit');
+  }));
+
+  it('should render delete and shopping list buttons as disabled', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const disabledButtons = fixture.nativeElement.querySelectorAll('.action-button:disabled');
+    expect(disabledButtons.length).toBe(2);
   }));
 
   it('should call getRecipeById with correct identifier', fakeAsync(() => {

--- a/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.html
@@ -1,0 +1,26 @@
+<div class="recipe-edit-container" *transloco="let t">
+  <a [routerLink]="['/recipes', identifier]" class="back-link">
+    &larr; {{ t('recipes.edit.back') }}
+  </a>
+
+  @if (isLoading()) {
+    <div class="loading">
+      <span class="spinner"></span>
+      <span>{{ t('recipes.edit.loading') }}</span>
+    </div>
+  }
+
+  @if (serverError()) {
+    <div class="error-banner">{{ t(serverError()!) }}</div>
+  }
+
+  @if (recipeData(); as recipe) {
+    <yn-recipe-preview
+      [recipe]="recipe"
+      [isSaving]="isSaving()"
+      [previewTitle]="t('recipes.edit.title')"
+      (save)="onSave($event)"
+      (discard)="onDiscard()"
+    />
+  }
+</div>

--- a/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.scss
+++ b/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.scss
@@ -1,0 +1,24 @@
+@use '../../shared/banners';
+
+.recipe-edit-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 1.5rem;
+  color: #f97316;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  &:hover {
+    color: #ea580c;
+  }
+}
+
+.loading {
+  padding: 4rem 0;
+}

--- a/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.spec.ts
@@ -1,0 +1,345 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter, ActivatedRoute, Router } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, Subject, throwError } from 'rxjs';
+import { RecipeEditComponent } from './recipe-edit.component';
+import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
+import { HttpErrorResponse } from '@angular/common/http';
+
+const mockRecipeDetail: RecipeDetail = {
+  identifier: 'abc-123',
+  title: 'Pasta Carbonara',
+  description: 'A classic Italian dish',
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: 'medium',
+  imageUrl: 'https://example.com/image.jpg',
+  sourceUrl: 'https://example.com/recipe',
+  createdAt: '2026-03-10T00:00:00Z',
+  ingredients: [
+    { name: 'Spaghetti', amount: 400, unit: 'g' },
+    { name: 'Eggs', amount: 4, unit: null },
+  ],
+  steps: [
+    { number: 1, description: 'Cook pasta' },
+    { number: 2, description: 'Mix eggs' },
+  ],
+};
+
+const en = {
+  shared: {
+    editableList: {
+      moveUp: 'Move up',
+      moveDown: 'Move down',
+      remove: 'Remove',
+    },
+  },
+  recipes: {
+    edit: {
+      title: 'Edit Recipe',
+      back: 'Back to Recipe',
+      loading: 'Loading recipe...',
+      success: 'Recipe "{{title}}" updated successfully!',
+      errors: {
+        notFound: 'Recipe not found.',
+        generic: 'Failed to update recipe. Please try again later.',
+      },
+    },
+  },
+  dashboard: {
+    preview: {
+      title: 'Review Extracted Recipe',
+      recipeTitle: 'Title',
+      description: 'Description',
+      servings: 'Servings',
+      prepTime: 'Prep Time (min)',
+      cookTime: 'Cook Time (min)',
+      difficulty: 'Difficulty',
+      ingredients: 'Ingredients',
+      ingredientName: 'Ingredient',
+      amount: 'Amount',
+      unit: 'Unit',
+      addIngredient: 'Add Ingredient',
+      steps: 'Steps',
+      stepDescription: 'Step Description',
+      addStep: 'Add Step',
+      save: 'Save Recipe',
+      discard: 'Discard',
+      errors: {
+        titleRequired: 'Title is required.',
+        titleMaxLength: 'Title must not exceed 200 characters.',
+        ingredientNameRequired: 'Ingredient name is required.',
+        stepDescriptionRequired: 'Step description is required.',
+      },
+    },
+    save: {
+      saving: 'Saving...',
+    },
+  },
+};
+
+describe('RecipeEditComponent', () => {
+  let component: RecipeEditComponent;
+  let fixture: ComponentFixture<RecipeEditComponent>;
+  let recipeApiMock: {
+    getRecipeById: ReturnType<typeof vi.fn>;
+    updateRecipe: ReturnType<typeof vi.fn>;
+  };
+  let router: Router;
+
+  function setupTestBed(
+    getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
+    updateRecipeReturn: ReturnType<typeof vi.fn> = vi.fn(),
+    identifier = 'abc-123',
+  ) {
+    recipeApiMock = {
+      getRecipeById: getRecipeByIdReturn,
+      updateRecipe: updateRecipeReturn,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        RecipeEditComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: {
+            availableLangs: ['en'],
+            defaultLang: 'en',
+          },
+        }),
+      ],
+      providers: [
+        provideRouter([]),
+        { provide: RecipeApiService, useValue: recipeApiMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => (key === 'identifier' ? identifier : null),
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(RecipeEditComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  }
+
+  it('should create the component', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component).toBeTruthy();
+  }));
+
+  it('should load recipe on init', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    expect(recipeApiMock.getRecipeById).toHaveBeenCalledWith('abc-123');
+    expect(component.recipeData()).toBeTruthy();
+    expect(component.recipeData()!.title).toBe('Pasta Carbonara');
+  }));
+
+  it('should show loading state while fetching', fakeAsync(() => {
+    const subject = new Subject<RecipeDetail>();
+    setupTestBed(vi.fn().mockReturnValue(subject));
+    fixture.detectChanges();
+
+    const loading = fixture.nativeElement.querySelector('.loading');
+    expect(loading).toBeTruthy();
+    expect(loading.textContent).toContain('Loading recipe...');
+
+    subject.next(mockRecipeDetail);
+    subject.complete();
+    tick();
+  }));
+
+  it('should hide loading state after fetch', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.isLoading()).toBe(false);
+  }));
+
+  it('should show error on fetch failure', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 500 });
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => httpError)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Failed to update recipe.');
+  }));
+
+  it('should show not-found on 404 fetch', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 404 });
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => httpError)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Recipe not found.');
+  }));
+
+  it('should show not-found when route has no identifier', fakeAsync(() => {
+    setupTestBed(vi.fn(), vi.fn(), null as unknown as string);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(recipeApiMock.getRecipeById).not.toHaveBeenCalled();
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Recipe not found.');
+  }));
+
+  it('should render recipe-preview after load', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const preview = fixture.nativeElement.querySelector('yn-recipe-preview');
+    expect(preview).toBeTruthy();
+  }));
+
+  it('should map RecipeDetail to ImportRecipeResponse excluding sourceUrl and createdAt', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    const data = component.recipeData()!;
+    expect(data.title).toBe('Pasta Carbonara');
+    expect(data.description).toBe('A classic Italian dish');
+    expect(data.servings).toBe(4);
+    expect(data.prepTimeMinutes).toBe(10);
+    expect(data.cookTimeMinutes).toBe(20);
+    expect(data.difficulty).toBe('medium');
+    expect(data.imageUrl).toBe('https://example.com/image.jpg');
+    expect(data.ingredients).toEqual(mockRecipeDetail.ingredients);
+    expect(data.steps).toEqual(mockRecipeDetail.steps);
+    expect((data as Record<string, unknown>)['sourceUrl']).toBeUndefined();
+    expect((data as Record<string, unknown>)['createdAt']).toBeUndefined();
+  }));
+
+  it('should navigate to detail on discard', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    component.onDiscard();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/recipes', 'abc-123']);
+  }));
+
+  it('should call updateRecipe on save', fakeAsync(() => {
+    setupTestBed(
+      vi.fn().mockReturnValue(of(mockRecipeDetail)),
+      vi.fn().mockReturnValue(of(mockRecipeDetail)),
+    );
+    fixture.detectChanges();
+    tick();
+
+    component.onSave({
+      title: 'Updated Pasta',
+      description: null,
+      ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
+      steps: [{ number: 1, description: 'Mix' }],
+      servings: 2,
+      prepTimeMinutes: 5,
+      cookTimeMinutes: 10,
+      difficulty: 'easy',
+      imageUrl: null,
+    });
+    tick();
+
+    expect(recipeApiMock.updateRecipe).toHaveBeenCalledWith('abc-123', {
+      title: 'Updated Pasta',
+      description: null,
+      ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
+      steps: [{ number: 1, description: 'Mix' }],
+      servings: 2,
+      prepTimeMinutes: 5,
+      cookTimeMinutes: 10,
+      difficulty: 'easy',
+      imageUrl: null,
+    });
+  }));
+
+  it('should navigate to detail on successful update', fakeAsync(() => {
+    setupTestBed(
+      vi.fn().mockReturnValue(of(mockRecipeDetail)),
+      vi.fn().mockReturnValue(of(mockRecipeDetail)),
+    );
+    fixture.detectChanges();
+    tick();
+
+    component.onSave({
+      title: 'Updated Pasta',
+      description: null,
+      ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
+      steps: [{ number: 1, description: 'Mix' }],
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      imageUrl: null,
+    });
+    tick();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/recipes', 'abc-123']);
+  }));
+
+  it('should show error on update failure', fakeAsync(() => {
+    const httpError = new HttpErrorResponse({ status: 500 });
+    setupTestBed(
+      vi.fn().mockReturnValue(of(mockRecipeDetail)),
+      vi.fn().mockReturnValue(throwError(() => httpError)),
+    );
+    fixture.detectChanges();
+    tick();
+
+    component.onSave({
+      title: 'Updated Pasta',
+      description: null,
+      ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
+      steps: [{ number: 1, description: 'Mix' }],
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      imageUrl: null,
+    });
+    tick();
+    fixture.detectChanges();
+
+    expect(component.isSaving()).toBe(false);
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+  }));
+
+  it('should render back link', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const backLink = fixture.nativeElement.querySelector('.back-link');
+    expect(backLink).toBeTruthy();
+    expect(backLink.textContent).toContain('Back to Recipe');
+  }));
+});

--- a/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.spec.ts
@@ -146,7 +146,7 @@ describe('RecipeEditComponent', () => {
 
     expect(recipeApiMock.getRecipeById).toHaveBeenCalledWith('abc-123');
     expect(component.recipeData()).toBeTruthy();
-    expect(component.recipeData()!.title).toBe('Pasta Carbonara');
+    expect(component.recipeData()?.title).toBe('Pasta Carbonara');
   }));
 
   it('should show loading state while fetching', fakeAsync(() => {
@@ -222,16 +222,17 @@ describe('RecipeEditComponent', () => {
     fixture.detectChanges();
     tick();
 
-    const data = component.recipeData()!;
-    expect(data.title).toBe('Pasta Carbonara');
-    expect(data.description).toBe('A classic Italian dish');
-    expect(data.servings).toBe(4);
-    expect(data.prepTimeMinutes).toBe(10);
-    expect(data.cookTimeMinutes).toBe(20);
-    expect(data.difficulty).toBe('medium');
-    expect(data.imageUrl).toBe('https://example.com/image.jpg');
-    expect(data.ingredients).toEqual(mockRecipeDetail.ingredients);
-    expect(data.steps).toEqual(mockRecipeDetail.steps);
+    const data = component.recipeData();
+    expect(data).toBeTruthy();
+    expect(data?.title).toBe('Pasta Carbonara');
+    expect(data?.description).toBe('A classic Italian dish');
+    expect(data?.servings).toBe(4);
+    expect(data?.prepTimeMinutes).toBe(10);
+    expect(data?.cookTimeMinutes).toBe(20);
+    expect(data?.difficulty).toBe('medium');
+    expect(data?.imageUrl).toBe('https://example.com/image.jpg');
+    expect(data?.ingredients).toEqual(mockRecipeDetail.ingredients);
+    expect(data?.steps).toEqual(mockRecipeDetail.steps);
     expect((data as Record<string, unknown>)['sourceUrl']).toBeUndefined();
     expect((data as Record<string, unknown>)['createdAt']).toBeUndefined();
   }));

--- a/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/shell/src/app/recipes/recipe-edit/recipe-edit.component.ts
@@ -1,0 +1,121 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  OnInit,
+  DestroyRef,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  RecipeApiService,
+  ImportRecipeResponse,
+  UpdateRecipeRequest,
+} from '@yumney/shared/api-client';
+import { mapHttpError, HttpErrorMap } from '@yumney/shared/models';
+import { RecipePreviewComponent } from '../../dashboard/recipe-preview/recipe-preview.component';
+
+@Component({
+  selector: 'yn-recipe-edit',
+  imports: [TranslocoModule, RouterLink, RecipePreviewComponent],
+  templateUrl: './recipe-edit.component.html',
+  styleUrl: './recipe-edit.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecipeEditComponent implements OnInit {
+  private static readonly errorMap: HttpErrorMap = {
+    404: 'recipes.edit.errors.notFound',
+    default: 'recipes.edit.errors.generic',
+  };
+
+  private recipeApi = inject(RecipeApiService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
+
+  recipeData = signal<ImportRecipeResponse | null>(null);
+  isLoading = signal(false);
+  isSaving = signal(false);
+  serverError = signal<string | null>(null);
+
+  identifier = '';
+
+  ngOnInit(): void {
+    this.identifier = this.route.snapshot.paramMap.get('identifier') ?? '';
+    if (!this.identifier) {
+      this.serverError.set('recipes.edit.errors.notFound');
+      return;
+    }
+
+    this.isLoading.set(true);
+
+    this.recipeApi
+      .getRecipeById(this.identifier)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (recipe) => {
+          this.recipeData.set({
+            title: recipe.title,
+            description: recipe.description,
+            ingredients: recipe.ingredients,
+            steps: recipe.steps,
+            servings: recipe.servings,
+            prepTimeMinutes: recipe.prepTimeMinutes,
+            cookTimeMinutes: recipe.cookTimeMinutes,
+            difficulty: recipe.difficulty,
+            imageUrl: recipe.imageUrl,
+          });
+          this.isLoading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading.set(false);
+          this.serverError.set(mapHttpError(err, RecipeEditComponent.errorMap));
+        },
+      });
+  }
+
+  onSave(recipe: ImportRecipeResponse): void {
+    const request: UpdateRecipeRequest = {
+      title: recipe.title,
+      description: recipe.description,
+      ingredients: recipe.ingredients.map((i) => ({
+        name: i.name,
+        amount: i.amount,
+        unit: i.unit,
+      })),
+      steps: recipe.steps.map((s) => ({
+        number: s.number,
+        description: s.description,
+      })),
+      servings: recipe.servings,
+      prepTimeMinutes: recipe.prepTimeMinutes,
+      cookTimeMinutes: recipe.cookTimeMinutes,
+      difficulty: recipe.difficulty,
+      imageUrl: recipe.imageUrl,
+    };
+
+    this.isSaving.set(true);
+    this.serverError.set(null);
+
+    this.recipeApi
+      .updateRecipe(this.identifier, request)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isSaving.set(false);
+          this.router.navigate(['/recipes', this.identifier]);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isSaving.set(false);
+          this.serverError.set(mapHttpError(err, RecipeEditComponent.errorMap));
+        },
+      });
+  }
+
+  onDiscard(): void {
+    this.router.navigate(['/recipes', this.identifier]);
+  }
+}

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.html
@@ -75,5 +75,4 @@
       <span>{{ t('recipes.list.loading') }}</span>
     </div>
   }
-
 </div>

--- a/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-list/recipe-list.component.spec.ts
@@ -21,6 +21,7 @@ class MockIntersectionObserver implements IntersectionObserver {
     this.observedElement = target;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   unobserve(): void {}
 
   disconnect(): void {

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -6,6 +6,7 @@ export {
   type ExtractedIngredient,
   type ExtractedStep,
   type SaveRecipeRequest,
+  type UpdateRecipeRequest,
   type SavedRecipeResponse,
   type RecipeListItem,
   type RecipeListResponse,

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -43,6 +43,18 @@ export interface SaveRecipeRequest {
   sourceUrl?: string;
 }
 
+export interface UpdateRecipeRequest {
+  title: string;
+  description: string | null;
+  ingredients: { name: string; amount: number | null; unit: string | null }[];
+  steps: { number: number; description: string }[];
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  difficulty: string | null;
+  imageUrl: string | null;
+}
+
 export interface SavedRecipeResponse {
   identifier: string;
   title: string;
@@ -103,6 +115,10 @@ export class RecipeApiService {
 
   saveRecipe(request: SaveRecipeRequest): Observable<SavedRecipeResponse> {
     return this.http.post<SavedRecipeResponse>('/api/v1/recipes', request);
+  }
+
+  updateRecipe(identifier: string, request: UpdateRecipeRequest): Observable<RecipeDetail> {
+    return this.http.put<RecipeDetail>(`/api/v1/recipes/${identifier}`, request);
   }
 
   getRecipeById(identifier: string): Observable<RecipeDetail> {

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -44,6 +44,13 @@ public static class RecipesEndpoints
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status409Conflict);
 
+        group.MapPut("/{identifier:guid}", UpdateAsync)
+            .WithName("UpdateRecipe")
+            .WithTags("Recipes")
+            .Produces<RecipeDetailDto>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -97,6 +104,31 @@ public static class RecipesEndpoints
     {
         var query = GetRecipeByIdQuery.From(identifier);
         var result = await handler.HandleAsync(query, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return Results.Problem(result.Error!.Message, statusCode: result.Error.HttpStatusCode);
+        }
+
+        return Results.Ok(result.Value);
+    }
+
+    private static async Task<IResult> UpdateAsync(
+        Guid identifier,
+        UpdateRecipeRequest request,
+        IValidator<UpdateRecipeRequest> validator,
+        ICommandHandler<UpdateRecipeCommand, Result<RecipeDetailDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+
+        if (!validationResult.IsValid)
+        {
+            return Results.ValidationProblem(validationResult.ToDictionary());
+        }
+
+        var command = UpdateRecipeCommand.From(identifier, request);
+        var result = await handler.HandleAsync(command, cancellationToken);
 
         if (result.IsFailure)
         {

--- a/src/Yumney.Recipes.Application/Commands/UpdateRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/UpdateRecipeCommand.cs
@@ -1,0 +1,39 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record UpdateRecipeCommand(
+    RecipeIdentifier Identifier,
+    RecipeTitle Title,
+    IReadOnlyList<SaveRecipeIngredientItem> Ingredients,
+    IReadOnlyList<SaveRecipeStepItem> Steps,
+    RecipeDescription? Description = null,
+    Servings? Servings = null,
+    PreparationTime? PreparationTime = null,
+    CookingTime? CookingTime = null,
+    Difficulty? Difficulty = null,
+    ImageUrl? ImageUrl = null) : ICommand<Result<RecipeDetailDto>>
+{
+    public static UpdateRecipeCommand From(Guid identifier, UpdateRecipeRequest request)
+    {
+        return new UpdateRecipeCommand(
+            new RecipeIdentifier(identifier),
+            new RecipeTitle(request.Title),
+            request.Ingredients.Select(i => new SaveRecipeIngredientItem(
+                new IngredientName(i.Name),
+                Amount.FromNullable(i.Amount),
+                Unit.FromNullable(i.Unit))).ToList(),
+            request.Steps.Select(s => new SaveRecipeStepItem(
+                new StepNumber(s.Number),
+                new StepDescription(s.Description))).ToList(),
+            RecipeDescription.FromNullable(request.Description),
+            Servings.FromNullable(request.Servings),
+            PreparationTime.FromNullable(request.PrepTimeMinutes),
+            CookingTime.FromNullable(request.CookTimeMinutes),
+            Difficulty.FromNullable(request.Difficulty),
+            ImageUrl.FromNullable(request.ImageUrl));
+    }
+}

--- a/src/Yumney.Recipes.Application/Commands/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/UpdateRecipeCommandHandler.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+#pragma warning disable SA1601 // Partial elements should be documented (LoggerMessage generates partial methods)
+public sealed partial class UpdateRecipeCommandHandler(
+    IRecipeRepository recipes,
+    ICurrentUser currentUser,
+    ILogger<UpdateRecipeCommandHandler> logger)
+    : ICommandHandler<UpdateRecipeCommand, Result<RecipeDetailDto>>
+{
+    public async Task<Result<RecipeDetailDto>> HandleAsync(UpdateRecipeCommand command, CancellationToken cancellationToken = default)
+    {
+        var (identifier, title, ingredientCommands, stepCommands, description, servings,
+             preparationTime, cookingTime, difficulty, imageUrl) = command;
+
+        var owner = new OwnerIdentifier(currentUser.UserId);
+
+        LogUpdateRecipe(identifier, owner.Value);
+
+        var recipe = await recipes.GetByIdAsync(identifier, cancellationToken);
+
+        if (recipe is null)
+        {
+            LogRecipeNotFound(identifier);
+            return Result<RecipeDetailDto>.Failure(UpdateRecipeErrors.NotFound);
+        }
+
+        if (recipe.Owner != owner)
+        {
+            LogRecipeAccessDenied(identifier, owner.Value);
+            return Result<RecipeDetailDto>.Failure(UpdateRecipeErrors.AccessDenied);
+        }
+
+        var ingredients = ingredientCommands
+            .Select(i => Ingredient.Create(i.Name, i.Amount, i.Unit))
+            .ToList();
+
+        var steps = stepCommands
+            .Select(s => Step.Create(s.Number, s.Description))
+            .ToList();
+
+        recipe.Update(
+            title,
+            ingredients,
+            steps,
+            description,
+            servings,
+            preparationTime,
+            cookingTime,
+            difficulty,
+            imageUrl);
+
+        await recipes.UpdateAsync(recipe, cancellationToken);
+
+        LogRecipeUpdated(recipe.Id, title.Value);
+
+        var dto = new RecipeDetailDto(
+            recipe.Id,
+            recipe.Title.Value,
+            recipe.Description?.Value,
+            recipe.Servings?.Value,
+            recipe.PreparationTime?.Value,
+            recipe.CookingTime?.Value,
+            recipe.Difficulty?.Value,
+            recipe.ImageUrl?.Value,
+            recipe.SourceUrl?.Value,
+            recipe.CreatedAt,
+            recipe.Ingredients.Select(i => new RecipeIngredientDto(
+                i.Name.Value,
+                i.Amount?.Value,
+                i.Unit?.Value)).ToList(),
+            recipe.Steps.Select(s => new RecipeStepDto(
+                s.Number.Value,
+                s.Description.Value)).ToList());
+
+        return Result<RecipeDetailDto>.Success(dto);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Updating recipe {RecipeIdentifier} for owner {OwnerId}")]
+    private partial void LogUpdateRecipe(RecipeIdentifier recipeIdentifier, string ownerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recipe {RecipeIdentifier} not found for update")]
+    private partial void LogRecipeNotFound(RecipeIdentifier recipeIdentifier);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Access denied to update recipe {RecipeIdentifier} for owner {OwnerId}")]
+    private partial void LogRecipeAccessDenied(RecipeIdentifier recipeIdentifier, string ownerId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe {RecipeIdentifier} '{Title}' updated successfully")]
+    private partial void LogRecipeUpdated(Guid recipeIdentifier, string title);
+}

--- a/src/Yumney.Recipes.Application/Commands/UpdateRecipeErrors.cs
+++ b/src/Yumney.Recipes.Application/Commands/UpdateRecipeErrors.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public static class UpdateRecipeErrors
+{
+    public static readonly ApiError NotFound = new("RECIPE_NOT_FOUND", "Recipe not found.", 404);
+    public static readonly ApiError AccessDenied = new("RECIPE_ACCESS_DENIED", "Recipe not found.", 404);
+}

--- a/src/Yumney.Recipes.Application/Commands/UpdateRecipeRequest.cs
+++ b/src/Yumney.Recipes.Application/Commands/UpdateRecipeRequest.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record UpdateRecipeRequest(
+    string Title,
+    string? Description,
+    List<SaveRecipeIngredientRequest> Ingredients,
+    List<SaveRecipeStepRequest> Steps,
+    int? Servings,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    string? Difficulty,
+    string? ImageUrl);

--- a/src/Yumney.Recipes.Application/Commands/UpdateRecipeRequestValidator.cs
+++ b/src/Yumney.Recipes.Application/Commands/UpdateRecipeRequestValidator.cs
@@ -1,0 +1,73 @@
+using FluentValidation;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed class UpdateRecipeRequestValidator : AbstractValidator<UpdateRecipeRequest>
+{
+    public UpdateRecipeRequestValidator()
+    {
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .MaximumLength(RecipeTitle.MaxLength);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(RecipeDescription.MaxLength)
+            .When(x => x.Description is not null);
+
+        RuleFor(x => x.ImageUrl!)
+            .MustBeValidHttpUrl(ImageUrl.MaxLength)
+            .When(x => !string.IsNullOrWhiteSpace(x.ImageUrl));
+
+        RuleFor(x => x.Difficulty)
+            .NotEmpty()
+            .MaximumLength(Difficulty.MaxLength)
+            .When(x => x.Difficulty is not null);
+
+        RuleFor(x => x.Servings)
+            .GreaterThan(0)
+            .When(x => x.Servings.HasValue);
+
+        RuleFor(x => x.PrepTimeMinutes)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.PrepTimeMinutes.HasValue);
+
+        RuleFor(x => x.CookTimeMinutes)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.CookTimeMinutes.HasValue);
+
+        RuleFor(x => x.Ingredients)
+            .NotEmpty()
+            .WithMessage("At least one ingredient is required.");
+
+        RuleForEach(x => x.Ingredients).ChildRules(ingredient =>
+        {
+            ingredient.RuleFor(i => i.Name)
+                .NotEmpty()
+                .MaximumLength(IngredientName.MaxLength);
+
+            ingredient.RuleFor(i => i.Amount)
+                .GreaterThanOrEqualTo(0)
+                .When(i => i.Amount.HasValue);
+
+            ingredient.RuleFor(i => i.Unit)
+                .MaximumLength(Unit.MaxLength)
+                .When(i => i.Unit is not null);
+        });
+
+        RuleFor(x => x.Steps)
+            .NotEmpty()
+            .WithMessage("At least one step is required.");
+
+        RuleForEach(x => x.Steps).ChildRules(step =>
+        {
+            step.RuleFor(s => s.Number)
+                .GreaterThan(0);
+
+            step.RuleFor(s => s.Description)
+                .NotEmpty()
+                .MaximumLength(StepDescription.MaxLength);
+        });
+    }
+}

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeUpdatedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeUpdatedEvent.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
+
+public sealed record RecipeUpdatedEvent(RecipeIdentifier RecipeIdentifier, RecipeTitle Title) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
@@ -15,4 +15,6 @@ public interface IRecipeRepository
         PagingOptions paging,
         SortingOptions<RecipeSortField> sorting,
         CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Recipe recipe, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
@@ -75,4 +75,35 @@ public sealed class Recipe : AggregateRoot<Guid>
 
         return recipe;
     }
+
+    public void Update(
+        RecipeTitle title,
+        IReadOnlyList<Ingredient> ingredients,
+        IReadOnlyList<Step> steps,
+        RecipeDescription? description = null,
+        Servings? servings = null,
+        PreparationTime? preparationTime = null,
+        CookingTime? cookingTime = null,
+        Difficulty? difficulty = null,
+        ImageUrl? imageUrl = null)
+    {
+        Ensure.That((IReadOnlyCollection<Ingredient>)ingredients).IsNotEmpty();
+        Ensure.That((IReadOnlyCollection<Step>)steps).IsNotEmpty();
+
+        Title = title;
+        Description = description;
+        Servings = servings;
+        PreparationTime = preparationTime;
+        CookingTime = cookingTime;
+        Difficulty = difficulty;
+        ImageUrl = imageUrl;
+
+        this.ingredients.Clear();
+        this.ingredients.AddRange(ingredients);
+
+        this.steps.Clear();
+        this.steps.AddRange(steps);
+
+        AddDomainEvent(new RecipeUpdatedEvent(new RecipeIdentifier(Id), title));
+    }
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -27,6 +27,11 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
         return await recipes.AnyAsync(r => r.SourceUrl == sourceUrl && r.Owner == owner, cancellationToken);
     }
 
+    public async Task UpdateAsync(Recipe recipe, CancellationToken cancellationToken = default)
+    {
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task<(IReadOnlyList<Recipe> Items, int TotalCount)> GetByOwnerAsync(
         OwnerIdentifier owner,
         PagingOptions paging,

--- a/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
@@ -1,0 +1,265 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
+
+public class UpdateRecipeCommandHandlerTests
+{
+    private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ILogger<UpdateRecipeCommandHandler> logger = Substitute.For<ILogger<UpdateRecipeCommandHandler>>();
+    private readonly UpdateRecipeCommandHandler handler;
+
+    public UpdateRecipeCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new UpdateRecipeCommandHandler(recipes, currentUser, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_ReturnsSuccess()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_ReturnsRecipeDetailDto()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.Identifier.Should().Be(recipe.Id);
+        result.Value.Title.Should().Be("Updated Pasta");
+        result.Value.Ingredients.Should().HaveCount(1);
+        result.Value.Steps.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeNotFound_ReturnsFailure()
+    {
+        var recipeId = new RecipeIdentifier(Guid.NewGuid());
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns((Recipe?)null);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(UpdateRecipeErrors.NotFound);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongOwner_ReturnsAccessDenied()
+    {
+        var recipe = CreateTestRecipe("other-user");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(UpdateRecipeErrors.AccessDenied);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecipeNotFound_DoesNotCallUpdateAsync()
+    {
+        var recipeId = new RecipeIdentifier(Guid.NewGuid());
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns((Recipe?)null);
+
+        var command = CreateValidCommand(recipeId);
+
+        await handler.HandleAsync(command);
+
+        await recipes.DidNotReceive().UpdateAsync(Arg.Any<Recipe>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongOwner_DoesNotCallUpdateAsync()
+    {
+        var recipe = CreateTestRecipe("other-user");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        await handler.HandleAsync(command);
+
+        await recipes.DidNotReceive().UpdateAsync(Arg.Any<Recipe>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_CallsUpdateAsync()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        await handler.HandleAsync(command);
+
+        await recipes.Received(1).UpdateAsync(recipe, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCommand_UpdatesRecipeFields()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = new UpdateRecipeCommand(
+            recipeId,
+            new RecipeTitle("New Title"),
+            [new SaveRecipeIngredientItem(new IngredientName("Butter"), new Amount(200), new Unit("g"))],
+            [new SaveRecipeStepItem(new StepNumber(1), new StepDescription("Melt butter"))],
+            new RecipeDescription("New description"),
+            new Servings(6),
+            new PreparationTime(15),
+            new CookingTime(30),
+            new Difficulty("hard"),
+            new ImageUrl("https://example.com/new.jpg"));
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.Title.Should().Be("New Title");
+        result.Value.Description.Should().Be("New description");
+        result.Value.Servings.Should().Be(6);
+        result.Value.PrepTimeMinutes.Should().Be(15);
+        result.Value.CookTimeMinutes.Should().Be(30);
+        result.Value.Difficulty.Should().Be("hard");
+        result.Value.ImageUrl.Should().Be("https://example.com/new.jpg");
+        result.Value.Ingredients.Should().HaveCount(1);
+        result.Value.Ingredients[0].Name.Should().Be("Butter");
+        result.Value.Steps.Should().HaveCount(1);
+        result.Value.Steps[0].Description.Should().Be("Melt butter");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForwardsCancellationToken()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+        var cts = new CancellationTokenSource();
+
+        var command = CreateValidCommand(recipeId);
+
+        await handler.HandleAsync(command, cts.Token);
+
+        await recipes.Received(1).GetByIdAsync(recipeId, cts.Token);
+        await recipes.Received(1).UpdateAsync(recipe, cts.Token);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PreservesSourceUrl()
+    {
+        var recipe = CreateTestRecipeWithSourceUrl("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.SourceUrl.Should().Be("https://example.com/recipe");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NullOptionalFields_ClearsExistingValues()
+    {
+        var recipe = Recipe.Create(
+            new RecipeTitle("Original"),
+            new OwnerIdentifier("user-123"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))],
+            new RecipeDescription("Old description"),
+            new Servings(4),
+            new PreparationTime(10),
+            new CookingTime(20),
+            new Difficulty("easy"),
+            new ImageUrl("https://example.com/old.jpg"));
+
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = new UpdateRecipeCommand(
+            recipeId,
+            new RecipeTitle("Updated"),
+            [new SaveRecipeIngredientItem(new IngredientName("Butter"), null, null)],
+            [new SaveRecipeStepItem(new StepNumber(1), new StepDescription("Melt"))]);
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.Description.Should().BeNull();
+        result.Value.Servings.Should().BeNull();
+        result.Value.PrepTimeMinutes.Should().BeNull();
+        result.Value.CookTimeMinutes.Should().BeNull();
+        result.Value.Difficulty.Should().BeNull();
+        result.Value.ImageUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_PreservesCreatedAt()
+    {
+        var recipe = CreateTestRecipe("user-123");
+        var recipeId = new RecipeIdentifier(recipe.Id);
+        var originalCreatedAt = recipe.CreatedAt;
+        recipes.GetByIdAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);
+
+        var command = CreateValidCommand(recipeId);
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.CreatedAt.Should().Be(originalCreatedAt);
+    }
+
+    private static UpdateRecipeCommand CreateValidCommand(RecipeIdentifier identifier)
+    {
+        return new UpdateRecipeCommand(
+            identifier,
+            new RecipeTitle("Updated Pasta"),
+            [new SaveRecipeIngredientItem(new IngredientName("Spaghetti"), new Amount(400), new Unit("g"))],
+            [new SaveRecipeStepItem(new StepNumber(1), new StepDescription("Cook pasta"))]);
+    }
+
+    private static Recipe CreateTestRecipe(string ownerId)
+    {
+        return Recipe.Create(
+            new RecipeTitle("Test Recipe"),
+            new OwnerIdentifier(ownerId),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+    }
+
+    private static Recipe CreateTestRecipeWithSourceUrl(string ownerId)
+    {
+        return Recipe.Create(
+            new RecipeTitle("Test Recipe"),
+            new OwnerIdentifier(ownerId),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))],
+            sourceUrl: new RecipeUrl("https://example.com/recipe"));
+    }
+}

--- a/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeRequestValidatorTests.cs
@@ -1,0 +1,379 @@
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
+
+public class UpdateRecipeRequestValidatorTests
+{
+    private readonly UpdateRecipeRequestValidator validator = new();
+
+    [Fact]
+    public void Validate_ValidRequest_HasNoErrors()
+    {
+        var request = CreateValidRequest();
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_EmptyTitle_HasError(string? title)
+    {
+        var request = CreateValidRequest() with { Title = title! };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public void Validate_TitleExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with { Title = new string('a', 201) };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public void Validate_TitleAtMaxLength_HasNoError()
+    {
+        var request = CreateValidRequest() with { Title = new string('a', 200) };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public void Validate_EmptyIngredients_HasError()
+    {
+        var request = CreateValidRequest() with { Ingredients = [] };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Ingredients);
+    }
+
+    [Fact]
+    public void Validate_IngredientWithEmptyName_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest(string.Empty, null, null)],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptySteps_HasError()
+    {
+        var request = CreateValidRequest() with { Steps = [] };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Steps);
+    }
+
+    [Fact]
+    public void Validate_StepWithEmptyDescription_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Steps = [new SaveRecipeStepRequest(1, string.Empty)],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_NullOptionalFields_HasNoErrors()
+    {
+        var request = CreateValidRequest() with
+        {
+            Description = null,
+            Servings = null,
+            PrepTimeMinutes = null,
+            CookTimeMinutes = null,
+            Difficulty = null,
+            ImageUrl = null,
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ZeroServings_HasError()
+    {
+        var request = CreateValidRequest() with { Servings = 0 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Servings);
+    }
+
+    [Fact]
+    public void Validate_NegativeServings_HasError()
+    {
+        var request = CreateValidRequest() with { Servings = -1 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Servings);
+    }
+
+    [Fact]
+    public void Validate_PositiveServings_HasNoError()
+    {
+        var request = CreateValidRequest() with { Servings = 1 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Servings);
+    }
+
+    [Fact]
+    public void Validate_NegativePrepTime_HasError()
+    {
+        var request = CreateValidRequest() with { PrepTimeMinutes = -1 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.PrepTimeMinutes);
+    }
+
+    [Fact]
+    public void Validate_ZeroPrepTime_HasNoError()
+    {
+        var request = CreateValidRequest() with { PrepTimeMinutes = 0 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.PrepTimeMinutes);
+    }
+
+    [Fact]
+    public void Validate_NegativeCookTime_HasError()
+    {
+        var request = CreateValidRequest() with { CookTimeMinutes = -1 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.CookTimeMinutes);
+    }
+
+    [Fact]
+    public void Validate_ZeroCookTime_HasNoError()
+    {
+        var request = CreateValidRequest() with { CookTimeMinutes = 0 };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.CookTimeMinutes);
+    }
+
+    [Fact]
+    public void Validate_DescriptionExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with { Description = new string('a', 2001) };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_DescriptionAtMaxLength_HasNoError()
+    {
+        var request = CreateValidRequest() with { Description = new string('a', 2000) };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_DifficultyExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with { Difficulty = new string('a', 51) };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Difficulty);
+    }
+
+    [Fact]
+    public void Validate_EmptyDifficulty_HasError()
+    {
+        var request = CreateValidRequest() with { Difficulty = string.Empty };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Difficulty);
+    }
+
+    [Fact]
+    public void Validate_InvalidImageUrl_HasError()
+    {
+        var request = CreateValidRequest() with { ImageUrl = "not-a-url" };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImageUrl);
+    }
+
+    [Fact]
+    public void Validate_ValidImageUrl_HasNoError()
+    {
+        var request = CreateValidRequest() with { ImageUrl = "https://example.com/image.jpg" };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.ImageUrl);
+    }
+
+    [Fact]
+    public void Validate_ImageUrlExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            ImageUrl = "https://example.com/" + new string('a', 2040),
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImageUrl);
+    }
+
+    [Fact]
+    public void Validate_IngredientNameExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest(new string('a', 201), null, null)],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_NegativeIngredientAmount_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest("Flour", -1, "g")],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ZeroIngredientAmount_HasNoError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest("Flour", 0, "g")],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_IngredientWithNullAmountAndUnit_HasNoError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest("Salt", null, null)],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_IngredientUnitExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Ingredients = [new SaveRecipeIngredientRequest("Flour", 500, new string('a', 51))],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_StepDescriptionExceedsMaxLength_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Steps = [new SaveRecipeStepRequest(1, new string('a', 2001))],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ZeroStepNumber_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Steps = [new SaveRecipeStepRequest(0, "Cook pasta")],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_NegativeStepNumber_HasError()
+    {
+        var request = CreateValidRequest() with
+        {
+            Steps = [new SaveRecipeStepRequest(-1, "Cook pasta")],
+        };
+
+        var result = validator.TestValidate(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    private static UpdateRecipeRequest CreateValidRequest()
+    {
+        return new UpdateRecipeRequest(
+            "Pasta Carbonara",
+            "A classic dish",
+            [new SaveRecipeIngredientRequest("Spaghetti", 400, "g")],
+            [new SaveRecipeStepRequest(1, "Cook pasta")],
+            4,
+            10,
+            20,
+            "medium",
+            null);
+    }
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -180,6 +180,207 @@ public class RecipeTests
         domainEvent.RecipeIdentifier.Value.Should().Be(recipe.Id);
     }
 
+    [Fact]
+    public void Update_ValidInput_SetsAllEditableFields()
+    {
+        var recipe = CreateValidRecipe(
+            description: new RecipeDescription("Old description"),
+            servings: new Servings(2));
+
+        var newTitle = new RecipeTitle("Updated Recipe");
+        var newDescription = new RecipeDescription("Updated description");
+        var newServings = new Servings(6);
+        var newPrepTime = new PreparationTime(15);
+        var newCookTime = new CookingTime(30);
+        var newDifficulty = new Difficulty("hard");
+        var newImageUrl = new ImageUrl("https://example.com/new.jpg");
+        var newIngredients = new List<Ingredient>
+        {
+            Ingredient.Create(new IngredientName("Butter"), new Amount(100), new Unit("g")),
+        };
+        var newSteps = new List<Step>
+        {
+            Step.Create(new StepNumber(1), new StepDescription("Melt butter")),
+        };
+
+        recipe.Update(newTitle, newIngredients, newSteps, newDescription, newServings, newPrepTime, newCookTime, newDifficulty, newImageUrl);
+
+        recipe.Title.Should().Be(newTitle);
+        recipe.Description.Should().Be(newDescription);
+        recipe.Servings.Should().Be(newServings);
+        recipe.PreparationTime.Should().Be(newPrepTime);
+        recipe.CookingTime.Should().Be(newCookTime);
+        recipe.Difficulty.Should().Be(newDifficulty);
+        recipe.ImageUrl.Should().Be(newImageUrl);
+    }
+
+    [Fact]
+    public void Update_ReplacesIngredients()
+    {
+        var recipe = CreateValidRecipe(ingredients:
+        [
+            Ingredient.Create(new IngredientName("Flour"), new Amount(500), new Unit("g")),
+            Ingredient.Create(new IngredientName("Sugar"), new Amount(200), new Unit("g")),
+        ]);
+
+        var newIngredients = new List<Ingredient>
+        {
+            Ingredient.Create(new IngredientName("Butter"), new Amount(100), new Unit("g")),
+        };
+
+        recipe.Update(new RecipeTitle("Updated"), newIngredients, [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.Ingredients.Should().HaveCount(1);
+        recipe.Ingredients[0].Name.Value.Should().Be("Butter");
+    }
+
+    [Fact]
+    public void Update_ReplacesSteps()
+    {
+        var recipe = CreateValidRecipe(steps:
+        [
+            Step.Create(new StepNumber(1), new StepDescription("Step one")),
+            Step.Create(new StepNumber(2), new StepDescription("Step two")),
+        ]);
+
+        var newSteps = new List<Step>
+        {
+            Step.Create(new StepNumber(1), new StepDescription("New only step")),
+        };
+
+        recipe.Update(new RecipeTitle("Updated"), [Ingredient.Create(new IngredientName("Flour"), null, null)], newSteps);
+
+        recipe.Steps.Should().HaveCount(1);
+        recipe.Steps[0].Description.Value.Should().Be("New only step");
+    }
+
+    [Fact]
+    public void Update_RaisesRecipeUpdatedEvent()
+    {
+        var recipe = CreateValidRecipe();
+        recipe.ClearDomainEvents();
+
+        var newTitle = new RecipeTitle("Updated Recipe");
+
+        recipe.Update(
+            newTitle,
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<RecipeUpdatedEvent>()
+            .Which.Title.Should().Be(newTitle);
+    }
+
+    [Fact]
+    public void Update_RecipeUpdatedEvent_ContainsRecipeId()
+    {
+        var recipe = CreateValidRecipe();
+        recipe.ClearDomainEvents();
+
+        recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        var domainEvent = recipe.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<RecipeUpdatedEvent>().Subject;
+
+        domainEvent.RecipeIdentifier.Value.Should().Be(recipe.Id);
+    }
+
+    [Fact]
+    public void Update_EmptyIngredients_ThrowsGuardException()
+    {
+        var recipe = CreateValidRecipe();
+
+        var act = () => recipe.Update(
+            new RecipeTitle("Updated"),
+            [],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Update_EmptySteps_ThrowsGuardException()
+    {
+        var recipe = CreateValidRecipe();
+
+        var act = () => recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            []);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Update_DoesNotChangeOwner()
+    {
+        var owner = new OwnerIdentifier("user-123");
+        var recipe = CreateValidRecipe(owner: owner);
+
+        recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.Owner.Should().Be(owner);
+    }
+
+    [Fact]
+    public void Update_DoesNotChangeSourceUrl()
+    {
+        var sourceUrl = new RecipeUrl("https://example.com/recipe");
+        var recipe = CreateValidRecipe(sourceUrl: sourceUrl);
+
+        recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.SourceUrl.Should().Be(sourceUrl);
+    }
+
+    [Fact]
+    public void Update_DoesNotChangeCreatedAt()
+    {
+        var recipe = CreateValidRecipe();
+        var originalCreatedAt = recipe.CreatedAt;
+
+        recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.CreatedAt.Should().Be(originalCreatedAt);
+    }
+
+    [Fact]
+    public void Update_WithoutOptionalFields_ClearsExistingValues()
+    {
+        var recipe = CreateValidRecipe(
+            description: new RecipeDescription("Old"),
+            servings: new Servings(4),
+            preparationTime: new PreparationTime(10),
+            cookingTime: new CookingTime(20),
+            difficulty: new Difficulty("easy"),
+            imageUrl: new ImageUrl("https://example.com/old.jpg"));
+
+        recipe.Update(
+            new RecipeTitle("Updated"),
+            [Ingredient.Create(new IngredientName("Flour"), null, null)],
+            [Step.Create(new StepNumber(1), new StepDescription("Mix"))]);
+
+        recipe.Description.Should().BeNull();
+        recipe.Servings.Should().BeNull();
+        recipe.PreparationTime.Should().BeNull();
+        recipe.CookingTime.Should().BeNull();
+        recipe.Difficulty.Should().BeNull();
+        recipe.ImageUrl.Should().BeNull();
+    }
+
     private static Domain.Recipe.Recipe CreateValidRecipe(
         RecipeTitle? title = null,
         RecipeUrl? sourceUrl = null,


### PR DESCRIPTION
## Summary
- Add `Recipe.Update()` domain method with `RecipeUpdatedEvent`, keeping Owner/SourceUrl/CreatedAt immutable
- Add `UpdateRecipeCommand`, handler (with ownership check), request DTO, validator, errors, and `PUT /recipes/{identifier}` endpoint
- Add `RecipeEditComponent` that reuses `yn-recipe-preview` form, with `updateRecipe()` API method and edit route
- Wire Edit button in recipe detail as a routerLink, add i18n keys (EN/DE)
- Comprehensive tests: 12 domain, 12 handler, 23 validator, 14 frontend, plus updated detail spec

## Test plan
- [ ] `dotnet test` — all 570+ backend tests pass
- [ ] `npx nx test shell` — all 280 frontend tests pass
- [ ] `npx nx build shell` — production build succeeds
- [ ] Manual: navigate to recipe detail → click Edit → modify fields → Save → verify changes persisted
- [ ] Manual: click Edit → Discard → verify navigation back to detail without changes
- [ ] Manual: verify non-owner cannot update another user's recipe (404 response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)