### PR TITLE
feat(recipes): add interactive servings scaling (US-050)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -143,6 +143,7 @@
           "generic": "Rezept konnte nicht gelöscht werden. Bitte versuche es später erneut."
         }
       },
+      "resetServings": "Zurücksetzen",
       "errors": {
         "generic": "Rezept konnte nicht geladen werden. Bitte versuche es später erneut."
       }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -143,6 +143,7 @@
           "generic": "Failed to delete recipe. Please try again later."
         }
       },
+      "resetServings": "Reset",
       "errors": {
         "generic": "Failed to load recipe. Please try again later."
       }

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.html
@@ -29,10 +29,18 @@
 
     <div class="meta-bar">
       @if (recipe.servings) {
-        <div class="meta-item">
-          <span class="meta-label">{{
-            t('recipes.detail.servings', { count: recipe.servings })
-          }}</span>
+        <div class="meta-item servings-adjuster">
+          <span class="meta-label">{{ t('recipes.detail.servings', { count: desiredServings() }) }}</span>
+          <div class="servings-control">
+            <button class="servings-button" (click)="onDecreaseServings()" [disabled]="desiredServings() === 1">&minus;</button>
+            <span class="servings-value">{{ desiredServings() }}</span>
+            <button class="servings-button" (click)="onIncreaseServings()">+</button>
+          </div>
+          @if (isScaled()) {
+            <button class="reset-link" (click)="onResetServings()">
+              {{ t('recipes.detail.resetServings') }}
+            </button>
+          }
         </div>
       }
       @if (recipe.prepTimeMinutes) {
@@ -88,7 +96,7 @@
     <section class="ingredients-section">
       <h2>{{ t('recipes.detail.ingredients') }}</h2>
       <ul class="ingredients-list">
-        @for (ingredient of recipe.ingredients; track ingredient.name) {
+        @for (ingredient of scaledIngredients(); track ingredient.name) {
           <li>
             @if (ingredient.amount) {
               <span class="ingredient-amount">{{ ingredient.amount }}</span>

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.scss
@@ -82,6 +82,64 @@
   letter-spacing: 0.05em;
 }
 
+.servings-adjuster {
+  gap: 0.375rem;
+}
+
+.servings-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.servings-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid #f97316;
+  border-radius: 50%;
+  background: transparent;
+  color: #f97316;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  line-height: 1;
+
+  &:hover:not(:disabled) {
+    background: #f97316;
+    color: #fff;
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+}
+
+.servings-value {
+  min-width: 1.5rem;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.reset-link {
+  background: none;
+  border: none;
+  color: #f97316;
+  font-size: 0.6875rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+
+  &:hover {
+    color: #ea580c;
+  }
+}
+
 .meta-value {
   font-size: 0.875rem;
   font-weight: 600;

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.spec.ts
@@ -58,6 +58,7 @@ const en = {
           generic: 'Failed to delete recipe. Please try again later.',
         },
       },
+      resetServings: 'Reset',
       errors: {
         generic: 'Failed to load recipe. Please try again later.',
       },
@@ -509,5 +510,80 @@ describe('RecipeDetailComponent', () => {
     expect(error).toBeTruthy();
     expect(error.textContent).toContain('Failed to delete recipe.');
     vi.restoreAllMocks();
+  }));
+
+  it('should initialize desiredServings from recipe.servings', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.desiredServings()).toBe(4);
+  }));
+
+  it('should increase servings on + click', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    component.onIncreaseServings();
+
+    expect(component.desiredServings()).toBe(5);
+  }));
+
+  it('should decrease servings on - click', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    component.onDecreaseServings();
+
+    expect(component.desiredServings()).toBe(3);
+  }));
+
+  it('should not decrease below 1', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    component.desiredServings.set(1);
+    component.onDecreaseServings();
+
+    expect(component.desiredServings()).toBe(1);
+  }));
+
+  it('should reset to original servings', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    component.desiredServings.set(8);
+    component.onResetServings();
+
+    expect(component.desiredServings()).toBe(4);
+  }));
+
+  it('should display scaled ingredient amounts', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    component.desiredServings.set(8);
+    fixture.detectChanges();
+
+    const scaled = component.scaledIngredients();
+    expect(scaled[0].amount).toBe(800);
+    expect(scaled[1].amount).toBe(8);
+  }));
+
+  it('should show isScaled as true when servings differ', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.isScaled()).toBe(false);
+
+    component.desiredServings.set(6);
+
+    expect(component.isScaled()).toBe(true);
   }));
 });

