### PR TITLE
fix(infra): add ACA redirect URIs to Keycloak realm config (US-000)

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -55,12 +55,20 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
-      "redirectUris": ["http://localhost:5100/*", "http://localhost:*"],
-      "webOrigins": ["http://localhost:5100", "http://localhost:*"],
+      "redirectUris": [
+        "http://localhost:5100/*",
+        "http://localhost:*",
+        "https://*.azurecontainerapps.io/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5100",
+        "http://localhost:*",
+        "https://*.azurecontainerapps.io"
+      ],
       "protocol": "openid-connect",
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "http://localhost:5100/*"
+        "post.logout.redirect.uris": "http://localhost:5100/* https://*.azurecontainerapps.io/*"
       },
       "protocolMappers": [
         {


### PR DESCRIPTION
## Summary
- Add `https://*.azurecontainerapps.io/*` wildcard to yumney-web client redirect URIs, web origins, and post-logout redirect URIs
- Fixes OIDC login failure on staging after Keycloak reprovisioning (realm import only had localhost URIs)

## Action required
Update `KEYCLOAK_URL` GitHub variable to the new ACA environment URL before deploying.

## Test plan
- [ ] Keycloak OIDC discovery endpoint returns 200 on staging
- [ ] Frontend can complete OIDC login flow
- [ ] Registration works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)