### PR TITLE
refactor(domain): add New() factory method to Guid-based identifiers

### DIFF
--- a/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Recipe.cs
@@ -62,7 +62,7 @@ public sealed class Recipe : AggregateRoot<RecipeIdentifier>
 
         var recipe = new Recipe
         {
-            Id = new RecipeIdentifier(Guid.NewGuid()),
+            Id = RecipeIdentifier.New(),
             Title = title,
             SourceUrl = sourceUrl,
             Owner = owner,

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeIdentifier.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeIdentifier.cs
@@ -11,5 +11,7 @@ public sealed record RecipeIdentifier
         Value = Ensure.That(value).IsNotEmpty().AndReturn();
     }
 
+    public static RecipeIdentifier New() => new(Guid.NewGuid());
+
     public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListItemDto.cs
@@ -1,3 +1,8 @@
 namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
-public sealed record ShoppingListItemDto(Guid Identifier, string Name, decimal? Amount, string? Unit, bool IsChecked);
+public sealed record ShoppingListItemDto(
+    Guid Identifier,
+    string Name,
+    decimal? Amount,
+    string? Unit,
+    bool IsChecked);

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -14,7 +14,9 @@ public sealed partial class GetShoppingListByIdQueryHandler(
     ILogger<GetShoppingListByIdQueryHandler> logger)
     : IQueryHandler<GetShoppingListByIdQuery, Result<ShoppingListDetailDto>>
 {
-    public async Task<Result<ShoppingListDetailDto>> HandleAsync(GetShoppingListByIdQuery query, CancellationToken cancellationToken = default)
+    public async Task<Result<ShoppingListDetailDto>> HandleAsync(
+        GetShoppingListByIdQuery query,
+        CancellationToken cancellationToken = default)
     {
         var identifier = query.Identifier;
 

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -32,7 +32,7 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
         var shoppingList = new ShoppingList
         {
-            Id = new ShoppingListIdentifier(Guid.NewGuid()),
+            Id = ShoppingListIdentifier.New(),
             Title = title,
             Owner = owner,
             RecipeReference = recipeReference,

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListIdentifier.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListIdentifier.cs
@@ -11,5 +11,7 @@ public sealed record ShoppingListIdentifier
         Value = Ensure.That(value).IsNotEmpty().AndReturn();
     }
 
+    public static ShoppingListIdentifier New() => new(Guid.NewGuid());
+
     public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
@@ -20,7 +20,7 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
     {
         return new AppUserProfile
         {
-            Id = new AppUserProfileIdentifier(Guid.NewGuid()),
+            Id = AppUserProfileIdentifier.New(),
             KeycloakUserId = keycloakUserId,
             DisplayName = displayName,
         };

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
@@ -11,5 +11,7 @@ public sealed record AppUserProfileIdentifier
         Value = Ensure.That(value).IsNotEmpty().AndReturn();
     }
 
+    public static AppUserProfileIdentifier New() => new(Guid.NewGuid());
+
     public override string ToString() => Value.ToString();
 }


### PR DESCRIPTION
## Summary
- Add `New()` static factory method to `RecipeIdentifier`, `ShoppingListIdentifier`, `AppUserProfileIdentifier`
- Replace `new XxxIdentifier(Guid.NewGuid())` with `XxxIdentifier.New()` in all aggregates

## Test plan
- [x] 196 recipe domain tests pass
- [x] 68 shopping domain tests pass
- [x] 76 users domain tests pass

Generated with [Claude Code](https://claude.com/claude-code)