### PR TITLE
feat(infra): connect Keycloak to PostgreSQL for persistence (US-000)

### DIFF
--- a/src/Yumney.AppHost/Keycloak/Dockerfile
+++ b/src/Yumney.AppHost/Keycloak/Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/keycloak/keycloak:26.5 AS builder
 
 WORKDIR /opt/keycloak
 
+ENV KC_DB=postgres
 ENV KC_HTTP_ENABLED=true
 ENV KC_HEALTH_ENABLED=true
 

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -27,6 +27,7 @@ var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
 var recipesDb = postgres.AddDatabase("recipesdb");
 var shoppingDb = postgres.AddDatabase("shoppingdb");
 var usersDb = postgres.AddDatabase("usersdb");
+var keycloakDb = postgres.AddDatabase("keycloakdb");
 
 var migrationRunner = builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
     .WithReference(recipesDb).WithReference(shoppingDb).WithReference(usersDb)
@@ -63,6 +64,16 @@ else
 {
     keycloak
         .WithDockerfile(".", "Keycloak/Dockerfile")
+        .WithReference(keycloakDb)
+        .WaitFor(keycloakDb)
+        .WithEnvironment("KC_DB", "postgres")
+        .WithEnvironment(context =>
+        {
+            context.EnvironmentVariables["KC_DB_URL_HOST"] = keycloakDb.Resource.Parent.GetEndpoint("tcp");
+            context.EnvironmentVariables["KC_DB_URL_DATABASE"] = "keycloakdb";
+            context.EnvironmentVariables["KC_DB_USERNAME"] = postgresUser.Resource;
+            context.EnvironmentVariables["KC_DB_PASSWORD"] = postgresPassword.Resource;
+        })
         .WithEnvironment("KC_HTTP_ENABLED", "true")
         .WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
         .WithEnvironment("KC_HOSTNAME_STRICT", "false")


### PR DESCRIPTION
## Summary
- Add `keycloakdb` database to the PostgreSQL server
- Configure Keycloak in publish mode to use PostgreSQL via `KC_DB_*` env vars
- Multi-stage Dockerfile builds with `KC_DB=postgres` for proper JDBC driver inclusion
- Dev mode unchanged (H2 with data volume)

## Test plan
- [ ] Keycloak starts successfully on staging with PostgreSQL
- [ ] Realm import works on first start
- [ ] Users persist across Keycloak container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)