### PR TITLE
refactor(recipes): extract mapping extension methods for command items

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -167,18 +167,21 @@ public static class RecipesEndpoints
             return problem;
         }
 
+        var (title, description, ingredients, steps, servings, prepTimeMinutes, cookTimeMinutes, difficulty, imageUrl,
+            tags) = request;
+
         var command = new UpdateRecipeCommand(
             RecipeIdentifier.From(identifier),
-            new RecipeTitle(request.Title),
-            request.Ingredients.Select(i => i.ToCommandItem()).ToList(),
-            request.Steps.Select(s => s.ToCommandItem()).ToList(),
-            RecipeDescription.FromNullable(request.Description),
-            Servings.FromNullable(request.Servings),
-            PreparationTime.FromNullable(request.PrepTimeMinutes),
-            CookingTime.FromNullable(request.CookTimeMinutes),
-            Difficulty.FromNullable(request.Difficulty),
-            ImageUrl.FromNullable(request.ImageUrl),
-            request.Tags?.Select(t => new RecipeTag(t)).ToList());
+            new RecipeTitle(title),
+            ingredients.Select(i => i.ToCommandItem()).ToList(),
+            steps.Select(s => s.ToCommandItem()).ToList(),
+            RecipeDescription.FromNullable(description),
+            Servings.FromNullable(servings),
+            PreparationTime.FromNullable(prepTimeMinutes),
+            CookingTime.FromNullable(cookTimeMinutes),
+            Difficulty.FromNullable(difficulty),
+            ImageUrl.FromNullable(imageUrl),
+            tags?.Select(t => new RecipeTag(t)).ToList());
         var result = await handler.HandleAsync(command, cancellationToken);
 
         if (result.IsFailure)

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -117,13 +117,8 @@ public static class RecipesEndpoints
 
         var command = new SaveRecipeCommand(
             new RecipeTitle(request.Title),
-            request.Ingredients.Select(i => new SaveRecipeIngredientItem(
-                new IngredientName(i.Name),
-                Amount.FromNullable(i.Amount),
-                Unit.FromNullable(i.Unit))).ToList(),
-            request.Steps.Select(s => new SaveRecipeStepItem(
-                new StepNumber(s.Number),
-                new StepDescription(s.Description))).ToList(),
+            request.Ingredients.Select(i => i.ToCommandItem()).ToList(),
+            request.Steps.Select(s => s.ToCommandItem()).ToList(),
             RecipeDescription.FromNullable(request.Description),
             Servings.FromNullable(request.Servings),
             PreparationTime.FromNullable(request.PrepTimeMinutes),
@@ -175,13 +170,8 @@ public static class RecipesEndpoints
         var command = new UpdateRecipeCommand(
             RecipeIdentifier.From(identifier),
             new RecipeTitle(request.Title),
-            request.Ingredients.Select(i => new SaveRecipeIngredientItem(
-                new IngredientName(i.Name),
-                Amount.FromNullable(i.Amount),
-                Unit.FromNullable(i.Unit))).ToList(),
-            request.Steps.Select(s => new SaveRecipeStepItem(
-                new StepNumber(s.Number),
-                new StepDescription(s.Description))).ToList(),
+            request.Ingredients.Select(i => i.ToCommandItem()).ToList(),
+            request.Steps.Select(s => s.ToCommandItem()).ToList(),
             RecipeDescription.FromNullable(request.Description),
             Servings.FromNullable(request.Servings),
             PreparationTime.FromNullable(request.PrepTimeMinutes),

--- a/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
+++ b/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
@@ -1,7 +1,8 @@
+using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
+namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
 public static class RequestMappingExtensions
 {

--- a/src/Yumney.Recipes.Api/Requests/RequestMappingExtensions.cs
+++ b/src/Yumney.Recipes.Api/Requests/RequestMappingExtensions.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
+
+public static class RequestMappingExtensions
+{
+    public static SaveRecipeIngredientItem ToCommandItem(this SaveRecipeIngredientRequest request)
+    {
+        return new SaveRecipeIngredientItem(
+            new IngredientName(request.Name),
+            Amount.FromNullable(request.Amount),
+            Unit.FromNullable(request.Unit));
+    }
+
+    public static SaveRecipeStepItem ToCommandItem(this SaveRecipeStepRequest request)
+    {
+        return new SaveRecipeStepItem(
+            new StepNumber(request.Number),
+            new StepDescription(request.Description));
+    }
+}

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -25,13 +25,8 @@ public sealed partial class SaveRecipeCommandHandler(
             return Result<SavedRecipeDto>.Failure(SaveRecipeErrors.AlreadyImported);
         }
 
-        var ingredients = ingredientCommands
-            .Select(i => Ingredient.Create(i.Name, i.Amount, i.Unit))
-            .ToList();
-
-        var steps = stepCommands
-            .Select(s => Step.Create(s.Number, s.Description))
-            .ToList();
+        var ingredients = ingredientCommands.Select(i => i.ToDomain()).ToList();
+        var steps = stepCommands.Select(s => s.ToDomain()).ToList();
 
         var recipe = Recipe.Create(
             title,

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -36,13 +36,8 @@ public sealed partial class UpdateRecipeCommandHandler(
             return Result<RecipeDetailDto>.Failure(UpdateRecipeErrors.AccessDenied);
         }
 
-        var ingredients = ingredientCommands
-            .Select(i => Ingredient.Create(i.Name, i.Amount, i.Unit))
-            .ToList();
-
-        var steps = stepCommands
-            .Select(s => Step.Create(s.Number, s.Description))
-            .ToList();
+        var ingredients = ingredientCommands.Select(i => i.ToDomain()).ToList();
+        var steps = stepCommands.Select(s => s.ToDomain()).ToList();
 
         recipe.Update(
             title,

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeIngredientItem.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeIngredientItem.cs
@@ -5,4 +5,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 public sealed record SaveRecipeIngredientItem(
     IngredientName Name,
     Amount? Amount,
-    Unit? Unit);
+    Unit? Unit)
+{
+    public Ingredient ToDomain() => Ingredient.Create(Name, Amount, Unit);
+}

--- a/src/Yumney.Recipes.Application/Commands/SaveRecipeStepItem.cs
+++ b/src/Yumney.Recipes.Application/Commands/SaveRecipeStepItem.cs
@@ -2,4 +2,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 
-public sealed record SaveRecipeStepItem(StepNumber Number, StepDescription Description);
+public sealed record SaveRecipeStepItem(StepNumber Number, StepDescription Description)
+{
+    public Step ToDomain() => Step.Create(Number, Description);
+}


### PR DESCRIPTION
## Summary
- Add `ToDomain()` on `SaveRecipeIngredientItem`/`SaveRecipeStepItem` for handler mappings
- Add `ToCommandItem()` on `SaveRecipeIngredientRequest`/`SaveRecipeStepRequest` for endpoint mappings
- Replace 4 duplicated inline LINQ lambdas with clean extension method calls

## Test plan
- [x] 85 application tests pass
- [x] 86 API tests pass

Generated with [Claude Code](https://claude.com/claude-code)