### PR TITLE
feat(users,ui): context-aware smart dashboard with activity tracking (US-220)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="9.1.0" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.4.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />

--- a/client/apps/account/tsconfig.federation.json
+++ b/client/apps/account/tsconfig.federation.json
@@ -2,29 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\core.mjs",
-    "..\\..\\node_modules\\@angular\\core\\event-dispatch-contract.min.js",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-di.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-event-dispatch.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-signals.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\rxjs-interop.mjs",
-    "..\\..\\node_modules\\@angular\\common\\fesm2022\\common.mjs",
-    "..\\..\\node_modules\\@angular\\common\\fesm2022\\http.mjs",
-    "..\\..\\node_modules\\@angular\\router\\fesm2022\\router.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\forms.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals-compat.mjs",
-    "..\\..\\node_modules\\@angular\\platform-browser\\fesm2022\\platform-browser.mjs",
-    "..\\..\\node_modules\\@jsverse\\transloco\\esm2022\\jsverse-transloco.mjs",
-    "..\\..\\node_modules\\angular-oauth2-oidc\\fesm2022\\angular-oauth2-oidc.mjs",
-    "..\\..\\node_modules\\rxjs\\dist\\esm\\index.js",
-    "..\\..\\node_modules\\rxjs\\dist\\esm\\operators\\index.js"
+    "..\\..\\libs\\shared\\models\\src\\index.ts",
+    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
+    "..\\..\\libs\\ui\\src\\index.ts",
+    "..\\..\\libs\\shared\\auth\\src\\index.ts"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/apps/account/tsconfig.federation.json
+++ b/client/apps/account/tsconfig.federation.json
@@ -2,14 +2,29 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",
-    "..\\..\\libs\\shared\\models\\src\\index.ts",
-    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
-    "..\\..\\libs\\ui\\src\\index.ts",
-    "..\\..\\libs\\shared\\auth\\src\\index.ts"
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\core.mjs",
+    "..\\..\\node_modules\\@angular\\core\\event-dispatch-contract.min.js",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-di.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-event-dispatch.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-signals.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\rxjs-interop.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\common.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\http.mjs",
+    "..\\..\\node_modules\\@angular\\router\\fesm2022\\router.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\forms.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals-compat.mjs",
+    "..\\..\\node_modules\\@angular\\platform-browser\\fesm2022\\platform-browser.mjs",
+    "..\\..\\node_modules\\@jsverse\\transloco\\esm2022\\jsverse-transloco.mjs",
+    "..\\..\\node_modules\\angular-oauth2-oidc\\fesm2022\\angular-oauth2-oidc.mjs",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\index.js",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\operators\\index.js"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/apps/recipes/tsconfig.federation.json
+++ b/client/apps/recipes/tsconfig.federation.json
@@ -2,29 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\core.mjs",
-    "..\\..\\node_modules\\@angular\\core\\event-dispatch-contract.min.js",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-di.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-event-dispatch.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-signals.mjs",
-    "..\\..\\node_modules\\@angular\\core\\fesm2022\\rxjs-interop.mjs",
-    "..\\..\\node_modules\\@angular\\common\\fesm2022\\common.mjs",
-    "..\\..\\node_modules\\@angular\\common\\fesm2022\\http.mjs",
-    "..\\..\\node_modules\\@angular\\router\\fesm2022\\router.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\forms.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals.mjs",
-    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals-compat.mjs",
-    "..\\..\\node_modules\\@angular\\platform-browser\\fesm2022\\platform-browser.mjs",
-    "..\\..\\node_modules\\@jsverse\\transloco\\esm2022\\jsverse-transloco.mjs",
-    "..\\..\\node_modules\\angular-oauth2-oidc\\fesm2022\\angular-oauth2-oidc.mjs",
-    "..\\..\\node_modules\\rxjs\\dist\\esm\\index.js",
-    "..\\..\\node_modules\\rxjs\\dist\\esm\\operators\\index.js"
+    "..\\..\\libs\\shared\\models\\src\\index.ts",
+    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
+    "..\\..\\libs\\ui\\src\\index.ts",
+    "..\\..\\libs\\shared\\auth\\src\\index.ts"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/apps/recipes/tsconfig.federation.json
+++ b/client/apps/recipes/tsconfig.federation.json
@@ -2,14 +2,29 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",
-    "..\\..\\libs\\shared\\models\\src\\index.ts",
-    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
-    "..\\..\\libs\\ui\\src\\index.ts",
-    "..\\..\\libs\\shared\\auth\\src\\index.ts"
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\core.mjs",
+    "..\\..\\node_modules\\@angular\\core\\event-dispatch-contract.min.js",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-di.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-event-dispatch.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\primitives-signals.mjs",
+    "..\\..\\node_modules\\@angular\\core\\fesm2022\\rxjs-interop.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\common.mjs",
+    "..\\..\\node_modules\\@angular\\common\\fesm2022\\http.mjs",
+    "..\\..\\node_modules\\@angular\\router\\fesm2022\\router.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\forms.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals.mjs",
+    "..\\..\\node_modules\\@angular\\forms\\fesm2022\\signals-compat.mjs",
+    "..\\..\\node_modules\\@angular\\platform-browser\\fesm2022\\platform-browser.mjs",
+    "..\\..\\node_modules\\@jsverse\\transloco\\esm2022\\jsverse-transloco.mjs",
+    "..\\..\\node_modules\\angular-oauth2-oidc\\fesm2022\\angular-oauth2-oidc.mjs",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\index.js",
+    "..\\..\\node_modules\\rxjs\\dist\\esm\\operators\\index.js"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -216,7 +216,8 @@
         "timeout": "Die Extraktion hat zu lange gedauert. Bitte versuche es erneut.",
         "noRecipe": "Auf dieser Seite wurde kein Rezept gefunden.",
         "generic": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut."
-      }
+      },
+      "sectionTitle": "Rezept importieren oder erstellen"
     },
     "photoImport": {
       "title": "Aus Fotos importieren",
@@ -262,6 +263,33 @@
         "titleMaxLength": "Titel darf maximal 200 Zeichen lang sein.",
         "ingredientNameRequired": "Zutatname ist erforderlich.",
         "stepDescriptionRequired": "Schrittbeschreibung ist erforderlich."
+      }
+    },
+    "suggestions": {
+      "title": "Vorschl�ge f�r dich"
+    },
+    "quickActions": {
+      "breakfast_ideas": "Fr�hst�cksideen",
+      "quick_meals": "Schnelle Gerichte",
+      "lunch_recipes": "Mittagsrezepte",
+      "whats_for_dinner": "Was gibt es zum Abendessen?",
+      "30_min_recipes": "30-Min-Rezepte",
+      "snack_ideas": "Snack-Ideen",
+      "meal_prep": "Meal Prep",
+      "try_something_new": "Etwas Neues probieren",
+      "cook_now": "Jetzt kochen",
+      "add_to_shopping_list": "Zur Einkaufsliste"
+    },
+    "recentActivity": {
+      "title": "Letzte Aktivit�t",
+      "empty": "Noch keine Aktivit�t. Importiere dein erstes Rezept!",
+      "unknownRecipe": "Unbekanntes Rezept",
+      "types": {
+        "recipe_imported": "Rezept importiert",
+        "recipe_viewed": "Rezept angesehen",
+        "recipe_edited": "Rezept bearbeitet",
+        "recipe_deleted": "Rezept gel�scht",
+        "shopping_list_created": "Einkaufsliste erstellt"
       }
     }
   },

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -216,7 +216,8 @@
         "timeout": "Extraction timed out. Please try again.",
         "noRecipe": "No recipe found on this page.",
         "generic": "An unexpected error occurred. Please try again later."
