### PR TITLE
feat(recipes): glass redesign for recipe list and detail views (US-260)

### DIFF
--- a/client/apps/recipes/project.json
+++ b/client/apps/recipes/project.json
@@ -52,8 +52,8 @@
             },
             {
               "type": "anyComponentStyle",
-              "maximumWarning": "6kb",
-              "maximumError": "12kb"
+              "maximumWarning": "8kb",
+              "maximumError": "16kb"
             }
           ],
           "outputHashing": "all"

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -19,12 +19,17 @@
           loading="eager"
           fetchpriority="high"
         />
+        <div class="hero-overlay">
+          <h1 class="hero-title">{{ recipe.title }}</h1>
+        </div>
       } @else {
         <div class="hero-placeholder"></div>
       }
     </div>
 
-    <h1 class="recipe-title">{{ recipe.title }}</h1>
+    @if (!recipe.imageUrl) {
+      <h1 class="recipe-title">{{ recipe.title }}</h1>
+    }
 
     @if (recipe.description) {
       <p class="recipe-description">{{ recipe.description }}</p>
@@ -151,6 +156,15 @@
         </a>
       </div>
     }
+
+    <div class="floating-actions">
+      <a class="btn-primary" [routerLink]="['/recipes', recipe.identifier, 'edit']">
+        {{ t('recipes.detail.actions.edit') }}
+      </a>
+      <a class="btn-secondary" [routerLink]="['/shopping', 'create', recipe.identifier]">
+        {{ t('recipes.detail.actions.shoppingList') }}
+      </a>
+    </div>
 
     @if (showDeleteConfirm()) {
       <yn-confirm-dialog

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -1,10 +1,13 @@
 @use 'banners';
 @use 'buttons';
+@use 'glass';
+@use 'breakpoints' as bp;
 
 .recipe-detail-container {
   max-width: 900px;
   margin: 0 auto;
   padding: var(--yn-space-8) var(--yn-space-5);
+  padding-bottom: 5rem; // space for floating action bar
 }
 
 // .back-link provided by @use 'buttons'
@@ -13,9 +16,11 @@
   padding: 4rem 0;
 }
 
+// ── Hero with glass overlay ──
 .recipe-hero {
+  position: relative;
   margin-bottom: var(--yn-space-7);
-  border-radius: var(--yn-radius-card);
+  border-radius: var(--yn-radius-card-lg);
   overflow: hidden;
 }
 
@@ -23,12 +28,31 @@
   width: 100%;
   max-height: 400px;
   object-fit: cover;
+  display: block;
 }
 
 .hero-placeholder {
   width: 100%;
   height: 240px;
   background: linear-gradient(135deg, var(--yn-primary-light), var(--yn-primary-light-end));
+}
+
+.hero-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: var(--yn-space-7) var(--yn-space-6);
+  background: linear-gradient(transparent, rgb(0 0 0 / 60%));
+  color: #fff;
+}
+
+.hero-title {
+  margin: 0;
+  font-size: var(--yn-text-4xl);
+  font-weight: var(--yn-font-bold);
+  line-height: var(--yn-leading-tight);
+  text-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 .recipe-title {
@@ -45,15 +69,15 @@
   line-height: var(--yn-leading-relaxed);
 }
 
+// ── Glass metadata chips ──
 .meta-bar {
+  @include glass.glass-surface(1);
   display: flex;
   flex-wrap: wrap;
   gap: var(--yn-space-5);
   padding: var(--yn-space-5);
   margin-bottom: var(--yn-space-7);
-  background: var(--yn-surface);
   border-radius: var(--yn-radius-card);
-  box-shadow: var(--yn-shadow-md);
 }
 
 .meta-item {
@@ -96,10 +120,13 @@
   font-weight: var(--yn-font-semibold);
   cursor: pointer;
   line-height: var(--yn-leading-none);
+  transition:
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    color var(--yn-duration-fast) var(--yn-ease-glass);
 
   &:hover:not(:disabled) {
     background: var(--yn-primary);
-    color: var(--yn-surface);
+    color: var(--yn-text-inverse);
   }
 
   &:disabled {
@@ -136,6 +163,7 @@
   color: var(--yn-text);
 }
 
+// ── Tags as glass chips ──
 .tags {
   display: flex;
   flex-wrap: wrap;
@@ -147,22 +175,61 @@
   display: inline-block;
   padding: var(--yn-space-1) var(--yn-space-4);
   border-radius: var(--yn-radius-badge);
-  background-color: var(--yn-primary-light);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   color: var(--yn-primary);
   font-size: var(--yn-text-sm);
   font-weight: var(--yn-font-medium);
 }
 
+// ── Actions bar (replaced by floating bar on mobile) ──
 .actions-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--yn-space-4);
-  margin-bottom: var(--yn-space-8);
+  display: none;
+
+  @include bp.respond-to('md') {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--yn-space-4);
+    margin-bottom: var(--yn-space-8);
+  }
 }
 
