### PR TITLE
test(e2e): add check-off shopping items E2E tests (US-041)

### DIFF
--- a/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
@@ -1,0 +1,27 @@
+import { type Page, type Locator } from '@playwright/test';
+
+export class ShoppingDetailPage {
+  readonly heading: Locator;
+  readonly itemCheckboxes: Locator;
+  readonly items: Locator;
+  readonly checkedItems: Locator;
+  readonly checkAllButton: Locator;
+  readonly resetButton: Locator;
+  readonly progress: Locator;
+  readonly backLink: Locator;
+
+  constructor(private page: Page) {
+    this.heading = page.getByRole('heading', { level: 1 });
+    this.itemCheckboxes = page.locator('.items-list input[type="checkbox"]');
+    this.items = page.locator('.items-list li');
+    this.checkedItems = page.locator('.items-list li.checked');
+    this.checkAllButton = page.getByRole('button', { name: /check all/i });
+    this.resetButton = page.getByRole('button', { name: /reset/i });
+    this.progress = page.locator('.progress');
+    this.backLink = page.locator('.back-link');
+  }
+
+  async goto(identifier: string): Promise<void> {
+    await this.page.goto(`/shopping/${identifier}`);
+  }
+}

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { DashboardPage } from '../pages/dashboard.page';
 import { ShoppingCreatePage } from '../pages/shopping-create.page';
+import { ShoppingDetailPage } from '../pages/shopping-detail.page';
 import { uniqueTitle } from '../helpers/test-data.helper';
 
 test.describe('Shopping List — Generate from Recipe (US-040)', () => {
@@ -112,6 +113,64 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     const cards = authenticatedPage.locator('.list-card');
     const empty = authenticatedPage.locator('.empty-state');
     await expect(cards.or(empty).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
+    test.skip(!recipeIdentifier, 'No recipe created');
+
+    // Navigate to the most recently created shopping list
+    await authenticatedPage.goto('/shopping');
+    const firstCard = authenticatedPage.locator('.list-card').first();
+    await firstCard.click();
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+
+    const detailPage = new ShoppingDetailPage(authenticatedPage);
+    await expect(detailPage.items.first()).toBeVisible({ timeout: 10_000 });
+
+    // Check the first item
+    const firstCheckbox = detailPage.itemCheckboxes.first();
+    await firstCheckbox.check();
+
+    // Verify strikethrough (checked class)
+    await expect(detailPage.checkedItems.first()).toBeVisible();
+  });
+
+  test('should check all items and reset', async ({ authenticatedPage }) => {
+    test.skip(!recipeIdentifier, 'No recipe created');
+
+    await authenticatedPage.goto('/shopping');
+    const firstCard = authenticatedPage.locator('.list-card').first();
+    await firstCard.click();
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+
+    const detailPage = new ShoppingDetailPage(authenticatedPage);
+    await expect(detailPage.items.first()).toBeVisible({ timeout: 10_000 });
+
+    // Check all
+    await detailPage.checkAllButton.click();
+    const allItems = await detailPage.items.all();
+    for (const item of allItems) {
+      await expect(item).toHaveClass(/checked/);
+    }
+
+    // Reset
+    await detailPage.resetButton.click();
+    for (const item of allItems) {
+      await expect(item).not.toHaveClass(/checked/);
+    }
+  });
+
+  test('should show progress counter', async ({ authenticatedPage }) => {
+    test.skip(!recipeIdentifier, 'No recipe created');
+
+    await authenticatedPage.goto('/shopping');
+    const firstCard = authenticatedPage.locator('.list-card').first();
+    await firstCard.click();
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+
+    const detailPage = new ShoppingDetailPage(authenticatedPage);
+    await expect(detailPage.progress).toBeVisible({ timeout: 10_000 });
+    await expect(detailPage.progress).toContainText('/');
   });
 
   // Cleanup: delete the recipe (cascade should handle shopping list)


### PR DESCRIPTION
## Summary
- Add ShoppingDetailPage page object for E2E tests
- Add 3 E2E tests for US-041 check-off functionality:
  - Check off individual item with strikethrough visual
  - Check all / Reset buttons toggle all items
  - Progress counter (checked / total) displays correctly

## Test plan
- [x] E2E tests compile and follow existing patterns
- [ ] Manual: run with full Aspire stack to verify

Generated with [Claude Code](https://claude.com/claude-code)