### PR TITLE
refactor(ui): recipe form UX improvements and frontend cleanup (US-000)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -151,6 +151,11 @@
     "drop": "Tropfen",
     "sprig": "Zweig",
     "stalk": "Stange",
-    "sheet": "Blatt"
+    "sheet": "Blatt",
+    "group": {
+      "volume": "Volumen",
+      "weight": "Gewicht",
+      "count": "Anzahl / Sonstiges"
+    }
   }
 }

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -151,6 +151,11 @@
     "drop": "drop",
     "sprig": "sprig",
     "stalk": "stalk",
-    "sheet": "sheet"
+    "sheet": "sheet",
+    "group": {
+      "volume": "Volume",
+      "weight": "Weight",
+      "count": "Count / Other"
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -290,6 +290,11 @@
     "drop": "Tropfen",
     "sprig": "Zweig",
     "stalk": "Stange",
-    "sheet": "Blatt"
+    "sheet": "Blatt",
+    "group": {
+      "volume": "Volumen",
+      "weight": "Gewicht",
+      "count": "Anzahl / Sonstiges"
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -290,6 +290,11 @@
     "drop": "drop",
     "sprig": "sprig",
     "stalk": "stalk",
-    "sheet": "sheet"
+    "sheet": "sheet",
+    "group": {
+      "volume": "Volume",
+      "weight": "Weight",
+      "count": "Count / Other"
+    }
   }
 }

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -16,5 +16,12 @@ export {
   mapDetailToImportResponse,
 } from './lib/recipe-mapping';
 export { createMfeAppConfig } from './lib/mfe-app-config';
-export { KNOWN_UNITS, type KnownUnit } from './lib/known-units';
+export {
+  KNOWN_UNITS,
+  UNIT_GROUPS,
+  getGroupedUnits,
+  type KnownUnit,
+  type UnitGroup,
+  type UnitGroupInfo,
+} from './lib/known-units';
 export { ROUTES } from './lib/route-paths';

--- a/client/libs/shared/models/src/lib/known-units.ts
+++ b/client/libs/shared/models/src/lib/known-units.ts
@@ -1,37 +1,60 @@
+export type UnitGroup = 'volume' | 'weight' | 'count';
+
 export interface KnownUnit {
   value: string;
   labelKey: string;
+  group: UnitGroup;
 }
+
+export interface UnitGroupInfo {
+  key: UnitGroup;
+  labelKey: string;
+  units: KnownUnit[];
+}
+
+export const UNIT_GROUPS: readonly { key: UnitGroup; labelKey: string }[] = [
+  { key: 'volume', labelKey: 'units.group.volume' },
+  { key: 'weight', labelKey: 'units.group.weight' },
+  { key: 'count', labelKey: 'units.group.count' },
+] as const;
 
 export const KNOWN_UNITS: readonly KnownUnit[] = [
   // Volume
-  { value: 'ml', labelKey: 'units.ml' },
-  { value: 'cl', labelKey: 'units.cl' },
-  { value: 'dl', labelKey: 'units.dl' },
-  { value: 'l', labelKey: 'units.l' },
-  { value: 'tsp', labelKey: 'units.tsp' },
-  { value: 'tbsp', labelKey: 'units.tbsp' },
-  { value: 'cup', labelKey: 'units.cup' },
-  { value: 'fl oz', labelKey: 'units.flOz' },
+  { value: 'ml', labelKey: 'units.ml', group: 'volume' },
+  { value: 'cl', labelKey: 'units.cl', group: 'volume' },
+  { value: 'dl', labelKey: 'units.dl', group: 'volume' },
+  { value: 'l', labelKey: 'units.l', group: 'volume' },
+  { value: 'tsp', labelKey: 'units.tsp', group: 'volume' },
+  { value: 'tbsp', labelKey: 'units.tbsp', group: 'volume' },
+  { value: 'cup', labelKey: 'units.cup', group: 'volume' },
+  { value: 'fl oz', labelKey: 'units.flOz', group: 'volume' },
 
   // Weight
-  { value: 'g', labelKey: 'units.g' },
-  { value: 'kg', labelKey: 'units.kg' },
-  { value: 'oz', labelKey: 'units.oz' },
-  { value: 'lb', labelKey: 'units.lb' },
+  { value: 'g', labelKey: 'units.g', group: 'weight' },
+  { value: 'kg', labelKey: 'units.kg', group: 'weight' },
+  { value: 'oz', labelKey: 'units.oz', group: 'weight' },
+  { value: 'lb', labelKey: 'units.lb', group: 'weight' },
 
   // Count / Misc
-  { value: 'piece', labelKey: 'units.piece' },
-  { value: 'slice', labelKey: 'units.slice' },
-  { value: 'pinch', labelKey: 'units.pinch' },
-  { value: 'bunch', labelKey: 'units.bunch' },
-  { value: 'clove', labelKey: 'units.clove' },
-  { value: 'can', labelKey: 'units.can' },
-  { value: 'pack', labelKey: 'units.pack' },
-  { value: 'handful', labelKey: 'units.handful' },
-  { value: 'dash', labelKey: 'units.dash' },
-  { value: 'drop', labelKey: 'units.drop' },
-  { value: 'sprig', labelKey: 'units.sprig' },
-  { value: 'stalk', labelKey: 'units.stalk' },
-  { value: 'sheet', labelKey: 'units.sheet' },
+  { value: 'piece', labelKey: 'units.piece', group: 'count' },
+  { value: 'slice', labelKey: 'units.slice', group: 'count' },
+  { value: 'pinch', labelKey: 'units.pinch', group: 'count' },
+  { value: 'bunch', labelKey: 'units.bunch', group: 'count' },
+  { value: 'clove', labelKey: 'units.clove', group: 'count' },
+  { value: 'can', labelKey: 'units.can', group: 'count' },
+  { value: 'pack', labelKey: 'units.pack', group: 'count' },
+  { value: 'handful', labelKey: 'units.handful', group: 'count' },
+  { value: 'dash', labelKey: 'units.dash', group: 'count' },
+  { value: 'drop', labelKey: 'units.drop', group: 'count' },
+  { value: 'sprig', labelKey: 'units.sprig', group: 'count' },
+  { value: 'stalk', labelKey: 'units.stalk', group: 'count' },
+  { value: 'sheet', labelKey: 'units.sheet', group: 'count' },
 ] as const;
