### PR TITLE
fix(infra): escape nginx regex to avoid brace parsing error (US-000)

### DIFF
--- a/client/docker/nginx.conf
+++ b/client/docker/nginx.conf
@@ -12,7 +12,7 @@ server {
                application/wasm font/woff2;
 
     # Hashed assets — immutable cache (Angular uses base64-like hashes e.g. chunk-GEF4BW3U.js)
-    location ~* [-\.][0-9a-zA-Z]{7,}\.(js|css|woff2|svg|png|jpg|jpeg|webp|avif|gif)$ {
+    location ~* [-\.][0-9a-zA-Z][0-9a-zA-Z][0-9a-zA-Z][0-9a-zA-Z][0-9a-zA-Z][0-9a-zA-Z][0-9a-zA-Z]+\.(js|css|woff2|svg|png|jpg|jpeg|webp|avif|gif)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }


### PR DESCRIPTION
## Summary
- Fix nginx crash on startup: `{7,}` regex quantifier was parsed as a block directive
- Rewrite to explicit character class repetition

## Test plan
- [ ] Frontend container starts without errors on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)