### PR TITLE
feat(shared): make backend services horizontally scalable (US-140)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.3" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.1.3" />
     <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.1.3" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.3" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.3" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.1.3" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.1.3" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.1.3-preview.1.26166.8" />
@@ -35,6 +38,8 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <!-- Reverse Proxy -->
+    <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.4.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -1,5 +1,7 @@
 <Solution>
-    <Folder Name="/src/" />
+    <Folder Name="/src/">
+        <Project Path="src/Yumney.Shared.Events.MassTransit/Yumney.Shared.Events.MassTransit.csproj" />
+    </Folder>
     <Folder Name="/src/Host/">
       <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
       <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -1,7 +1,5 @@
 <Solution>
-    <Folder Name="/src/">
-        <Project Path="src/Yumney.Shared.Events.MassTransit/Yumney.Shared.Events.MassTransit.csproj" />
-    </Folder>
+    <Folder Name="/src/" />
     <Folder Name="/src/Host/">
       <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
       <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
@@ -12,6 +10,7 @@
       <Project Path="src/Yumney.Shared/Yumney.Shared.csproj" />
       <Project Path="src/Yumney.Shared.Guards/Yumney.Shared.Guards.csproj" />
       <Project Path="src/Yumney.Shared.CQRS/Yumney.Shared.CQRS.csproj" />
+        <Project Path="src/Yumney.Shared.Events.MassTransit/Yumney.Shared.Events.MassTransit.csproj" />
       <Project Path="src/Yumney.Shared.Events/Yumney.Shared.Events.csproj" />
       <Project Path="src/Yumney.Shared.Events.InProcess/Yumney.Shared.Events.InProcess.csproj" />
       <Project Path="src/Yumney.Shared.Persistence/Yumney.Shared.Persistence.csproj" />

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -27,6 +27,11 @@ var usersDb = postgres.AddDatabase("usersdb");
 var redis = builder.AddRedis("redis")
     .WithDataVolume();
 
+// RabbitMQ
+var messaging = builder.AddRabbitMQ("messaging")
+    .WithDataVolume()
+    .WithManagementPlugin();
+
 // Keycloak
 var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword)
     .WithDataVolume();
@@ -82,9 +87,11 @@ var recipesApi = builder.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
     .WithReference(keycloak)
     .WithReference(recipesDb)
     .WithReference(redis)
+    .WithReference(messaging)
     .WaitFor(keycloak)
     .WaitFor(migrationRunner)
     .WaitFor(redis)
