### PR TITLE
fix(infra): bake Keycloak realm into container image for ACA (US-000)

### DIFF
--- a/src/Yumney.AppHost/Keycloak/Dockerfile
+++ b/src/Yumney.AppHost/Keycloak/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/keycloak/keycloak:26.5
+
+COPY Realms/ /opt/keycloak/data/import/

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -50,10 +50,10 @@ if (isRunMode)
     keycloak.WithDataVolume();
 }
 
-keycloak.WithRealmImport("Realms");
-
 if (isRunMode)
 {
+    keycloak.WithRealmImport("Realms");
+
     var mailpit = builder.AddContainer("mailpit", "axllent/mailpit", "latest")
         .WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
         .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp");
@@ -62,6 +62,8 @@ if (isRunMode)
 else
 {
     keycloak
+        .WithDockerfile(".", "Keycloak/Dockerfile")
+        .WithArgs("--import-realm")
         .WithEnvironment("KC_HTTP_ENABLED", "true")
         .WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
         .WithEnvironment("KC_HOSTNAME_STRICT", "false")


### PR DESCRIPTION
## Summary
- `WithRealmImport` uses bind mounts which don't work on Azure Container Apps
- Add custom Keycloak Dockerfile that COPYs `Realms/yumney-realm.json` into the image at `/opt/keycloak/data/import/`
- In publish mode, use `WithDockerfile` + `WithArgs("--import-realm")` instead of `WithRealmImport`
- Dev mode unchanged (still uses bind mounts via `WithRealmImport`)

## Action required
- Delete `keycloak` container app on staging before deploy (or it will be updated in place)
- Verify `KEYCLOAK_URL` GitHub variable points to the correct ACA environment

## Test plan
- [ ] `https://<keycloak-url>/realms/yumney/.well-known/openid-configuration` returns JSON
- [ ] Frontend OIDC login flow works
- [ ] Registration creates user in Keycloak

🤖 Generated with [Claude Code](https://claude.com/claude-code)