### PR TITLE
fix(infra): add explicit Redis password parameter (US-000)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,7 @@ jobs:
           Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
           Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
           Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
+          Parameters__RedisPassword: ${{ secrets.REDIS_PASSWORD }}
 
       - name: Deploy to Azure
         working-directory: src/Yumney.AppHost
@@ -160,3 +161,4 @@ jobs:
           Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
           Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
           Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
+          Parameters__RedisPassword: ${{ secrets.REDIS_PASSWORD }}

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -14,6 +14,7 @@ var postgresUser = builder.AddParameter("PostgresUser");
 var postgresPassword = builder.AddParameter("PostgresPassword", secret: true);
 var keycloakPassword = builder.AddParameter("KeycloakPassword", secret: true);
 var messagingPassword = builder.AddParameter("MessagingPassword", secret: true);
+var redisPassword = builder.AddParameter("RedisPassword", secret: true);
 
 var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
     .WithPasswordAuthentication(userName: postgresUser, password: postgresPassword)
@@ -38,7 +39,7 @@ if (options.DatabaseOnly)
 }
 
 // ── Infrastructure ── (data volumes only in dev — ACA breaks file permissions)
-var redis = builder.AddRedis("redis");
+var redis = builder.AddRedis("redis", password: redisPassword);
 var messaging = builder.AddRabbitMQ("messaging", password: messagingPassword).WithManagementPlugin();
 var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword);
 


### PR DESCRIPTION
## Summary
- Add `RedisPassword` parameter to AppHost (same pattern as RabbitMQ and PostgreSQL)
- Pass `REDIS_PASSWORD` secret in deploy workflow
- Fixes `NOAUTH Authentication required` errors that crashed the Keycloak token cache and broke user registration

## Action required
Add `REDIS_PASSWORD` as a repository secret in GitHub Actions before merging.

## Test plan
- [ ] Registration works on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)