-      }
+      },
+      "sectionTitle": "Import or Create a Recipe"
     },
     "photoImport": {
       "title": "Import from Photos",
@@ -262,6 +263,33 @@
         "titleMaxLength": "Title must not exceed 200 characters.",
         "ingredientNameRequired": "Ingredient name is required.",
         "stepDescriptionRequired": "Step description is required."
+      }
+    },
+    "suggestions": {
+      "title": "Suggested for You"
+    },
+    "quickActions": {
+      "breakfast_ideas": "Breakfast ideas",
+      "quick_meals": "Quick meals",
+      "lunch_recipes": "Lunch recipes",
+      "whats_for_dinner": "What's for dinner?",
+      "30_min_recipes": "30-min recipes",
+      "snack_ideas": "Snack ideas",
+      "meal_prep": "Meal prep",
+      "try_something_new": "Try something new",
+      "cook_now": "Cook now",
+      "add_to_shopping_list": "Add to shopping list"
+    },
+    "recentActivity": {
+      "title": "Recent Activity",
+      "empty": "No activity yet. Start by importing a recipe!",
+      "unknownRecipe": "Unknown recipe",
+      "types": {
+        "recipe_imported": "Imported a recipe",
+        "recipe_viewed": "Viewed a recipe",
+        "recipe_edited": "Edited a recipe",
+        "recipe_deleted": "Deleted a recipe",
+        "shopping_list_created": "Created a shopping list"
       }
     }
   },

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -2,90 +2,128 @@
   <h1>{{ t('dashboard.title') }}</h1>
   <p>{{ t('dashboard.welcome') }}</p>
 
-  <section class="url-import">
-    <h2>{{ t('dashboard.import.title') }}</h2>
-    <p class="subtitle">{{ t('dashboard.import.subtitle') }}</p>
+  @if (quickActions().length > 0) {
+    <yn-quick-actions [actions]="quickActions()" (actionClicked)="onQuickAction($event)" />
+  }
 
-    <form [formGroup]="form" (ngSubmit)="onImport()">
-      @if (serverError(); as error) {
-        <div class="error-banner" role="alert">{{ t(error) }}</div>
-      }
-
-      <div class="import-row">
-        <yn-form-field
-          for="url"
-          [control]="form.controls.url"
-          [errors]="{
-            required: 'dashboard.import.errors.urlRequired',
-            maxlength: 'dashboard.import.errors.urlTooLong',
-            invalidUrl: 'dashboard.import.errors.urlInvalid',
-          }"
-        >
-          <input
-            id="url"
-            type="url"
-            formControlName="url"
-            [placeholder]="t('dashboard.import.placeholder')"
-            [attr.aria-label]="t('dashboard.import.urlLabel')"
+  @if (suggestionsLoading()) {
+    <div class="suggestions-skeleton">
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+    </div>
+  } @else if (suggestions()?.suggestions?.length) {
+    <section class="suggestions-section">
+      <h2>{{ t('dashboard.suggestions.title') }}</h2>
+      <div class="suggestions-scroll">
+        @for (s of suggestions()!.suggestions; track s.recipeIdentifier) {
+          <yn-suggestion-card
+            [identifier]="s.recipeIdentifier"
+            [title]="s.title"
+            [imageUrl]="s.imageUrl"
+            [prepTimeMinutes]="s.prepTimeMinutes"
+            [reason]="s.reason"
           />
-        </yn-form-field>
-
-        <yn-submit-button
-          [loading]="isLoading()"
-          [disabled]="isSaving()"
-          label="dashboard.import.submit"
-          loadingLabel="dashboard.import.submitting"
-          [showSpinner]="true"
-        />
+        }
       </div>
-    </form>
+    </section>
+  }
 
-    @if (streamingStatus()) {
-      <div class="streaming-status">
-        <span class="btn-spinner"></span>
-        <span>{{ streamingStatus() }}</span>
-      </div>
-    }
-
-    @if (streamingChunks()) {
-      <pre class="streaming-preview">{{ streamingChunks() }}</pre>
-    }
-  </section>
-
-  <section class="photo-import">
-    <h2>{{ t('dashboard.photoImport.title') }}</h2>
-    <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
-    <label class="btn-dashed" [class.disabled]="isLoading() || isSaving()">
-      <input
-        type="file"
-        accept="image/jpeg,image/png,image/webp"
-        multiple
-        capture="environment"
-        [disabled]="isLoading() || isSaving()"
-        (change)="onImportFromPhotos($event)"
-        hidden
-      />
-      @if (isLoading()) {
-        <span class="btn-spinner"></span>
-        <span>{{ t('dashboard.photoImport.extracting') }}</span>
-      } @else {
-        <span>{{ t('dashboard.photoImport.submit') }}</span>
-      }
-    </label>
-    <p class="hint">{{ t('dashboard.photoImport.hint') }}</p>
-  </section>
-
-  <section class="manual-create">
-    <h2>{{ t('dashboard.create.title') }}</h2>
-    <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
-    <button
-      type="button"
-      class="btn-dashed create-btn"
-      [disabled]="isLoading() || isSaving() || extractedRecipe()"
-      (click)="onCreateManually()"
-    >
-      {{ t('dashboard.create.submit') }}
+  <section class="import-section" [class.expanded]="importSectionExpanded()">
+    <button class="import-toggle" (click)="toggleImportSection()">
+      <h2>{{ t('dashboard.import.sectionTitle') }}</h2>
+      <span class="toggle-chevron" [class.open]="importSectionExpanded()">&#x25BC;</span>
     </button>
