### PR TITLE
fix(infra): fix Keycloak CORS with '+' web origins (US-000)

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -60,11 +60,7 @@
         "http://localhost:*",
         "https://*.azurecontainerapps.io/*"
       ],
-      "webOrigins": [
-        "http://localhost:5100",
-        "http://localhost:*",
-        "https://*.azurecontainerapps.io"
-      ],
+      "webOrigins": ["+"],
       "protocol": "openid-connect",
       "attributes": {
         "pkce.code.challenge.method": "S256",


### PR DESCRIPTION
## Summary
- Replace `https://*.azurecontainerapps.io` with `+` in webOrigins
- `+` tells Keycloak to derive CORS origins from redirect URIs automatically

## Test plan
- [ ] No CORS errors in browser console on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)