### PR TITLE
feat(ui): micro-interactions and animations (US-211)

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -176,13 +176,24 @@
   border-radius: var(--yn-radius-card);
   box-shadow: var(--yn-shadow-md);
   overflow: hidden;
-  transition: box-shadow 0.2s ease;
+  transition:
+    box-shadow var(--yn-duration-normal) var(--yn-ease-glass),
+    transform var(--yn-duration-normal) var(--yn-ease-spring);
   text-decoration: none;
   color: inherit;
   cursor: pointer;
 
   &:hover {
     box-shadow: var(--yn-shadow-card-hover);
+    transform: translateY(-2px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
   }
 }
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
+  effect,
   ElementRef,
   HostListener,
   inject,
@@ -17,7 +18,7 @@ import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeListItem, GetRecipesParams } from '@yumney/shared/api-client';
 import { createAsyncState, HttpErrorMap, UI } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
-import { LoadingSpinnerComponent } from '@yumney/ui';
+import { LoadingSpinnerComponent, staggerFadeIn, prefersReducedMotion } from '@yumney/ui';
 
 @Component({
   selector: 'yn-recipe-list',
@@ -77,6 +78,26 @@ export class RecipeListComponent implements OnInit, AfterViewInit {
   }
 
   scrollSentinel = viewChild<ElementRef>('scrollSentinel');
+  private hostEl = inject(ElementRef);
+  private previousCardCount = 0;
+
+  constructor() {
+    effect(() => {
+      const count = this.recipes().length;
+      if (count > this.previousCardCount && !prefersReducedMotion()) {
+        requestAnimationFrame(() => {
+          const cards = this.hostEl.nativeElement.querySelectorAll('.recipe-card');
+          const newCards = Array.from(cards).slice(this.previousCardCount);
+          if (newCards.length > 0) {
+            staggerFadeIn(newCards as Element[]);
+          }
+          this.previousCardCount = count;
+        });
+      } else {
+        this.previousCardCount = count;
+      }
+    });
+  }
 
   recipes = signal<RecipeListItem[]>([]);
   totalCount = signal(0);

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -70,11 +70,13 @@
 .url-import {
   @extend %section-card;
   margin-bottom: var(--yn-space-4);
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-glass) both;
 }
 
 .photo-import {
   @extend %section-card;
   margin-bottom: var(--yn-space-4);
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-glass) 100ms both;
 
   .hint {
     margin: var(--yn-space-4) 0 0;
@@ -86,6 +88,15 @@
 .manual-create {
   @extend %section-card;
   margin-bottom: var(--yn-space-4);
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-glass) 200ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .url-import,
+  .photo-import,
+  .manual-create {
+    animation: none;
+  }
 }
 
 .photo-import label.disabled {

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -19,4 +19,5 @@ export {
   staggerFadeIn,
   prefersReducedMotion,
   safeAnimate,
+  observeReveal,
 } from './lib/animation/gsap-utils';

--- a/client/libs/ui/src/lib/animation/gsap-utils.ts
+++ b/client/libs/ui/src/lib/animation/gsap-utils.ts
@@ -98,3 +98,40 @@ export function safeAnimate(animationFn: () => gsap.core.Tween): gsap.core.Tween
   if (prefersReducedMotion()) return null;
   return animationFn();
 }
+
+/**
+ * Scroll-triggered reveal — fades in elements as they enter the viewport.
+ * Uses Intersection Observer (no GSAP ScrollTrigger plugin needed).
+ */
+export function observeReveal(
+  container: Element,
+  selector: string,
+  options: { threshold?: number; y?: number; duration?: number } = {},
+): IntersectionObserver | null {
+  if (prefersReducedMotion() || typeof IntersectionObserver === 'undefined') return null;
+
+  const { threshold = 0.1, y = 24, duration = 0.5 } = options;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          gsap.fromTo(
+            entry.target,
+            { opacity: 0, y },
+            { opacity: 1, y: 0, duration, ease: 'power3.out' },
+          );
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold },
+  );
+
+  container.querySelectorAll(selector).forEach((el) => {
+    (el as HTMLElement).style.opacity = '0';
+    observer.observe(el);
+  });
+
+  return observer;
+}

