### PR TITLE
feat(shopping): glass redesign for shopping list views (US-262)

### DIFF
--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -48,7 +48,9 @@
       "errors": {
         "notFound": "Einkaufsliste nicht gefunden.",
         "generic": "Einkaufsliste konnte nicht geladen werden. Bitte versuche es später erneut."
-      }
+      },
+      "allDone": "Alles erledigt!",
+      "allDoneMessage": "Alles auf deiner Liste ist abgehakt."
     }
   }
 }

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -48,7 +48,9 @@
       "errors": {
         "notFound": "Shopping list not found.",
         "generic": "Failed to load shopping list. Please try again later."
-      }
+      },
+      "allDone": "All done!",
+      "allDoneMessage": "Everything on your list is checked off."
     }
   }
 }

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.scss
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.scss
@@ -1,5 +1,6 @@
 @use 'banners';
 @use 'buttons';
+@use 'glass';
 
 .shopping-create-container {
   max-width: 900px;
@@ -20,6 +21,9 @@ h1 {
 }
 
 .title-field {
+  @include glass.glass-surface(0);
+  padding: var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
   margin-bottom: var(--yn-space-7);
 
   label {
@@ -32,10 +36,14 @@ h1 {
 
   input {
     width: 100%;
-    padding: var(--yn-space-2) var(--yn-space-4);
-    border: 1px solid var(--yn-border);
-    border-radius: var(--yn-radius-md);
+    padding: var(--yn-space-3) var(--yn-space-4);
+    border: 1px solid var(--yn-glass-border);
+    border-radius: var(--yn-radius-input);
+    background: var(--yn-glass-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     font-size: var(--yn-text-md);
+    color: var(--yn-text);
     box-sizing: border-box;
 
     &:focus {
@@ -47,6 +55,8 @@ h1 {
 }
 
 .ingredients-section {
+  @include glass.glass-card;
+  padding: var(--yn-space-6);
   margin-bottom: var(--yn-space-8);
 }
 
@@ -104,8 +114,8 @@ h1 {
   cursor: pointer;
 
   input[type='checkbox'] {
-    width: 1.125rem;
-    height: 1.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
     accent-color: var(--yn-primary);
     cursor: pointer;
   }

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
@@ -12,8 +12,17 @@
   @if (shoppingList(); as list) {
     <h1>{{ list.title }}</h1>
 
+    <div class="progress-bar-container">
+      <div class="progress-text">{{ checkedCount() }} / {{ totalItemCount() }}</div>
+      <div class="progress-track">
+        <div
+          class="progress-fill"
+          [style.width.%]="totalItemCount() > 0 ? (checkedCount() / totalItemCount()) * 100 : 0"
+        ></div>
+      </div>
+    </div>
+
     <div class="actions">
-      <span class="progress">{{ checkedCount() }} / {{ totalItemCount() }}</span>
       <button class="btn-secondary" (click)="onCheckAll()">
         {{ t('shopping.detail.checkAll') }}
       </button>
@@ -21,6 +30,13 @@
         {{ t('shopping.detail.reset') }}
       </button>
     </div>
+
+    @if (checkedCount() === totalItemCount() && totalItemCount() > 0) {
+      <div class="all-done">
+        <h2>{{ t('shopping.detail.allDone') }}</h2>
+        <p>{{ t('shopping.detail.allDoneMessage') }}</p>
+      </div>
+    }
 
     <ul class="items-list">
       @for (item of list.items; track item.identifier) {

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.scss
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.scss
@@ -1,5 +1,6 @@
 @use 'banners';
 @use 'buttons';
+@use 'glass';
 
 .shopping-detail-container {
   max-width: 900px;
@@ -26,41 +27,85 @@ h1 {
   margin-bottom: var(--yn-space-5);
 }
 
-.progress {
-  font-size: var(--yn-text-base);
-  color: var(--yn-text-muted);
-  margin-right: auto;
+// ── Glass progress bar ──
+.progress-bar-container {
+  @include glass.glass-surface(0);
+  padding: var(--yn-space-4) var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
+  margin-bottom: var(--yn-space-6);
 }
 
+.progress-text {
+  font-size: var(--yn-text-base);
+  color: var(--yn-text-muted);
+  margin-bottom: var(--yn-space-3);
+}
+
+.progress-track {
+  height: 6px;
+  border-radius: var(--yn-radius-full);
+  background: var(--yn-glass-bg);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: var(--yn-radius-full);
+  background: var(--yn-primary);
+  transition: width var(--yn-duration-normal) var(--yn-ease-spring);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+// ── Items list ──
 .items-list {
+  @include glass.glass-card;
   list-style: none;
-  padding: 0;
+  padding: var(--yn-space-5);
   margin: 0 0 var(--yn-space-8);
 
   li {
     display: flex;
     align-items: center;
     gap: var(--yn-space-3);
-    padding: var(--yn-space-3) 0;
+    padding: var(--yn-space-4) var(--yn-space-3);
     border-bottom: 1px solid var(--yn-border-light);
     font-size: var(--yn-text-md);
     cursor: pointer;
+    border-radius: var(--yn-radius-md);
+    transition:
+      background var(--yn-duration-fast) var(--yn-ease-glass),
+      opacity var(--yn-duration-normal) var(--yn-ease-glass);
 
     &:last-child {
       border-bottom: none;
     }
 
-    &.checked .item-name,
-    &.checked .item-amount,
-    &.checked .item-unit {
-      text-decoration: line-through;
-      color: var(--yn-text-light);
+    &:hover {
+      background: var(--yn-glass-bg);
+    }
+
+    &.checked {
+      opacity: 0.5;
+
+      .item-name,
+      .item-amount,
+      .item-unit {
+        text-decoration: line-through;
+        color: var(--yn-text-light);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
     }
   }
 
   input[type='checkbox'] {
-    width: 1.125rem;
-    height: 1.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
     accent-color: var(--yn-primary);
     cursor: pointer;
     flex-shrink: 0;
@@ -95,5 +140,29 @@ h1 {
     &:hover {
       text-decoration: underline;
     }
+  }
+}
+
+// ── All done celebration ──
+.all-done {
+  @include glass.glass-card;
+  text-align: center;
+  padding: var(--yn-space-8);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  h2 {
+    margin: 0 0 var(--yn-space-3);
+    font-size: var(--yn-text-2xl);
+    color: var(--yn-success);
+  }
+
+  p {
+    margin: 0;
+    color: var(--yn-text-muted);
+    font-size: var(--yn-text-base);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.scss
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.scss
@@ -1,4 +1,5 @@
 @use 'banners';
+@use 'glass';
 
 .shopping-list-container {
   max-width: 900px;
@@ -17,9 +18,10 @@ h1 {
 }
 
 .empty-state {
+  @include glass.glass-card;
   text-align: center;
   padding: 4rem var(--yn-space-5);
-  color: var(--yn-text-light);
+  animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
 
   h2 {
     margin: 0 0 var(--yn-space-3);
@@ -31,6 +33,11 @@ h1 {
   p {
     margin: 0;
     font-size: var(--yn-text-md);
+    color: var(--yn-text-light);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 
@@ -41,17 +48,26 @@ h1 {
 }
 
 .list-card {
+  @include glass.glass-card;
   display: block;
   padding: var(--yn-card-padding-sm);
-  background: var(--yn-surface);
-  border-radius: var(--yn-radius-card);
-  box-shadow: var(--yn-shadow-md);
   text-decoration: none;
   color: inherit;
-  transition: box-shadow 0.2s;
+  transition:
+    box-shadow var(--yn-duration-normal) var(--yn-ease-glass),
+    transform var(--yn-duration-normal) var(--yn-ease-spring);
 
   &:hover {
-    box-shadow: var(--yn-shadow-card-hover);
+    box-shadow: var(--yn-elevation-2);
+    transform: translateY(-2px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- **Overview**: Glass cards with hover lift animation for shopping lists
- **Detail**: Glass progress bar with animated fill, glass items list with hover highlight, checked items fade to 50% opacity, "All done!" celebration card with scale-up animation
- **Create**: Glass title field with backdrop blur, glass ingredients section card
- EN + DE translations for "All done!" celebration

## Test plan
- [x] `nx build shopping` — compiles
- [x] `nx test shopping` — 24 tests pass
- [ ] Visual: glass progress bar fills as items are checked
- [ ] Visual: checked items fade with transition
- [ ] Visual: "All done!" card appears when all checked
- [ ] Dark mode: all glass surfaces correct

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)