-// Action buttons use shared .btn-primary, .btn-secondary, .btn-danger from @use 'buttons'
+// ── Floating action bar (mobile) ──
+.floating-actions {
+  @include glass.glass-surface(2);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: var(--yn-space-4) var(--yn-space-5);
+  display: flex;
+  gap: var(--yn-space-3);
+  justify-content: center;
+  z-index: var(--yn-z-sticky);
+  border-radius: var(--yn-radius-card-lg) var(--yn-radius-card-lg) 0 0;
 
-.ingredients-section,
+  @include bp.respond-to('md') {
+    display: none;
+  }
+}
+
+// ── Glass ingredient section ──
+.ingredients-section {
+  @include glass.glass-card;
+  padding: var(--yn-space-6);
+  margin-bottom: var(--yn-space-7);
+  border-left: 3px solid var(--yn-primary);
+
+  h2 {
+    margin: 0 0 var(--yn-space-5);
+    font-size: var(--yn-text-2xl);
+    font-weight: var(--yn-font-semibold);
+  }
+}
+
+// ── Steps section ──
 .steps-section {
   margin-bottom: var(--yn-space-8);
 
@@ -206,21 +273,21 @@
   color: var(--yn-text);
 }
 
+// ── Glass step cards ──
 .steps-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  counter-reset: step-counter;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-4);
 
   li {
+    @include glass.glass-surface(0);
     display: flex;
     gap: var(--yn-space-5);
-    padding: var(--yn-space-5) 0;
-    border-bottom: 1px solid var(--yn-border-light);
-
-    &:last-child {
-      border-bottom: none;
-    }
+    padding: var(--yn-space-5);
+    border-radius: var(--yn-radius-card);
   }
 }
 
@@ -233,7 +300,7 @@
   height: 2rem;
   border-radius: var(--yn-radius-circle);
   background: var(--yn-primary);
-  color: var(--yn-surface);
+  color: var(--yn-text-inverse);
   font-size: var(--yn-text-base);
   font-weight: var(--yn-font-semibold);
 }

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -134,7 +134,9 @@ describe('RecipeDetailComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const title = fixture.nativeElement.querySelector('.recipe-title');
+    const title =
+      fixture.nativeElement.querySelector('.hero-title') ??
+      fixture.nativeElement.querySelector('.recipe-title');
     expect(title.textContent).toContain('Pasta Carbonara');
   }));
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -113,6 +113,10 @@
   <div #scrollSentinel class="scroll-sentinel"></div>
 
   @if (isLoading()) {
-    <yn-loading-spinner label="recipes.list.loading" />
+    <div class="skeleton-grid">
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+    </div>
   }
 </div>

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -1,4 +1,5 @@
 @use 'banners';
