### PR TITLE
feat(shell): enhance PWA share intent with toast and error handling (US-265)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -293,6 +293,11 @@
         "recipe_deleted": "Rezept gel�scht",
         "shopping_list_created": "Einkaufsliste erstellt"
       }
+    },
+    "share": {
+      "toastTitle": "Rezept geteilt",
+      "dismiss": "Schließen",
+      "noUrlFound": "Keine Rezept-URL im geteilten Text gefunden."
     }
   },
   "units": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -293,6 +293,11 @@
         "recipe_deleted": "Deleted a recipe",
         "shopping_list_created": "Created a shopping list"
       }
+    },
+    "share": {
+      "toastTitle": "Recipe shared",
+      "dismiss": "Dismiss",
+      "noUrlFound": "No recipe URL found in the shared text."
     }
   },
   "units": {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,23 @@
 <div class="dashboard-container" *transloco="let t">
+  @if (shareToast(); as sharedUrl) {
+    <div class="share-toast" role="status" aria-live="polite">
+      <div class="share-toast-content">
+        <span class="share-toast-icon">&#x2192;</span>
+        <div class="share-toast-text">
+          <strong>{{ t('dashboard.share.toastTitle') }}</strong>
+          <span class="share-toast-url">{{ sharedUrl }}</span>
+        </div>
+      </div>
+      <button
+        class="share-toast-dismiss"
+        (click)="dismissShareToast()"
+        [attr.aria-label]="t('dashboard.share.dismiss')"
+      >
+        &times;
+      </button>
+    </div>
+  }
+
   <h1>{{ t('dashboard.title') }}</h1>
   <p>{{ t('dashboard.welcome') }}</p>
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -373,3 +373,69 @@
     }
   }
 }
