### PR TITLE
feat(shared): add language switching and browser detection (US-060)

### DIFF
--- a/client/apps/account/public/assets/i18n/de.json
+++ b/client/apps/account/public/assets/i18n/de.json
@@ -6,7 +6,8 @@
       "login": "Anmelden",
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
-      "navigation": "Hauptnavigation"
+      "navigation": "Hauptnavigation",
+      "switchLanguage": "Sprache wechseln"
     }
   },
   "account": {

--- a/client/apps/account/public/assets/i18n/en.json
+++ b/client/apps/account/public/assets/i18n/en.json
@@ -6,7 +6,8 @@
       "login": "Sign in",
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
-      "navigation": "Main navigation"
+      "navigation": "Main navigation",
+      "switchLanguage": "Switch language"
     }
   },
   "account": {

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -6,7 +6,8 @@
       "login": "Anmelden",
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
-      "navigation": "Hauptnavigation"
+      "navigation": "Hauptnavigation",
+      "switchLanguage": "Sprache wechseln"
     }
   },
   "shared": {

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -6,7 +6,8 @@
       "login": "Sign in",
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
-      "navigation": "Main navigation"
+      "navigation": "Main navigation",
+      "switchLanguage": "Switch language"
     }
   },
   "shared": {

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -76,7 +76,8 @@
       "login": "Anmelden",
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
-      "navigation": "Hauptnavigation"
+      "navigation": "Hauptnavigation",
+      "switchLanguage": "Sprache wechseln"
     },
     "offlineIndicator": {
       "offline": "Du bist offline. Einige Funktionen sind nicht verfügbar.",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -76,7 +76,8 @@
       "login": "Sign in",
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
-      "navigation": "Main navigation"
+      "navigation": "Main navigation",
+      "switchLanguage": "Switch language"
     },
     "offlineIndicator": {
       "offline": "You are offline. Some features may be unavailable.",

--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -3,6 +3,7 @@ import {
   isDevMode,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
+  APP_INITIALIZER,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
@@ -10,7 +11,7 @@ import { provideServiceWorker } from '@angular/service-worker';
 import { provideTransloco } from '@jsverse/transloco';
 import { authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { appRoutes } from './app.routes';
-import { TranslocoHttpLoader } from '@yumney/shared/models';
+import { TranslocoHttpLoader, LanguageService } from '@yumney/shared/models';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -32,5 +33,11 @@ export const appConfig: ApplicationConfig = {
       },
       loader: TranslocoHttpLoader,
     }),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (lang: LanguageService) => () => lang.initialize(),
+      deps: [LanguageService],
+      multi: true,
+    },
   ],
 };

--- a/client/apps/shell/tsconfig.federation.json
+++ b/client/apps/shell/tsconfig.federation.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",

--- a/client/apps/shell/tsconfig.federation.json
+++ b/client/apps/shell/tsconfig.federation.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",

--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -6,7 +6,8 @@
       "login": "Anmelden",
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
-      "navigation": "Hauptnavigation"
+      "navigation": "Hauptnavigation",
+      "switchLanguage": "Sprache wechseln"
     }
   },
   "shopping": {

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -6,7 +6,8 @@
       "login": "Sign in",
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
-      "navigation": "Main navigation"
+      "navigation": "Main navigation",
+      "switchLanguage": "Switch language"
     }
   },
   "shopping": {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -8,3 +8,4 @@ export { UI } from './lib/ui-constants';
 export { createAsyncState, type AsyncState } from './lib/async-state';
 export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { IS_STANDALONE } from './lib/federation-context';
+export { LanguageService } from './lib/language.service';

--- a/client/libs/shared/models/src/lib/language.service.spec.ts
+++ b/client/libs/shared/models/src/lib/language.service.spec.ts
@@ -1,0 +1,67 @@
+import { LanguageService } from './language.service';
+
+describe('LanguageService', () => {
+  let service: LanguageService;
+  let mockTransloco: {
+    getActiveLang: ReturnType<typeof vi.fn>;
+    setActiveLang: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockTransloco = {
+      getActiveLang: vi.fn().mockReturnValue('en'),
+      setActiveLang: vi.fn().mockImplementation((lang: string) => {
+        mockTransloco.getActiveLang.mockReturnValue(lang);
+      }),
+    };
+
+    service = new LanguageService(mockTransloco as any);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('should use stored language on initialize', () => {
+    localStorage.setItem('yn-language', 'de');
+    service.initialize();
+    expect(mockTransloco.setActiveLang).toHaveBeenCalledWith('de');
+  });
+
+  it('should detect browser language on initialize when no stored language', () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'de-AT',
+      configurable: true,
+    });
+    service.initialize();
+    expect(mockTransloco.setActiveLang).toHaveBeenCalledWith('de');
+  });
+
+  it('should fallback to en for unsupported browser language', () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'ja-JP',
+      configurable: true,
+    });
+    service.initialize();
+    expect(mockTransloco.setActiveLang).toHaveBeenCalledWith('en');
+  });
+
+  it('should switch language and persist to localStorage', () => {
+    service.switchTo('de');
+    expect(mockTransloco.setActiveLang).toHaveBeenCalledWith('de');
+    expect(localStorage.getItem('yn-language')).toBe('de');
+  });
+
+  it('should ignore unsupported language', () => {
+    service.switchTo('fr');
+    expect(mockTransloco.setActiveLang).not.toHaveBeenCalled();
+    expect(localStorage.getItem('yn-language')).toBeNull();
+  });
+
+  it('should return active language from Transloco', () => {
+    mockTransloco.getActiveLang.mockReturnValue('de');
+    expect(service.activeLang).toBe('de');
+  });
+});