+
+    @if (importSectionExpanded()) {
+      <div class="import-content">
+        <section class="url-import">
+          <h3>{{ t('dashboard.import.title') }}</h3>
+          <p class="subtitle">{{ t('dashboard.import.subtitle') }}</p>
+
+          <form [formGroup]="form" (ngSubmit)="onImport()">
+            @if (serverError(); as error) {
+              <div class="error-banner" role="alert">{{ t(error) }}</div>
+            }
+
+            <div class="import-row">
+              <yn-form-field
+                for="url"
+                [control]="form.controls.url"
+                [errors]="{
+                  required: 'dashboard.import.errors.urlRequired',
+                  maxlength: 'dashboard.import.errors.urlTooLong',
+                  invalidUrl: 'dashboard.import.errors.urlInvalid',
+                }"
+              >
+                <input
+                  id="url"
+                  type="url"
+                  formControlName="url"
+                  [placeholder]="t('dashboard.import.placeholder')"
+                  [attr.aria-label]="t('dashboard.import.urlLabel')"
+                />
+              </yn-form-field>
+
+              <yn-submit-button
+                [loading]="isLoading()"
+                [disabled]="isSaving()"
+                label="dashboard.import.submit"
+                loadingLabel="dashboard.import.submitting"
+                [showSpinner]="true"
+              />
+            </div>
+          </form>
+
+          @if (streamingStatus()) {
+            <div class="streaming-status">
+              <span class="btn-spinner"></span>
+              <span>{{ streamingStatus() }}</span>
+            </div>
+          }
+
+          @if (streamingChunks()) {
+            <pre class="streaming-preview">{{ streamingChunks() }}</pre>
+          }
+        </section>
+
+        <section class="photo-import">
+          <h3>{{ t('dashboard.photoImport.title') }}</h3>
+          <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
+          <label class="btn-dashed" [class.disabled]="isLoading() || isSaving()">
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              multiple
+              capture="environment"
+              [disabled]="isLoading() || isSaving()"
+              (change)="onImportFromPhotos($event)"
+              hidden
+            />
+            @if (isLoading()) {
+              <span class="btn-spinner"></span>
+              <span>{{ t('dashboard.photoImport.extracting') }}</span>
+            } @else {
+              <span>{{ t('dashboard.photoImport.submit') }}</span>
+            }
+          </label>
+          <p class="hint">{{ t('dashboard.photoImport.hint') }}</p>
+        </section>
+
+        <section class="manual-create">
+          <h3>{{ t('dashboard.create.title') }}</h3>
+          <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
+          <button
+            type="button"
+            class="btn-dashed create-btn"
+            [disabled]="isLoading() || isSaving() || extractedRecipe()"
+            (click)="onCreateManually()"
+          >
+            {{ t('dashboard.create.submit') }}
+          </button>
+        </section>
+      </div>
+    }
   </section>
 
   @if (saveSuccess()) {
@@ -101,5 +139,9 @@
       (save)="onSaveRecipe($event)"
       (discard)="onDiscardRecipe()"
     />
+  }
+
+  @if (recentActivity().length > 0) {
+    <yn-recent-activity [activities]="recentActivity()" />
   }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -139,3 +139,136 @@
     }
   }
 }
