### PR TITLE
refactor(shared): extract DTO mapping extension methods

### DIFF
--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -50,8 +50,7 @@ public sealed partial class SaveRecipeCommandHandler(
         await recipes.AddAsync(recipe, cancellationToken);
 
         LogRecipeSaved(recipe.Id.Value, title.Value);
-        return Result<SavedRecipeDto>.Success(
-            new SavedRecipeDto(recipe.Id.Value, title.Value, recipe.CreatedAt));
+        return Result<SavedRecipeDto>.Success(recipe.ToSavedDto());
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Duplicate import attempt for URL {SourceUrl} by owner {Owner}")]

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -59,27 +59,7 @@ public sealed partial class UpdateRecipeCommandHandler(
 
         LogRecipeUpdated(recipe.Id.Value, title.Value);
 
-        var dto = new RecipeDetailDto(
-            recipe.Id.Value,
-            recipe.Title.Value,
-            recipe.Description?.Value,
-            recipe.Servings?.Value,
-            recipe.PreparationTime?.Value,
-            recipe.CookingTime?.Value,
-            recipe.Difficulty?.Value,
-            recipe.ImageUrl?.Value,
-            recipe.Language?.Value,
-            recipe.SourceUrl?.Value,
-            recipe.CreatedAt,
-            recipe.Ingredients.Select(i => new RecipeIngredientDto(
-                i.Name.Value,
-                i.Amount?.Value,
-                i.Unit?.Value)).ToList(),
-            recipe.Steps.Select(s => new RecipeStepDto(
-                s.Number.Value,
-                s.Description.Value)).ToList());
-
-        return Result<RecipeDetailDto>.Success(dto);
+        return Result<RecipeDetailDto>.Success(recipe.ToDetailDto());
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Updating recipe {RecipeIdentifier} for owner {OwnerId}")]

--- a/src/Yumney.Recipes.Application/DTOs/RecipeMappingExtensions.cs
+++ b/src/Yumney.Recipes.Application/DTOs/RecipeMappingExtensions.cs
@@ -1,0 +1,53 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+public static class RecipeMappingExtensions
+{
+    extension(Recipe recipe)
+    {
+        public RecipeDetailDto ToDetailDto()
+        {
+            return new RecipeDetailDto(
+                recipe.Id.Value,
+                recipe.Title.Value,
+                recipe.Description?.Value,
+                recipe.Servings?.Value,
+                recipe.PreparationTime?.Value,
+                recipe.CookingTime?.Value,
+                recipe.Difficulty?.Value,
+                recipe.ImageUrl?.Value,
+                recipe.Language?.Value,
+                recipe.SourceUrl?.Value,
+                recipe.CreatedAt,
+                recipe.Ingredients.Select(i => i.ToDto()).ToList(),
+                recipe.Steps.Select(s => s.ToDto()).ToList());
+        }
+
+        public RecipeListItemDto ToListItemDto()
+        {
+            return new RecipeListItemDto(
+                recipe.Id.Value,
+                recipe.Title.Value,
+                recipe.Description?.Value,
+                recipe.Servings?.Value,
+                recipe.PreparationTime?.Value,
+                recipe.CookingTime?.Value,
+                recipe.Difficulty?.Value,
+                recipe.ImageUrl?.Value,
+                recipe.CreatedAt);
+        }
+    }
+
+    public static RecipeIngredientDto ToDto(this Ingredient ingredient)
+    {
+        return new RecipeIngredientDto(
+            ingredient.Name.Value,
+            ingredient.Amount?.Value,
+            ingredient.Unit?.Value);
+    }
+
+    public static RecipeStepDto ToDto(this Step step) => new(step.Number.Value, step.Description.Value);
+
+    public static SavedRecipeDto ToSavedDto(this Recipe recipe) => new(recipe.Id.Value, recipe.Title.Value, recipe.CreatedAt);
+}

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
@@ -31,27 +31,7 @@ public sealed partial class GetRecipeByIdQueryHandler(IRecipeRepository recipes,
             return Result<RecipeDetailDto>.Failure(GetRecipeByIdErrors.AccessDenied);
         }
 
-        var dto = new RecipeDetailDto(
-            recipe.Id.Value,
-            recipe.Title.Value,
-            recipe.Description?.Value,
-            recipe.Servings?.Value,
-            recipe.PreparationTime?.Value,
-            recipe.CookingTime?.Value,
-            recipe.Difficulty?.Value,
-            recipe.ImageUrl?.Value,
-            recipe.Language?.Value,
-            recipe.SourceUrl?.Value,
-            recipe.CreatedAt,
-            recipe.Ingredients.Select(i => new RecipeIngredientDto(
-                i.Name.Value,
-                i.Amount?.Value,
-                i.Unit?.Value)).ToList(),
-            recipe.Steps.Select(s => new RecipeStepDto(
-                s.Number.Value,
-                s.Description.Value)).ToList());
-
-        return Result<RecipeDetailDto>.Success(dto);
+        return Result<RecipeDetailDto>.Success(recipe.ToDetailDto());
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Fetching recipe {RecipeIdentifier} for owner {OwnerId}")]

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
@@ -23,16 +23,7 @@ public sealed partial class GetRecipesQueryHandler(
         var (items, totalCount) = await recipes.GetByOwnerAsync(
             owner, paging, sorting, search, cancellationToken);
 
-        var dtoItems = items.Select(r => new RecipeListItemDto(
-            r.Id.Value,
-            r.Title.Value,
-            r.Description?.Value,
-            r.Servings?.Value,
-            r.PreparationTime?.Value,
-            r.CookingTime?.Value,
-            r.Difficulty?.Value,
-            r.ImageUrl?.Value,
-            r.CreatedAt)).ToList();
+        var dtoItems = items.Select(r => r.ToListItemDto()).ToList();
 
         return Result<PagedResult<RecipeListItemDto>>.Success(
             new PagedResult<RecipeListItemDto>(dtoItems, totalCount, paging.Page.Value, paging.PageSize.Value));

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
@@ -29,17 +29,7 @@ public sealed partial class CreateShoppingListCommandHandler(
 
         LogShoppingListCreated(shoppingList.Id.Value, title.Value);
 
-        var itemDtos = shoppingList.Items
-            .Select(i => new ShoppingListItemDto(i.Id, i.Name.Value, i.Amount?.Value, i.Unit?.Value, i.IsChecked))
-            .ToList();
-
-        return Result<ShoppingListDetailDto>.Success(
-            new ShoppingListDetailDto(
-                shoppingList.Id.Value,
-                title.Value,
-                shoppingList.RecipeReference?.Value,
-                shoppingList.CreatedAt,
-                itemDtos));
+        return Result<ShoppingListDetailDto>.Success(shoppingList.ToDetailDto());
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Shopping list {ShoppingListId} created: {Title}")]

--- a/src/Yumney.Shopping.Application/Commands/ShoppingListItem.cs
+++ b/src/Yumney.Shopping.Application/Commands/ShoppingListItem.cs
@@ -2,4 +2,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
-public sealed record ShoppingListItem(ItemName Name, Amount? Amount, Unit? Unit);
+public sealed record ShoppingListItem(
+    ItemName Name,
+    Amount? Amount,
+    Unit? Unit);

--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
@@ -1,0 +1,38 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public static class ShoppingListMappingExtensions
+{
+    extension(ShoppingList shoppingList)
+    {
+        public ShoppingListDetailDto ToDetailDto()
+        {
+            return new ShoppingListDetailDto(
+                shoppingList.Id.Value,
+                shoppingList.Title.Value,
+                shoppingList.RecipeReference?.Value,
+                shoppingList.CreatedAt,
+                shoppingList.Items.Select(i => i.ToDto()).ToList());
+        }
+
+        public ShoppingListSummaryDto ToSummaryDto()
+        {
+            return new ShoppingListSummaryDto(
+                shoppingList.Id.Value,
+                shoppingList.Title.Value,
+                shoppingList.Items.Count,
+                shoppingList.CreatedAt);
+        }
+    }
+
+    public static ShoppingListItemDto ToDto(this ShoppingListItem item)
+    {
+        return new ShoppingListItemDto(
+            item.Id,
+            item.Name.Value,
+            item.Amount?.Value,
+            item.Unit?.Value,
+            item.IsChecked);
+    }
+}

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -34,17 +34,7 @@ public sealed partial class GetShoppingListByIdQueryHandler(
             return Result<ShoppingListDetailDto>.Failure(GetShoppingListByIdErrors.AccessDenied);
         }
 
-        var itemDtos = shoppingList.Items
-            .Select(i => new ShoppingListItemDto(i.Id, i.Name.Value, i.Amount?.Value, i.Unit?.Value, i.IsChecked))
-            .ToList();
-
-        return Result<ShoppingListDetailDto>.Success(
-            new ShoppingListDetailDto(
-                shoppingList.Id.Value,
-                shoppingList.Title.Value,
-                shoppingList.RecipeReference?.Value,
-                shoppingList.CreatedAt,
-                itemDtos));
+        return Result<ShoppingListDetailDto>.Success(shoppingList.ToDetailDto());
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Fetching shopping list {ShoppingListId}")]

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -23,13 +23,7 @@ public sealed partial class GetShoppingListsQueryHandler(
 
         var lists = await shoppingLists.GetByOwnerAsync(owner, cancellationToken);
 
-        var dtos = lists
-            .Select(l => new ShoppingListSummaryDto(
-                l.Id.Value,
-                l.Title.Value,
-                l.Items.Count,
-                l.CreatedAt))
-            .ToList();
+        var dtos = lists.Select(l => l.ToSummaryDto()).ToList();
 
         return Result<IReadOnlyList<ShoppingListSummaryDto>>.Success(dtos);
     }


### PR DESCRIPTION
## Summary
- Extract `RecipeMappingExtensions` (ToDetailDto, ToListItemDto, ToSavedDto, child ToDto)
- Extract `ShoppingListMappingExtensions` (ToDetailDto, ToSummaryDto, item ToDto)
- Replace 8 inline DTO conversions across handlers with extension method calls
- Eliminates duplicated mapping code between query and command handlers

## Test plan
- [x] 192 recipe domain tests pass
- [x] 76 recipe application tests pass
- [x] 86 recipe API tests pass
- [x] 68 shopping domain tests pass
- [x] 13 shopping application tests pass
- [x] 9 shopping API tests pass
- [x] All 444 tests green — pure refactor, no behavior change

Generated with [Claude Code](https://claude.com/claude-code)