--- a/client/libs/ui/src/lib/animation/gsap-utils.ts
+++ b/client/libs/ui/src/lib/animation/gsap-utils.ts
@@ -85,6 +85,9 @@ export function staggerFadeIn(
  * Check if user prefers reduced motion
  */
 export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.scss
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.scss
@@ -8,4 +8,9 @@
 
 main {
   flex: 1;
+  animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
@@ -9,6 +9,7 @@
   align-items: center;
   justify-content: center;
   background: var(--yn-overlay);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
 }
 
 .confirm-dialog {
@@ -16,6 +17,14 @@
   padding: var(--yn-space-7);
   max-width: 400px;
   width: 90%;
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confirm-overlay,
+  .confirm-dialog {
+    animation: none;
+  }
 }
 
 .confirm-message {

--- a/client/libs/ui/src/lib/styles/_banners.scss
+++ b/client/libs/ui/src/lib/styles/_banners.scss
@@ -1,25 +1,28 @@
-.error-banner {
+%banner-base {
   padding: var(--yn-space-4) var(--yn-space-5);
   margin-bottom: var(--yn-space-5);
   border-radius: var(--yn-radius-button);
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: yn-slide-in-down var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.error-banner {
+  @extend %banner-base;
   border-left: 3px solid var(--yn-danger);
   background: var(--yn-danger-light);
   color: var(--yn-danger);
-  font-size: var(--yn-text-base);
-  font-weight: var(--yn-font-medium);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 
 .success-banner {
-  padding: var(--yn-space-4) var(--yn-space-5);
-  margin-bottom: var(--yn-space-5);
-  border-radius: var(--yn-radius-button);
+  @extend %banner-base;
   border-left: 3px solid var(--yn-success);
   background: var(--yn-success-light);
   color: var(--yn-success);
-  font-size: var(--yn-text-base);
-  font-weight: var(--yn-font-medium);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }

--- a/client/libs/ui/src/lib/styles/_buttons.scss
+++ b/client/libs/ui/src/lib/styles/_buttons.scss
@@ -10,19 +10,33 @@
   border: none;
   text-decoration: none;
   transition:
-    background 0.2s,
-    color 0.2s,
-    border-color 0.2s,
-    box-shadow 0.2s,
-    transform 0.1s;
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    color var(--yn-duration-fast) var(--yn-ease-glass),
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    box-shadow var(--yn-duration-fast) var(--yn-ease-glass),
+    transform var(--yn-duration-fast) var(--yn-ease-spring);
 
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
 
+  &:hover:not(:disabled) {
+    transform: scale(1.02);
+  }
+
   &:active:not(:disabled) {
-    transform: scale(0.98);
+    transform: scale(0.96);
+    transition-duration: 80ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover:not(:disabled),
+    &:active:not(:disabled) {
+      transform: none;
+    }
   }
 }
 

--- a/client/libs/ui/src/lib/styles/_cards.scss
+++ b/client/libs/ui/src/lib/styles/_cards.scss
@@ -6,6 +6,13 @@
   max-width: 420px;
   padding: var(--yn-space-8);
   border-radius: var(--yn-radius-card);
+  transition:
+    box-shadow var(--yn-duration-normal) var(--yn-ease-glass),
+    transform var(--yn-duration-normal) var(--yn-ease-spring);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 
   h1 {
     margin: 0 0 var(--yn-space-1);

--- a/client/libs/ui/src/lib/styles/_motion.scss
+++ b/client/libs/ui/src/lib/styles/_motion.scss
@@ -86,6 +86,34 @@
   }
 }
 
+// ── Skeleton Shimmer ──
+
+@keyframes yn-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@mixin skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--yn-glass-bg) 25%,
+    var(--yn-glass-bg-elevated) 50%,
+    var(--yn-glass-bg) 75%
+  );
+  background-size: 200% 100%;
+  animation: yn-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--yn-radius-md);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background: var(--yn-glass-bg);
+  }
+}
+
 /// Apply to :root or body to globally disable motion
 @mixin reduced-motion-global {
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- **Buttons**: spring-physics press (scale 0.96) and hover lift (scale 1.02) with token-based timing
- **Cards**: hover lift with shadow deepening transition on recipe cards
- **Dialog**: scale-up entrance animation (0.95→1.0) with spring easing + overlay fade-in
- **Banners**: slide-in from top with spring physics on error/success banners
- **Recipe list**: GSAP staggered fade-in on card load (50ms delay between items)
- **Dashboard**: staggered slide-in-up entrance for section cards (0/100/200ms delays)
- **Skeleton shimmer**: new `skeleton-shimmer` mixin in `_motion.scss` for loading states
- All animations respect `prefers-reduced-motion: reduce` — instant fallback
- `prefersReducedMotion()` guarded for SSR/test environments (no `matchMedia` error)

## Test plan
- [x] `nx build` — all 4 apps compile
- [x] `nx test recipes` — 85 tests pass
- [x] `nx test shell` — 199 tests pass
- [x] `nx test ui` — 50 tests pass
- [ ] Visual: click button — spring press/release visible
- [ ] Visual: hover recipe card — lifts with shadow
- [ ] Visual: open confirm dialog — scales up from center
- [ ] A11y: `prefers-reduced-motion: reduce` — no animations

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)