### PR TITLE
feat(ui): dark mode support with ThemeService and toggle (US-201)

### DIFF
--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -14,6 +14,7 @@ import { appRoutes } from './app.routes';
 import {
   TranslocoHttpLoader,
   LanguageService,
+  ThemeService,
   UI,
   SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
@@ -43,6 +44,12 @@ export const appConfig: ApplicationConfig = {
       provide: APP_INITIALIZER,
       useFactory: (lang: LanguageService) => () => lang.initialize(),
       deps: [LanguageService],
+      multi: true,
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (theme: ThemeService) => () => theme.initialize(),
+      deps: [ThemeService],
       multi: true,
     },
   ],

--- a/client/apps/shell/src/app/layout/header/header.component.spec.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.spec.ts
@@ -4,7 +4,7 @@ import { signal } from '@angular/core';
 import { TranslocoTestingModule } from '@jsverse/transloco';
 import { HeaderComponent } from '@yumney/ui';
 import { AuthService } from '@yumney/shared/auth';
-import { LanguageService } from '@yumney/shared/models';
+import { LanguageService, ThemeService } from '@yumney/shared/models';
 
 const en = {
   layout: {
@@ -45,6 +45,7 @@ describe('HeaderComponent', () => {
       logout: vi.fn(),
     };
     languageServiceMock = { activeLang: 'en', nextLanguage: 'de', switchTo: vi.fn() };
+    const themeServiceMock = { theme: signal('light'), toggle: vi.fn(), initialize: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [
@@ -61,6 +62,7 @@ describe('HeaderComponent', () => {
         provideRouter([]),
         { provide: AuthService, useValue: authServiceMock },
         { provide: LanguageService, useValue: languageServiceMock },
+        { provide: ThemeService, useValue: themeServiceMock },
       ],
     }).compileComponents();
 

--- a/client/apps/shell/src/styles.scss
+++ b/client/apps/shell/src/styles.scss
@@ -12,6 +12,9 @@ body {
   line-height: var(--yn-leading-relaxed);
   color: var(--yn-text);
   background: var(--yn-background);
+  transition:
+    background var(--yn-duration-normal) var(--yn-ease-glass),
+    color var(--yn-duration-normal) var(--yn-ease-glass);
 }
 
 a {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -25,3 +25,4 @@ export {
   type UnitGroupInfo,
 } from './lib/known-units';
 export { ROUTES } from './lib/route-paths';
+export { ThemeService, type Theme } from './lib/theme.service';

--- a/client/libs/shared/models/src/lib/theme.service.spec.ts
+++ b/client/libs/shared/models/src/lib/theme.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService, type Theme } from './theme.service';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ThemeService);
+  });
+
+  it('should default to light when no preference stored and system is light', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+      })),
+    });
+
+    const freshService = new ThemeService();
+    expect(freshService.theme()).toBe('light');
+  });
+
+  it('should apply theme to document on initialize', () => {
+    service.initialize();
+    expect(document.documentElement.getAttribute('data-theme')).toBe(service.theme());
+  });
+
+  it('should toggle between light and dark', () => {
+    service.setTheme('light');
+    service.toggle();
+    expect(service.theme()).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    service.toggle();
+    expect(service.theme()).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('should persist theme to localStorage', () => {
+    service.setTheme('dark');
+    expect(localStorage.getItem('yn-theme')).toBe('dark');
+  });
+
+  it('should restore theme from localStorage', () => {
+    localStorage.setItem('yn-theme', 'dark');
+    const freshService = new ThemeService();
+    expect(freshService.theme()).toBe('dark');
+  });
+});

--- a/client/libs/shared/models/src/lib/theme.service.ts
+++ b/client/libs/shared/models/src/lib/theme.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, signal } from '@angular/core';
+
+export type Theme = 'light' | 'dark';
+
+const THEME_KEY = 'yn-theme';
+const THEME_ATTRIBUTE = 'data-theme';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly theme = signal<Theme>(this.resolveInitialTheme());
+
+  initialize(): void {
+    this.applyTheme(this.theme());
+  }
+
+  toggle(): void {
+    const next: Theme = this.theme() === 'light' ? 'dark' : 'light';
+    this.setTheme(next);
+  }
+
+  setTheme(theme: Theme): void {
+    this.theme.set(theme);
+    this.applyTheme(theme);
+    localStorage.setItem(THEME_KEY, theme);
+  }
+
+  private resolveInitialTheme(): Theme {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    return this.detectSystemPreference();
+  }
+
+  private detectSystemPreference(): Theme {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  private applyTheme(theme: Theme): void {
+    document.documentElement.setAttribute(THEME_ATTRIBUTE, theme);
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -24,6 +24,13 @@
         </a>
       }
       <button
+        class="theme-toggle"
+        (click)="onToggleTheme()"
+        [attr.aria-label]="isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
+      >
+        {{ isDark() ? '☀' : '☾' }}
+      </button>
+      <button
         class="lang-toggle"
         (click)="onSwitchLanguage()"
         [attr.aria-label]="t('layout.header.switchLanguage')"

--- a/client/libs/ui/src/lib/header/header.component.scss
+++ b/client/libs/ui/src/lib/header/header.component.scss
@@ -74,6 +74,21 @@ nav {
   }
 }
 
