### PR TITLE
test(shell): add e2e tests for PWA share intent (US-124)

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/share-intent.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/share-intent.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { DashboardPage } from '../pages/dashboard.page';
+
+test.describe('Dashboard — Share Intent (US-124)', () => {
+  test('should populate URL field from ?url query param', async ({ authenticatedPage }) => {
+    const dashboard = new DashboardPage(authenticatedPage);
+    await authenticatedPage.goto('/dashboard?url=https://example.com/recipe');
+
+    await expect(dashboard.urlInput).toHaveValue('https://example.com/recipe');
+  });
+
+  test('should auto-start import when ?url is provided', async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/v1/recipes/import/stream*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'event: status\ndata: Fetching page...\n\n',
+      }),
+    );
+
+    const dashboard = new DashboardPage(authenticatedPage);
+    await authenticatedPage.goto('/dashboard?url=https://example.com/recipe');
+
+    await expect(authenticatedPage.getByText(/fetching|extracting|loading/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test('should extract URL from ?text query param', async ({ authenticatedPage }) => {
+    const dashboard = new DashboardPage(authenticatedPage);
+    await authenticatedPage.goto('/dashboard?text=Check+this+recipe+https://example.com/recipe');
+
+    await expect(dashboard.urlInput).toHaveValue('https://example.com/recipe');
+  });
+
+  test('should not auto-import when no query params', async ({ authenticatedPage }) => {
+    const dashboard = new DashboardPage(authenticatedPage);
+    await dashboard.goto();
+
+    await expect(dashboard.urlInput).toHaveValue('');
+    await expect(authenticatedPage.getByText(/fetching|extracting/i)).not.toBeVisible();
+  });
+
+  test('should not auto-import when ?text has no URL', async ({ authenticatedPage }) => {
+    const dashboard = new DashboardPage(authenticatedPage);
+    await authenticatedPage.goto('/dashboard?text=just+some+text');
+
+    await expect(dashboard.urlInput).toHaveValue('');
+  });
+});

--- a/client/apps/shell-e2e/src/pwa/share-intent.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/share-intent.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('PWA Share Intent (US-124)', () => {
+  test('should declare share_target in manifest', async ({ page }) => {
+    const response = await page.goto('/manifest.webmanifest');
+    const manifest = await response?.json();
+
+    expect(manifest.share_target).toBeDefined();
+    expect(manifest.share_target.action).toBe('/dashboard');
+    expect(manifest.share_target.method).toBe('GET');
+    expect(manifest.share_target.params.url).toBe('url');
+    expect(manifest.share_target.params.text).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Playwright e2e tests for PWA share intent feature
- Dashboard share intent: tests URL population from query params
- PWA manifest: tests share_target declaration

## Test plan
- [ ] CI passes (lint, format, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)