+@use 'glass';
 
 .recipe-list-container {
   max-width: 1200px;
@@ -28,16 +29,22 @@
   align-items: center;
   gap: var(--yn-space-3);
   padding: var(--yn-space-3) var(--yn-space-4);
-  border: 1px solid var(--yn-border);
-  border-radius: var(--yn-radius-md);
-  background: var(--yn-surface);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   font-size: var(--yn-text-base);
   cursor: pointer;
   white-space: nowrap;
   outline: none;
+  transition:
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    background var(--yn-duration-fast) var(--yn-ease-glass);
 
   &:hover {
     border-color: var(--yn-primary);
+    background: var(--yn-glass-bg-elevated);
   }
 
   &:focus-visible {
@@ -48,26 +55,33 @@
 
 .sort-chevron {
   font-size: 0.625rem;
-  transition: transform 0.2s ease;
+  transition: transform var(--yn-duration-fast) var(--yn-ease-glass);
 
   &.open {
     transform: rotate(180deg);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .sort-menu {
+  @include glass.glass-surface(2);
   position: absolute;
   right: 0;
   top: calc(100% + 4px);
   margin: 0;
   padding: var(--yn-space-1) 0;
   list-style: none;
-  background: var(--yn-surface);
-  border: 1px solid var(--yn-border);
   border-radius: var(--yn-radius-md);
-  box-shadow: var(--yn-shadow-lg);
   min-width: 100%;
   z-index: var(--yn-z-dropdown);
+  animation: yn-scale-up var(--yn-duration-fast) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 .sort-menu-item {
@@ -77,7 +91,7 @@
   white-space: nowrap;
 
   &:hover {
-    background: var(--yn-background-subtle);
+    background: var(--yn-glass-bg-elevated);
   }
 
   &.active {
@@ -86,6 +100,7 @@
   }
 }
 
+// ── Search bar with glass ──
 .search-bar {
   position: relative;
   margin-bottom: var(--yn-space-7);
@@ -111,12 +126,19 @@
 
 .search-input {
   width: 100%;
-  padding: var(--yn-space-2) var(--yn-space-4);
-  border: 1px solid var(--yn-border);
-  border-radius: var(--yn-radius-md);
-  font-size: var(--yn-text-base);
+  padding: var(--yn-space-4) var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+  font-size: var(--yn-text-md);
+  color: var(--yn-text);
   outline: none;
   box-sizing: border-box;
+  transition:
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    box-shadow var(--yn-duration-fast) var(--yn-ease-glass);
 
   &:focus {
     border-color: var(--yn-primary);
@@ -128,12 +150,12 @@
   }
 }
 
+// ── Empty state ──
 .empty-state {
+  @include glass.glass-card;
   text-align: center;
   padding: 4rem var(--yn-space-8);
-  background: var(--yn-surface);
-  border-radius: var(--yn-radius-card);
-  box-shadow: var(--yn-shadow-md);
+  animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
 
   h2 {
     margin: 0 0 var(--yn-space-3);
@@ -146,14 +168,18 @@
     color: var(--yn-text-muted);
     font-size: var(--yn-text-base);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 .cta-button {
   display: inline-block;
   padding: var(--yn-button-padding-y) var(--yn-button-padding-x);
-  border-radius: var(--yn-radius-md);
+  border-radius: var(--yn-radius-button);
   background: var(--yn-primary);
-  color: var(--yn-surface);
+  color: var(--yn-text-inverse);
   font-size: var(--yn-text-lg);
   font-weight: var(--yn-font-medium);
   text-decoration: none;
@@ -161,9 +187,11 @@
 
   &:hover {
     background: var(--yn-primary-hover);
+    box-shadow: var(--yn-shadow-primary-glow);
   }
 }
 
+// ── Recipe grid ──
 .recipe-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -171,10 +199,8 @@
 }
 
 .recipe-card {
+  @include glass.glass-card;
   display: block;
-  background: var(--yn-surface);
-  border-radius: var(--yn-radius-card);
-  box-shadow: var(--yn-shadow-md);
   overflow: hidden;
   transition:
     box-shadow var(--yn-duration-normal) var(--yn-ease-glass),
@@ -184,8 +210,8 @@
   cursor: pointer;
 
   &:hover {
-    box-shadow: var(--yn-shadow-card-hover);
-    transform: translateY(-2px);
+    box-shadow: var(--yn-elevation-2);
+    transform: translateY(-4px);
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -201,6 +227,7 @@
   width: 100%;
   height: 180px;
   object-fit: cover;
+  border-radius: var(--yn-radius-card) var(--yn-radius-card) 0 0;
 }
 
 .recipe-image-placeholder {
@@ -240,9 +267,37 @@
 .meta-item {
   font-size: var(--yn-text-sm);
   color: var(--yn-text-light);
-  background: var(--yn-background-subtle);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
   padding: var(--yn-space-1) var(--yn-space-3);
-  border-radius: var(--yn-radius-sm);
+  border-radius: var(--yn-radius-badge);
+}
+
+// ── Skeleton shimmer for infinite scroll loading ──
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--yn-space-7);
+  margin-top: var(--yn-space-7);
+}
+
+.skeleton-card {
+  height: 280px;
+  border-radius: var(--yn-radius-card);
+  background: linear-gradient(
+    90deg,
+    var(--yn-glass-bg) 25%,
+    var(--yn-glass-bg-elevated) 50%,
+    var(--yn-glass-bg) 75%
+  );
+  background-size: 200% 100%;
+  animation: yn-shimmer 1.5s ease-in-out infinite;
+  border: 1px solid var(--yn-glass-border-subtle);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background: var(--yn-glass-bg);
+  }
 }
 
 .scroll-sentinel {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
@@ -224,9 +224,8 @@ describe('RecipeListComponent', () => {
     setupTestBed(vi.fn().mockReturnValue(subject));
     fixture.detectChanges();
 
-    const loading = fixture.nativeElement.querySelector('.loading');
-    expect(loading).toBeTruthy();
-    expect(loading.textContent).toContain('Loading recipes...');
+    const skeleton = fixture.nativeElement.querySelector('.skeleton-grid');
+    expect(skeleton).toBeTruthy();
 
     subject.next(emptyResponse);
     subject.complete();


### PR DESCRIPTION
## Summary

### Recipe List
- Glass cards with hover lift (translateY -4px) and elevation-2 shadow
- Glass search bar with backdrop blur and ambient glow on focus
- Sort controls as glass pill buttons with scale-up dropdown animation
- Skeleton shimmer cards replace spinner for infinite scroll loading
- Glass empty state with fade-in animation
- Meta items as glass chips with subtle border

### Recipe Detail
- Hero image with glass gradient overlay showing title
- Glass metadata bar (glass-surface level 1) for servings/time/difficulty
- Ingredients section as glass card with left border accent
- Steps as individual glass step cards (glass-surface level 0)
- Tags as glass chips with backdrop blur
- Floating glass action bar on mobile (edit + shopping list)
- Desktop: inline action buttons (unchanged)

## Test plan
- [x] `nx build recipes` — compiles (budget raised to 16kb for detail styles)
- [x] `nx test recipes` — 85 tests pass
- [ ] Visual: glass cards with hover animation on recipe list
- [ ] Visual: hero overlay with title on recipe detail
- [ ] Visual: floating action bar on mobile viewport
- [ ] Dark mode: all glass surfaces switch correctly

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)