+.theme-toggle {
+  padding: var(--yn-space-1) var(--yn-space-3);
+  border: 1px solid var(--yn-border);
+  border-radius: var(--yn-radius-sm);
+  background: none;
+  font-size: var(--yn-text-lg);
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  line-height: var(--yn-leading-none);
+
+  &:hover {
+    background-color: var(--yn-background);
+  }
+}
+
 .lang-toggle {
   padding: var(--yn-space-1) var(--yn-space-3);
   border: 1px solid var(--yn-border);

--- a/client/libs/ui/src/lib/header/header.component.ts
+++ b/client/libs/ui/src/lib/header/header.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/c
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthService } from '@yumney/shared/auth';
-import { LanguageService } from '@yumney/shared/models';
+import { LanguageService, ThemeService } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-header',
@@ -14,6 +14,9 @@ import { LanguageService } from '@yumney/shared/models';
 export class HeaderComponent {
   protected authService = inject(AuthService);
   protected languageService = inject(LanguageService);
+  protected themeService = inject(ThemeService);
+
+  protected isDark = computed(() => this.themeService.theme() === 'dark');
 
   protected nextLanguageKey = computed(() => {
     const lang = this.languageService.nextLanguage;
@@ -26,5 +29,9 @@ export class HeaderComponent {
 
   onSwitchLanguage(): void {
     this.languageService.switchTo(this.languageService.nextLanguage);
+  }
+
+  onToggleTheme(): void {
+    this.themeService.toggle();
   }
 }

--- a/client/libs/ui/src/lib/styles/_dark-mode.scss
+++ b/client/libs/ui/src/lib/styles/_dark-mode.scss
@@ -1,0 +1,134 @@
+// ==========================================================================
+// Dark Mode — Token Overrides
+// ==========================================================================
+// Applied via [data-theme="dark"] on <html>.
+// Falls back to prefers-color-scheme for users without explicit preference.
+
+[data-theme='dark'] {
+  // ---------------------------------------------------------------------------
+  // Brand — slightly brighter for dark backgrounds
+  // ---------------------------------------------------------------------------
+  --yn-primary: #fb923c;
+  --yn-primary-hover: #f97316;
+  --yn-primary-light: rgb(249 115 22 / 12%);
+  --yn-primary-light-end: rgb(249 115 22 / 8%);
+
+  // ---------------------------------------------------------------------------
+  // Status
+  // ---------------------------------------------------------------------------
+  --yn-danger: #f87171;
+  --yn-danger-light: rgb(220 38 38 / 12%);
+  --yn-danger-border: rgb(248 113 113 / 30%);
+
+  --yn-success: #34d399;
+  --yn-success-light: rgb(5 150 105 / 12%);
+
+  --yn-warning: #fbbf24;
+  --yn-warning-light: rgb(217 119 6 / 12%);
+
+  --yn-info: #38bdf8;
+  --yn-info-light: rgb(2 132 199 / 12%);
+
+  // ---------------------------------------------------------------------------
+  // Text — light text on dark surfaces
+  // ---------------------------------------------------------------------------
+  --yn-text: #e8f5e9;
+  --yn-text-secondary: #c8e6c9;
+  --yn-text-muted: #a5d6a7;
+  --yn-text-light: #81c784;
+  --yn-text-placeholder: rgb(165 214 167 / 50%);
+  --yn-text-body: #c8e6c9;
+  --yn-text-inverse: #1a2e1a;
+
+  // ---------------------------------------------------------------------------
+  // Links
+  // ---------------------------------------------------------------------------
+  --yn-link: #fb923c;
+  --yn-link-hover: #fdba74;
+
+  // ---------------------------------------------------------------------------
+  // Accent
+  // ---------------------------------------------------------------------------
+  --yn-accent: #34d399;
+  --yn-accent-light: rgb(52 211 153 / 12%);
+
+  // ---------------------------------------------------------------------------
+  // Surface & Background — deep greens
+  // ---------------------------------------------------------------------------
+  --yn-surface: #1a2e1a;
+  --yn-surface-elevated: #243524;
+  --yn-background: #0f1f0f;
+  --yn-background-subtle: #1e321e;
+  --yn-background-hover: #2d4a2d;
+  --yn-overlay: rgb(0 0 0 / 70%);
+
+  // ---------------------------------------------------------------------------
+  // Border — subtle on dark
+  // ---------------------------------------------------------------------------
+  --yn-border: rgb(165 214 167 / 20%);
+  --yn-border-light: rgb(165 214 167 / 10%);
+  --yn-border-medium: rgb(165 214 167 / 15%);
+  --yn-border-strong: rgb(165 214 167 / 30%);
+
+  // ---------------------------------------------------------------------------
+  // Component-specific
+  // ---------------------------------------------------------------------------
+  --yn-spinner-track: rgb(251 146 60 / 30%);
+
+  // ---------------------------------------------------------------------------
+  // Glass — deeper tints with cooler reflections
+  // ---------------------------------------------------------------------------
+  --yn-glass-bg: rgb(30 30 46 / 30%);
+  --yn-glass-bg-elevated: rgb(30 30 46 / 40%);
+  --yn-glass-bg-strong: rgb(30 30 46 / 50%);
+  --yn-glass-border: rgb(200 200 255 / 15%);
+  --yn-glass-border-subtle: rgb(200 200 255 / 8%);
+
+  // ---------------------------------------------------------------------------
+  // Elevation — stronger shadows on dark
+  // ---------------------------------------------------------------------------
+  --yn-elevation-1: 0 1px 3px rgb(0 0 0 / 20%), 0 2px 8px rgb(0 0 0 / 15%);
+  --yn-elevation-2: 0 2px 8px rgb(0 0 0 / 25%), 0 8px 24px rgb(0 0 0 / 20%);
+  --yn-elevation-3: 0 4px 16px rgb(0 0 0 / 30%), 0 12px 32px rgb(0 0 0 / 25%);
+
+  // ---------------------------------------------------------------------------
+  // Shadows — darker
+  // ---------------------------------------------------------------------------
+  --yn-shadow-xs: 0 1px 2px rgb(0 0 0 / 20%);
+  --yn-shadow-sm: 0 1px 4px rgb(0 0 0 / 25%);
+  --yn-shadow-md: 0 2px 8px rgb(0 0 0 / 30%);
+  --yn-shadow-lg: 0 4px 16px rgb(0 0 0 / 35%);
+  --yn-shadow-xl: 0 4px 24px rgb(0 0 0 / 40%);
+  --yn-shadow-card: 0 1px 3px rgb(0 0 0 / 20%), 0 4px 16px rgb(0 0 0 / 15%);
+  --yn-shadow-card-hover: 0 4px 16px rgb(0 0 0 / 30%);
+  --yn-shadow-dropdown: 0 4px 16px rgb(0 0 0 / 35%);
+  --yn-shadow-dialog: 0 4px 24px rgb(0 0 0 / 40%);
+  --yn-ring-primary: 0 0 0 3px rgb(251 146 60 / 20%);
+  --yn-ring-danger: 0 0 0 3px rgb(248 113 113 / 15%);
+  --yn-shadow-primary-glow: 0 2px 8px rgb(251 146 60 / 30%);
+  --yn-shadow-danger-glow: 0 2px 8px rgb(248 113 113 / 30%);
+
+  // ---------------------------------------------------------------------------
+  // Ambient — deep purple/blue orbs for dark mode
+  // ---------------------------------------------------------------------------
+  --yn-ambient-orb-1: rgb(139 92 246 / 15%);
+  --yn-ambient-orb-2: rgb(6 182 212 / 12%);
+  --yn-ambient-orb-3: rgb(236 72 153 / 8%);
+}
+
+// Fallback for users without explicit preference — use OS setting
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    // Same overrides as above — repeated for the media query fallback.
+    // Only brand + text + surface essentials to keep DRY; full override
+    // happens when ThemeService sets [data-theme="dark"].
+    --yn-text: #e8f5e9;
+    --yn-text-secondary: #c8e6c9;
+    --yn-text-muted: #a5d6a7;
+    --yn-surface: #1a2e1a;
+    --yn-background: #0f1f0f;
+    --yn-background-subtle: #1e321e;
+    --yn-border: rgb(165 214 167 / 20%);
+    --yn-border-light: rgb(165 214 167 / 10%);
+  }
+}

--- a/client/libs/ui/src/lib/styles/_tokens.scss
+++ b/client/libs/ui/src/lib/styles/_tokens.scss
@@ -11,3 +11,4 @@
 @use 'shadows';
 @use 'z-index';
 @use 'motion';
+@use 'dark-mode';


### PR DESCRIPTION
## Summary
- Create `_dark-mode.scss` with full token overrides: deep green surfaces, light text, cooler glass tints (`rgba(30,30,46,0.3)`), purple/cyan ambient orbs, stronger shadows
- Add signal-based `ThemeService`: reads `prefers-color-scheme`, persists to `localStorage`, sets `data-theme` attribute on `<html>` for cross-MFE propagation
- Add theme toggle button (sun/moon) to header next to language toggle
- Smooth 300ms transition on body background/color when switching themes
- `prefers-color-scheme: dark` media query fallback for essential tokens

## Test plan
- [x] `nx build` — all 4 apps compile
- [x] `nx test shell` — 199 tests pass (including header with ThemeService mock)
- [x] `nx test ui` — 50 tests pass
- [x] `prettier --check` — all files formatted
- [ ] Visual: toggle dark mode, verify all surfaces switch to dark tints
- [ ] Persistence: set dark, reload — stays dark
- [ ] MFE: navigate shell → recipes → shopping — theme consistent
- [ ] A11y: dark mode text on surfaces meets WCAG AA 4.5:1

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)