+
+export function getGroupedUnits(): UnitGroupInfo[] {
+  return UNIT_GROUPS.map(({ key, labelKey }) => ({
+    key,
+    labelKey,
+    units: KNOWN_UNITS.filter((u) => u.group === key),
+  }));
+}

--- a/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.scss
+++ b/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.scss
@@ -24,10 +24,10 @@
   width: 1.75rem;
   height: 1.75rem;
   padding: 0;
-  border: 1px solid var(--yn-border);
+  border: 1px solid var(--yn-primary);
   border-radius: 4px;
-  background: var(--yn-surface);
-  color: var(--yn-text-body);
+  background: transparent;
+  color: var(--yn-primary);
   font-size: 0.75rem;
   cursor: pointer;
   display: flex;
@@ -35,7 +35,8 @@
   justify-content: center;
 
   &:hover:not(:disabled) {
-    background: var(--yn-background-hover);
+    background: var(--yn-primary);
+    color: var(--yn-surface);
   }
 
   &:disabled {
@@ -46,10 +47,18 @@
 
 .remove-btn {
   color: var(--yn-danger);
-  font-size: 1rem;
+  border-color: var(--yn-danger);
 
   &:hover:not(:disabled) {
-    background: var(--yn-danger-light);
-    border-color: var(--yn-danger-border);
+    background: var(--yn-danger);
+    color: var(--yn-surface);
+  }
+}
+
+@media (max-width: 640px) {
+  .action-btn {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.625rem;
   }
 }

--- a/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.html
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.html
@@ -95,8 +95,12 @@
               <yn-form-field class="ingredient-unit" [control]="ingredients.at(i).get('unit')!">
                 <select formControlName="unit">
                   <option [ngValue]="null">{{ t('dashboard.preview.unit') }}</option>
-                  @for (unit of knownUnits; track unit.value) {
-                    <option [ngValue]="unit.value">{{ t(unit.labelKey) }}</option>
+                  @for (group of unitGroups; track group.key) {
+                    <optgroup [label]="t(group.labelKey)">
+                      @for (unit of group.units; track unit.value) {
+                        <option [ngValue]="unit.value">{{ t(unit.labelKey) }}</option>
+                      }
+                    </optgroup>
                   }
                 </select>
               </yn-form-field>

--- a/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.scss
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.scss
@@ -55,13 +55,12 @@
 }
 
 .form-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
-  flex-wrap: wrap;
 
   .form-field {
-    flex: 1;
-    min-width: 120px;
+    min-width: 0;
   }
 }
 
