### PR TITLE
refactor(domain): add From() and FromNullable() to Guid identifiers

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -150,7 +150,7 @@ public static class RecipesEndpoints
         IQueryHandler<GetRecipeByIdQuery, Result<RecipeDetailDto>> handler,
         CancellationToken cancellationToken)
     {
-        var query = new GetRecipeByIdQuery(new RecipeIdentifier(identifier));
+        var query = new GetRecipeByIdQuery(RecipeIdentifier.From(identifier));
         var result = await handler.HandleAsync(query, cancellationToken);
 
         if (result.IsFailure)
@@ -175,7 +175,7 @@ public static class RecipesEndpoints
         }
 
         var command = new UpdateRecipeCommand(
-            new RecipeIdentifier(identifier),
+            RecipeIdentifier.From(identifier),
             new RecipeTitle(request.Title),
             request.Ingredients.Select(i => new SaveRecipeIngredientItem(
                 new IngredientName(i.Name),
@@ -206,7 +206,7 @@ public static class RecipesEndpoints
         ICommandHandler<DeleteRecipeCommand, Result> handler,
         CancellationToken cancellationToken)
     {
-        var command = new DeleteRecipeCommand(new RecipeIdentifier(identifier));
+        var command = new DeleteRecipeCommand(RecipeIdentifier.From(identifier));
         var result = await handler.HandleAsync(command, cancellationToken);
 
         if (result.IsFailure)

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeIdentifier.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeIdentifier.cs
@@ -13,5 +13,10 @@ public sealed record RecipeIdentifier
 
     public static RecipeIdentifier New() => new(Guid.NewGuid());
 
+    public static RecipeIdentifier From(Guid value) => new(value);
+
+    public static RecipeIdentifier? FromNullable(Guid? value) =>
+        value.HasValue ? new RecipeIdentifier(value.Value) : null;
+
     public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -101,7 +101,7 @@ public static class ShoppingEndpoints
         IQueryHandler<GetShoppingListByIdQuery, Result<ShoppingListDetailDto>> handler,
         CancellationToken cancellationToken)
     {
-        var query = new GetShoppingListByIdQuery(new ShoppingListIdentifier(identifier));
+        var query = new GetShoppingListByIdQuery(ShoppingListIdentifier.From(identifier));
         var result = await handler.HandleAsync(query, cancellationToken);
 
         if (result.IsFailure)
@@ -120,7 +120,7 @@ public static class ShoppingEndpoints
         CancellationToken cancellationToken)
     {
         var command = new CheckOffItemCommand(
-            new ShoppingListIdentifier(identifier),
+            ShoppingListIdentifier.From(identifier),
             itemId,
             request.IsChecked);
         var result = await handler.HandleAsync(command, cancellationToken);
@@ -140,7 +140,7 @@ public static class ShoppingEndpoints
         CancellationToken cancellationToken)
     {
         var command = new CheckOffAllItemsCommand(
-            new ShoppingListIdentifier(identifier),
+            ShoppingListIdentifier.From(identifier),
             request.IsChecked);
         var result = await handler.HandleAsync(command, cancellationToken);
 

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListIdentifier.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListIdentifier.cs
@@ -13,5 +13,10 @@ public sealed record ShoppingListIdentifier
 
     public static ShoppingListIdentifier New() => new(Guid.NewGuid());
 
+    public static ShoppingListIdentifier From(Guid value) => new(value);
+
+    public static ShoppingListIdentifier? FromNullable(Guid? value) =>
+        value.HasValue ? new ShoppingListIdentifier(value.Value) : null;
+
     public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
@@ -13,5 +13,10 @@ public sealed record AppUserProfileIdentifier
 
     public static AppUserProfileIdentifier New() => new(Guid.NewGuid());
 
+    public static AppUserProfileIdentifier From(Guid value) => new(value);
+
+    public static AppUserProfileIdentifier? FromNullable(Guid? value) =>
+        value.HasValue ? new AppUserProfileIdentifier(value.Value) : null;
+
     public override string ToString() => Value.ToString();
 }


### PR DESCRIPTION
## Summary
- Add `From(Guid)` and `FromNullable(Guid?)` to all Guid-based identifiers
- Update API endpoint usages to `XxxIdentifier.From(identifier)`
- Constructor kept public for EF Core `HasConversion` compatibility

## Test plan
- [x] All domain and API tests pass (435 tests)

Generated with [Claude Code](https://claude.com/claude-code)