--- a/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/shell/src/app/recipes/recipe-detail/recipe-detail.component.ts
@@ -5,13 +5,14 @@ import {
   OnInit,
   DestroyRef,
   signal,
+  computed,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
-import { mapHttpError, HttpErrorMap } from '@yumney/shared/models';
+import { mapHttpError, HttpErrorMap, scaleIngredients } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-recipe-detail',
@@ -41,6 +42,25 @@ export class RecipeDetailComponent implements OnInit {
   isLoading = signal(false);
   isDeleting = signal(false);
   serverError = signal<string | null>(null);
+  desiredServings = signal<number | null>(null);
+
+  scaledIngredients = computed(() => {
+    const recipe = this.recipe();
+    if (!recipe) {
+      return [];
+    }
+    const desired = this.desiredServings();
+    if (!desired || !recipe.servings) {
+      return recipe.ingredients;
+    }
+    return scaleIngredients(recipe.ingredients, recipe.servings, desired);
+  });
+
+  isScaled = computed(() => {
+    const recipe = this.recipe();
+    const desired = this.desiredServings();
+    return recipe?.servings != null && desired != null && desired !== recipe.servings;
+  });
 
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
@@ -57,6 +77,7 @@ export class RecipeDetailComponent implements OnInit {
       .subscribe({
         next: (recipe) => {
           this.recipe.set(recipe);
+          this.desiredServings.set(recipe.servings);
           this.isLoading.set(false);
         },
         error: (err: HttpErrorResponse) => {
@@ -77,6 +98,27 @@ export class RecipeDetailComponent implements OnInit {
       return null;
     }
     return prep + cook;
+  }
+
+  onIncreaseServings(): void {
+    const current = this.desiredServings();
+    if (current !== null) {
+      this.desiredServings.set(current + 1);
+    }
+  }
+
+  onDecreaseServings(): void {
+    const current = this.desiredServings();
+    if (current !== null && current > 1) {
+      this.desiredServings.set(current - 1);
+    }
+  }
+
+  onResetServings(): void {
+    const recipe = this.recipe();
+    if (recipe?.servings != null) {
+      this.desiredServings.set(recipe.servings);
+    }
   }
 
   onDelete(): void {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -3,3 +3,7 @@ export { mapHttpError, type HttpErrorMap } from './lib/http-error-utils';
 export { type PagedResponse, type PaginationParams } from './lib/pagination';
 export { urlValidator, passwordsMatchValidator } from './lib/validators';
 export { VALIDATION } from './lib/validation-constants';
+export {
+  scaleIngredients,
+  type ScalableIngredient,
+} from './lib/scale-ingredients';

--- a/client/libs/shared/models/src/lib/scale-ingredients.spec.ts
+++ b/client/libs/shared/models/src/lib/scale-ingredients.spec.ts
@@ -1,0 +1,67 @@
+import {
+  scaleIngredients,
+  ScalableIngredient,
+} from './scale-ingredients';
+
+describe('scaleIngredients', () => {
+  const baseIngredients: ScalableIngredient[] = [
+    { name: 'Spaghetti', amount: 400, unit: 'g' },
+    { name: 'Eggs', amount: 3, unit: null },
+    { name: 'Olive Oil', amount: 1.5, unit: 'tbsp' },
+    { name: 'Salt', amount: null, unit: null },
+  ];
+
+  it('should double amounts when servings doubled (4->8)', () => {
+    const result = scaleIngredients(baseIngredients, 4, 8);
+
+    expect(result[0].amount).toBe(800);
+    expect(result[1].amount).toBe(6);
+    expect(result[2].amount).toBe(3);
+  });
+
+  it('should halve amounts when servings halved (4->2)', () => {
+    const result = scaleIngredients(baseIngredients, 4, 2);
+
+    expect(result[0].amount).toBe(200);
+    expect(result[1].amount).toBe(2);
+    expect(result[2].amount).toBe(0.75);
+  });
+
+  it('should round whole-number amounts to whole numbers (3 eggs, 4->3 = 2)', () => {
+    const result = scaleIngredients(baseIngredients, 4, 3);
+
+    expect(result[1].amount).toBe(2);
+  });
+
+  it('should return original amounts when servings unchanged (4->4)', () => {
+    const result = scaleIngredients(baseIngredients, 4, 4);
+
+    expect(result).toBe(baseIngredients);
+  });
+
+  it('should handle null amounts (no amount ingredient)', () => {
+    const result = scaleIngredients(baseIngredients, 4, 8);
+
+    expect(result[3].amount).toBeNull();
+    expect(result[3].name).toBe('Salt');
+  });
+
+  it('should round decimal amounts to 2 decimal places', () => {
+    const ingredients: ScalableIngredient[] = [
+      { name: 'Butter', amount: 1.5, unit: 'tbsp' },
+    ];
+
+    const result = scaleIngredients(ingredients, 4, 3);
+
+    expect(result[0].amount).toBe(1.13);
+  });
+
+  it('should preserve ingredient names and units', () => {
+    const result = scaleIngredients(baseIngredients, 4, 8);
+
+    expect(result[0].name).toBe('Spaghetti');
+    expect(result[0].unit).toBe('g');
+    expect(result[1].name).toBe('Eggs');
+    expect(result[1].unit).toBeNull();
+  });
+});

--- a/client/libs/shared/models/src/lib/scale-ingredients.ts
+++ b/client/libs/shared/models/src/lib/scale-ingredients.ts
@@ -1,0 +1,28 @@
+export interface ScalableIngredient {
+  name: string;
+  amount: number | null;
+  unit: string | null;
+}
+
+function roundAmount(scaled: number, original: number): number {
+  if (Number.isInteger(original)) {
+    return Math.round(scaled);
+  }
+  return Math.round(scaled * 100) / 100;
+}
+
+export function scaleIngredients(
+  ingredients: ScalableIngredient[],
+  originalServings: number,
+  desiredServings: number,
+): ScalableIngredient[] {
+  if (originalServings === desiredServings) {
+    return ingredients;
+  }
+  const ratio = desiredServings / originalServings;
+  return ingredients.map((i) => ({
+    ...i,
+    amount:
+      i.amount !== null ? roundAmount(i.amount * ratio, i.amount) : null,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add `scaleIngredients` utility with intelligent rounding (whole-number ingredients round to whole numbers, decimals round to 2dp)
- Add +/- servings controls to recipe detail page with proportional ingredient recalculation
- Add reset button to restore original servings
- Add i18n keys (EN/DE) for the reset label

## Test plan
- [x] `scaleIngredients` utility: 7 unit tests (double, halve, rounding, null amounts, identity)
- [x] Recipe detail component: 7 new tests (init, increase, decrease, min boundary, reset, scaling, isScaled)
- [x] All 300 shell tests pass, all 27 shared-models tests pass
- [x] Lint passes (0 errors)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)