--- a/client/libs/shared/models/src/lib/language.service.ts
+++ b/client/libs/shared/models/src/lib/language.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
+
+const LANGUAGE_KEY = 'yn-language';
+const SUPPORTED_LANGUAGES = ['en', 'de'];
+const DEFAULT_LANGUAGE = 'en';
+
+@Injectable({ providedIn: 'root' })
+export class LanguageService {
+  constructor(private transloco: TranslocoService) {}
+
+  initialize(): void {
+    const lang = this.getStoredLanguage() ?? this.detectBrowserLanguage();
+    this.transloco.setActiveLang(lang);
+  }
+
+  get activeLang(): string {
+    return this.transloco.getActiveLang();
+  }
+
+  switchTo(lang: string): void {
+    if (!SUPPORTED_LANGUAGES.includes(lang)) {
+      return;
+    }
+
+    this.transloco.setActiveLang(lang);
+    localStorage.setItem(LANGUAGE_KEY, lang);
+  }
+
+  private getStoredLanguage(): string | null {
+    const stored = localStorage.getItem(LANGUAGE_KEY);
+    return stored && SUPPORTED_LANGUAGES.includes(stored) ? stored : null;
+  }
+
+  private detectBrowserLanguage(): string {
+    const browserLang = navigator.language?.split('-')[0]?.toLowerCase();
+    return SUPPORTED_LANGUAGES.includes(browserLang) ? browserLang : DEFAULT_LANGUAGE;
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -20,6 +20,13 @@
           {{ t('layout.header.login') }}
         </a>
       }
+      <button
+        class="lang-toggle"
+        (click)="onSwitchLanguage()"
+        [attr.aria-label]="t('layout.header.switchLanguage')"
+      >
+        {{ languageService.activeLang === 'en' ? 'DE' : 'EN' }}
+      </button>
     </nav>
   </div>
 </header>

--- a/client/libs/ui/src/lib/header/header.component.scss
+++ b/client/libs/ui/src/lib/header/header.component.scss
@@ -48,6 +48,22 @@ nav {
   }
 }
 
+.lang-toggle {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--yn-border);
+  border-radius: 4px;
+  background: none;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  letter-spacing: 0.05em;
+
+  &:hover {
+    background-color: var(--yn-background);
+  }
+}
+
 .login-link {
   font-size: 0.875rem;
   color: var(--yn-link);

--- a/client/libs/ui/src/lib/header/header.component.ts
+++ b/client/libs/ui/src/lib/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthService } from '@yumney/shared/auth';
+import { LanguageService } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-header',
@@ -12,8 +13,14 @@ import { AuthService } from '@yumney/shared/auth';
 })
 export class HeaderComponent {
   protected authService = inject(AuthService);
+  protected languageService = inject(LanguageService);
 
   onLogout(): void {
     this.authService.logout();
+  }
+
+  onSwitchLanguage(): void {
+    const next = this.languageService.activeLang === 'en' ? 'de' : 'en';
+    this.languageService.switchTo(next);
   }
 }

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -22,7 +22,11 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
     {
     }
 
-    public static ShoppingList Create(ShoppingListTitle title, OwnerIdentifier owner, IReadOnlyList<ShoppingListItem> items, RecipeReference? recipeReference = null)
+    public static ShoppingList Create(
+        ShoppingListTitle title,
+        OwnerIdentifier owner,
+        IReadOnlyList<ShoppingListItem> items,
+        RecipeReference? recipeReference = null)
     {
         Ensure.That((IReadOnlyCollection<ShoppingListItem>)items).IsNotEmpty();
 


### PR DESCRIPTION
## Summary
- Add `LanguageService` with browser language detection, localStorage persistence, and Transloco integration
- Add DE/EN toggle button in the header component
- Initialize language on app startup via `APP_INITIALIZER` — detects browser language on first visit, persists choice
- Fallback to EN for unsupported browser languages

## Test plan
- [x] 6 unit tests for LanguageService (stored lang, browser detection, fallback, switch, ignore unsupported)
- [x] 33 shared-models tests pass
- [x] 188 shell tests pass
- [x] Production build succeeds
- [ ] Manual: switch language, verify persistence across reload, verify browser detection

Closes #18

Generated with [Claude Code](https://claude.com/claude-code)