### PR TITLE
refactor(shared): backend cleanup round 2

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -10,7 +10,7 @@ import {
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
-import { createAsyncState, scaleIngredients, HttpErrorMap } from '@yumney/shared/models';
+import { createAsyncState, scaleIngredients, HttpErrorMap, ROUTES } from '@yumney/shared/models';
 import { ConfirmDialogComponent } from '@yumney/ui';
 
 @Component({
@@ -131,7 +131,7 @@ export class RecipeDetailComponent implements OnInit {
     this.deleteState.execute(
       this.recipeApi.deleteRecipe(recipe.identifier),
       RecipeDetailComponent.deleteErrorMap,
-      () => this.router.navigate(['/recipes']),
+      () => this.router.navigate([ROUTES.recipes.list]),
       (error) => this.serverError.set(error),
     );
   }

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -14,6 +14,7 @@ import {
   mapToUpdateRecipeRequest,
   mapDetailToImportResponse,
   HttpErrorMap,
+  ROUTES,
 } from '@yumney/shared/models';
 import { RecipePreviewComponent } from '@yumney/ui';
 
@@ -66,12 +67,12 @@ export class RecipeEditComponent implements OnInit {
     this.saveState.execute(
       this.recipeApi.updateRecipe(this.identifier(), request),
       RecipeEditComponent.errorMap,
-      () => this.router.navigate(['/recipes', this.identifier()]),
+      () => this.router.navigate([ROUTES.recipes.list, this.identifier()]),
       (error) => this.serverError.set(error),
     );
   }
 
   onDiscard(): void {
-    this.router.navigate(['/recipes', this.identifier()]);
+    this.router.navigate([ROUTES.recipes.list, this.identifier()]);
   }
 }

--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -11,7 +11,13 @@ import { provideServiceWorker } from '@angular/service-worker';
 import { provideTransloco } from '@jsverse/transloco';
 import { authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { appRoutes } from './app.routes';
-import { TranslocoHttpLoader, LanguageService, UI } from '@yumney/shared/models';
+import {
+  TranslocoHttpLoader,
+  LanguageService,
+  UI,
+  SUPPORTED_LANGUAGES,
+  DEFAULT_LANGUAGE,
+} from '@yumney/shared/models';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -26,8 +32,8 @@ export const appConfig: ApplicationConfig = {
     }),
     provideTransloco({
       config: {
-        availableLangs: ['en', 'de'],
-        defaultLang: 'en',
+        availableLangs: [...SUPPORTED_LANGUAGES],
+        defaultLang: DEFAULT_LANGUAGE,
         reRenderOnLangChange: true,
         prodMode: !isDevMode(),
       },

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -11,7 +11,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';
 import { ShoppingApiService, CreateShoppingListItem } from '@yumney/shared/api-client';
-import { createAsyncState, HttpErrorMap } from '@yumney/shared/models';
+import { createAsyncState, HttpErrorMap, ROUTES } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-shopping-create',
@@ -107,7 +107,7 @@ export class ShoppingCreateComponent implements OnInit {
         recipeIdentifier: recipe.identifier,
       }),
       ShoppingCreateComponent.createErrorMap,
-      (result) => this.router.navigate(['/shopping', result.identifier]),
+      (result) => this.router.navigate([ROUTES.shopping.list, result.identifier]),
       (error) => this.serverError.set(error),
     );
   }

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -1,0 +1,22 @@
+const API_BASE = '/api/v1';
+
+export const API_ENDPOINTS = {
+  recipes: {
+    base: `${API_BASE}/recipes`,
+    import: `${API_BASE}/recipes/import`,
+    importFromPhotos: `${API_BASE}/recipes/import-from-photos`,
+    byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
+  },
+  shoppingLists: {
+    base: `${API_BASE}/shopping-lists`,
+    byIdentifier: (identifier: string) => `${API_BASE}/shopping-lists/${identifier}`,
+    checkItem: (listIdentifier: string, itemIdentifier: string) =>
+      `${API_BASE}/shopping-lists/${listIdentifier}/items/${itemIdentifier}/check`,
+    checkAll: (listIdentifier: string) =>
+      `${API_BASE}/shopping-lists/${listIdentifier}/check-all`,
+  },
+  auth: {
+    register: `${API_BASE}/auth/register`,
+    resendVerificationEmail: `${API_BASE}/auth/resend-verification-email`,
+  },
+} as const;

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -12,8 +12,7 @@ export const API_ENDPOINTS = {
     byIdentifier: (identifier: string) => `${API_BASE}/shopping-lists/${identifier}`,
     checkItem: (listIdentifier: string, itemIdentifier: string) =>
       `${API_BASE}/shopping-lists/${listIdentifier}/items/${itemIdentifier}/check`,
-    checkAll: (listIdentifier: string) =>
-      `${API_BASE}/shopping-lists/${listIdentifier}/check-all`,
+    checkAll: (listIdentifier: string) => `${API_BASE}/shopping-lists/${listIdentifier}/check-all`,
   },
   auth: {
     register: `${API_BASE}/auth/register`,

--- a/client/libs/shared/api-client/src/lib/auth-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/auth-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
 
 export interface RegisterRequest {
   email: string;
@@ -25,14 +26,14 @@ export class AuthApiService {
   private http = inject(HttpClient);
 
   register(request: RegisterRequest): Observable<RegisterResponse> {
-    return this.http.post<RegisterResponse>('/api/v1/auth/register', request);
+    return this.http.post<RegisterResponse>(API_ENDPOINTS.auth.register, request);
   }
 
   resendVerificationEmail(
     request: ResendVerificationRequest,
   ): Observable<ResendVerificationResponse> {
     return this.http.post<ResendVerificationResponse>(
-      '/api/v1/auth/resend-verification-email',
+      API_ENDPOINTS.auth.resendVerificationEmail,
       request,
     );
   }

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { PagedResponse, PaginationParams } from '@yumney/shared/models';
+import { API_ENDPOINTS } from './api-endpoints';
 
 export interface ImportRecipeRequest {
   url: string;
@@ -115,33 +116,33 @@ export class RecipeApiService {
   private http = inject(HttpClient);
 
   importRecipe(request: ImportRecipeRequest): Observable<ImportRecipeResponse> {
-    return this.http.post<ImportRecipeResponse>('/api/v1/recipes/import', request);
+    return this.http.post<ImportRecipeResponse>(API_ENDPOINTS.recipes.import, request);
   }
 
   importFromPhotos(photos: File[]): Observable<ImportRecipeResponse> {
     const formData = new FormData();
     photos.forEach((photo) => formData.append('photos', photo));
-    return this.http.post<ImportRecipeResponse>('/api/v1/recipes/import-from-photos', formData);
+    return this.http.post<ImportRecipeResponse>(API_ENDPOINTS.recipes.importFromPhotos, formData);
   }
 
   saveRecipe(request: SaveRecipeRequest): Observable<SavedRecipeResponse> {
-    return this.http.post<SavedRecipeResponse>('/api/v1/recipes', request);
+    return this.http.post<SavedRecipeResponse>(API_ENDPOINTS.recipes.base, request);
   }
 
   updateRecipe(identifier: string, request: UpdateRecipeRequest): Observable<RecipeDetail> {
-    return this.http.put<RecipeDetail>(`/api/v1/recipes/${identifier}`, request);
+    return this.http.put<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier), request);
   }
 
   deleteRecipe(identifier: string): Observable<void> {
-    return this.http.delete<void>(`/api/v1/recipes/${identifier}`);
+    return this.http.delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier));
   }
 
   getRecipeById(identifier: string): Observable<RecipeDetail> {
-    return this.http.get<RecipeDetail>(`/api/v1/recipes/${identifier}`);
+    return this.http.get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier));
   }
 
   getRecipes(params: GetRecipesParams = {}): Observable<RecipeListResponse> {
-    return this.http.get<RecipeListResponse>('/api/v1/recipes', {
+    return this.http.get<RecipeListResponse>(API_ENDPOINTS.recipes.base, {
       params: {
         ...(params.page != null && { page: params.page }),
         ...(params.pageSize != null && { pageSize: params.pageSize }),

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
 
 export interface CreateShoppingListItem {
   name: string;
@@ -42,15 +43,15 @@ export class ShoppingApiService {
   private http = inject(HttpClient);
 
   createShoppingList(request: CreateShoppingListRequest): Observable<ShoppingListDetail> {
-    return this.http.post<ShoppingListDetail>('/api/v1/shopping-lists', request);
+    return this.http.post<ShoppingListDetail>(API_ENDPOINTS.shoppingLists.base, request);
   }
 
   getShoppingLists(): Observable<ShoppingListSummary[]> {
-    return this.http.get<ShoppingListSummary[]>('/api/v1/shopping-lists');
+    return this.http.get<ShoppingListSummary[]>(API_ENDPOINTS.shoppingLists.base);
   }
 
   getShoppingListById(identifier: string): Observable<ShoppingListDetail> {
-    return this.http.get<ShoppingListDetail>(`/api/v1/shopping-lists/${identifier}`);
+    return this.http.get<ShoppingListDetail>(API_ENDPOINTS.shoppingLists.byIdentifier(identifier));
   }
 
   checkOffItem(
@@ -59,13 +60,13 @@ export class ShoppingApiService {
     isChecked: boolean,
   ): Observable<void> {
     return this.http.put<void>(
-      `/api/v1/shopping-lists/${listIdentifier}/items/${itemIdentifier}/check`,
+      API_ENDPOINTS.shoppingLists.checkItem(listIdentifier, itemIdentifier),
       { isChecked },
     );
   }
 
   checkOffAllItems(listIdentifier: string, isChecked: boolean): Observable<void> {
-    return this.http.put<void>(`/api/v1/shopping-lists/${listIdentifier}/check-all`, {
+    return this.http.put<void>(API_ENDPOINTS.shoppingLists.checkAll(listIdentifier), {
       isChecked,
     });
   }

--- a/client/libs/shared/auth/src/lib/auth.guard.ts
+++ b/client/libs/shared/auth/src/lib/auth.guard.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import { ROUTES } from '@yumney/shared/models';
 import { AuthService } from './auth.service';
 
 export const authGuard: CanActivateFn = () => {
@@ -10,5 +11,5 @@ export const authGuard: CanActivateFn = () => {
     return true;
   }
 
-  return router.createUrlTree(['/auth/login']);
+  return router.createUrlTree([ROUTES.auth.login]);
 };

--- a/client/libs/shared/auth/src/lib/guest.guard.ts
+++ b/client/libs/shared/auth/src/lib/guest.guard.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import { ROUTES } from '@yumney/shared/models';
 import { AuthService } from './auth.service';
 
 export const guestGuard: CanActivateFn = () => {
@@ -7,7 +8,7 @@ export const guestGuard: CanActivateFn = () => {
   const router = inject(Router);
 
   if (authService.isAuthenticated()) {
-    return router.createUrlTree(['/dashboard']);
+    return router.createUrlTree([ROUTES.dashboard]);
   }
 
   return true;

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -8,10 +8,16 @@ export { UI } from './lib/ui-constants';
 export { createAsyncState, type AsyncState } from './lib/async-state';
 export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { IS_STANDALONE } from './lib/federation-context';
-export { LanguageService, type LanguageCode } from './lib/language.service';
+export {
+  LanguageService,
+  type LanguageCode,
+  SUPPORTED_LANGUAGES,
+  DEFAULT_LANGUAGE,
+} from './lib/language.service';
 export {
   mapToSaveRecipeRequest,
   mapToUpdateRecipeRequest,
   mapDetailToImportResponse,
 } from './lib/recipe-mapping';
 export { createMfeAppConfig } from './lib/mfe-app-config';
+export { ROUTES } from './lib/route-paths';

--- a/client/libs/shared/models/src/lib/language.service.ts
+++ b/client/libs/shared/models/src/lib/language.service.ts
@@ -3,9 +3,10 @@ import { TranslocoService } from '@jsverse/transloco';
 
 export type LanguageCode = 'en' | 'de';
 
+export const SUPPORTED_LANGUAGES: readonly LanguageCode[] = ['en', 'de'] as const;
+export const DEFAULT_LANGUAGE: LanguageCode = 'en';
+
 const LANGUAGE_KEY = 'yn-language';
-const SUPPORTED_LANGUAGES: readonly LanguageCode[] = ['en', 'de'] as const;
-const DEFAULT_LANGUAGE: LanguageCode = 'en';
 
 function isSupportedLanguage(lang: string): lang is LanguageCode {
   return SUPPORTED_LANGUAGES.includes(lang as LanguageCode);

--- a/client/libs/shared/models/src/lib/mfe-app-config.ts
+++ b/client/libs/shared/models/src/lib/mfe-app-config.ts
@@ -9,6 +9,7 @@ import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/
 import { provideTransloco } from '@jsverse/transloco';
 import { authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { TranslocoHttpLoader } from './transloco-loader';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './language.service';
 
 export function createMfeAppConfig(routes: Routes): ApplicationConfig {
   return {
@@ -20,8 +21,8 @@ export function createMfeAppConfig(routes: Routes): ApplicationConfig {
       provideAuth(),
       provideTransloco({
         config: {
-          availableLangs: ['en', 'de'],
-          defaultLang: 'en',
+          availableLangs: [...SUPPORTED_LANGUAGES],
+          defaultLang: DEFAULT_LANGUAGE,
           reRenderOnLangChange: true,
           prodMode: !isDevMode(),
         },

--- a/client/libs/shared/models/src/lib/route-paths.ts
+++ b/client/libs/shared/models/src/lib/route-paths.ts
@@ -1,0 +1,14 @@
+export const ROUTES = {
+  dashboard: '/dashboard',
+  auth: {
+    login: '/auth/login',
+  },
+  recipes: {
+    list: '/recipes',
+    detail: (identifier: string) => `/recipes/${identifier}`,
+  },
+  shopping: {
+    list: '/shopping',
+    detail: (identifier: string) => `/shopping/${identifier}`,
+  },
+} as const;

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeRequestValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeRequestValidator.cs
@@ -16,6 +16,13 @@ public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeReq
             .MustBeValidHttpUrl(RecipeUrl.MaxLength)
             .When(x => !string.IsNullOrWhiteSpace(x.SourceUrl));
 
+        ConfigureOptionalFieldRules();
+        ConfigureIngredientRules();
+        ConfigureStepRules();
+    }
+
+    private void ConfigureOptionalFieldRules()
+    {
         RuleFor(x => x.Description)
             .MaximumLength(RecipeDescription.MaxLength)
             .When(x => x.Description is not null);
@@ -40,7 +47,10 @@ public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeReq
         RuleFor(x => x.CookTimeMinutes)
             .GreaterThanOrEqualTo(0)
             .When(x => x.CookTimeMinutes.HasValue);
+    }
 
+    private void ConfigureIngredientRules()
+    {
         RuleFor(x => x.Ingredients)
             .NotEmpty()
             .WithMessage("At least one ingredient is required.");
@@ -59,7 +69,10 @@ public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeReq
                 .MaximumLength(Unit.MaxLength)
                 .When(i => i.Unit is not null);
         });
+    }
 
+    private void ConfigureStepRules()
+    {
         RuleFor(x => x.Steps)
             .NotEmpty()
             .WithMessage("At least one step is required.");

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
@@ -73,38 +73,19 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
 
     public async Task<Result<ExtractedRecipeDto>> ExtractAsync(ScrapedContent content, CancellationToken cancellationToken = default)
     {
-        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
         var sanitized = SanitizeContent(content.CleanedText);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddSystemMessage(systemPrompt);
         chatHistory.AddUserMessage($"<webpage_content>{sanitized}</webpage_content>");
 
-        string response;
-        try
-        {
-            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
-            response = result.Content ?? string.Empty;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogLlmCallFailed(content.SourceUrl.Value, ex.Message);
-            return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
-        }
-
-        return ParseResponse(response, content.SourceUrl.Value);
+        return await CallLlmAndParseAsync(chatHistory, content.SourceUrl.Value, cancellationToken);
     }
 
     public async Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(
         IReadOnlyList<PhotoData> photos,
         CancellationToken cancellationToken = default)
     {
-        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
-
         var chatHistory = new ChatHistory();
         chatHistory.AddSystemMessage(photoSystemPrompt);
 
@@ -118,23 +99,7 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
 
         chatHistory.AddUserMessage(messageItems);
 
-        string response;
-        try
-        {
-            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
-            response = result.Content ?? string.Empty;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogLlmCallFailed("photo-import", ex.Message);
-            return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
-        }
-
-        return ParseResponse(response, "photo-import");
+        return await CallLlmAndParseAsync(chatHistory, "photo-import", cancellationToken);
     }
 
     private static string ExtractJson(string response)
@@ -163,6 +128,32 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
         var sanitized = injectionPatterns.Replace(text, string.Empty);
         sanitized = excessiveWhitespace.Replace(sanitized, " ");
         return sanitized.Trim();
+    }
+
+    private async Task<Result<ExtractedRecipeDto>> CallLlmAndParseAsync(
+        ChatHistory chatHistory,
+        string source,
+        CancellationToken cancellationToken)
+    {
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+        string response;
+        try
+        {
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+            response = result.Content ?? string.Empty;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogLlmCallFailed(source, ex.Message);
+            return Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed);
+        }
+
+        return ParseResponse(response, source);
     }
 
     private Result<ExtractedRecipeDto> ParseResponse(string response, string sourceUrl)

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -22,16 +22,16 @@ public static class HostBuilderExtensions
     {
         builder.AddServiceDefaults();
 
-        var realm = builder.Configuration.GetValue<string>("Keycloak:Realm") ?? "yumney";
+        var realm = builder.Configuration.GetValue<string>(KeycloakDefaults.RealmConfigKey) ?? KeycloakDefaults.DefaultRealm;
 
-        var keycloakUrl = builder.Configuration.GetConnectionString("keycloak")
-            ?? "http://localhost:8080";
+        var keycloakUrl = builder.Configuration.GetConnectionString(KeycloakDefaults.ConnectionStringName)
+            ?? KeycloakDefaults.DefaultUrl;
 
         builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
                 options.Authority = $"{keycloakUrl}/realms/{realm}";
-                options.Audience = "yumney-api";
+                options.Audience = KeycloakDefaults.Audience;
                 options.RequireHttpsMetadata = false;
             });
 

--- a/src/Yumney.Shared.Web/KeycloakDefaults.cs
+++ b/src/Yumney.Shared.Web/KeycloakDefaults.cs
@@ -1,0 +1,10 @@
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+public static class KeycloakDefaults
+{
+    public const string RealmConfigKey = "Keycloak:Realm";
+    public const string ConnectionStringName = "keycloak";
+    public const string DefaultRealm = "yumney";
+    public const string DefaultUrl = "http://localhost:8080";
+    public const string Audience = "yumney-api";
+}

--- a/src/Yumney.Users.Api/AuthEndpoints.cs
+++ b/src/Yumney.Users.Api/AuthEndpoints.cs
@@ -21,11 +21,18 @@ public static class AuthEndpoints
 
         group.MapPost("/register", RegisterAsync)
             .AllowAnonymous()
-            .WithName("RegisterUser");
+            .WithName("RegisterUser")
+            .WithTags("Auth")
+            .Produces<RegisterUserResultDto>(StatusCodes.Status201Created)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         group.MapPost("/resend-verification-email", ResendVerificationEmailAsync)
             .AllowAnonymous()
-            .WithName("ResendVerificationEmail");
+            .WithName("ResendVerificationEmail")
+            .WithTags("Auth")
+            .Produces<ResendVerificationEmailResultDto>()
+            .ProducesValidationProblem();
 
         return app;
     }

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -117,6 +117,23 @@ public sealed class KeycloakAdminService(
         }
     }
 
+    private static object BuildUserPayload(Email email, Password password, DisplayName displayName)
+    {
+        return new
+        {
+            username = email.Value,
+            email = email.Value,
+            enabled = true,
+            emailVerified = false,
+            firstName = displayName.Value,
+            requiredActions = new[] { "VERIFY_EMAIL" },
+            credentials = new[]
+            {
+                new { type = "password", value = password.Value, temporary = false },
+            },
+        };
+    }
+
     private async Task<Result<string>> GetServiceAccountTokenAsync(CancellationToken cancellationToken)
     {
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
@@ -155,62 +172,60 @@ public sealed class KeycloakAdminService(
         string accessToken,
         CancellationToken cancellationToken)
     {
-        var userPayload = new
-        {
-            username = email.Value,
-            email = email.Value,
-            enabled = true,
-            emailVerified = false,
-            firstName = displayName.Value,
-            requiredActions = new[] { "VERIFY_EMAIL" },
-            credentials = new[]
-            {
-                new
-                {
-                    type = "password",
-                    value = password.Value,
-                    temporary = false,
-                },
-            },
-        };
-
         var url = $"/admin/realms/{options.Value.Realm}/users";
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        request.Content = JsonContent.Create(userPayload, options: jsonOptions);
+        request.Content = JsonContent.Create(BuildUserPayload(email, password, displayName), options: jsonOptions);
 
         try
         {
             var response = await httpClient.SendAsync(request, cancellationToken);
-
-            if (response.StatusCode == HttpStatusCode.Conflict)
-            {
-                return Result<KeycloakUserId>.Failure(RegistrationErrors.EmailAlreadyExists);
-            }
-
-            if (!response.IsSuccessStatusCode)
-            {
-                var body = await response.Content.ReadAsStringAsync(cancellationToken);
-                logger.LogError("Failed to create Keycloak user. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
-                return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
-            }
-
-            var locationHeader = response.Headers.Location?.ToString();
-            if (string.IsNullOrEmpty(locationHeader))
-            {
-                logger.LogError("Keycloak did not return a Location header after user creation");
-                return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
-            }
-
-            var keycloakUserIdString = locationHeader.Split('/').Last();
-            return Result<KeycloakUserId>.Success(new KeycloakUserId(keycloakUserIdString));
+            return await HandleUserCreationResponseAsync(response, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
             logger.LogError(ex, "HTTP error while creating Keycloak user");
             return Result<KeycloakUserId>.Failure(RegistrationErrors.IdentityProviderUnavailable);
         }
+    }
+
+    private async Task<Result<KeycloakUserId>> HandleUserCreationResponseAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            return Result<KeycloakUserId>.Failure(RegistrationErrors.EmailAlreadyExists);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError("Failed to create Keycloak user. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
+            return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
+        }
+
+        return ExtractKeycloakUserId(response);
+    }
+
+    private Result<KeycloakUserId> ExtractKeycloakUserId(HttpResponseMessage response)
+    {
+        var locationHeader = response.Headers.Location?.ToString();
+        if (string.IsNullOrEmpty(locationHeader))
+        {
+            logger.LogError("Keycloak did not return a Location header after user creation");
+            return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
+        }
+
+        var keycloakUserIdString = locationHeader.Split('/').LastOrDefault();
+        if (string.IsNullOrEmpty(keycloakUserIdString))
+        {
+            logger.LogError("Malformed Location header: {LocationHeader}", locationHeader);
+            return Result<KeycloakUserId>.Failure(RegistrationErrors.UserCreationFailed);
+        }
+
+        return Result<KeycloakUserId>.Success(new KeycloakUserId(keycloakUserIdString));
     }
 
     private sealed record TokenResponse(


### PR DESCRIPTION
## Summary
- Add OpenAPI metadata to AuthEndpoints
- Fix unsafe location header parsing in KeycloakAdminService
- Extract duplicated LLM call pattern into `CallLlmAndParseAsync`
- Break down 64-line `CreateKeycloakUserAsync` into focused helpers
- Add `KeycloakDefaults` constants class
- Extract validator helper methods

## Test plan
- [x] All 248 affected tests pass (API, application, infrastructure, architecture)

Generated with [Claude Code](https://claude.com/claude-code)