### PR TITLE
chore(infra): upgrade .NET Aspire to 13.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,19 +4,19 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.3-preview.1.26166.8" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.3" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.3" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.1.3-preview.1.26166.8" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.2.0-preview.1.26170.3" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.2.1-beta.532" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.2.0-preview.1.26170.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- Upgrade all Aspire packages from 13.1.3 to **13.2.0** (today's release)
- Aspire.AppHost.Sdk 13.1.3 → 13.2.0
- Keycloak preview packages → 13.2.0-preview.1.26170.3
- CommunityToolkit Ollama → 13.2.1-beta.532

## Test plan
- [ ] All unit tests pass
- [ ] Aspire dashboard starts correctly
- [ ] All resources (PostgreSQL, Redis, RabbitMQ, Keycloak) healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)