### PR TITLE
feat(recipes): add multilingual recipe extraction (US-061)

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -121,6 +121,7 @@ public static class RecipesEndpoints
             CookingTime.FromNullable(request.CookTimeMinutes),
             Difficulty.FromNullable(request.Difficulty),
             ImageUrl.FromNullable(request.ImageUrl),
+            RecipeLanguage.FromNullable(request.Language),
             RecipeUrl.FromNullable(request.SourceUrl));
         var result = await handler.HandleAsync(command, cancellationToken);
 

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeRequest.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeRequest.cs
@@ -10,4 +10,5 @@ public sealed record SaveRecipeRequest(
     int? CookTimeMinutes,
     string? Difficulty,
     string? ImageUrl,
+    string? Language = null,
     string? SourceUrl = null);

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed partial class SaveRecipeCommandHandler(
 {
     public async Task<Result<SavedRecipeDto>> HandleAsync(SaveRecipeCommand command, CancellationToken cancellationToken = default)
     {
-        var (title, ingredientCommands, stepCommands, description, servings, preparationTime, cookingTime, difficulty, imageUrl, sourceUrl) = command;
+        var (title, ingredientCommands, stepCommands, description, servings, preparationTime, cookingTime, difficulty, imageUrl, language, sourceUrl) = command;
 
         var owner = new OwnerIdentifier(currentUser.UserId);
 
@@ -44,6 +44,7 @@ public sealed partial class SaveRecipeCommandHandler(
             cookingTime,
             difficulty,
             imageUrl,
+            language,
             sourceUrl);
 
         await recipes.AddAsync(recipe, cancellationToken);

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -68,6 +68,7 @@ public sealed partial class UpdateRecipeCommandHandler(
             recipe.CookingTime?.Value,
             recipe.Difficulty?.Value,
             recipe.ImageUrl?.Value,
+            recipe.Language?.Value,
             recipe.SourceUrl?.Value,
             recipe.CreatedAt,
             recipe.Ingredients.Select(i => new RecipeIngredientDto(

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeCommand.cs
@@ -15,4 +15,5 @@ public sealed record SaveRecipeCommand(
     CookingTime? CookingTime = null,
     Difficulty? Difficulty = null,
     ImageUrl? ImageUrl = null,
+    RecipeLanguage? Language = null,
     RecipeUrl? SourceUrl = null) : ICommand<Result<SavedRecipeDto>>;

--- a/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ExtractedRecipeDto.cs
@@ -5,6 +5,7 @@ public sealed record ExtractedRecipeDto(
     IReadOnlyList<ExtractedIngredientDto> Ingredients,
     IReadOnlyList<ExtractedStepDto> Steps,
     string? Description = null,
+    string? Language = null,
     int? Servings = null,
     int? PrepTimeMinutes = null,
     int? CookTimeMinutes = null,

--- a/src/Yumney.Recipes.Application/DTOs/RecipeDetailDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/RecipeDetailDto.cs
@@ -9,6 +9,7 @@ public sealed record RecipeDetailDto(
     int? CookTimeMinutes,
     string? Difficulty,
     string? ImageUrl,
+    string? Language,
     string? SourceUrl,
     DateTime CreatedAt,
     IReadOnlyList<RecipeIngredientDto> Ingredients,

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
@@ -40,6 +40,7 @@ public sealed partial class GetRecipeByIdQueryHandler(IRecipeRepository recipes,
             recipe.CookingTime?.Value,
             recipe.Difficulty?.Value,
             recipe.ImageUrl?.Value,
+            recipe.Language?.Value,
             recipe.SourceUrl?.Value,
             recipe.CreatedAt,
             recipe.Ingredients.Select(i => new RecipeIngredientDto(

--- a/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
@@ -23,6 +23,8 @@ public sealed class Recipe : AggregateRoot<RecipeIdentifier>
 
     public ImageUrl? ImageUrl { get; private set; }
 
+    public RecipeLanguage? Language { get; private set; }
+
     public RecipeUrl? SourceUrl { get; private set; }
 
     public OwnerIdentifier Owner { get; private set; } = default!;
@@ -48,6 +50,7 @@ public sealed class Recipe : AggregateRoot<RecipeIdentifier>
         CookingTime? cookingTime = null,
         Difficulty? difficulty = null,
         ImageUrl? imageUrl = null,
+        RecipeLanguage? language = null,
         RecipeUrl? sourceUrl = null)
     {
         Ensure.That((IReadOnlyCollection<Ingredient>)ingredients).IsNotEmpty();
@@ -65,6 +68,7 @@ public sealed class Recipe : AggregateRoot<RecipeIdentifier>
             CookingTime = cookingTime,
             Difficulty = difficulty,
             ImageUrl = imageUrl,
+            Language = language,
             CreatedAt = DateTime.UtcNow,
         };
 

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeLanguage.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeLanguage.cs
@@ -1,0 +1,24 @@
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+public sealed record RecipeLanguage
+{
+    public const int MaxLength = 10;
+
+    public string Value { get; }
+
+    public RecipeLanguage(string value)
+    {
+        string validated = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .AndReturn();
+        Value = validated.Trim().ToLowerInvariant();
+    }
+
+    public static RecipeLanguage? FromNullable(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : new RecipeLanguage(value);
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
@@ -23,12 +23,15 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
     private const string fenceMarker = "```";
 
     private const string systemPrompt = $$"""
-        You are a recipe extraction assistant. Extract structured recipe data
+        You are a multilingual recipe extraction assistant. Extract structured recipe data
         from the webpage content enclosed in <webpage_content> tags.
+        The content may be in any language (e.g. English, German, French, Italian, Spanish, or others).
+        Detect the language automatically and KEEP all text in the ORIGINAL language — do NOT translate.
         Respond ONLY with valid JSON matching this schema:
         {
           "title": "string (required)",
           "description": "string or null",
+          "language": "string (required, ISO 639-1 code: en, de, fr, it, es, etc.)",
           "ingredients": [{ "name": "string", "amount": number or null, "unit": "string or null" }],
           "steps": [{ "number": integer, "description": "string" }],
           "servings": integer or null,

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/20260322161417_AddLanguageToRecipes.Designer.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/20260322161417_AddLanguageToRecipes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(RecipesDbContext))]
-    partial class RecipesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322161417_AddLanguageToRecipes")]
+    partial class AddLanguageToRecipes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/20260322161417_AddLanguageToRecipes.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/20260322161417_AddLanguageToRecipes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanguageToRecipes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Language",
+                table: "Recipes",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Language",
+                table: "Recipes");
+        }
+    }
+}

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDbContext.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDbContext.cs
@@ -40,6 +40,9 @@ public sealed class RecipesDbContext(DbContextOptions<RecipesDbContext> options)
             entity.Property(e => e.ImageUrl)
                 .ConfigureNullableStringValueObject(v => v.Value, ImageUrl.FromNullable, ImageUrl.MaxLength);
 
+            entity.Property(e => e.Language)
+                .ConfigureNullableStringValueObject(v => v.Value, RecipeLanguage.FromNullable, RecipeLanguage.MaxLength);
+
             entity.Property(e => e.SourceUrl)
                 .ConfigureNullableStringValueObject(v => v.Value, RecipeUrl.FromNullable, RecipeUrl.MaxLength);
 

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -160,7 +160,7 @@ public class SaveRecipeCommandHandlerTests
             new CookingTime(20),
             new Difficulty("easy"),
             new ImageUrl("https://example.com/image.jpg"),
-            new RecipeUrl("https://example.com/recipe"));
+            SourceUrl: new RecipeUrl("https://example.com/recipe"));
 
         await handler.HandleAsync(command);
 

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
@@ -216,7 +216,7 @@ public class GetRecipeByIdQueryHandlerTests
             new CookingTime(20),
             new Difficulty("easy"),
             new ImageUrl("https://example.com/image.jpg"),
-            new RecipeUrl("https://example.com/recipe"));
+            sourceUrl: new RecipeUrl("https://example.com/recipe"));
     }
 
     private static Recipe CreateTestRecipeWithIngredients(string ownerId)

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -461,6 +461,6 @@ public class RecipeTests
             cookingTime,
             difficulty,
             imageUrl,
-            sourceUrl);
+            sourceUrl: sourceUrl);
     }
 }


### PR DESCRIPTION
## Summary
- Update LLM system prompt to detect source language automatically (ISO 639-1), preserve original language text, and support DE, EN, FR, IT, ES and other languages
- Add `RecipeLanguage` value object and `Language` property to Recipe aggregate
- Add `language` field to `ExtractedRecipeDto`, `RecipeDetailDto`, `SaveRecipeCommand`, and `SaveRecipeRequest`
- Add EF Core migration for `Language` column on `Recipes` table

## Test plan
- [x] 192 recipe domain tests pass
- [x] 76 recipe application tests pass
- [x] 86 recipe API tests pass
- [ ] Manual: import recipe from German/French/Italian website, verify language detected and text preserved

Closes #19

Generated with [Claude Code](https://claude.com/claude-code)