### PR TITLE
fix(infra): use wildcard redirect URIs for Keycloak (US-000)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,10 @@ jobs:
             "keycloakClientId": "yumney-web"
           }' > client/dist/apps/shell/browser/assets/config/app-config.json
 
+      - name: Inject gateway URL into Keycloak realm config
+        run: |
+          sed -i "s|__GATEWAY_URL__|${{ vars.GATEWAY_URL }}|g" src/Yumney.AppHost/Realms/yumney-realm.json
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -55,12 +55,16 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
-      "redirectUris": ["*"],
+      "redirectUris": [
+        "http://localhost:5100/*",
+        "http://localhost:*",
+        "__GATEWAY_URL__/*"
+      ],
       "webOrigins": ["+"],
       "protocol": "openid-connect",
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "+"
+        "post.logout.redirect.uris": "http://localhost:5100/* __GATEWAY_URL__/*"
       },
       "protocolMappers": [
         {

--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -55,16 +55,12 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
-      "redirectUris": [
-        "http://localhost:5100/*",
-        "http://localhost:*",
-        "https://*.azurecontainerapps.io/*"
-      ],
+      "redirectUris": ["*"],
       "webOrigins": ["+"],
       "protocol": "openid-connect",
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "http://localhost:5100/* https://*.azurecontainerapps.io/*"
+        "post.logout.redirect.uris": "+"
       },
       "protocolMappers": [
         {


### PR DESCRIPTION
Use wildcard redirect URIs since Keycloak doesn't support subdomain patterns. Fixes invalid redirect_uri on login.