@@ -116,18 +115,16 @@
 
 .add-btn {
   padding: 0.5rem 1rem;
-  border: 1px dashed var(--yn-border);
+  border: 1px dashed var(--yn-primary);
   border-radius: 6px;
   background: transparent;
-  color: var(--yn-text-muted);
+  color: var(--yn-primary);
   font-size: 0.875rem;
   cursor: pointer;
   width: 100%;
   margin-top: 0.5rem;
 
   &:hover {
-    border-color: var(--yn-primary);
-    color: var(--yn-primary);
     background: var(--yn-primary-light);
   }
 }
@@ -142,16 +139,22 @@
 
 .discard-btn {
   padding: 0.75rem 1.5rem;
-  border: 1px solid var(--yn-border);
+  border: 1px solid var(--yn-primary);
   border-radius: 8px;
-  background: var(--yn-surface);
-  color: var(--yn-text-body);
+  background: transparent;
+  color: var(--yn-primary);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
 
   &:hover {
-    background: var(--yn-background-hover);
+    background: var(--yn-primary);
+    color: var(--yn-surface);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 }
 
@@ -167,5 +170,39 @@
 
   &:hover {
     background: var(--yn-primary-hover);
+  }
+}
+
+@media (max-width: 640px) {
+  .recipe-preview {
+    padding: 1rem;
+  }
+
+  .form-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .ingredient-fields {
+    flex-wrap: wrap;
+
+    .ingredient-name {
+      flex-basis: 100%;
+    }
+
+    .ingredient-amount,
+    .ingredient-unit {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+
+  .action-buttons {
+    flex-direction: column;
+
+    .discard-btn,
+    ::ng-deep .save-btn {
+      width: 100%;
+      text-align: center;
+    }
   }
 }

--- a/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.ts
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.ts
@@ -13,7 +13,7 @@ import {
   ExtractedIngredient,
   ExtractedStep,
 } from '@yumney/shared/api-client';
-import { VALIDATION, KNOWN_UNITS } from '@yumney/shared/models';
+import { VALIDATION, getGroupedUnits, type UnitGroupInfo } from '@yumney/shared/models';
 import { EditableListItemComponent } from '../editable-list-item/editable-list-item.component';
 import { FormFieldComponent } from '../form-field/form-field.component';
 import { SubmitButtonComponent } from '../submit-button/submit-button.component';
@@ -51,7 +51,7 @@ export class RecipePreviewComponent implements OnInit {
 
   private fb = inject(FormBuilder);
 
-  readonly knownUnits = KNOWN_UNITS;
+  readonly unitGroups: UnitGroupInfo[] = getGroupedUnits();
 
   form = this.fb.nonNullable.group({
     title: [

--- a/client/libs/ui/src/lib/styles/_buttons.scss
+++ b/client/libs/ui/src/lib/styles/_buttons.scss
@@ -46,6 +46,31 @@
   }
 }
 
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: 1px solid var(--yn-primary);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--yn-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--yn-primary);
+    color: var(--yn-surface);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
 .btn-danger {
   display: inline-flex;
   align-items: center;

--- a/client/libs/ui/src/lib/submit-button/submit-button.component.scss
+++ b/client/libs/ui/src/lib/submit-button/submit-button.component.scss
@@ -1,7 +1,10 @@
+@use 'buttons';
+
 :host {
   display: inline-block;
 }
 
 :host button {
+  @extend .btn-primary;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- **Grouped unit select**: Unit dropdown now uses `<optgroup>` to organize 25 units into Volume, Weight, and Count/Other groups for easier scanning
- **Mobile-responsive form**: Metadata row uses CSS grid (4-col desktop, 2-col mobile), ingredient fields stack vertically on narrow screens, action buttons go full-width on mobile
- **Primary button styling**: Discard, add, and editable-list action buttons now use the design system's orange primary color instead of default grey. Submit button component inherits `.btn-primary` by default so all submit buttons (including the dashboard import button) render correctly
- **Shared `.btn-secondary` class**: Reusable outlined primary-colored button style added to `_buttons.scss`
- **Prior cleanup commits**: Federation config fixes, sort dropdown refactor, value object conversions, logger source generators, and other maintenance

## Test plan
- [ ] `npx nx build recipes` and `npx nx build shell` — 0 errors
- [ ] Verify unit dropdown shows grouped options with section headers
- [ ] Verify all buttons (import, save, discard, add, move up/down) use orange/primary styling
- [ ] Verify ingredient rows stack on narrow screens (Chrome DevTools, ~375px width)
- [ ] Verify metadata row wraps to 2 columns on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)