### PR TITLE
refactor(shared): add ParseNullable enum extension method

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -86,9 +86,7 @@ public static class RecipesEndpoints
         string? search = null,
         CancellationToken cancellationToken = default)
     {
-        var sortField = Enum.TryParse<RecipeSortField>(sortBy, ignoreCase: true, out var parsed)
-            ? parsed
-            : RecipeSortField.Date;
+        var sortField = default(RecipeSortField).ParseNullable(sortBy) ?? RecipeSortField.Date;
 
         var query = new GetRecipesQuery(
             PagingOptions.Of(Page.From(page), PageSize.From(pageSize)),

--- a/src/Yumney.Shared/Common/EnumExtensions.cs
+++ b/src/Yumney.Shared/Common/EnumExtensions.cs
@@ -1,0 +1,16 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+public static class EnumExtensions
+{
+#pragma warning disable SA1313
+    public static TEnum? ParseNullable<TEnum>(this TEnum _, string? value)
+        where TEnum : struct, Enum
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Enum.TryParse<TEnum>(value, ignoreCase: true, out var result) ? result : null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EnumExtensions.ParseNullable<TEnum>()` for clean enum parsing with null fallback
- Replace verbose `Enum.TryParse` ternary with `default(T).ParseNullable(value) ?? fallback`

## Test plan
- [x] 86 recipe API tests pass

Generated with [Claude Code](https://claude.com/claude-code)