### PR TITLE
feat(shell): glass auth flow with ambient background (US-263)

### DIFF
--- a/client/apps/shell/src/app/auth/login/login.component.scss
+++ b/client/apps/shell/src/app/auth/login/login.component.scss
@@ -21,6 +21,7 @@
     width: 1rem;
     height: 1rem;
     cursor: pointer;
+    accent-color: var(--yn-primary);
   }
 }
 
@@ -36,12 +37,15 @@ button {
   font-size: var(--yn-text-base);
 
   a {
-    color: var(--yn-link);
+    color: var(--yn-text-muted);
     text-decoration: none;
     cursor: pointer;
+    padding: var(--yn-space-1) var(--yn-space-3);
+    border-radius: var(--yn-radius-badge);
+    transition: color var(--yn-duration-fast) var(--yn-ease-glass);
 
     &:hover {
-      text-decoration: underline;
+      color: var(--yn-primary);
     }
   }
 }

--- a/client/apps/shell/src/app/auth/register/register.component.scss
+++ b/client/apps/shell/src/app/auth/register/register.component.scss
@@ -2,40 +2,22 @@
 @use 'forms';
 @use 'buttons';
 @use 'cards';
+@use 'glass';
 
 .register-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  padding: var(--yn-space-5);
-  background-color: var(--yn-background);
+  @extend .auth-container;
 }
 
 .register-card {
-  width: 100%;
-  max-width: 420px;
-  padding: var(--yn-space-8);
-  background: var(--yn-surface);
-  border-radius: var(--yn-radius-md);
-  box-shadow: var(--yn-shadow-md);
-
-  h1 {
-    margin: 0 0 var(--yn-space-1);
-    font-size: var(--yn-text-4xl);
-    font-weight: var(--yn-font-semibold);
-  }
-
-  .subtitle {
-    margin: 0 0 var(--yn-space-7);
-    color: var(--yn-text-muted);
-    font-size: var(--yn-text-base);
-  }
+  @extend .auth-card;
 }
 
 .success-message {
+  @include glass.glass-surface(1);
   text-align: center;
-  padding: var(--yn-space-5) 0;
+  padding: var(--yn-space-6);
+  border-radius: var(--yn-radius-card);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
 
   h2 {
     margin: 0 0 var(--yn-space-3);
@@ -47,6 +29,10 @@
     color: var(--yn-text-muted);
     font-size: var(--yn-text-base);
     line-height: var(--yn-leading-normal);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
@@ -2,38 +2,23 @@
 @use 'forms';
 @use 'buttons';
 @use 'cards';
+@use 'glass';
 
 .resend-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  padding: var(--yn-space-5);
+  @extend .auth-container;
 }
 
 .resend-card {
-  width: 100%;
-  max-width: 420px;
-  padding: var(--yn-space-8);
-  border-radius: var(--yn-radius-md);
-  box-shadow: var(--yn-shadow-md);
-  background: var(--yn-surface);
-
-  h1 {
-    margin: 0 0 var(--yn-space-1);
-    font-size: var(--yn-text-4xl);
-  }
-
-  .subtitle {
-    margin: 0 0 var(--yn-space-7);
-    color: var(--yn-text-muted);
-    font-size: var(--yn-text-md);
-  }
+  @extend .auth-card;
 }
 
 .success-message {
+  @include glass.glass-surface(1);
   text-align: center;
+  padding: var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
   color: var(--yn-success);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
 
   h2 {
     margin: 0 0 var(--yn-space-3);
@@ -41,6 +26,10 @@
 
   p {
     margin: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 

--- a/client/libs/ui/src/lib/styles/_cards.scss
+++ b/client/libs/ui/src/lib/styles/_cards.scss
@@ -27,11 +27,24 @@
   }
 }
 
+.auth-card {
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
 .auth-container {
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: 100vh;
   padding: var(--yn-space-5);
-  background-color: var(--yn-background);
+  position: relative;
+  background:
+    radial-gradient(ellipse 500px 500px at 15% 25%, var(--yn-ambient-orb-1), transparent),
+    radial-gradient(ellipse 400px 400px at 80% 65%, var(--yn-ambient-orb-2), transparent),
+    radial-gradient(ellipse 350px 350px at 50% 85%, var(--yn-ambient-orb-3), transparent),
+    var(--yn-background);
 }


### PR DESCRIPTION
## Summary
- Auth container: full-screen ambient gradient orbs (3 orbs) behind glass cards
- Auth card: scale-up entrance animation with spring easing
- Register + resend-verification cards now extend shared `.auth-card` glass pattern (DRY)
- Success messages use glass surface with scale-up animation
- Login: subtle forgot-password hover, checkbox accent color matches brand
- All respects `prefers-reduced-motion`

## Test plan
- [x] `nx build shell` — compiles
- [x] `nx test shell` — 199 tests pass
- [ ] Visual: login page shows ambient orbs behind glass card
- [ ] Visual: card scales up on page load
- [ ] Visual: dark mode — deeper orbs, glass card correct
- [ ] Mobile: full-width card layout

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)