### PR TITLE
fix(infra): remove duplicate --import-realm arg (US-000)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -63,7 +63,6 @@ else
 {
     keycloak
         .WithDockerfile(".", "Keycloak/Dockerfile")
-        .WithArgs("--import-realm")
         .WithEnvironment("KC_HTTP_ENABLED", "true")
         .WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
         .WithEnvironment("KC_HOSTNAME_STRICT", "false")


### PR DESCRIPTION
Aspire already passes --import-realm. Duplicate flag caused Keycloak to exit on startup.