### PR TITLE
feat(shopping): add check-off shopping list items (US-041)

### DIFF
--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -42,6 +42,8 @@
       "back": "Zurück zu Einkaufslisten",
       "loading": "Einkaufsliste wird geladen...",
       "viewRecipe": "Rezept anzeigen",
+      "checkAll": "Alle abhaken",
+      "reset": "Zurücksetzen",
       "errors": {
         "notFound": "Einkaufsliste nicht gefunden.",
         "generic": "Einkaufsliste konnte nicht geladen werden. Bitte versuche es später erneut."

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -42,6 +42,8 @@
       "back": "Back to Shopping Lists",
       "loading": "Loading shopping list...",
       "viewRecipe": "View Recipe",
+      "checkAll": "Check all",
+      "reset": "Reset",
       "errors": {
         "notFound": "Shopping list not found.",
         "generic": "Failed to load shopping list. Please try again later."

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
@@ -15,9 +15,26 @@
   @if (shoppingList(); as list) {
     <h1>{{ list.title }}</h1>
 
+    <div class="actions">
+      <span class="progress">{{ checkedCount }} / {{ totalCount }}</span>
+      <button class="btn-secondary" (click)="onCheckAll()">
+        {{ t('shopping.detail.checkAll') }}
+      </button>
+      <button class="btn-secondary" (click)="onReset()">
+        {{ t('shopping.detail.reset') }}
+      </button>
+    </div>
+
     <ul class="items-list">
-      @for (item of list.items; track item.name) {
-        <li>
+      @for (item of list.items; track item.identifier) {
+        <li [class.checked]="item.isChecked" (click)="onToggleItem(item)">
+          <input
+            type="checkbox"
+            [checked]="item.isChecked"
+            [attr.aria-label]="item.name"
+            (click)="$event.stopPropagation()"
+            (change)="onToggleItem(item)"
+          />
           @if (item.amount) {
             <span class="item-amount">{{ item.amount }}</span>
           }

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.scss
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.scss
@@ -19,6 +19,19 @@ h1 {
   font-weight: 700;
 }
 
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.progress {
+  font-size: 0.875rem;
+  color: var(--yn-text-muted);
+  margin-right: auto;
+}
+
 .items-list {
   list-style: none;
   padding: 0;
@@ -26,14 +39,31 @@ h1 {
 
   li {
     display: flex;
+    align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0;
     border-bottom: 1px solid var(--yn-border-light);
     font-size: 0.9375rem;
+    cursor: pointer;
 
     &:last-child {
       border-bottom: none;
     }
+
+    &.checked .item-name,
+    &.checked .item-amount,
+    &.checked .item-unit {
+      text-decoration: line-through;
+      color: var(--yn-text-light);
+    }
+  }
+
+  input[type='checkbox'] {
+    width: 1.125rem;
+    height: 1.125rem;
+    accent-color: var(--yn-primary);
+    cursor: pointer;
+    flex-shrink: 0;
   }
 }
 

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -6,9 +6,14 @@ import {
   DestroyRef,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { ShoppingApiService, ShoppingListDetail } from '@yumney/shared/api-client';
+import {
+  ShoppingApiService,
+  ShoppingListDetail,
+  ShoppingListItemResponse,
+} from '@yumney/shared/api-client';
 import { createAsyncState, HttpErrorMap } from '@yumney/shared/models';
 
 @Component({
@@ -26,6 +31,7 @@ export class ShoppingDetailComponent implements OnInit {
 
   private shoppingApi = inject(ShoppingApiService);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(inject(DestroyRef));
 
   shoppingList = signal<ShoppingListDetail | null>(null);
@@ -44,5 +50,59 @@ export class ShoppingDetailComponent implements OnInit {
       ShoppingDetailComponent.errorMap,
       (list) => this.shoppingList.set(list),
     );
+  }
+
+  onToggleItem(item: ShoppingListItemResponse): void {
+    const list = this.shoppingList();
+    if (!list) {
+      return;
+    }
+
+    const newState = !item.isChecked;
+    item.isChecked = newState;
+    this.shoppingList.set({ ...list });
+
+    this.shoppingApi
+      .checkOffItem(list.identifier, item.identifier, newState)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  onCheckAll(): void {
+    const list = this.shoppingList();
+    if (!list) {
+      return;
+    }
+
+    list.items.forEach((item) => (item.isChecked = true));
+    this.shoppingList.set({ ...list });
+
+    this.shoppingApi
+      .checkOffAllItems(list.identifier, true)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  onReset(): void {
+    const list = this.shoppingList();
+    if (!list) {
+      return;
+    }
+
+    list.items.forEach((item) => (item.isChecked = false));
+    this.shoppingList.set({ ...list });
+
+    this.shoppingApi
+      .checkOffAllItems(list.identifier, false)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  get checkedCount(): number {
+    return this.shoppingList()?.items.filter((i) => i.isChecked).length ?? 0;
+  }
+
+  get totalCount(): number {
+    return this.shoppingList()?.items.length ?? 0;
   }
 }

--- a/client/apps/shopping/tsconfig.federation.json
+++ b/client/apps/shopping/tsconfig.federation.json
@@ -6,10 +6,23 @@
   },
   "include": [
     "src/**/*.ts",
-    "..\\..\\libs\\shared\\models\\src\\index.ts",
-    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
-    "..\\..\\libs\\ui\\src\\index.ts",
-    "..\\..\\libs\\shared\\auth\\src\\index.ts"
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\core.mjs",
+    "..\\..\\node_modules\\@angular\\core\\event-dispatch-contract.min.js",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-di.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-event-dispatch.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-signals.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\rxjs-interop.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\common.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\http.mjs",
+    "..\\..\\node_modules\\@angular\\router\\fesm2022\\router.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\forms.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals-compat.mjs",
+    "..\\..\\node_modules\\@angular\\platform-browser\\fesm2022\\platform-browser.mjs",
+    "..\\..\\node_modules\\@jsverse\\transloco\\esm2022\\jsverse-transloco.mjs",
+    "..\\..\\node_modules\\angular-oauth2-oidc\\fesm2022\\angular-oauth2-oidc.mjs",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\index.js",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\operators\\index.js"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -15,9 +15,11 @@ export interface CreateShoppingListRequest {
 }
 
 export interface ShoppingListItemResponse {
+  identifier: string;
   name: string;
   amount: number | null;
   unit: string | null;
+  isChecked: boolean;
 }
 
 export interface ShoppingListDetail {
@@ -49,5 +51,22 @@ export class ShoppingApiService {
 
   getShoppingListById(identifier: string): Observable<ShoppingListDetail> {
     return this.http.get<ShoppingListDetail>(`/api/v1/shopping-lists/${identifier}`);
+  }
+
+  checkOffItem(
+    listIdentifier: string,
+    itemIdentifier: string,
+    isChecked: boolean,
+  ): Observable<void> {
+    return this.http.put<void>(
+      `/api/v1/shopping-lists/${listIdentifier}/items/${itemIdentifier}/check`,
+      { isChecked },
+    );
+  }
+
+  checkOffAllItems(listIdentifier: string, isChecked: boolean): Observable<void> {
+    return this.http.put<void>(`/api/v1/shopping-lists/${listIdentifier}/check-all`, {
+      isChecked,
+    });
   }
 }

--- a/src/Yumney.Shopping.Api/Requests/CheckOffItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/CheckOffItemRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record CheckOffItemRequest(bool IsChecked);

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -37,6 +37,18 @@ public static class ShoppingEndpoints
             .Produces<ShoppingListDetailDto>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapPut("/{identifier:guid}/items/{itemId:guid}/check", CheckOffItemAsync)
+            .WithName("CheckOffItem")
+            .WithTags("Shopping")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPut("/{identifier:guid}/check-all", CheckOffAllItemsAsync)
+            .WithName("CheckOffAllItems")
+            .WithTags("Shopping")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -98,5 +110,45 @@ public static class ShoppingEndpoints
         }
 
         return Results.Ok(result.Value);
+    }
+
+    private static async Task<IResult> CheckOffItemAsync(
+        Guid identifier,
+        Guid itemId,
+        CheckOffItemRequest request,
+        ICommandHandler<CheckOffItemCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new CheckOffItemCommand(
+            new ShoppingListIdentifier(identifier),
+            itemId,
+            request.IsChecked);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return Results.Problem(result.Error!.Message, statusCode: result.Error.HttpStatusCode);
+        }
+
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> CheckOffAllItemsAsync(
+        Guid identifier,
+        CheckOffItemRequest request,
+        ICommandHandler<CheckOffAllItemsCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new CheckOffAllItemsCommand(
+            new ShoppingListIdentifier(identifier),
+            request.IsChecked);
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return Results.Problem(result.Error!.Message, statusCode: result.Error.HttpStatusCode);
+        }
+
+        return Results.NoContent();
     }
 }

--- a/src/Yumney.Shopping.Application/Commands/CheckOffAllItemsCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/CheckOffAllItemsCommand.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record CheckOffAllItemsCommand(
+    ShoppingListIdentifier ListIdentifier,
+    bool IsChecked) : ICommand<Result>;

--- a/src/Yumney.Shopping.Application/Commands/CheckOffItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/CheckOffItemCommand.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record CheckOffItemCommand(
+    ShoppingListIdentifier ListIdentifier,
+    Guid ItemId,
+    bool IsChecked) : ICommand<Result>;

--- a/src/Yumney.Shopping.Application/Commands/CheckOffItemErrors.cs
+++ b/src/Yumney.Shopping.Application/Commands/CheckOffItemErrors.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public static class CheckOffItemErrors
+{
+    public static readonly ApiError ListNotFound = new("SHOPPING_LIST_NOT_FOUND", "Shopping list not found.", 404);
+
+    public static readonly ApiError AccessDenied = new("SHOPPING_LIST_ACCESS_DENIED", "Shopping list not found.", 404);
+}

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffAllItemsCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffAllItemsCommandHandler.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class CheckOffAllItemsCommandHandler(
+    IShoppingListRepository shoppingLists,
+    ICurrentUser currentUser,
+    ILogger<CheckOffAllItemsCommandHandler> logger)
+    : ICommandHandler<CheckOffAllItemsCommand, Result>
+{
+    public async Task<Result> HandleAsync(CheckOffAllItemsCommand command, CancellationToken cancellationToken = default)
+    {
+        var (listIdentifier, isChecked) = command;
+
+        var shoppingList = await shoppingLists.GetByIdForUpdateAsync(listIdentifier, cancellationToken);
+
+        if (shoppingList is null)
+        {
+            return Result.Failure(CheckOffItemErrors.ListNotFound);
+        }
+
+        var owner = new OwnerIdentifier(currentUser.UserId);
+
+        if (shoppingList.Owner != owner)
+        {
+            return Result.Failure(CheckOffItemErrors.AccessDenied);
+        }
+
+        if (isChecked)
+        {
+            shoppingList.CheckAllItems();
+        }
+        else
+        {
+            shoppingList.UncheckAllItems();
+        }
+
+        await shoppingLists.SaveChangesAsync(cancellationToken);
+
+        LogAllItemsChecked(listIdentifier.Value, isChecked);
+
+        return Result.Success();
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "All items in shopping list {ShoppingListId} set to checked={IsChecked}")]
+    private partial void LogAllItemsChecked(Guid shoppingListId, bool isChecked);
+}

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffItemCommandHandler.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class CheckOffItemCommandHandler(
+    IShoppingListRepository shoppingLists,
+    ICurrentUser currentUser,
+    ILogger<CheckOffItemCommandHandler> logger)
+    : ICommandHandler<CheckOffItemCommand, Result>
+{
+    public async Task<Result> HandleAsync(CheckOffItemCommand command, CancellationToken cancellationToken = default)
+    {
+        var (listIdentifier, itemId, isChecked) = command;
+
+        var shoppingList = await shoppingLists.GetByIdForUpdateAsync(listIdentifier, cancellationToken);
+
+        if (shoppingList is null)
+        {
+            return Result.Failure(CheckOffItemErrors.ListNotFound);
+        }
+
+        var owner = new OwnerIdentifier(currentUser.UserId);
+
+        if (shoppingList.Owner != owner)
+        {
+            return Result.Failure(CheckOffItemErrors.AccessDenied);
+        }
+
+        if (isChecked)
+        {
+            shoppingList.CheckOffItem(itemId);
+        }
+        else
+        {
+            shoppingList.UncheckItem(itemId);
+        }
+
+        await shoppingLists.SaveChangesAsync(cancellationToken);
+
+        LogItemCheckedOff(listIdentifier.Value, itemId, isChecked);
+
+        return Result.Success();
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Item {ItemId} in shopping list {ShoppingListId} set to checked={IsChecked}")]
+    private partial void LogItemCheckedOff(Guid shoppingListId, Guid itemId, bool isChecked);
+}

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
@@ -30,7 +30,7 @@ public sealed partial class CreateShoppingListCommandHandler(
         LogShoppingListCreated(shoppingList.Id.Value, title.Value);
 
         var itemDtos = shoppingList.Items
-            .Select(i => new ShoppingListItemDto(i.Name.Value, i.Amount?.Value, i.Unit?.Value))
+            .Select(i => new ShoppingListItemDto(i.Id, i.Name.Value, i.Amount?.Value, i.Unit?.Value, i.IsChecked))
             .ToList();
 
         return Result<ShoppingListDetailDto>.Success(

--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListItemDto.cs
@@ -1,3 +1,3 @@
 namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
-public sealed record ShoppingListItemDto(string Name, decimal? Amount, string? Unit);
+public sealed record ShoppingListItemDto(Guid Identifier, string Name, decimal? Amount, string? Unit, bool IsChecked);

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -35,7 +35,7 @@ public sealed partial class GetShoppingListByIdQueryHandler(
         }
 
         var itemDtos = shoppingList.Items
-            .Select(i => new ShoppingListItemDto(i.Name.Value, i.Amount?.Value, i.Unit?.Value))
+            .Select(i => new ShoppingListItemDto(i.Id, i.Name.Value, i.Amount?.Value, i.Unit?.Value, i.IsChecked))
             .ToList();
 
         return Result<ShoppingListDetailDto>.Success(

--- a/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListRepository.cs
@@ -6,5 +6,9 @@ public interface IShoppingListRepository
 
     Task<ShoppingList?> GetByIdAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
 
+    Task<ShoppingList?> GetByIdForUpdateAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<ShoppingList>> GetByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -41,4 +41,32 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
         return shoppingList;
     }
+
+    public void CheckOffItem(Guid itemId)
+    {
+        var item = items.First(i => i.Id == itemId);
+        item.Check();
+    }
+
+    public void UncheckItem(Guid itemId)
+    {
+        var item = items.First(i => i.Id == itemId);
+        item.Uncheck();
+    }
+
+    public void CheckAllItems()
+    {
+        foreach (var item in items)
+        {
+            item.Check();
+        }
+    }
+
+    public void UncheckAllItems()
+    {
+        foreach (var item in items)
+        {
+            item.Uncheck();
+        }
+    }
 }

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
@@ -10,6 +10,8 @@ public sealed class ShoppingListItem : Entity<Guid>
 
     public Unit? Unit { get; private set; }
 
+    public bool IsChecked { get; private set; }
+
     private ShoppingListItem()
     {
     }
@@ -22,6 +24,17 @@ public sealed class ShoppingListItem : Entity<Guid>
             Name = name,
             Amount = amount,
             Unit = unit,
+            IsChecked = false,
         };
+    }
+
+    public void Check()
+    {
+        IsChecked = true;
+    }
+
+    public void Uncheck()
+    {
+        IsChecked = false;
     }
 }

--- a/src/Yumney.Shopping.Infrastructure/Migrations/20260322122005_AddIsCheckedToShoppingListItems.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Migrations/20260322122005_AddIsCheckedToShoppingListItems.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322122005_AddIsCheckedToShoppingListItems")]
+    partial class AddIsCheckedToShoppingListItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Migrations/20260322122005_AddIsCheckedToShoppingListItems.cs
+++ b/src/Yumney.Shopping.Infrastructure/Migrations/20260322122005_AddIsCheckedToShoppingListItems.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsCheckedToShoppingListItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsChecked",
+                table: "ShoppingListItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsChecked",
+                table: "ShoppingListItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
@@ -23,6 +23,20 @@ public sealed class ShoppingListRepository(ShoppingDbContext context) : IShoppin
             .FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken);
     }
 
+    public async Task<ShoppingList?> GetByIdForUpdateAsync(
+        ShoppingListIdentifier identifier,
+        CancellationToken cancellationToken = default)
+    {
+        return await shoppingLists
+            .Include(l => l.Items)
+            .FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<ShoppingList>> GetByOwnerAsync(
         OwnerIdentifier owner,
         CancellationToken cancellationToken = default)

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
@@ -37,4 +37,33 @@ public class ShoppingListItemTests
         item.Unit.Should().BeNull();
         item.Amount!.Value.Should().Be(3);
     }
+
+    [Fact]
+    public void Create_SetsIsCheckedToFalse()
+    {
+        var item = ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g"));
+
+        item.IsChecked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Check_SetsIsCheckedToTrue()
+    {
+        var item = ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g"));
+
+        item.Check();
+
+        item.IsChecked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Uncheck_SetsIsCheckedToFalse()
+    {
+        var item = ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g"));
+        item.Check();
+
+        item.Uncheck();
+
+        item.IsChecked.Should().BeFalse();
+    }
 }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -119,6 +119,76 @@ public class ShoppingListTests
         list1.Id.Should().NotBe(list2.Id);
     }
 
+    [Fact]
+    public void CheckOffItem_ChecksTheItem()
+    {
+        var items = new List<ShoppingListItem>
+        {
+            ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g")),
+        };
+        var shoppingList = CreateValidShoppingList(items: items);
+
+        shoppingList.CheckOffItem(items[0].Id);
+
+        shoppingList.Items[0].IsChecked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UncheckItem_UnchecksTheItem()
+    {
+        var items = new List<ShoppingListItem>
+        {
+            ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g")),
+        };
+        var shoppingList = CreateValidShoppingList(items: items);
+        shoppingList.CheckOffItem(items[0].Id);
+
+        shoppingList.UncheckItem(items[0].Id);
+
+        shoppingList.Items[0].IsChecked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckAllItems_ChecksAllItems()
+    {
+        var items = new List<ShoppingListItem>
+        {
+            ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g")),
+            ShoppingListItem.Create(new ItemName("Sugar"), new Amount(200), new Unit("g")),
+        };
+        var shoppingList = CreateValidShoppingList(items: items);
+
+        shoppingList.CheckAllItems();
+
+        shoppingList.Items.Should().OnlyContain(i => i.IsChecked);
+    }
+
+    [Fact]
+    public void UncheckAllItems_UnchecksAllItems()
+    {
+        var items = new List<ShoppingListItem>
+        {
+            ShoppingListItem.Create(new ItemName("Flour"), new Amount(500), new Unit("g")),
+            ShoppingListItem.Create(new ItemName("Sugar"), new Amount(200), new Unit("g")),
+        };
+        var shoppingList = CreateValidShoppingList(items: items);
+        shoppingList.CheckAllItems();
+
+        shoppingList.UncheckAllItems();
+
+        shoppingList.Items.Should().OnlyContain(i => !i.IsChecked);
+    }
+
+    [Fact]
+    public void CheckOffItem_InvalidItemId_Throws()
+    {
+        var shoppingList = CreateValidShoppingList();
+
+        var act = () => shoppingList.CheckOffItem(Guid.NewGuid());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
     private static Domain.ShoppingList.ShoppingList CreateValidShoppingList(
         ShoppingListTitle? title = null,
         OwnerIdentifier? owner = null,


### PR DESCRIPTION
## Summary
- Add `IsChecked` property to `ShoppingListItem` with `Check()`/`Uncheck()` domain methods
- Add `CheckOffItem`/`UncheckItem`/`CheckAllItems`/`UncheckAllItems` on `ShoppingList` aggregate
- Add `CheckOffItemCommand` and `CheckOffAllItemsCommand` with handlers (ownership validation)
- Add `PUT /shopping-lists/{id}/items/{itemId}/check` and `PUT /shopping-lists/{id}/check-all` endpoints
- Update shopping detail UI with checkboxes, strikethrough on checked items, check all / reset buttons, progress counter
- Add EF Core migration for `IsChecked` column on `ShoppingListItems`

## Test plan
- [x] 8 new domain tests (check, uncheck, check all, uncheck all, invalid item ID)
- [x] 68 total shopping domain tests pass
- [x] 9 shopping API tests pass
- [x] 24 shopping frontend tests pass
- [x] Full backend build + all tests green
- [ ] Manual: check off items, verify strikethrough + persistence

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)