+
+// ── Suggestions Section ──
+.suggestions-section {
+  margin-bottom: var(--yn-space-6);
+
+  h2 {
+    margin: 0 0 var(--yn-space-4);
+    font-size: var(--yn-text-xl);
+    font-weight: var(--yn-font-semibold);
+    color: var(--yn-text);
+  }
+}
+
+.suggestions-scroll {
+  display: flex;
+  gap: var(--yn-space-5);
+  overflow-x: auto;
+  padding-bottom: var(--yn-space-3);
+  scroll-snap-type: x mandatory;
+
+  > * {
+    scroll-snap-align: start;
+  }
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--yn-border);
+    border-radius: var(--yn-radius-full);
+  }
+}
+
+// ── Suggestions Skeleton ──
+.suggestions-skeleton {
+  display: flex;
+  gap: var(--yn-space-5);
+  margin-bottom: var(--yn-space-6);
+}
+
+.skeleton-card {
+  min-width: 200px;
+  height: 180px;
+  border-radius: var(--yn-radius-card);
+  background: linear-gradient(
+    90deg,
+    var(--yn-glass-bg) 25%,
+    var(--yn-glass-bg-elevated) 50%,
+    var(--yn-glass-bg) 75%
+  );
+  background-size: 200% 100%;
+  animation: yn-shimmer 1.5s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background: var(--yn-glass-bg);
+  }
+}
+
+// ── Collapsible Import Section ──
+.import-section {
+  @include glass.glass-surface(1);
+  border-radius: var(--yn-radius-card-lg);
+  margin-bottom: var(--yn-space-6);
+  overflow: hidden;
+}
+
+.import-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: var(--yn-card-padding-sm);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--yn-text);
+
+  h2 {
+    margin: 0;
+    font-size: var(--yn-text-xl);
+    font-weight: var(--yn-font-bold);
+  }
+}
+
+.toggle-chevron {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  transition: transform var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &.open {
+    transform: rotate(180deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.import-content {
+  padding: 0 var(--yn-card-padding-sm) var(--yn-card-padding-sm);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+
+  .url-import,
+  .photo-import,
+  .manual-create {
+    // Reset glass surface — already inside glass parent
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: var(--yn-background-subtle);
+    border: 1px solid var(--yn-border-light);
+    box-shadow: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@include bp.respond-to('md') {
+  .import-toggle {
+    padding: var(--yn-space-7);
+  }
+
+  .import-content {
+    padding: 0 var(--yn-space-7) var(--yn-space-7);
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -11,6 +11,7 @@ import {
   ImportRecipeResponse,
   ImportStreamEvent,
   SavedRecipeResponse,
+  DashboardApiService,
 } from '@yumney/shared/api-client';
 
 const mockRecipe: ImportRecipeResponse = {
@@ -127,6 +128,10 @@ describe('DashboardComponent', () => {
     routerMock = { navigate: vi.fn() };
     activatedRouteMock = { snapshot: { queryParams: {} } };
 
+    const dashboardApiMock = {
+      getSuggestions: vi.fn().mockReturnValue(of({ suggestions: [], quickActions: [] })),
+      getRecentActivity: vi.fn().mockReturnValue(of([])),
+    };
     await TestBed.configureTestingModule({
       imports: [
         DashboardComponent,
@@ -140,6 +145,7 @@ describe('DashboardComponent', () => {
       ],
       providers: [
         { provide: RecipeApiService, useValue: recipeApiMock },
+        { provide: DashboardApiService, useValue: dashboardApiMock },
         { provide: Router, useValue: routerMock },
         { provide: ActivatedRoute, useValue: activatedRouteMock },
       ],
@@ -985,6 +991,10 @@ describe('DashboardComponent – Share Intent', () => {
   });
 
   function createComponentWithQueryParams(queryParams: Record<string, string>) {
+    const dashboardMock = {
+      getSuggestions: vi.fn().mockReturnValue(of({ suggestions: [], quickActions: [] })),
+      getRecentActivity: vi.fn().mockReturnValue(of([])),
+    };
     TestBed.configureTestingModule({
       imports: [
         DashboardComponent,
@@ -998,6 +1008,7 @@ describe('DashboardComponent – Share Intent', () => {
       ],
       providers: [
         { provide: RecipeApiService, useValue: recipeApiMock },
+        { provide: DashboardApiService, useValue: dashboardMock },
         { provide: Router, useValue: routerMock },
         { provide: ActivatedRoute, useValue: { snapshot: { queryParams } } },
       ],

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -14,6 +14,9 @@ import {
   RecipeApiService,
   ImportRecipeResponse,
   ImportStreamEvent,
+  DashboardApiService,
+  type UserActivityItem,
+  type SuggestionsResponse,
 } from '@yumney/shared/api-client';
 import {
   urlValidator,
@@ -23,7 +26,15 @@ import {
   HttpErrorMap,
   ROUTES,
 } from '@yumney/shared/models';
-import { RecipePreviewComponent, FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
+import {
+  RecipePreviewComponent,
+  FormFieldComponent,
+  SubmitButtonComponent,
+  QuickActionsComponent,
+  type QuickAction,
+  SuggestionCardComponent,
+  RecentActivityComponent,
+} from '@yumney/ui';
 
 @Component({
   selector: 'yn-dashboard',
@@ -33,6 +44,9 @@ import { RecipePreviewComponent, FormFieldComponent, SubmitButtonComponent } fro
     RecipePreviewComponent,
     FormFieldComponent,
     SubmitButtonComponent,
+    QuickActionsComponent,
+    SuggestionCardComponent,
+    RecentActivityComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -55,6 +69,7 @@ export class DashboardComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private recipeApi = inject(RecipeApiService);
+  private dashboardApi = inject(DashboardApiService);
   private destroyRef = inject(DestroyRef);
   private importState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
@@ -68,6 +83,13 @@ export class DashboardComponent implements OnInit {
   isManualEntry = signal(false);
   streamingStatus = signal<string | null>(null);
   streamingChunks = signal('');
+  importSectionExpanded = signal(false);
+
+  // Smart dashboard state
+  quickActions = signal<QuickAction[]>([]);
+  suggestions = signal<SuggestionsResponse | null>(null);
+  recentActivity = signal<UserActivityItem[]>([]);
+  suggestionsLoading = signal(true);
 
   form = this.formBuilder.nonNullable.group({
     url: [
@@ -86,8 +108,50 @@ export class DashboardComponent implements OnInit {
 
     if (sharedUrl) {
       this.form.controls.url.setValue(sharedUrl);
+      this.importSectionExpanded.set(true);
       this.onImport();
     }
+
+    this.loadDashboardData();
+  }
+
+  toggleImportSection(): void {
+    this.importSectionExpanded.update((v) => !v);
+  }
+
+  onQuickAction(actionKey: string): void {
+    if (actionKey === 'cook_now') {
+      this.router.navigate([ROUTES.recipes.list]);
+    } else {
+      this.importSectionExpanded.set(true);
+    }
+  }
+
+  private loadDashboardData(): void {
+    this.dashboardApi
+      .getSuggestions()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((response) => {
+        this.suggestions.set(response);
+        this.quickActions.set(this.mapQuickActions(response.quickActions));
+        this.suggestionsLoading.set(false);
+
+        if (response.quickActions.length === 0 && response.suggestions.length === 0) {
+          this.importSectionExpanded.set(true);
+        }
+      });
+
+    this.dashboardApi
+      .getRecentActivity(5)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((activity) => this.recentActivity.set(activity));
+  }
+
+  private mapQuickActions(keys: string[]): QuickAction[] {
+    return keys.map((key) => ({
+      key,
+      labelKey: 'dashboard.quickActions.' + key,
+    }));
   }
 
   onImport(): void {

--- a/client/apps/shell/tsconfig.federation.json
+++ b/client/apps/shell/tsconfig.federation.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",

--- a/client/apps/shell/tsconfig.federation.json
+++ b/client/apps/shell/tsconfig.federation.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",

--- a/client/apps/shopping/tsconfig.federation.json
+++ b/client/apps/shopping/tsconfig.federation.json
@@ -2,14 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "include": [
-    "src/**/*.ts",
-    "..\\..\\libs\\shared\\models\\src\\index.ts",
-    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
-    "..\\..\\libs\\ui\\src\\index.ts",
-    "..\\..\\libs\\shared\\auth\\src\\index.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/apps/shopping/tsconfig.federation.json
+++ b/client/apps/shopping/tsconfig.federation.json
@@ -2,12 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "..\\..\\libs\\shared\\models\\src\\index.ts",
+    "..\\..\\libs\\shared\\api-client\\src\\index.ts",
+    "..\\..\\libs\\ui\\src\\index.ts",
+    "..\\..\\libs\\shared\\auth\\src\\index.ts"
   ],
   "exclude": [
     "jest.config.ts",

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -24,3 +24,6 @@ export type { CreateShoppingListRequest } from './lib/create-shopping-list-reque
 export type { ShoppingListItemResponse } from './lib/shopping-list-item-response';
 export type { ShoppingListDetail } from './lib/shopping-list-detail';
 export type { ShoppingListSummary } from './lib/shopping-list-summary';
+export { DashboardApiService } from './lib/dashboard-api.service';
+export type { UserActivityItem } from './lib/user-activity';
+export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -20,4 +20,8 @@ export const API_ENDPOINTS = {
     register: `${API_BASE}/auth/register`,
     resendVerificationEmail: `${API_BASE}/auth/resend-verification-email`,
   },
+  users: {
+    activity: `${API_BASE}/users/me/activity`,
+    suggestions: `${API_BASE}/users/me/suggestions`,
+  },
 } as const;

--- a/client/libs/shared/api-client/src/lib/dashboard-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/dashboard-api.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, of } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
+import type { UserActivityItem } from './user-activity';
+import type { SuggestionsResponse } from './suggestion';
+
+@Injectable({ providedIn: 'root' })
+export class DashboardApiService {
+  private http = inject(HttpClient);
+
+  getRecentActivity(limit = 5): Observable<UserActivityItem[]> {
+    return this.http
+      .get<UserActivityItem[]>(API_ENDPOINTS.users.activity, {
+        params: { limit: limit.toString() },
+      })
+      .pipe(catchError(() => of([])));
+  }
+
+  getSuggestions(): Observable<SuggestionsResponse> {
+    return this.http
+      .get<SuggestionsResponse>(API_ENDPOINTS.users.suggestions)
+      .pipe(
+        catchError(() => of({ suggestions: [], quickActions: [] } satisfies SuggestionsResponse)),
+      );
+  }
+}

--- a/client/libs/shared/api-client/src/lib/suggestion.ts
+++ b/client/libs/shared/api-client/src/lib/suggestion.ts
@@ -1,0 +1,12 @@
+export interface SuggestionItem {
+  recipeIdentifier: string;
+  title: string;
+  imageUrl: string | null;
+  prepTimeMinutes: number | null;
+  reason: string;
+}
+
+export interface SuggestionsResponse {
+  suggestions: SuggestionItem[];
+  quickActions: string[];
+}

--- a/client/libs/shared/api-client/src/lib/user-activity.ts
+++ b/client/libs/shared/api-client/src/lib/user-activity.ts
@@ -1,0 +1,6 @@
+export interface UserActivityItem {
+  type: string;
+  recipeIdentifier: string | null;
+  recipeTitle: string | null;
+  occurredAt: string;
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -21,3 +21,14 @@ export {
   safeAnimate,
   observeReveal,
 } from './lib/animation/gsap-utils';
+
+// Dashboard components
+export {
+  QuickActionsComponent,
+  type QuickAction,
+} from './lib/quick-actions/quick-actions.component';
+export { SuggestionCardComponent } from './lib/suggestion-card/suggestion-card.component';
+export {
+  RecentActivityComponent,
+  type ActivityItem,
+} from './lib/recent-activity/recent-activity.component';

--- a/client/libs/ui/src/lib/quick-actions/quick-actions.component.scss
+++ b/client/libs/ui/src/lib/quick-actions/quick-actions.component.scss
@@ -1,0 +1,43 @@
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-3);
+  margin-bottom: var(--yn-space-6);
+}
+
+.action-chip {
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--yn-text);
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+  cursor: pointer;
+  transition:
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    transform var(--yn-duration-fast) var(--yn-ease-spring);
+
+  &:hover {
+    background: var(--yn-primary-light);
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+    transform: scale(1.02);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover,
+    &:active {
+      transform: none;
+    }
+  }
+}

--- a/client/libs/ui/src/lib/quick-actions/quick-actions.component.ts
+++ b/client/libs/ui/src/lib/quick-actions/quick-actions.component.ts
@@ -1,0 +1,28 @@
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+export interface QuickAction {
+  key: string;
+  labelKey: string;
+}
+
+@Component({
+  selector: 'yn-quick-actions',
+  standalone: true,
+  imports: [TranslocoModule],
+  template: `
+    <div class="quick-actions" *transloco="let t">
+      @for (action of actions(); track action.key) {
+        <button class="action-chip" (click)="actionClicked.emit(action.key)">
+          {{ t(action.labelKey) }}
+        </button>
+      }
+    </div>
+  `,
+  styleUrl: './quick-actions.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class QuickActionsComponent {
+  actions = input.required<QuickAction[]>();
+  actionClicked = output<string>();
+}

--- a/client/libs/ui/src/lib/recent-activity/recent-activity.component.scss
+++ b/client/libs/ui/src/lib/recent-activity/recent-activity.component.scss
@@ -1,0 +1,73 @@
+.recent-activity {
+  margin-top: var(--yn-space-6);
+}
+
+.activity-heading {
+  margin: 0 0 var(--yn-space-4);
+  font-size: var(--yn-text-lg);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+}
+
+.activity-empty {
+  color: var(--yn-text-muted);
+  font-size: var(--yn-text-base);
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.activity-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--yn-space-4);
+  padding: var(--yn-space-3) 0;
+  border-bottom: 1px solid var(--yn-border-light);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.activity-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--yn-radius-circle);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+  font-size: var(--yn-text-sm);
+  flex-shrink: 0;
+}
+
+.activity-detail {
+  flex: 1;
+  min-width: 0;
+}
+
+.activity-link {
+  display: block;
+  color: var(--yn-link);
+  text-decoration: none;
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.activity-time {
+  display: block;
+  font-size: var(--yn-text-xs);
+  color: var(--yn-text-light);
+  margin-top: var(--yn-space-1);
+}

--- a/client/libs/ui/src/lib/recent-activity/recent-activity.component.ts
+++ b/client/libs/ui/src/lib/recent-activity/recent-activity.component.ts
@@ -1,0 +1,59 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { RouterLink } from '@angular/router';
+import { DatePipe } from '@angular/common';
+
+export interface ActivityItem {
+  type: string;
+  recipeIdentifier: string | null;
+  recipeTitle: string | null;
+  occurredAt: string;
+}
+
+@Component({
+  selector: 'yn-recent-activity',
+  standalone: true,
+  imports: [TranslocoModule, RouterLink, DatePipe],
+  template: `
+    <div class="recent-activity" *transloco="let t">
+      <h3 class="activity-heading">{{ t('dashboard.recentActivity.title') }}</h3>
+      @if (activities().length === 0) {
+        <p class="activity-empty">{{ t('dashboard.recentActivity.empty') }}</p>
+      } @else {
+        <ul class="activity-list">
+          @for (item of activities(); track item.occurredAt) {
+            <li class="activity-item">
+              <span class="activity-icon">{{ getIcon(item.type) }}</span>
+              <div class="activity-detail">
+                @if (item.recipeIdentifier) {
+                  <a [routerLink]="['/recipes', item.recipeIdentifier]" class="activity-link">
+                    {{ item.recipeTitle ?? t('dashboard.recentActivity.unknownRecipe') }}
+                  </a>
+                } @else {
+                  <span>{{ t('dashboard.recentActivity.types.' + item.type) }}</span>
+                }
+                <time class="activity-time">{{ item.occurredAt | date: 'short' }}</time>
+              </div>
+            </li>
+          }
+        </ul>
+      }
+    </div>
+  `,
+  styleUrl: './recent-activity.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecentActivityComponent {
+  activities = input.required<ActivityItem[]>();
+
+  getIcon(type: string): string {
+    const icons: Record<string, string> = {
+      recipe_imported: '+',
+      recipe_viewed: '○',
+      recipe_edited: '✎',
+      recipe_deleted: '×',
+      shopping_list_created: '☐',
+    };
+    return icons[type] ?? '·';
+  }
+}

--- a/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.scss
+++ b/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.scss
@@ -1,0 +1,69 @@
+.suggestion-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  max-width: 240px;
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+  border: 1px solid var(--yn-glass-border);
+  box-shadow: var(--yn-elevation-1);
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    box-shadow var(--yn-duration-normal) var(--yn-ease-glass),
+    transform var(--yn-duration-normal) var(--yn-ease-spring);
+  flex-shrink: 0;
+
+  &:hover {
+    box-shadow: var(--yn-elevation-2);
+    transform: translateY(-2px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+}
+
+.suggestion-image {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.suggestion-image-placeholder {
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(135deg, var(--yn-primary-light), var(--yn-primary-light-end));
+}
+
+.suggestion-info {
+  padding: var(--yn-space-4);
+}
+
+.suggestion-title {
+  margin: 0 0 var(--yn-space-1);
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+}
+
+.suggestion-time {
+  display: inline-block;
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-light);
+  margin-bottom: var(--yn-space-2);
+}
+
+.suggestion-reason {
+  display: block;
+  font-size: var(--yn-text-xs);
+  color: var(--yn-text-muted);
+  font-style: italic;
+}

--- a/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
+++ b/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
@@ -1,0 +1,33 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'yn-suggestion-card',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <a class="suggestion-card" [routerLink]="['/recipes', identifier()]">
+      @if (imageUrl()) {
+        <img class="suggestion-image" [src]="imageUrl()!" [alt]="title()" loading="lazy" />
+      } @else {
+        <div class="suggestion-image-placeholder"></div>
+      }
+      <div class="suggestion-info">
+        <h3 class="suggestion-title">{{ title() }}</h3>
+        @if (prepTimeMinutes()) {
+          <span class="suggestion-time">{{ prepTimeMinutes() }} min</span>
+        }
+        <span class="suggestion-reason">{{ reason() }}</span>
+      </div>
+    </a>
+  `,
+  styleUrl: './suggestion-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SuggestionCardComponent {
+  identifier = input.required<string>();
+  title = input.required<string>();
+  imageUrl = input<string | null>(null);
+  prepTimeMinutes = input<number | null>(null);
+  reason = input.required<string>();
+}

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -48,8 +48,12 @@ else
 if (!options.DatabaseOnly)
 {
     var migrationRunner = builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
-        .WithReference(recipesDb).WithReference(shoppingDb).WithReference(usersDb)
-        .WaitFor(recipesDb).WaitFor(shoppingDb).WaitFor(usersDb);
+        .WithReference(recipesDb)
+        .WithReference(shoppingDb)
+        .WithReference(usersDb)
+        .WaitFor(recipesDb)
+        .WaitFor(shoppingDb)
+        .WaitFor(usersDb);
 
     // ── Infrastructure ── (data volumes only in dev — ACA breaks file permissions)
     var redis = builder.AddRedis("redis", password: redisPassword);
@@ -161,7 +165,7 @@ if (!options.DatabaseOnly)
     if (isRunMode)
     {
         var keycloakRealmUrl = "http://localhost:8080/realms/yumney";
-        var scalar = builder.AddScalarApiReference("scalar", options => options
+        var scalar = builder.AddScalarApiReference("scalar", scalarOptions => scalarOptions
                 .WithTheme(ScalarTheme.Mars)
                 .AddAuthorizationCodeFlow("keycloak", flow => flow
                     .WithClientId("yumney-web")
@@ -186,14 +190,23 @@ if (!options.DatabaseOnly)
 
         builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
             .WithHttpEndpoint(port: 5100)
-            .WithReference(recipesApi).WithReference(shoppingApi).WithReference(usersApi)
-            .WithReference(shell).WithReference(keycloak)
-            .WaitFor(recipesApi).WaitFor(shoppingApi).WaitFor(usersApi)
-            .WaitFor(shell).WaitFor(recipesMfe).WaitFor(shoppingMfe).WaitFor(accountMfe);
+            .WithReference(recipesApi)
+            .WithReference(shoppingApi)
+            .WithReference(usersApi)
+            .WithReference(shell)
+            .WithReference(keycloak)
+            .WaitFor(recipesApi)
+            .WaitFor(shoppingApi)
+            .WaitFor(usersApi)
+            .WaitFor(shell)
+            .WaitFor(recipesMfe)
+            .WaitFor(shoppingMfe)
+            .WaitFor(accountMfe);
     }
     else
     {
-        var frontend = builder.AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
+        var frontend = builder
+            .AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
             .WithHttpEndpoint(targetPort: 80);
 
 #pragma warning disable ASPIRECOMPUTE003
@@ -203,7 +216,8 @@ if (!options.DatabaseOnly)
         }
 #pragma warning restore ASPIRECOMPUTE003
 
-        builder.AddYarp("yumney-gateway")
+        builder
+            .AddYarp("yumney-gateway")
             .WithConfiguration(yarp =>
             {
                 yarp.AddRoute("/api/v1/recipes/{**catch-all}", recipesApi);

--- a/src/Yumney.Users.Api/AuthEndpoints.cs
+++ b/src/Yumney.Users.Api/AuthEndpoints.cs
@@ -1,7 +1,4 @@
 using FluentValidation;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
@@ -47,8 +44,13 @@ public static class AuthEndpoints
         if (problem is not null) return problem;
 
         var (email, password, displayName) = request;
-        var command = new RegisterUserCommand(Email.From(email), Password.From(password), DisplayName.From(displayName));
+        var command = new RegisterUserCommand(
+            Email.From(email),
+            Password.From(password),
+            DisplayName.From(displayName));
+
         var result = await handler.HandleAsync(command, cancellationToken);
+
         return result.ToCreated("/api/v1/users/me");
     }
 
@@ -62,6 +64,7 @@ public static class AuthEndpoints
         if (problem is not null) return problem;
 
         var command = new ResendVerificationEmailCommand(Email.From(request.Email));
+
         var result = await handler.HandleAsync(command, cancellationToken);
 
         // Always return 200 to prevent email enumeration

--- a/src/Yumney.Users.Api/UserActivityEndpoints.cs
+++ b/src/Yumney.Users.Api/UserActivityEndpoints.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+namespace SmartSolutionsLab.Yumney.Users.Api;
+
+public static class UserActivityEndpoints
+{
+    public static IEndpointRouteBuilder MapUserActivityEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/users/me");
+
+        group.MapGet("/activity", GetRecentActivityAsync)
+            .RequireAuthorization()
+            .WithName("GetRecentActivity")
+            .WithTags("Users")
+            .Produces<IReadOnlyList<UserActivityDto>>();
+
+        group.MapGet("/suggestions", GetSuggestionsAsync)
+            .RequireAuthorization()
+            .WithName("GetSuggestions")
+            .WithTags("Users")
+            .Produces<SuggestionsResponseDto>();
+
+        return app;
+    }
+
+    private static async Task<IResult> GetRecentActivityAsync(
+        IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>> handler,
+        int limit = 5,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetRecentActivityQuery(limit);
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> GetSuggestionsAsync(
+        IQueryHandler<GetSuggestionsQuery, Result<SuggestionsResponseDto>> handler,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetSuggestionsQuery();
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return result.ToOk();
+    }
+}

--- a/src/Yumney.Users.Api/UserActivityEndpoints.cs
+++ b/src/Yumney.Users.Api/UserActivityEndpoints.cs
@@ -1,6 +1,3 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;

--- a/src/Yumney.Users.Api/UsersEndpoints.cs
+++ b/src/Yumney.Users.Api/UsersEndpoints.cs
@@ -7,6 +7,7 @@ public static class UsersEndpoints
     public static IEndpointRouteBuilder MapUsersEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapAuthEndpoints();
+        app.MapUserActivityEndpoints();
 
         return app;
     }

--- a/src/Yumney.Users.Application/Commands/Handlers/RegisterUserCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/RegisterUserCommandHandler.cs
@@ -13,9 +13,7 @@ public sealed partial class RegisterUserCommandHandler(
     IAppUserProfileRepository users,
     ILogger<RegisterUserCommandHandler> logger) : ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>>
 {
-    public async Task<Result<RegisterUserResultDto>> HandleAsync(
-        RegisterUserCommand command,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<RegisterUserResultDto>> HandleAsync(RegisterUserCommand command, CancellationToken cancellationToken = default)
     {
         var (email, password, displayName) = command;
 

--- a/src/Yumney.Users.Application/DTOs/SuggestionDto.cs
+++ b/src/Yumney.Users.Application/DTOs/SuggestionDto.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record SuggestionDto(
+    Guid RecipeIdentifier,
+    string Title,
+    string? ImageUrl,
+    int? PrepTimeMinutes,
+    string Reason);
+
+public sealed record SuggestionsResponseDto(
+    IReadOnlyList<SuggestionDto> Suggestions,
+    IReadOnlyList<string> QuickActions);

--- a/src/Yumney.Users.Application/DTOs/UserActivityDto.cs
+++ b/src/Yumney.Users.Application/DTOs/UserActivityDto.cs
@@ -1,0 +1,7 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record UserActivityDto(
+    string Type,
+    Guid? RecipeIdentifier,
+    string? RecipeTitle,
+    DateTime OccurredAt);

--- a/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
+++ b/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
@@ -1,0 +1,18 @@
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public static class UserActivityMappingExtensions
+{
+    extension(UserActivity activity)
+    {
+        public UserActivityDto ToDto()
+        {
+            return new UserActivityDto(
+                activity.Type.Value,
+                activity.RecipeIdentifier,
+                activity.RecipeTitle,
+                activity.OccurredAt);
+        }
+    }
+}

--- a/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+public sealed record GetRecentActivityQuery(int Limit = 5)
+    : IQuery<Result<IReadOnlyList<UserActivityDto>>>;

--- a/src/Yumney.Users.Application/Queries/GetSuggestionsQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetSuggestionsQuery.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+public sealed record GetSuggestionsQuery() : IQuery<Result<SuggestionsResponseDto>>;

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
+
+public sealed partial class GetRecentActivityQueryHandler(
+    IUserActivityRepository activities,
+    ICurrentUser currentUser,
+    ILogger<GetRecentActivityQueryHandler> logger)
+    : IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>>
+{
+    public async Task<Result<IReadOnlyList<UserActivityDto>>> HandleAsync(
+        GetRecentActivityQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var owner = OwnerIdentifier.From(currentUser.UserId);
+
+        LogGetRecentActivity(owner.Value, query.Limit);
+
+        var recentActivities = await activities.GetRecentAsync(owner, query.Limit, cancellationToken);
+
+        var dtos = recentActivities
+            .Select(a => new UserActivityDto(
+                a.Type.Value,
+                a.RecipeIdentifier,
+                a.RecipeTitle,
+                a.OccurredAt))
+            .ToList();
+
+        return Result.Success<IReadOnlyList<UserActivityDto>>(dtos);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Getting recent activity for user {UserId}, limit {Limit}")]
+    private partial void LogGetRecentActivity(string userId, int limit);
+}

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -6,15 +6,15 @@ using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
 
+#pragma warning disable SA1601
 public sealed partial class GetRecentActivityQueryHandler(
+#pragma warning restore SA1601
     IUserActivityRepository activities,
     ICurrentUser currentUser,
     ILogger<GetRecentActivityQueryHandler> logger)
     : IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>>
 {
-    public async Task<Result<IReadOnlyList<UserActivityDto>>> HandleAsync(
-        GetRecentActivityQuery query,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<IReadOnlyList<UserActivityDto>>> HandleAsync(GetRecentActivityQuery query, CancellationToken cancellationToken = default)
     {
         var owner = OwnerIdentifier.From(currentUser.UserId);
 
@@ -22,13 +22,7 @@ public sealed partial class GetRecentActivityQueryHandler(
 
         var recentActivities = await activities.GetRecentAsync(owner, query.Limit, cancellationToken);
 
-        var dtos = recentActivities
-            .Select(a => new UserActivityDto(
-                a.Type.Value,
-                a.RecipeIdentifier,
-                a.RecipeTitle,
-                a.OccurredAt))
-            .ToList();
+        var dtos = recentActivities.Select(a => a.ToDto()).ToList();
 
         return Result.Success<IReadOnlyList<UserActivityDto>>(dtos);
     }

--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -6,15 +6,13 @@ using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
 
+#pragma warning disable SA1601
 public sealed partial class GetSuggestionsQueryHandler(
-    IUserActivityRepository activities,
-    ICurrentUser currentUser,
-    ILogger<GetSuggestionsQueryHandler> logger)
+#pragma warning restore SA1601
+    IUserActivityRepository activities, ICurrentUser currentUser, ILogger<GetSuggestionsQueryHandler> logger)
     : IQueryHandler<GetSuggestionsQuery, Result<SuggestionsResponseDto>>
 {
-    public async Task<Result<SuggestionsResponseDto>> HandleAsync(
-        GetSuggestionsQuery query,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<SuggestionsResponseDto>> HandleAsync(GetSuggestionsQuery query, CancellationToken cancellationToken = default)
     {
         var owner = OwnerIdentifier.From(currentUser.UserId);
 
@@ -24,9 +22,7 @@ public sealed partial class GetSuggestionsQueryHandler(
 
         var quickActions = BuildQuickActions(recentActivities);
 
-        return Result.Success(new SuggestionsResponseDto(
-            Suggestions: [],
-            QuickActions: quickActions));
+        return Result.Success(new SuggestionsResponseDto(Suggestions: [], QuickActions: quickActions));
     }
 
     private static List<string> BuildQuickActions(IReadOnlyList<UserActivity> recentActivities)

--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
+
+public sealed partial class GetSuggestionsQueryHandler(
+    IUserActivityRepository activities,
+    ICurrentUser currentUser,
+    ILogger<GetSuggestionsQueryHandler> logger)
+    : IQueryHandler<GetSuggestionsQuery, Result<SuggestionsResponseDto>>
+{
+    public async Task<Result<SuggestionsResponseDto>> HandleAsync(
+        GetSuggestionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var owner = OwnerIdentifier.From(currentUser.UserId);
+
+        LogGetSuggestions(owner.Value);
+
+        var recentActivities = await activities.GetRecentAsync(owner, 10, cancellationToken);
+
+        var quickActions = BuildQuickActions(recentActivities);
+
+        return Result.Success(new SuggestionsResponseDto(
+            Suggestions: [],
+            QuickActions: quickActions));
+    }
+
+    private static List<string> BuildQuickActions(IReadOnlyList<UserActivity> recentActivities)
+    {
+        var actions = new List<string>();
+        var hour = DateTime.UtcNow.Hour;
+        var dayOfWeek = DateTime.UtcNow.DayOfWeek;
+
+        if (hour >= 5 && hour < 11)
+        {
+            actions.Add("breakfast_ideas");
+            actions.Add("quick_meals");
+        }
+        else if (hour >= 11 && hour < 15)
+        {
+            actions.Add("lunch_recipes");
+            actions.Add("quick_meals");
+        }
+        else if (hour >= 15 && hour < 21)
+        {
+            actions.Add("whats_for_dinner");
+            actions.Add("30_min_recipes");
+        }
+        else
+        {
+            actions.Add("snack_ideas");
+            actions.Add("meal_prep");
+        }
+
+        if (dayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+        {
+            actions.Add("meal_prep");
+            actions.Add("try_something_new");
+        }
+
+        var hasRecentImport = recentActivities.Any(a =>
+            a.Type == ActivityType.RecipeImported &&
+            a.OccurredAt > DateTime.UtcNow.AddHours(-1));
+
+        if (hasRecentImport)
+        {
+            actions.Insert(0, "cook_now");
+            actions.Insert(1, "add_to_shopping_list");
+        }
+
+        return actions.Distinct().Take(4).ToList();
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Getting suggestions for user {UserId}")]
+    private partial void LogGetSuggestions(string userId);
+}

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -11,15 +11,6 @@ public sealed record ActivityType : IValueObject<string>
     public static readonly ActivityType RecipeDeleted = new("recipe_deleted");
     public static readonly ActivityType ShoppingListCreated = new("shopping_list_created");
 
-    private static readonly HashSet<string> KnownTypes =
-    [
-        RecipeImported.Value,
-        RecipeViewed.Value,
-        RecipeEdited.Value,
-        RecipeDeleted.Value,
-        ShoppingListCreated.Value,
-    ];
-
     public string Value { get; }
 
     private ActivityType(string value)

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -1,0 +1,37 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+public sealed record ActivityType : IValueObject<string>
+{
+    public static readonly ActivityType RecipeImported = new("recipe_imported");
+    public static readonly ActivityType RecipeViewed = new("recipe_viewed");
+    public static readonly ActivityType RecipeEdited = new("recipe_edited");
+    public static readonly ActivityType RecipeDeleted = new("recipe_deleted");
+    public static readonly ActivityType ShoppingListCreated = new("shopping_list_created");
+
+    private static readonly HashSet<string> KnownTypes =
+    [
+        RecipeImported.Value,
+        RecipeViewed.Value,
+        RecipeEdited.Value,
+        RecipeDeleted.Value,
+        ShoppingListCreated.Value,
+    ];
+
+    public string Value { get; }
+
+    private ActivityType(string value)
+    {
+        Value = Ensure.That(value).IsNotNullOrWhiteSpace().AndReturn();
+    }
+
+    public static ActivityType From(string value)
+    {
+        Ensure.That(value).IsNotNullOrWhiteSpace();
+        return new ActivityType(value);
+    }
+
+    public static implicit operator string(ActivityType type) => type.Value;
+}

--- a/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
+++ b/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+public interface IUserActivityRepository
+{
+    Task AddAsync(UserActivity activity, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserActivity>> GetRecentAsync(
+        OwnerIdentifier owner,
+        int limit = 5,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Users.Domain/UserActivity/OwnerIdentifier.cs
+++ b/src/Yumney.Users.Domain/UserActivity/OwnerIdentifier.cs
@@ -1,0 +1,24 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+public sealed record OwnerIdentifier : IValueObject<string>
+{
+    public const int MaxLength = 255;
+
+    public string Value { get; }
+
+    private OwnerIdentifier(string value)
+    {
+        string validated = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .AndReturn();
+        Value = validated.Trim();
+    }
+
+    public static OwnerIdentifier From(string value) => new(value);
+
+    public static implicit operator string(OwnerIdentifier obj) => obj.Value;
+}

--- a/src/Yumney.Users.Domain/UserActivity/UserActivity.cs
+++ b/src/Yumney.Users.Domain/UserActivity/UserActivity.cs
@@ -1,0 +1,37 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+public sealed class UserActivity : Entity<UserActivityIdentifier>
+{
+    public OwnerIdentifier Owner { get; private set; } = default!;
+
+    public ActivityType Type { get; private set; } = default!;
+
+    public Guid? RecipeIdentifier { get; private set; }
+
+    public string? RecipeTitle { get; private set; }
+
+    public DateTime OccurredAt { get; private set; }
+
+    private UserActivity()
+    {
+    }
+
+    public static UserActivity Record(
+        OwnerIdentifier owner,
+        ActivityType type,
+        Guid? recipeIdentifier = null,
+        string? recipeTitle = null)
+    {
+        return new UserActivity
+        {
+            Id = UserActivityIdentifier.New(),
+            Owner = owner,
+            Type = type,
+            RecipeIdentifier = recipeIdentifier,
+            RecipeTitle = recipeTitle,
+            OccurredAt = DateTime.UtcNow,
+        };
+    }
+}

--- a/src/Yumney.Users.Domain/UserActivity/UserActivityIdentifier.cs
+++ b/src/Yumney.Users.Domain/UserActivity/UserActivityIdentifier.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+public sealed record UserActivityIdentifier : IValueObject
+{
+    public Guid Value { get; }
+
+    private UserActivityIdentifier(Guid value)
+    {
+        Value = Ensure.That(value).IsNotEmpty().AndReturn();
+    }
+
+    public static UserActivityIdentifier New() => new(Guid.CreateVersion7());
+
+    public static UserActivityIdentifier From(Guid value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/UserActivityConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/UserActivityConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Configurations;
+
+internal sealed class UserActivityConfiguration : IEntityTypeConfiguration<UserActivity>
+{
+    public void Configure(EntityTypeBuilder<UserActivity> entity)
+    {
+        entity.ToTable("UserActivities");
+        entity.HasKey(e => e.Id);
+        entity.Property(e => e.Id)
+            .HasConversion<UserActivityIdentifierConverter>();
+
+        entity.Property(e => e.Owner)
+            .HasConversion<UserActivityOwnerIdentifierConverter>()
+            .HasMaxLength(OwnerIdentifier.MaxLength)
+            .IsRequired();
+
+        entity.Property(e => e.Type)
+            .HasConversion<ActivityTypeConverter>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        entity.Property(e => e.RecipeIdentifier);
+
+        entity.Property(e => e.RecipeTitle)
+            .HasMaxLength(200);
+
+        entity.Property(e => e.OccurredAt)
+            .IsRequired();
+
+        entity.HasIndex(e => new { e.Owner, e.OccurredAt })
+            .IsDescending(false, true);
+    }
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/ActivityTypeConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/ActivityTypeConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class ActivityTypeConverter()
+    : ValueConverter<ActivityType, string>(v => v.Value, v => ActivityType.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/UserActivityIdentifierConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/UserActivityIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class UserActivityIdentifierConverter()
+    : ValueConverter<UserActivityIdentifier, Guid>(v => v.Value, v => UserActivityIdentifier.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/UserActivityOwnerIdentifierConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/UserActivityOwnerIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class UserActivityOwnerIdentifierConverter()
+    : ValueConverter<OwnerIdentifier, string>(v => v.Value, v => OwnerIdentifier.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260405212538_AddUserActivities.Designer.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260405212538_AddUserActivities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260405212538_AddUserActivities")]
+    partial class AddUserActivities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260405212538_AddUserActivities.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260405212538_AddUserActivities.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserActivities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserActivities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Owner = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    RecipeIdentifier = table.Column<Guid>(type: "uuid", nullable: true),
+                    RecipeTitle = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserActivities", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserActivities_Owner_OccurredAt",
+                table: "UserActivities",
+                columns: new[] { "Owner", "OccurredAt" },
+                descending: new[] { false, true });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserActivities");
+        }
+    }
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
+
+public sealed class UserActivityRepository(UsersDbContext context) : IUserActivityRepository
+{
+    private readonly DbSet<UserActivity> activities = context.Set<UserActivity>();
+
+    public async Task AddAsync(UserActivity activity, CancellationToken cancellationToken = default)
+    {
+        await activities.AddAsync(activity, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<UserActivity>> GetRecentAsync(
+        OwnerIdentifier owner,
+        int limit = 5,
+        CancellationToken cancellationToken = default)
+    {
+        return await activities
+            .AsNoTracking()
+            .Where(a => a.Owner == owner)
+            .OrderByDescending(a => a.OccurredAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/UsersDbContext.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UsersDbContext.cs
@@ -1,11 +1,14 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
 public sealed class UsersDbContext(DbContextOptions<UsersDbContext> options) : DbContext(options)
 {
     public DbSet<AppUserProfile> AppUserProfiles => Set<AppUserProfile>();
+
+    public DbSet<UserActivity> UserActivities => Set<UserActivity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Http.Resilience;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
 
@@ -28,6 +29,7 @@ public static class UsersInfrastructureServiceCollectionExtensions
         });
 
         services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
+        services.AddScoped<IUserActivityRepository, UserActivityRepository>();
 
         services.AddHttpClient<IKeycloakAdminService, KeycloakAdminService>(client =>
         {


### PR DESCRIPTION
## Summary

### Backend
- New `UserActivity` domain entity with `ActivityType`, `OwnerIdentifier` value objects
- `GetRecentActivityQuery` + `GetSuggestionsQuery` with CQRS handlers
- EF Core persistence: repository, converters, configuration, `AddUserActivities` migration
- REST endpoints: `GET /users/me/activity`, `GET /users/me/suggestions`
- Time-of-day based quick actions (morning/evening/weekend/post-import)

### Frontend
- `DashboardApiService` with graceful error fallback (degrades to expanded import)
- 3 new glass-styled UI components: `yn-quick-actions`, `yn-suggestion-card`, `yn-recent-activity`
- Dashboard refactored into smart layout: quick actions bar, suggestions horizontal scroll, collapsible import section with progressive disclosure, skeleton shimmer loading, recent activity timeline
- All components work in light and dark mode

## Test plan
- [x] Backend builds: `dotnet build src/Yumney.Users.Api`
- [x] Frontend builds: `nx build shell,recipes,shopping,account`
- [x] `nx test shell` — 199 tests pass (DashboardApiService mocked)
- [x] `nx test ui` — 50 tests pass
- [x] `prettier --check` — all formatted
- [x] EF migration created for UserActivities table
- [ ] Visual: quick action chips adapt to time of day
- [ ] Visual: collapsible import section expands/collapses
- [ ] Visual: skeleton shimmer while loading
- [ ] Edge case: new user with no activity — import section auto-expanded

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)