+
+// ── Share Toast (US-265) ──
+.share-toast {
+  @include glass.glass-surface(2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--yn-space-4);
+  padding: var(--yn-space-4) var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
+  border-left: 3px solid var(--yn-primary);
+  margin-bottom: var(--yn-space-5);
+  animation: yn-slide-in-down var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.share-toast-content {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-4);
+  min-width: 0;
+  flex: 1;
+}
+
+.share-toast-icon {
+  font-size: var(--yn-text-2xl);
+  color: var(--yn-primary);
+  flex-shrink: 0;
+}
+
+.share-toast-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+
+  strong {
+    font-size: var(--yn-text-base);
+    color: var(--yn-text);
+  }
+}
+
+.share-toast-url {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-toast-dismiss {
+  background: none;
+  border: none;
+  font-size: var(--yn-text-3xl);
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  padding: 0 var(--yn-space-2);
+  line-height: var(--yn-leading-none);
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--yn-text);
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -117,7 +117,10 @@ describe('DashboardComponent', () => {
     saveRecipe: ReturnType<typeof vi.fn>;
   };
   let routerMock: { navigate: ReturnType<typeof vi.fn> };
-  let activatedRouteMock: { snapshot: { queryParams: Record<string, string> } };
+  let activatedRouteMock: {
+    snapshot: { queryParams: Record<string, string> };
+    queryParams: import('rxjs').Observable<Record<string, string>>;
+  };
 
   beforeEach(async () => {
     recipeApiMock = {
@@ -126,7 +129,7 @@ describe('DashboardComponent', () => {
       saveRecipe: vi.fn(),
     };
     routerMock = { navigate: vi.fn() };
-    activatedRouteMock = { snapshot: { queryParams: {} } };
+    activatedRouteMock = { snapshot: { queryParams: {} }, queryParams: of({}) };
 
     const dashboardApiMock = {
       getSuggestions: vi.fn().mockReturnValue(of({ suggestions: [], quickActions: [] })),
@@ -1010,7 +1013,10 @@ describe('DashboardComponent – Share Intent', () => {
         { provide: RecipeApiService, useValue: recipeApiMock },
         { provide: DashboardApiService, useValue: dashboardMock },
         { provide: Router, useValue: routerMock },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParams } } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParams }, queryParams: of(queryParams) },
+        },
       ],
     });
 
@@ -1110,4 +1116,52 @@ describe('DashboardComponent – Share Intent', () => {
 
     expect(recipeApiMock.importRecipeStream).not.toHaveBeenCalled();
   });
+
+  it('should show share toast when URL is shared', fakeAsync(() => {
+    const { fixture, component } = createComponentWithQueryParams({
+      url: 'https://example.com/recipe',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.shareToast()).toBe('https://example.com/recipe');
+  }));
+
+  it('should expand import section when URL is shared', fakeAsync(() => {
+    const { fixture, component } = createComponentWithQueryParams({
+      url: 'https://example.com/recipe',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.importSectionExpanded()).toBe(true);
+  }));
+
+  it('should show error when shared text contains no URL', fakeAsync(() => {
+    const { fixture, component } = createComponentWithQueryParams({
+      text: 'Just some text without a link',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.serverError()).toBe('dashboard.share.noUrlFound');
+    expect(component.importSectionExpanded()).toBe(true);
+    expect(recipeApiMock.importRecipeStream).not.toHaveBeenCalled();
+  }));
+
+  it('should dismiss share toast when dismissShareToast is called', fakeAsync(() => {
+    const { fixture, component } = createComponentWithQueryParams({
+      url: 'https://example.com/recipe',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.shareToast()).toBeTruthy();
+    component.dismissShareToast();
+    expect(component.shareToast()).toBeNull();
+  }));
 });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -89,6 +89,7 @@ export class DashboardComponent implements OnInit {
   streamingChunks = signal('');
   importSectionExpanded = signal(false);
   cameraActive = signal(false);
+  shareToast = signal<string | null>(null);
 
   // Smart dashboard state
   quickActions = signal<QuickAction[]>([]);
@@ -108,16 +109,37 @@ export class DashboardComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    const params = this.route.snapshot.queryParams;
-    const sharedUrl = params['url'] || this.extractUrl(params['text']);
-
-    if (sharedUrl) {
-      this.form.controls.url.setValue(sharedUrl);
-      this.importSectionExpanded.set(true);
-      this.onImport();
-    }
-
     this.loadDashboardData();
+
+    // Subscribe to query params so subsequent shares (when app already open) also work
+    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
+      const urlParam = params['url'] as string | undefined;
+      const textParam = params['text'] as string | undefined;
+      const sharedText = urlParam || textParam;
+
+      if (!sharedText) return;
+
+      const sharedUrl = urlParam || this.extractUrl(textParam);
+
+      if (sharedUrl) {
+        this.handleSharedUrl(sharedUrl);
+      } else if (textParam) {
+        // Shared text without a recognizable URL
+        this.serverError.set('dashboard.share.noUrlFound');
+        this.importSectionExpanded.set(true);
+      }
+    });
+  }
+
+  private handleSharedUrl(sharedUrl: string): void {
+    this.form.controls.url.setValue(sharedUrl);
+    this.importSectionExpanded.set(true);
+    this.shareToast.set(sharedUrl);
+    this.onImport();
+  }
+
+  dismissShareToast(): void {
+    this.shareToast.set(null);
   }
 
   toggleImportSection(): void {


### PR DESCRIPTION
## Summary
- Subscribe to `ActivatedRoute.queryParams` stream so subsequent shares trigger handling even when dashboard is already mounted (PWA single instance behavior)
- Glass share toast notification with slide-in-down spring animation showing the received URL
- Auto-expand import section on share
- Inline error when shared text contains no recognizable URL (instead of silently failing)
- Dismiss button on share toast
- EN + DE translations
- 4 new tests for share intent enhancements

The PWA `share_target` manifest entry was already in place from US-124. This story adds the missing UX polish, error handling, and stream-based handling for in-app shares.

## Test plan
- [x] `nx build shell` — compiles
- [x] `nx test shell` — 203 tests pass (199 existing + 4 new share tests)
- [x] `prettier --check` — formatted
- [ ] Visual: share URL from another app — toast appears with slide-in animation
- [ ] Visual: share text without URL — error banner appears
- [ ] Visual: dismiss button removes toast

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)