### PR TITLE
fix(infra): add explicit RabbitMQ password parameter (US-000)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,8 @@ jobs:
           Parameters__PostgresPassword: ${{ secrets.POSTGRES_PASSWORD }}
           Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
           Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
+          Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
+          Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
 
       - name: Deploy to Azure
         working-directory: src/Yumney.AppHost
@@ -158,3 +160,4 @@ jobs:
           Parameters__PostgresPassword: ${{ secrets.POSTGRES_PASSWORD }}
           Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
           Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
+          Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -13,6 +13,7 @@ builder.AddAzureContainerAppEnvironment("cae");
 var postgresUser = builder.AddParameter("PostgresUser");
 var postgresPassword = builder.AddParameter("PostgresPassword", secret: true);
 var keycloakPassword = builder.AddParameter("KeycloakPassword", secret: true);
+var messagingPassword = builder.AddParameter("MessagingPassword", secret: true);
 
 var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
     .WithPasswordAuthentication(userName: postgresUser, password: postgresPassword)
@@ -38,7 +39,7 @@ if (options.DatabaseOnly)
 
 // ── Infrastructure ── (data volumes only in dev — ACA breaks file permissions)
 var redis = builder.AddRedis("redis");
-var messaging = builder.AddRabbitMQ("messaging").WithManagementPlugin();
+var messaging = builder.AddRabbitMQ("messaging", password: messagingPassword).WithManagementPlugin();
 var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword);
 
 if (isRunMode)


### PR DESCRIPTION
## Summary
- Add `MessagingPassword` parameter to AppHost (like Keycloak and PostgreSQL already have)
- Pass `MESSAGING_PASSWORD` secret in deploy workflow
- Fixes RabbitMQ credential mismatch causing 500 errors on user registration

## Action required
Add `MESSAGING_PASSWORD` as a repository secret in GitHub Actions before merging.

## Test plan
- [ ] Registration works on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)