### PR TITLE
fix(shell): run copy-remotes in build:all for production manifests (US-000)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,7 @@
     "serve:shopping": "nx serve shopping",
     "serve:account": "nx serve account",
     "serve:all": "nx run-many --target=serve --projects=shell,recipes,shopping,account --parallel=4",
-    "build:all": "nx run-many --target=build --projects=shell,recipes,shopping,account --parallel=4",
-    "postbuild:all": "node scripts/copy-remotes.mjs"
+    "build:all": "nx run-many --target=build --projects=shell,recipes,shopping,account --parallel=4 && node scripts/copy-remotes.mjs"
   },
   "dependencies": {
     "@angular-devkit/build-angular": "21.2.1",


### PR DESCRIPTION
## Summary
- Yarn Berry doesn't run `postbuild:all` lifecycle scripts automatically
- The `copy-remotes.mjs` script never ran, so MFE remote entries pointed to localhost
- Inline the post-build step into `build:all` command

## Test plan
- [ ] No `localhost:4201-4203` errors in browser console on staging
- [ ] MFE routes (recipes, shopping, account) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)