+    .WaitFor(messaging)
     .WithUrlForEndpoint("http", url =>
     {
         url.DisplayText = "Scalar";
@@ -113,9 +120,11 @@ var shoppingApi = builder.AddProject<Projects.Yumney_Shopping_Api>("shopping-api
     .WithReference(keycloak)
     .WithReference(shoppingDb)
     .WithReference(redis)
+    .WithReference(messaging)
     .WaitFor(keycloak)
     .WaitFor(migrationRunner)
     .WaitFor(redis)
+    .WaitFor(messaging)
     .WithUrlForEndpoint("http", url =>
     {
         url.DisplayText = "Scalar";
@@ -128,9 +137,11 @@ var usersApi = builder.AddProject<Projects.Yumney_Users_Api>("users-api")
     .WithReference(keycloak)
     .WithReference(usersDb)
     .WithReference(redis)
+    .WithReference(messaging)
     .WaitFor(keycloak)
     .WaitFor(migrationRunner)
     .WaitFor(redis)
+    .WaitFor(messaging)
     .WithUrlForEndpoint("http", url =>
     {
         url.DisplayText = "Scalar";

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Keycloak" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.Redis" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ollama" />
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -42,6 +42,11 @@
     },
     "Clusters": {
       "recipes-api": {
+        "SessionAffinity": {
+          "Enabled": true,
+          "Policy": "Cookie",
+          "AffinityKeyName": ".Yumney.Affinity"
+        },
         "Destinations": {
           "primary": {
             "Address": "https+http://recipes-api"

--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -7,6 +9,7 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 
 /// <summary>
 /// Background worker that applies EF Core migrations for all modules on startup.
+/// Uses PostgreSQL advisory locks to prevent concurrent migration from multiple instances.
 /// </summary>
 public sealed partial class MigrationWorker(
     IServiceProvider serviceProvider,
@@ -47,26 +50,59 @@ public sealed partial class MigrationWorker(
     [LoggerMessage(Level = LogLevel.Information, Message = "{Module}: {Count} migration(s) now applied")]
     private static partial void LogMigrationsApplied(ILogger logger, string module, int count);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "{Module}: acquiring advisory lock {LockId}")]
+    private static partial void LogAcquiringLock(ILogger logger, string module, int lockId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "{Module}: advisory lock released")]
+    private static partial void LogLockReleased(ILogger logger, string module);
+
+    private static int GenerateLockId(string moduleName)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"yumney-migration-{moduleName}"));
+        return BitConverter.ToInt32(hash, 0);
+    }
+
     private async Task ApplyMigrationsAsync<TContext>(string moduleName, CancellationToken cancellationToken)
         where TContext : DbContext
     {
         await using var scope = serviceProvider.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<TContext>();
 
-        var pending = (await context.Database.GetPendingMigrationsAsync(cancellationToken)).ToList();
+        var lockId = GenerateLockId(moduleName);
+        LogAcquiringLock(logger, moduleName, lockId);
 
-        if (pending.Count == 0)
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        try
         {
-            LogNoPendingMigrations(logger, moduleName);
-            return;
+            await using var lockCmd = connection.CreateCommand();
+            lockCmd.CommandText = $"SELECT pg_advisory_lock({lockId})";
+            await lockCmd.ExecuteNonQueryAsync(cancellationToken);
+
+            var pending = (await context.Database.GetPendingMigrationsAsync(cancellationToken)).ToList();
+
+            if (pending.Count == 0)
+            {
+                LogNoPendingMigrations(logger, moduleName);
+                return;
+            }
+
+            var migrationNames = string.Join(", ", pending);
+            LogApplyingMigrations(logger, moduleName, pending.Count, migrationNames);
+
+            await context.Database.MigrateAsync(cancellationToken);
+
+            var appliedCount = (await context.Database.GetAppliedMigrationsAsync(cancellationToken)).Count();
+            LogMigrationsApplied(logger, moduleName, appliedCount);
         }
+        finally
+        {
+            await using var unlockCmd = connection.CreateCommand();
+            unlockCmd.CommandText = $"SELECT pg_advisory_unlock({lockId})";
+            await unlockCmd.ExecuteNonQueryAsync(CancellationToken.None);
 
-        var migrationNames = string.Join(", ", pending);
-        LogApplyingMigrations(logger, moduleName, pending.Count, migrationNames);
-
-        await context.Database.MigrateAsync(cancellationToken);
-
-        var appliedCount = (await context.Database.GetAppliedMigrationsAsync(cancellationToken)).Count();
-        LogMigrationsApplied(logger, moduleName, appliedCount);
+            LogLockReleased(logger, moduleName);
+        }
     }
 }

--- a/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
+++ b/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
@@ -12,6 +12,8 @@ public static class EventingServiceCollectionExtensions
     /// When using a distributed event bus (e.g. MassTransit), call this first for domain events,
     /// then register the distributed IEventBus which will override the in-process one.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddInProcessEventBus(this IServiceCollection services)
     {
         services.AddScoped<IDomainEventDispatcher, InProcessDomainEventDispatcher>();

--- a/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
+++ b/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
@@ -2,8 +2,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace SmartSolutionsLab.Yumney.Shared.Events;
 
+/// <summary>
+/// Extension methods for registering in-process event dispatching.
+/// </summary>
 public static class EventingServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers in-process domain event dispatcher and in-process event bus.
+    /// When using a distributed event bus (e.g. MassTransit), call this first for domain events,
+    /// then register the distributed IEventBus which will override the in-process one.
+    /// </summary>
     public static IServiceCollection AddInProcessEventBus(this IServiceCollection services)
     {
         services.AddScoped<IDomainEventDispatcher, InProcessDomainEventDispatcher>();

--- a/src/Yumney.Shared.Events.MassTransit/IntegrationEventConsumer.cs
+++ b/src/Yumney.Shared.Events.MassTransit/IntegrationEventConsumer.cs
@@ -8,6 +8,7 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.MassTransit;
 /// <summary>
 /// Generic MassTransit consumer that delegates to IIntegrationEventHandler&lt;TEvent&gt; implementations.
 /// </summary>
+/// <typeparam name="TEvent">The integration event type to consume.</typeparam>
 public sealed class IntegrationEventConsumer<TEvent>(
     IServiceProvider serviceProvider,
     ILogger<IntegrationEventConsumer<TEvent>> logger) : IConsumer<TEvent>

--- a/src/Yumney.Shared.Events.MassTransit/IntegrationEventConsumer.cs
+++ b/src/Yumney.Shared.Events.MassTransit/IntegrationEventConsumer.cs
@@ -1,0 +1,33 @@
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.MassTransit;
+
+/// <summary>
+/// Generic MassTransit consumer that delegates to IIntegrationEventHandler&lt;TEvent&gt; implementations.
+/// </summary>
+public sealed class IntegrationEventConsumer<TEvent>(
+    IServiceProvider serviceProvider,
+    ILogger<IntegrationEventConsumer<TEvent>> logger) : IConsumer<TEvent>
+    where TEvent : class, IIntegrationEvent
+{
+    public async Task Consume(ConsumeContext<TEvent> context)
+    {
+        var handlers = serviceProvider.GetServices<IIntegrationEventHandler<TEvent>>();
+
+        foreach (var handler in handlers)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug(
+                    "Handling integration event {EventType} with {HandlerType}",
+                    typeof(TEvent).Name,
+                    handler.GetType().Name);
+            }
+
+            await handler.HandleAsync(context.Message, context.CancellationToken);
+        }
+    }
+}

--- a/src/Yumney.Shared.Events.MassTransit/MassTransitEventBus.cs
+++ b/src/Yumney.Shared.Events.MassTransit/MassTransitEventBus.cs
@@ -1,0 +1,22 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.MassTransit;
+
+/// <summary>
+/// IEventBus implementation that publishes integration events via MassTransit/RabbitMQ.
+/// </summary>
+public sealed class MassTransitEventBus(IPublishEndpoint publishEndpoint, ILogger<MassTransitEventBus> logger) : IEventBus
+{
+    public async Task PublishAsync<TEvent>(TEvent integrationEvent, CancellationToken cancellationToken = default)
+        where TEvent : IIntegrationEvent
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug("Publishing integration event {EventType} via MassTransit", typeof(TEvent).Name);
+        }
+
+        await publishEndpoint.Publish(integrationEvent, cancellationToken);
+    }
+}

--- a/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
@@ -1,0 +1,39 @@
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.MassTransit;
+
+/// <summary>
+/// Extension methods for registering MassTransit-based event bus.
+/// </summary>
+public static class MassTransitEventBusExtensions
+{
+    /// <summary>
+    /// Registers MassTransit with RabbitMQ as the integration event bus.
+    /// Domain events remain in-process via InProcessDomainEventDispatcher.
+    /// </summary>
+    public static IServiceCollection AddMassTransitEventBus(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMassTransit(x =>
+        {
+            x.SetKebabCaseEndpointNameFormatter();
+
+            x.UsingRabbitMq((context, cfg) =>
+            {
+                var connectionString = configuration.GetConnectionString("messaging");
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    cfg.Host(connectionString);
+                }
+
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+
+        services.AddScoped<IEventBus, MassTransitEventBus>();
+
+        return services;
+    }
+}

--- a/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,13 +14,25 @@ public static class MassTransitEventBusExtensions
     /// <summary>
     /// Registers MassTransit with RabbitMQ as the integration event bus.
     /// Domain events remain in-process via InProcessDomainEventDispatcher.
+    /// Integration events are published/consumed via RabbitMQ.
     /// </summary>
-    /// <returns></returns>
-    public static IServiceCollection AddMassTransitEventBus(this IServiceCollection services, IConfiguration configuration)
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="assemblies">Assemblies to scan for IIntegrationEventHandler implementations.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMassTransitEventBus(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        params Assembly[] assemblies)
     {
         services.AddMassTransit(x =>
         {
             x.SetKebabCaseEndpointNameFormatter();
+
+            foreach (var assembly in assemblies)
+            {
+                x.AddConsumers(assembly);
+            }
 
             x.UsingRabbitMq((context, cfg) =>
             {

--- a/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.MassTransit/MassTransitEventBusExtensions.cs
@@ -14,6 +14,7 @@ public static class MassTransitEventBusExtensions
     /// Registers MassTransit with RabbitMQ as the integration event bus.
     /// Domain events remain in-process via InProcessDomainEventDispatcher.
     /// </summary>
+    /// <returns></returns>
     public static IServiceCollection AddMassTransitEventBus(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddMassTransit(x =>

--- a/src/Yumney.Shared.Events.MassTransit/Yumney.Shared.Events.MassTransit.csproj
+++ b/src/Yumney.Shared.Events.MassTransit/Yumney.Shared.Events.MassTransit.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SmartSolutionsLab.Yumney.Shared.Events.MassTransit</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MassTransit.RabbitMQ" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using System.Threading.RateLimiting;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -6,13 +6,16 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using RedisRateLimiting;
 using Scalar.AspNetCore;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.MassTransit;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web.Middleware;
 using SmartSolutionsLab.Yumney.Shared.Web.Services;
+using StackExchange.Redis;
 
 namespace SmartSolutionsLab.Yumney.Shared.Web;
 
@@ -21,6 +24,13 @@ public static class HostBuilderExtensions
     public static WebApplicationBuilder AddYumneyDefaults(this WebApplicationBuilder builder)
     {
         builder.AddServiceDefaults();
+        builder.AddRedisDistributedCache("redis");
+        builder.AddRedisClient("redis");
+
+        builder.Services.Configure<HostOptions>(options =>
+        {
+            options.ShutdownTimeout = TimeSpan.FromSeconds(30);
+        });
 
         var realm = builder.Configuration.GetValue<string>(KeycloakDefaults.RealmConfigKey) ?? KeycloakDefaults.DefaultRealm;
 
@@ -39,19 +49,34 @@ public static class HostBuilderExtensions
         builder.Services.AddHttpContextAccessor();
         builder.Services.AddScoped<ICurrentUser, CurrentUserProvider>();
         builder.Services.AddInProcessEventBus();
+        builder.Services.AddMassTransitEventBus(builder.Configuration);
         builder.Services.AddScoped<DomainEventDispatchInterceptor>();
         builder.Services.AddOpenApi();
 
         builder.Services.AddRateLimiter(options =>
         {
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-            options.AddSlidingWindowLimiter("RecipeImport", limiter =>
+
+            options.AddPolicy(RateLimitPolicies.RecipeImport, context =>
             {
-                limiter.Window = TimeSpan.FromMinutes(1);
-                limiter.SegmentsPerWindow = 4;
-                limiter.PermitLimit = 10;
-                limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiter.QueueLimit = 2;
+                var userId = context.User?.FindFirstValue("sub") ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+                return RedisRateLimitPartition.GetSlidingWindowRateLimiter(userId, _ => new RedisSlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = 10,
+                    Window = TimeSpan.FromMinutes(1),
+                    ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
+                });
+            });
+
+            options.AddPolicy(RateLimitPolicies.GeneralApi, context =>
+            {
+                var userId = context.User?.FindFirstValue("sub") ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+                return RedisRateLimitPartition.GetFixedWindowRateLimiter(userId, _ => new RedisFixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 60,
+                    Window = TimeSpan.FromMinutes(1),
+                    ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
+                });
             });
         });
 
@@ -84,4 +109,14 @@ public static class HostBuilderExtensions
 
         return app;
     }
+}
+
+/// <summary>Rate limit policy names.</summary>
+public static class RateLimitPolicies
+{
+    /// <summary>Strict limit for LLM recipe import (10/min).</summary>
+    public const string RecipeImport = "RecipeImport";
+
+    /// <summary>General API rate limit (60/min).</summary>
+    public const string GeneralApi = "GeneralApi";
 }

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -48,8 +48,13 @@ public static class HostBuilderExtensions
         builder.Services.AddAuthorization();
         builder.Services.AddHttpContextAccessor();
         builder.Services.AddScoped<ICurrentUser, CurrentUserProvider>();
+
+        // Domain events: dispatched in-process (same transaction boundary)
+        // Integration events: published via MassTransit/RabbitMQ (cross-instance)
+        // MassTransit registration overrides InProcessEventBus for IEventBus (last-wins in DI)
         builder.Services.AddInProcessEventBus();
         builder.Services.AddMassTransitEventBus(builder.Configuration);
+
         builder.Services.AddScoped<DomainEventDispatchInterceptor>();
         builder.Services.AddOpenApi();
 

--- a/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
+++ b/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
@@ -7,13 +7,17 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Shared\Yumney.Shared.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.MassTransit\Yumney.Shared.Events.MassTransit.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
     <ProjectReference Include="..\Yumney.ServiceDefaults\Yumney.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Keycloak.Authentication" />
+    <PackageReference Include="Aspire.StackExchange.Redis" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="RedisRateLimiting" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
   </ItemGroup>

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SmartSolutionsLab.Yumney.Shared.Common;
@@ -17,15 +18,19 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
 public sealed class KeycloakAdminService(
     HttpClient httpClient,
     IOptions<KeycloakOptions> options,
+    IDistributedCache cache,
     ILogger<KeycloakAdminService> logger)
     : IKeycloakAdminService
 {
+    private const string TokenCacheKey = "keycloak:admin:token";
+
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
+    private static readonly TimeSpan tokenExpiryBuffer = TimeSpan.FromSeconds(30);
     private static readonly string[] verifyEmailActions = ["VERIFY_EMAIL"];
 
     public async Task<Result<KeycloakUserId>> CreateUserAsync(
@@ -136,6 +141,12 @@ public sealed class KeycloakAdminService(
 
     private async Task<Result<string>> GetServiceAccountTokenAsync(CancellationToken cancellationToken)
     {
+        var cachedToken = await cache.GetStringAsync(TokenCacheKey, cancellationToken);
+        if (!string.IsNullOrEmpty(cachedToken))
+        {
+            return Result<string>.Success(cachedToken);
+        }
+
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["grant_type"] = "client_credentials",
@@ -156,7 +167,16 @@ public sealed class KeycloakAdminService(
 
             var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(jsonOptions, cancellationToken);
 
-            return Result<string>.Success(tokenResponse!.AccessToken);
+            await cache.SetStringAsync(
+                TokenCacheKey,
+                tokenResponse!.AccessToken,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(tokenResponse.ExpiresIn) - tokenExpiryBuffer,
+                },
+                cancellationToken);
+
+            return Result<string>.Success(tokenResponse.AccessToken);
         }
         catch (HttpRequestException ex)
         {
@@ -229,7 +249,8 @@ public sealed class KeycloakAdminService(
     }
 
     private sealed record TokenResponse(
-        [property: JsonPropertyName("access_token")] string AccessToken);
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
 
     private sealed record KeycloakUserRepresentation(
         [property: JsonPropertyName("id")] string Id,

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -14,6 +14,7 @@ using SmartSolutionsLab.Yumney.Users.Infrastructure;
 
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
 
+#pragma warning disable SA1303 // Const field names should begin with upper-case letter (editorconfig requires camelCase for private fields)
 #pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter (editorconfig requires camelCase for private fields)
 public sealed class KeycloakAdminService(
     HttpClient httpClient,
@@ -22,7 +23,7 @@ public sealed class KeycloakAdminService(
     ILogger<KeycloakAdminService> logger)
     : IKeycloakAdminService
 {
-    private const string TokenCacheKey = "keycloak:admin:token";
+    private const string tokenCacheKey = "keycloak:admin:token";
 
     private static readonly JsonSerializerOptions jsonOptions = new()
     {
@@ -141,7 +142,7 @@ public sealed class KeycloakAdminService(
 
     private async Task<Result<string>> GetServiceAccountTokenAsync(CancellationToken cancellationToken)
     {
-        var cachedToken = await cache.GetStringAsync(TokenCacheKey, cancellationToken);
+        var cachedToken = await cache.GetStringAsync(tokenCacheKey, cancellationToken);
         if (!string.IsNullOrEmpty(cachedToken))
         {
             return Result<string>.Success(cachedToken);
@@ -168,7 +169,7 @@ public sealed class KeycloakAdminService(
             var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>(jsonOptions, cancellationToken);
 
             await cache.SetStringAsync(
-                TokenCacheKey,
+                tokenCacheKey,
                 tokenResponse!.AccessToken,
                 new DistributedCacheEntryOptions
                 {

--- a/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
@@ -150,6 +150,58 @@ public class KeycloakAdminServiceTests
         result.Error.Should().Be(VerificationErrors.SendFailed);
     }
 
+    [Fact]
+    public async Task CreateUserAsync_SecondCall_UsesDistributedCacheToken()
+    {
+        var handler = new FakeHttpHandler()
+            .WithTokenResponse()
+            .WithResponse(
+                HttpMethod.Post,
+                "/admin/realms/test-realm/users",
+                HttpStatusCode.Created,
+                new Dictionary<string, string> { { "Location", "/admin/realms/test-realm/users/kc-123" } });
+
+        // Simulate cache miss on first call, cache hit on second
+        cache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(
+                (byte[]?)null,
+                System.Text.Encoding.UTF8.GetBytes("fake-token"));
+
+        var service = CreateService(handler);
+
+        await service.CreateUserAsync(
+            new Email("first@test.com"), new Password("Test123!"), new DisplayName("First"));
+        await service.CreateUserAsync(
+            new Email("second@test.com"), new Password("Test123!"), new DisplayName("Second"));
+
+        handler.TokenRequestCount.Should().Be(1, "second call should use cached token");
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_CachesTokenWithCorrectTTL()
+    {
+        var handler = new FakeHttpHandler()
+            .WithTokenResponse()
+            .WithResponse(
+                HttpMethod.Post,
+                "/admin/realms/test-realm/users",
+                HttpStatusCode.Created,
+                new Dictionary<string, string> { { "Location", "/admin/realms/test-realm/users/kc-123" } });
+
+        var service = CreateService(handler);
+
+        await service.CreateUserAsync(
+            new Email("test@test.com"), new Password("Test123!"), new DisplayName("Test"));
+
+        await cache.Received(1).SetAsync(
+            "keycloak:admin:token",
+            Arg.Any<byte[]>(),
+            Arg.Is<DistributedCacheEntryOptions>(o =>
+                o.AbsoluteExpirationRelativeToNow > TimeSpan.FromSeconds(200) &&
+                o.AbsoluteExpirationRelativeToNow < TimeSpan.FromSeconds(300)),
+            Arg.Any<CancellationToken>());
+    }
+
     private KeycloakAdminService CreateService(HttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://keycloak.test") };
@@ -160,10 +212,12 @@ public class KeycloakAdminServiceTests
     {
         private readonly List<(HttpMethod Method, string PathPrefix, HttpStatusCode Status, string? JsonBody, Dictionary<string, string>? Headers)> responses = [];
 
+        public int TokenRequestCount { get; private set; }
+
         public FakeHttpHandler WithTokenResponse()
         {
             responses.Add((HttpMethod.Post, "/realms/test-realm/protocol/openid-connect/token",
-                HttpStatusCode.OK, JsonSerializer.Serialize(new { access_token = "fake-token" }), null));
+                HttpStatusCode.OK, JsonSerializer.Serialize(new { access_token = "fake-token", expires_in = 300 }), null));
             return this;
         }
 
@@ -181,6 +235,11 @@ public class KeycloakAdminServiceTests
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (request.RequestUri!.PathAndQuery.Contains("openid-connect/token"))
+            {
+                TokenRequestCount++;
+            }
+
             var match = responses.FirstOrDefault(r =>
                 r.Method == request.Method &&
                 request.RequestUri!.PathAndQuery.StartsWith(r.PathPrefix, StringComparison.OrdinalIgnoreCase));

--- a/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -15,6 +16,7 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Tests.Services;
 
 public class KeycloakAdminServiceTests
 {
+    private readonly IDistributedCache cache = Substitute.For<IDistributedCache>();
     private readonly ILogger<KeycloakAdminService> logger = Substitute.For<ILogger<KeycloakAdminService>>();
 
     private readonly IOptions<KeycloakOptions> options = Options.Create(new KeycloakOptions
@@ -151,7 +153,7 @@ public class KeycloakAdminServiceTests
     private KeycloakAdminService CreateService(HttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://keycloak.test") };
-        return new KeycloakAdminService(httpClient, options, logger);
+        return new KeycloakAdminService(httpClient, options, cache, logger);
     }
 
     private sealed class FakeHttpHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary
- **FA-140-1**: Redis-backed rate limiting via `RedisRateLimiting` — per-user limits enforced globally across all instances (partitioned by JWT `sub` claim, fallback to IP)
- **FA-140-2**: PostgreSQL `pg_advisory_lock` in MigrationWorker — only one instance runs migrations at a time, others wait safely
- **FA-140-3**: RabbitMQ + MassTransit distributed event bus — new `Yumney.Shared.Events.MassTransit` project with `MassTransitEventBus` and generic `IntegrationEventConsumer<T>` adapter; domain events remain in-process
- **FA-140-4**: Keycloak admin token cached in Redis via `IDistributedCache` with TTL matching token expiry minus 30s buffer
- **FA-140-5**: YARP session affinity (cookie-based) on recipes-api cluster for SSE streaming

## Infrastructure added
- RabbitMQ container in Aspire AppHost (with management plugin)
- Redis client (`IConnectionMultiplexer`) registered for rate limiting
- Redis distributed cache (`IDistributedCache`) registered for token caching
- New `Yumney.Shared.Events.MassTransit` project added to solution

## Test plan
- [ ] Verify rate limiting works per-user across instances (not per-instance)
- [ ] Verify migrations run safely with concurrent instance startups (pg_advisory_lock)
- [ ] Verify MassTransit connects to RabbitMQ on startup (check Aspire dashboard)
- [ ] Verify Keycloak token is cached in Redis (check Redis CLI)
- [ ] Verify SSE streaming maintains connection via cookie affinity
- [ ] All existing unit tests pass

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)