### PR TITLE
feat: AI ingredient recognition from camera (US-251)

### DIFF
--- a/client/apps/shell/project.json
+++ b/client/apps/shell/project.json
@@ -58,8 +58,8 @@
             },
             {
               "type": "anyComponentStyle",
-              "maximumWarning": "8kb",
-              "maximumError": "16kb"
+              "maximumWarning": "10kb",
+              "maximumError": "20kb"
             }
           ],
           "outputHashing": "all"

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -225,7 +225,8 @@
       "submit": "Fotos hochladen",
       "extracting": "Rezept wird extrahiert...",
       "hint": "JPG, PNG oder WebP. Bis zu 10 Bilder, max. 10 MB pro Bild.",
-      "scanRecipe": "Mit Kamera scannen"
+      "scanRecipe": "Mit Kamera scannen",
+      "scanIngredients": "Zutaten scannen"
     },
     "create": {
       "title": "Rezept erstellen",
@@ -298,6 +299,10 @@
       "toastTitle": "Rezept geteilt",
       "dismiss": "Schließen",
       "noUrlFound": "Keine Rezept-URL im geteilten Text gefunden."
+    },
+    "scanner": {
+      "foundIngredients": "{{count}} Zutaten erkannt",
+      "dismiss": "Schließen"
     }
   },
   "units": {
@@ -343,6 +348,19 @@
       "notSupported": "Kamera wird auf diesem Gerät nicht unterstützt",
       "permissionDenied": "Kamera-Zugriff verweigert",
       "captureFailed": "Foto konnte nicht aufgenommen werden"
+    }
+  },
+  "scanner": {
+    "scan": "Scannen",
+    "cancel": "Abbrechen",
+    "removeIngredient": "Zutat entfernen",
+    "useIngredients": "{{count}} Zutaten verwenden",
+    "errors": {
+      "notSupported": "Kamera wird auf diesem Gerät nicht unterstützt",
+      "permissionDenied": "Kamera-Zugriff verweigert",
+      "captureFailed": "Bild konnte nicht aufgenommen werden",
+      "recognitionFailed": "Zutaten konnten nicht erkannt werden. Bitte erneut versuchen.",
+      "nothingDetected": "Keine Zutaten erkannt. Bessere Beleuchtung oder näher rangehen."
     }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -225,7 +225,8 @@
       "submit": "Upload Photos",
       "extracting": "Extracting recipe...",
       "hint": "JPG, PNG or WebP. Up to 10 images, max 10 MB each.",
-      "scanRecipe": "Scan with camera"
+      "scanRecipe": "Scan with camera",
+      "scanIngredients": "Scan ingredients"
     },
     "create": {
       "title": "Create a Recipe",
@@ -298,6 +299,10 @@
       "toastTitle": "Recipe shared",
       "dismiss": "Dismiss",
       "noUrlFound": "No recipe URL found in the shared text."
+    },
+    "scanner": {
+      "foundIngredients": "Found {{count}} ingredients",
+      "dismiss": "Dismiss"
     }
   },
   "units": {
@@ -343,6 +348,19 @@
       "notSupported": "Camera not supported on this device",
       "permissionDenied": "Camera permission denied",
       "captureFailed": "Failed to capture photo"
+    }
+  },
+  "scanner": {
+    "scan": "Scan",
+    "cancel": "Cancel",
+    "removeIngredient": "Remove ingredient",
+    "useIngredients": "Use {{count}} ingredients",
+    "errors": {
+      "notSupported": "Camera not supported on this device",
+      "permissionDenied": "Camera permission denied",
+      "captureFailed": "Failed to capture frame",
+      "recognitionFailed": "Could not recognize ingredients. Please try again.",
+      "nothingDetected": "No ingredients detected. Try better lighting or move closer."
     }
   }
 }

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -122,6 +122,14 @@
               >
                 {{ t('dashboard.photoImport.scanRecipe') }}
               </button>
+              <button
+                type="button"
+                class="btn-dashed"
+                [disabled]="isLoading() || isSaving()"
+                (click)="onOpenScanner()"
+              >
+                {{ t('dashboard.photoImport.scanIngredients') }}
+              </button>
             }
             <label class="btn-dashed" [class.disabled]="isLoading() || isSaving()">
               <input
@@ -192,5 +200,34 @@
       (cancelled)="onCameraCancelled()"
       (fallbackRequested)="onCameraFallback()"
     />
+  }
+
+  @if (scannerActive()) {
+    <yn-ingredient-scanner
+      (ingredientsConfirmed)="onIngredientsConfirmed($event)"
+      (cancelled)="onScannerCancelled()"
+    />
+  }
+
+  @if (recognizedIngredients(); as ingredients) {
+    <div class="recognized-ingredients-toast" role="status" aria-live="polite">
+      <div class="recognized-ingredients-content">
+        <strong>{{
+          t('dashboard.scanner.foundIngredients', { count: ingredients.length })
+        }}</strong>
+        <div class="recognized-ingredients-chips">
+          @for (item of ingredients; track item.name) {
+            <span class="recognized-chip">{{ item.name }}</span>
+          }
+        </div>
+      </div>
+      <button
+        class="recognized-dismiss"
+        (click)="dismissRecognizedIngredients()"
+        [attr.aria-label]="t('dashboard.scanner.dismiss')"
+      >
+        &times;
+      </button>
+    </div>
   }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -439,3 +439,64 @@
     color: var(--yn-text);
   }
 }
+
+// ── Recognized Ingredients Toast (US-251) ──
+.recognized-ingredients-toast {
+  @include glass.glass-surface(2);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--yn-space-4);
+  padding: var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
+  border-left: 3px solid var(--yn-success);
+  margin-top: var(--yn-space-5);
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.recognized-ingredients-content {
+  flex: 1;
+  min-width: 0;
+
+  strong {
+    display: block;
+    font-size: var(--yn-text-base);
+    color: var(--yn-text);
+    margin-bottom: var(--yn-space-3);
+  }
+}
+
+.recognized-ingredients-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-2);
+}
+
+.recognized-chip {
+  display: inline-block;
+  padding: var(--yn-space-1) var(--yn-space-3);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+  color: var(--yn-text);
+  font-size: var(--yn-text-sm);
+}
+
+.recognized-dismiss {
+  background: none;
+  border: none;
+  font-size: var(--yn-text-3xl);
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  padding: 0 var(--yn-space-2);
+  line-height: var(--yn-leading-none);
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--yn-text);
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -35,8 +35,10 @@ import {
   SuggestionCardComponent,
   RecentActivityComponent,
   CameraCaptureComponent,
+  IngredientScannerComponent,
 } from '@yumney/ui';
 import { CameraService } from '@yumney/shared/models';
+import type { RecognizedIngredient } from '@yumney/shared/api-client';
 
 @Component({
   selector: 'yn-dashboard',
@@ -50,6 +52,7 @@ import { CameraService } from '@yumney/shared/models';
     SuggestionCardComponent,
     RecentActivityComponent,
     CameraCaptureComponent,
+    IngredientScannerComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -89,7 +92,9 @@ export class DashboardComponent implements OnInit {
   streamingChunks = signal('');
   importSectionExpanded = signal(false);
   cameraActive = signal(false);
+  scannerActive = signal(false);
   shareToast = signal<string | null>(null);
+  recognizedIngredients = signal<RecognizedIngredient[] | null>(null);
 
   // Smart dashboard state
   quickActions = signal<QuickAction[]>([]);
@@ -264,6 +269,23 @@ export class DashboardComponent implements OnInit {
 
   onCameraFallback(): void {
     this.cameraActive.set(false);
+  }
+
+  onOpenScanner(): void {
+    this.scannerActive.set(true);
+  }
+
+  onIngredientsConfirmed(ingredients: RecognizedIngredient[]): void {
+    this.scannerActive.set(false);
+    this.recognizedIngredients.set(ingredients);
+  }
+
+  onScannerCancelled(): void {
+    this.scannerActive.set(false);
+  }
+
+  dismissRecognizedIngredients(): void {
+    this.recognizedIngredients.set(null);
   }
 
   private importPhotos(photos: File[]): void {

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -27,3 +27,7 @@ export type { ShoppingListSummary } from './lib/shopping-list-summary';
 export { DashboardApiService } from './lib/dashboard-api.service';
 export type { UserActivityItem } from './lib/user-activity';
 export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';
+export type {
+  RecognizedIngredient,
+  RecognizedIngredientsResponse,
+} from './lib/recognized-ingredient';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -7,6 +7,7 @@ export const API_ENDPOINTS = {
     importStream: (url: string) =>
       `${API_BASE}/recipes/import/stream?url=${encodeURIComponent(url)}`,
     importFromPhotos: `${API_BASE}/recipes/import-from-photos`,
+    recognizeIngredients: `${API_BASE}/recipes/recognize-ingredients`,
     byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
   },
   shoppingLists: {

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -12,6 +12,7 @@ import type { SavedRecipeResponse } from './saved-recipe-response';
 import type { RecipeDetail } from './recipe-detail';
 import type { RecipeListResponse } from './recipe-list-response';
 import type { GetRecipesParams } from './get-recipes-params';
+import type { RecognizedIngredientsResponse } from './recognized-ingredient';
 
 @Injectable({ providedIn: 'root' })
 export class RecipeApiService {
@@ -112,6 +113,15 @@ export class RecipeApiService {
       formData.append('photos', photo);
     }
     return this.http.post<ImportRecipeResponse>(API_ENDPOINTS.recipes.importFromPhotos, formData);
+  }
+
+  recognizeIngredients(photo: Blob): Observable<RecognizedIngredientsResponse> {
+    const formData = new FormData();
+    formData.append('photo', photo, 'scan.jpg');
+    return this.http.post<RecognizedIngredientsResponse>(
+      API_ENDPOINTS.recipes.recognizeIngredients,
+      formData,
+    );
   }
 
   saveRecipe(request: SaveRecipeRequest): Observable<SavedRecipeResponse> {

--- a/client/libs/shared/api-client/src/lib/recognized-ingredient.ts
+++ b/client/libs/shared/api-client/src/lib/recognized-ingredient.ts
@@ -1,0 +1,9 @@
+export interface RecognizedIngredient {
+  name: string;
+  confidence: number;
+  category: string | null;
+}
+
+export interface RecognizedIngredientsResponse {
+  ingredients: RecognizedIngredient[];
+}

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -27,3 +27,4 @@ export {
 export { ROUTES } from './lib/route-paths';
 export { ThemeService, type Theme } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
+export { IngredientRecognitionService } from './lib/ingredient-recognition.service';

--- a/client/libs/shared/models/src/lib/ingredient-recognition.service.spec.ts
+++ b/client/libs/shared/models/src/lib/ingredient-recognition.service.spec.ts
@@ -1,0 +1,110 @@
+import { IngredientRecognitionService } from './ingredient-recognition.service';
+import type { RecognizedIngredient } from '@yumney/shared/api-client';
+
+describe('IngredientRecognitionService', () => {
+  let service: IngredientRecognitionService;
+
+  beforeEach(() => {
+    // Use Object.create to bypass DI — we only test pure methods
+    service = Object.create(IngredientRecognitionService.prototype) as IngredientRecognitionService;
+  });
+
+  describe('mergeIngredients', () => {
+    it('should add new ingredients to an empty list', () => {
+      const incoming: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.9, category: 'produce' },
+        { name: 'Onion', confidence: 0.8, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients([], incoming);
+
+      expect(result.length).toBe(2);
+      expect(result[0].name).toBe('Tomato');
+    });
+
+    it('should deduplicate by case-insensitive name', () => {
+      const existing: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.7, category: 'produce' },
+      ];
+      const incoming: RecognizedIngredient[] = [
+        { name: 'tomato', confidence: 0.9, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients(existing, incoming);
+
+      expect(result.length).toBe(1);
+    });
+
+    it('should keep the higher confidence on duplicate', () => {
+      const existing: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.6, category: 'produce' },
+      ];
+      const incoming: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.95, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients(existing, incoming);
+
+      expect(result[0].confidence).toBe(0.95);
+    });
+
+    it('should not lower confidence on duplicate with lower score', () => {
+      const existing: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.95, category: 'produce' },
+      ];
+      const incoming: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.6, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients(existing, incoming);
+
+      expect(result[0].confidence).toBe(0.95);
+    });
+
+    it('should sort results by confidence descending', () => {
+      const incoming: RecognizedIngredient[] = [
+        { name: 'Onion', confidence: 0.5, category: 'produce' },
+        { name: 'Tomato', confidence: 0.9, category: 'produce' },
+        { name: 'Garlic', confidence: 0.7, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients([], incoming);
+
+      expect(result.map((i) => i.name)).toEqual(['Tomato', 'Garlic', 'Onion']);
+    });
+
+    it('should merge mixed existing and incoming items', () => {
+      const existing: RecognizedIngredient[] = [
+        { name: 'Tomato', confidence: 0.9, category: 'produce' },
+        { name: 'Onion', confidence: 0.8, category: 'produce' },
+      ];
+      const incoming: RecognizedIngredient[] = [
+        { name: 'Garlic', confidence: 0.7, category: 'produce' },
+        { name: 'Tomato', confidence: 0.85, category: 'produce' },
+      ];
+
+      const result = service.mergeIngredients(existing, incoming);
+
+      expect(result.length).toBe(3);
+      expect(result.find((i) => i.name === 'Tomato')?.confidence).toBe(0.9);
+    });
+  });
+
+  describe('confidenceLevel', () => {
+    it('should classify high confidence at 0.8 and above', () => {
+      expect(service.confidenceLevel(0.9)).toBe('high');
+      expect(service.confidenceLevel(0.8)).toBe('high');
+      expect(service.confidenceLevel(1.0)).toBe('high');
+    });
+
+    it('should classify medium confidence between 0.5 and 0.8', () => {
+      expect(service.confidenceLevel(0.7)).toBe('medium');
+      expect(service.confidenceLevel(0.5)).toBe('medium');
+    });
+
+    it('should classify low confidence below 0.5', () => {
+      expect(service.confidenceLevel(0.4)).toBe('low');
+      expect(service.confidenceLevel(0.0)).toBe('low');
+    });
+  });
+});

--- a/client/libs/shared/models/src/lib/ingredient-recognition.service.ts
+++ b/client/libs/shared/models/src/lib/ingredient-recognition.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  RecipeApiService,
+  type RecognizedIngredientsResponse,
+  type RecognizedIngredient,
+} from '@yumney/shared/api-client';
+
+@Injectable({ providedIn: 'root' })
+export class IngredientRecognitionService {
+  private recipeApi = inject(RecipeApiService);
+
+  recognize(photo: Blob): Observable<RecognizedIngredientsResponse> {
+    return this.recipeApi.recognizeIngredients(photo);
+  }
+
+  /**
+   * Merge a new recognition result into an existing list, deduplicating by name
+   * (case-insensitive) and keeping the highest confidence score.
+   */
+  mergeIngredients(
+    existing: RecognizedIngredient[],
+    incoming: RecognizedIngredient[],
+  ): RecognizedIngredient[] {
+    const map = new Map<string, RecognizedIngredient>();
+
+    for (const item of existing) {
+      map.set(item.name.toLowerCase(), item);
+    }
+
+    for (const item of incoming) {
+      const key = item.name.toLowerCase();
+      const current = map.get(key);
+      if (!current || item.confidence > current.confidence) {
+        map.set(key, item);
+      }
+    }
+
+    return Array.from(map.values()).sort((a, b) => b.confidence - a.confidence);
+  }
+
+  /**
+   * Classify confidence score into a UI-friendly bucket.
+   */
+  confidenceLevel(confidence: number): 'high' | 'medium' | 'low' {
+    if (confidence >= 0.8) return 'high';
+    if (confidence >= 0.5) return 'medium';
+    return 'low';
+  }
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -34,3 +34,4 @@ export {
 } from './lib/recent-activity/recent-activity.component';
 
 export { CameraCaptureComponent } from './lib/camera-capture/camera-capture.component';
+export { IngredientScannerComponent } from './lib/ingredient-scanner/ingredient-scanner.component';

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.html
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.html
@@ -1,0 +1,52 @@
+<div class="ingredient-scanner" *transloco="let t">
+  <div class="viewfinder">
+    <video #video autoplay playsinline muted></video>
+
+    @if (ingredients().length > 0) {
+      <div class="results-overlay">
+        @for (item of ingredients(); track item.name) {
+          <div class="result-card" [class]="'confidence-' + confidenceLevel(item.confidence)">
+            <span class="result-name">{{ item.name }}</span>
+            <span class="result-confidence">{{ (item.confidence * 100).toFixed(0) }}%</span>
+            <button
+              class="result-remove"
+              (click)="onRemoveIngredient(item.name)"
+              [attr.aria-label]="t('scanner.removeIngredient')"
+            >
+              &times;
+            </button>
+          </div>
+        }
+      </div>
+    }
+
+    @if (error(); as err) {
+      <div class="scanner-error">{{ t(err) }}</div>
+    }
+  </div>
+
+  <div class="controls">
+    <button class="control-btn cancel-btn" (click)="onCancel()">
+      {{ t('scanner.cancel') }}
+    </button>
+    <button
+      class="scan-btn"
+      (click)="onScan()"
+      [disabled]="!isStreaming() || isScanning()"
+      [attr.aria-label]="t('scanner.scan')"
+    >
+      @if (isScanning()) {
+        <span class="scan-spinner"></span>
+      } @else {
+        {{ t('scanner.scan') }}
+      }
+    </button>
+    <button class="control-btn flip-btn" (click)="onToggleFacing()">&#x21bb;</button>
+  </div>
+
+  @if (ingredients().length > 0) {
+    <button class="confirm-btn btn-primary" (click)="onConfirm()">
+      {{ t('scanner.useIngredients', { count: ingredients().length }) }}
+    </button>
+  }
+</div>

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.scss
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.scss
@@ -1,0 +1,199 @@
+@use 'buttons';
+@use 'glass';
+
+.ingredient-scanner {
+  position: fixed;
+  inset: 0;
+  z-index: var(--yn-z-modal);
+  display: flex;
+  flex-direction: column;
+  background: #000;
+}
+
+// ── Viewfinder ──
+.viewfinder {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+
+  video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+// ── Results overlay ──
+.results-overlay {
+  position: absolute;
+  top: var(--yn-space-5);
+  left: var(--yn-space-5);
+  right: var(--yn-space-5);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-3);
+  max-height: 50%;
+  overflow-y: auto;
+}
+
+.result-card {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-radius: var(--yn-radius-badge);
+  background: rgb(255 255 255 / 15%);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+  border: 1px solid rgb(255 255 255 / 30%);
+  color: #fff;
+  animation: yn-scale-up var(--yn-duration-fast) var(--yn-ease-spring) both;
+
+  &.confidence-high {
+    border-color: var(--yn-success);
+  }
+
+  &.confidence-medium {
+    border-color: var(--yn-warning);
+  }
+
+  &.confidence-low {
+    border-color: rgb(255 255 255 / 30%);
+    opacity: 0.7;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.result-name {
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+}
+
+.result-confidence {
+  font-size: var(--yn-text-xs);
+  opacity: 0.8;
+}
+
+.result-remove {
+  background: none;
+  border: none;
+  color: rgb(255 255 255 / 80%);
+  font-size: var(--yn-text-lg);
+  cursor: pointer;
+  padding: 0 var(--yn-space-1);
+  line-height: var(--yn-leading-none);
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+// ── Error ──
+.scanner-error {
+  position: absolute;
+  bottom: var(--yn-space-7);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border-radius: var(--yn-radius-card);
+  background: rgb(0 0 0 / 70%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: #fff;
+  font-size: var(--yn-text-sm);
+  text-align: center;
+}
+
+// ── Controls ──
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--yn-space-7) var(--yn-space-8);
+  background: rgb(0 0 0 / 80%);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+}
+
+.control-btn {
+  background: none;
+  border: 1px solid rgb(255 255 255 / 30%);
+  color: rgb(255 255 255 / 90%);
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border-radius: var(--yn-radius-badge);
+  font-size: var(--yn-text-base);
+  cursor: pointer;
+  transition: background var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    background: rgb(255 255 255 / 10%);
+  }
+}
+
+.flip-btn {
+  font-size: var(--yn-text-2xl);
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--yn-radius-circle);
+}
+
+.scan-btn {
+  min-width: 8rem;
+  padding: var(--yn-space-4) var(--yn-space-7);
+  border: none;
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-primary);
+  color: #fff;
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-semibold);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--yn-primary-hover);
+  }
+}
+
+.scan-spinner {
+  display: inline-block;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2.5px solid rgb(255 255 255 / 30%);
+  border-top-color: #fff;
+  border-radius: var(--yn-radius-circle);
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// ── Confirm button ──
+.confirm-btn {
+  position: absolute;
+  bottom: 8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 220px;
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.spec.ts
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.spec.ts
@@ -1,0 +1,249 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, throwError } from 'rxjs';
+import { IngredientScannerComponent } from './ingredient-scanner.component';
+import { CameraService, IngredientRecognitionService } from '@yumney/shared/models';
+import type {
+  RecognizedIngredient,
+  RecognizedIngredientsResponse,
+} from '@yumney/shared/api-client';
+
+const en = {
+  scanner: {
+    scan: 'Scan',
+    cancel: 'Cancel',
+    removeIngredient: 'Remove',
+    useIngredients: 'Use {{ count }} ingredients',
+    errors: {
+      notSupported: 'Not supported',
+      permissionDenied: 'Permission denied',
+      captureFailed: 'Capture failed',
+      recognitionFailed: 'Recognition failed',
+      nothingDetected: 'Nothing detected',
+    },
+  },
+};
+
+interface CameraServiceMock {
+  cameraSupported: ReturnType<typeof signal<boolean>>;
+  openCamera: ReturnType<typeof vi.fn>;
+  captureFrame: ReturnType<typeof vi.fn>;
+  stopCamera: ReturnType<typeof vi.fn>;
+}
+
+interface RecognitionServiceMock {
+  recognize: ReturnType<typeof vi.fn>;
+  mergeIngredients: ReturnType<typeof vi.fn>;
+  confidenceLevel: ReturnType<typeof vi.fn>;
+}
+
+function createCameraMock(): CameraServiceMock {
+  return {
+    cameraSupported: signal(true),
+    openCamera: vi.fn().mockReturnValue(of({ getTracks: () => [] } as unknown as MediaStream)),
+    captureFrame: vi.fn().mockResolvedValue(new Blob(['x'], { type: 'image/jpeg' })),
+    stopCamera: vi.fn(),
+  };
+}
+
+function createRecognitionMock(): RecognitionServiceMock {
+  return {
+    recognize: vi.fn().mockReturnValue(
+      of({
+        ingredients: [{ name: 'Tomato', confidence: 0.9, category: 'produce' }],
+      } satisfies RecognizedIngredientsResponse),
+    ),
+    mergeIngredients: vi
+      .fn()
+      .mockImplementation((existing: RecognizedIngredient[], incoming: RecognizedIngredient[]) => [
+        ...existing,
+        ...incoming,
+      ]),
+    confidenceLevel: vi.fn().mockReturnValue('high'),
+  };
+}
+
+async function setup(
+  cameraMock: CameraServiceMock,
+  recognitionMock: RecognitionServiceMock,
+): Promise<ComponentFixture<IngredientScannerComponent>> {
+  await TestBed.resetTestingModule()
+    .configureTestingModule({
+      imports: [
+        IngredientScannerComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: { availableLangs: ['en'], defaultLang: 'en' },
+        }),
+      ],
+      providers: [
+        { provide: CameraService, useValue: cameraMock },
+        { provide: IngredientRecognitionService, useValue: recognitionMock },
+      ],
+    })
+    .compileComponents();
+
+  return TestBed.createComponent(IngredientScannerComponent);
+}
+
+describe('IngredientScannerComponent', () => {
+  let fixture: ComponentFixture<IngredientScannerComponent>;
+  let cameraMock: CameraServiceMock;
+  let recognitionMock: RecognitionServiceMock;
+
+  beforeEach(async () => {
+    cameraMock = createCameraMock();
+    recognitionMock = createRecognitionMock();
+    fixture = await setup(cameraMock, recognitionMock);
+  });
+
+  describe('initialization', () => {
+    it('should create the component', () => {
+      expect(fixture.componentInstance).toBeTruthy();
+    });
+
+    it('should request camera stream when supported', () => {
+      fixture.detectChanges();
+      expect(cameraMock.openCamera).toHaveBeenCalledWith('environment');
+    });
+
+    it('should set error when camera is not supported', async () => {
+      cameraMock.cameraSupported.set(false);
+      const noCamFixture = await setup(cameraMock, recognitionMock);
+      noCamFixture.detectChanges();
+      expect(noCamFixture.componentInstance['error']()).toBe('scanner.errors.notSupported');
+    });
+
+    it('should set error when permission is denied', async () => {
+      cameraMock.openCamera = vi.fn().mockReturnValue(throwError(() => new Error('denied')));
+      const errorFixture = await setup(cameraMock, recognitionMock);
+      errorFixture.detectChanges();
+      await Promise.resolve();
+      expect(errorFixture.componentInstance['error']()).toBe('scanner.errors.permissionDenied');
+    });
+  });
+
+  describe('scanning', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should capture and recognize on scan button click', async () => {
+      const scanBtn = fixture.nativeElement.querySelector('.scan-btn');
+      scanBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      fixture.detectChanges();
+
+      expect(cameraMock.captureFrame).toHaveBeenCalled();
+      expect(recognitionMock.recognize).toHaveBeenCalled();
+      expect(recognitionMock.mergeIngredients).toHaveBeenCalled();
+    });
+
+    it('should add detected ingredients to the list', async () => {
+      const scanBtn = fixture.nativeElement.querySelector('.scan-btn');
+      scanBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance['ingredients']().length).toBe(1);
+    });
+
+    it('should show error when nothing is detected', async () => {
+      recognitionMock.recognize = vi.fn().mockReturnValue(of({ ingredients: [] }));
+      const emptyFixture = await setup(cameraMock, recognitionMock);
+      emptyFixture.detectChanges();
+
+      const scanBtn = emptyFixture.nativeElement.querySelector('.scan-btn');
+      scanBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      emptyFixture.detectChanges();
+
+      expect(emptyFixture.componentInstance['error']()).toBe('scanner.errors.nothingDetected');
+    });
+
+    it('should show error when recognition API fails', async () => {
+      recognitionMock.recognize = vi.fn().mockReturnValue(throwError(() => new Error('fail')));
+      const failFixture = await setup(cameraMock, recognitionMock);
+      failFixture.detectChanges();
+
+      const scanBtn = failFixture.nativeElement.querySelector('.scan-btn');
+      scanBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      failFixture.detectChanges();
+
+      expect(failFixture.componentInstance['error']()).toBe('scanner.errors.recognitionFailed');
+    });
+  });
+
+  describe('ingredient management', () => {
+    beforeEach(async () => {
+      fixture.detectChanges();
+      const scanBtn = fixture.nativeElement.querySelector('.scan-btn');
+      scanBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      fixture.detectChanges();
+    });
+
+    it('should remove an ingredient when remove button is clicked', () => {
+      const removeBtn = fixture.nativeElement.querySelector('.result-remove');
+      removeBtn.click();
+      fixture.detectChanges();
+      expect(fixture.componentInstance['ingredients']().length).toBe(0);
+    });
+
+    it('should emit ingredientsConfirmed when confirm is clicked', () => {
+      const confirmedSpy = vi.fn();
+      fixture.componentInstance.ingredientsConfirmed.subscribe(confirmedSpy);
+
+      const confirmBtn = fixture.nativeElement.querySelector('.confirm-btn');
+      confirmBtn.click();
+
+      expect(confirmedSpy).toHaveBeenCalled();
+      expect(confirmedSpy.mock.calls[0][0].length).toBe(1);
+    });
+
+    it('should not show confirm button when no ingredients', () => {
+      fixture.componentInstance['ingredients'].set([]);
+      fixture.detectChanges();
+      const confirmBtn = fixture.nativeElement.querySelector('.confirm-btn');
+      expect(confirmBtn).toBeFalsy();
+    });
+  });
+
+  describe('cancel and flip', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should emit cancelled when cancel button is clicked', () => {
+      const cancelSpy = vi.fn();
+      fixture.componentInstance.cancelled.subscribe(cancelSpy);
+
+      const cancelBtn = fixture.nativeElement.querySelector('.cancel-btn');
+      cancelBtn.click();
+
+      expect(cancelSpy).toHaveBeenCalled();
+    });
+
+    it('should toggle facing mode when flip is clicked', () => {
+      cameraMock.openCamera.mockClear();
+      const flipBtn = fixture.nativeElement.querySelector('.flip-btn');
+      flipBtn.click();
+      expect(cameraMock.openCamera).toHaveBeenCalledWith('user');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should call stopCamera on destroy', () => {
+      fixture.detectChanges();
+      fixture.destroy();
+      expect(cameraMock.stopCamera).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.ts
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.ts
@@ -1,0 +1,145 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ElementRef,
+  inject,
+  output,
+  signal,
+  viewChild,
+  AfterViewInit,
+  OnDestroy,
+  DestroyRef,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  CameraService,
+  IngredientRecognitionService,
+  type FacingMode,
+} from '@yumney/shared/models';
+import type { RecognizedIngredient } from '@yumney/shared/api-client';
+
+@Component({
+  selector: 'yn-ingredient-scanner',
+  standalone: true,
+  imports: [TranslocoModule],
+  templateUrl: './ingredient-scanner.component.html',
+  styleUrl: './ingredient-scanner.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class IngredientScannerComponent implements AfterViewInit, OnDestroy {
+  ingredientsConfirmed = output<RecognizedIngredient[]>();
+  cancelled = output<void>();
+
+  videoRef = viewChild<ElementRef<HTMLVideoElement>>('video');
+
+  protected camera = inject(CameraService);
+  protected recognition = inject(IngredientRecognitionService);
+  private destroyRef = inject(DestroyRef);
+
+  protected facingMode = signal<FacingMode>('environment');
+  protected error = signal<string | null>(null);
+  protected isStreaming = signal(false);
+  protected isScanning = signal(false);
+  protected ingredients = signal<RecognizedIngredient[]>([]);
+  protected lastScanAt = signal<number>(0);
+
+  ngAfterViewInit(): void {
+    if (!this.camera.cameraSupported()) {
+      this.error.set('scanner.errors.notSupported');
+      return;
+    }
+    this.startStream();
+  }
+
+  ngOnDestroy(): void {
+    this.camera.stopCamera();
+  }
+
+  protected onScan(): void {
+    const video = this.videoRef()?.nativeElement;
+    if (!video || this.isScanning()) return;
+
+    this.isScanning.set(true);
+    this.error.set(null);
+
+    this.camera
+      .captureFrame(video)
+      .then((blob) => {
+        this.recognition
+          .recognize(blob)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (response) => {
+              const merged = this.recognition.mergeIngredients(
+                this.ingredients(),
+                response.ingredients,
+              );
+              this.ingredients.set(merged);
+              this.lastScanAt.set(Date.now());
+              this.isScanning.set(false);
+
+              if (response.ingredients.length === 0) {
+                this.error.set('scanner.errors.nothingDetected');
+              }
+            },
+            error: () => {
+              this.error.set('scanner.errors.recognitionFailed');
+              this.isScanning.set(false);
+            },
+          });
+      })
+      .catch(() => {
+        this.error.set('scanner.errors.captureFailed');
+        this.isScanning.set(false);
+      });
+  }
+
+  protected onRemoveIngredient(name: string): void {
+    this.ingredients.update((list) => list.filter((i) => i.name !== name));
+  }
+
+  protected onToggleFacing(): void {
+    const next: FacingMode = this.facingMode() === 'environment' ? 'user' : 'environment';
+    this.facingMode.set(next);
+    this.startStream();
+  }
+
+  protected onConfirm(): void {
+    if (this.ingredients().length === 0) return;
+    this.ingredientsConfirmed.emit(this.ingredients());
+  }
+
+  protected onCancel(): void {
+    this.cancelled.emit();
+  }
+
+  protected confidenceLevel(confidence: number): 'high' | 'medium' | 'low' {
+    return this.recognition.confidenceLevel(confidence);
+  }
+
+  private startStream(): void {
+    this.error.set(null);
+    this.camera
+      .openCamera(this.facingMode())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (stream) => {
+          const video = this.videoRef()?.nativeElement;
+          if (video) {
+            video.srcObject = stream;
+            const playResult = video.play?.();
+            if (playResult?.catch) {
+              playResult.catch(() => {
+                // Autoplay may be blocked
+              });
+            }
+            this.isStreaming.set(true);
+          }
+        },
+        error: () => {
+          this.error.set('scanner.errors.permissionDenied');
+        },
+      });
+  }
+}

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -57,6 +57,16 @@ public static class RecipesEndpoints
             .RequireRateLimiting("RecipeImport")
             .DisableAntiforgery();
 
+        group.MapPost("/recognize-ingredients", RecognizeIngredientsAsync)
+            .WithName("RecognizeIngredients")
+            .WithTags("Recipes")
+            .Produces<RecognizedIngredientsResponseDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests)
+            .RequireRateLimiting("RecipeImport")
+            .DisableAntiforgery();
+
         group.MapGet("/import/stream", ImportStreamAsync)
             .WithName("ImportRecipeStream")
             .WithTags("Recipes")
@@ -235,6 +245,28 @@ public static class RecipesEndpoints
 
         var command = new ImportRecipeFromPhotosCommand(photoDataList);
 
+        var result = await handler.HandleAsync(command, cancellationToken);
+
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> RecognizeIngredientsAsync(
+        IFormFile photo,
+        ICommandHandler<RecognizeIngredientsCommand, Result<RecognizedIngredientsResponseDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (photo.Length > maxPhotoSizeBytes)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status413PayloadTooLarge,
+                detail: $"Photo exceeds the maximum size of 10 MB.");
+        }
+
+        using var memoryStream = new MemoryStream((int)photo.Length);
+        await photo.CopyToAsync(memoryStream, cancellationToken);
+        var photoData = new PhotoData(memoryStream.ToArray(), photo.ContentType, photo.FileName);
+
+        var command = new RecognizeIngredientsCommand(photoData);
         var result = await handler.HandleAsync(command, cancellationToken);
 
         return result.ToOk();

--- a/src/Yumney.Recipes.Application/Commands/Handlers/RecognizeIngredientsCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/RecognizeIngredientsCommandHandler.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+#pragma warning disable SA1303
+#pragma warning disable SA1311
+public sealed partial class RecognizeIngredientsCommandHandler(
+    IIngredientRecognitionService recognitionService,
+    ILogger<RecognizeIngredientsCommandHandler> logger)
+    : ICommandHandler<RecognizeIngredientsCommand, Result<RecognizedIngredientsResponseDto>>
+{
+    private const long maxPhotoSizeBytes = 10 * 1024 * 1024;
+
+    private static readonly HashSet<string> allowedContentTypes =
+    [
+        MediaTypes.ImageJpeg,
+        MediaTypes.ImagePng,
+        MediaTypes.ImageWebp,
+    ];
+
+    public async Task<Result<RecognizedIngredientsResponseDto>> HandleAsync(
+        RecognizeIngredientsCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var photo = command.Photo;
+
+        if (photo.Content.Length > maxPhotoSizeBytes)
+        {
+            LogPhotoTooLarge(photo.FileName, photo.Content.Length);
+            return ImportRecipeErrors.PhotoTooLarge;
+        }
+
+        if (!allowedContentTypes.Contains(photo.ContentType.ToLowerInvariant()))
+        {
+            LogInvalidFormat(photo.FileName, photo.ContentType);
+            return ImportRecipeErrors.InvalidPhotoFormat;
+        }
+
+        LogRecognizingIngredients(photo.Content.Length);
+
+        return await recognitionService.RecognizeAsync(photo, cancellationToken);
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recognition photo too large: {FileName} ({SizeBytes} bytes)")]
+    private partial void LogPhotoTooLarge(string fileName, long sizeBytes);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recognition photo invalid format: {FileName} ({ContentType})")]
+    private partial void LogInvalidFormat(string fileName, string contentType);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recognizing ingredients from photo ({SizeBytes} bytes)")]
+    private partial void LogRecognizingIngredients(long sizeBytes);
+}

--- a/src/Yumney.Recipes.Application/Commands/RecognizeIngredientsCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/RecognizeIngredientsCommand.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record RecognizeIngredientsCommand(PhotoData Photo)
+    : ICommand<Result<RecognizedIngredientsResponseDto>>;

--- a/src/Yumney.Recipes.Application/DTOs/RecognizedIngredientDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/RecognizedIngredientDto.cs
@@ -1,0 +1,5 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+public sealed record RecognizedIngredientDto(string Name, double Confidence, string? Category);
+
+public sealed record RecognizedIngredientsResponseDto(IReadOnlyList<RecognizedIngredientDto> Ingredients);

--- a/src/Yumney.Recipes.Application/Interfaces/IIngredientRecognitionService.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IIngredientRecognitionService.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+public interface IIngredientRecognitionService
+{
+    Task<Result<RecognizedIngredientsResponseDto>> RecognizeAsync(
+        PhotoData photo,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ExtractionServiceCollectionExtensions
             .ConfigurePrimaryHttpMessageHandler(BrowserHttpClientDefaults.CreateHandler)
             .AddStandardResilienceHandler();
         services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
+        services.AddScoped<IIngredientRecognitionService, SemanticKernelIngredientRecognitionService>();
 
         var skOptions = configuration
             .GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/ExtractionPrompts.cs
+++ b/src/Yumney.Recipes.Extraction/Services/ExtractionPrompts.cs
@@ -43,5 +43,24 @@ public static class ExtractionPrompts
         IMPORTANT: Only extract recipe data. Ignore any non-recipe content in the images.
         """;
 
+    public const string IngredientRecognitionSchema = """
+        {
+          "ingredients": [
+            { "name": "string", "confidence": "number 0.0-1.0", "category": "string or null" }
+          ]
+        }
+        """;
+
+    public const string IngredientRecognition = $$"""
+        You are an ingredient recognition assistant. Identify all visible food ingredients
+        in the provided photo. For each ingredient provide a confidence score between 0.0 and 1.0
+        and an optional category (e.g. "produce", "dairy", "meat", "pantry").
+        Use the most common English name for each ingredient. Be conservative — only list
+        items you can clearly identify.
+        Respond ONLY with valid JSON matching this schema:
+        {{IngredientRecognitionSchema}}
+        If no food ingredients are visible, respond with: { "ingredients": [] }
+        """;
+
     public static string WrapInContentDelimiters(string content) => $"<webpage_content>{content}</webpage_content>";
 }

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+
+#pragma warning disable SA1601
+#pragma warning disable SA1311
+public sealed partial class SemanticKernelIngredientRecognitionService(
+    Kernel kernel,
+    ILogger<SemanticKernelIngredientRecognitionService> logger)
+    : IIngredientRecognitionService
+{
+    private static readonly JsonSerializerOptions jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public async Task<Result<RecognizedIngredientsResponseDto>> RecognizeAsync(
+        PhotoData photo,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("recognize.ingredients");
+        activity?.SetTag("recognize.photo_size", photo.Content.Length);
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage(ExtractionPrompts.IngredientRecognition);
+        ChatMessageContentItemCollection messageItems =
+        [
+            new TextContent("Identify the food ingredients in this image:"),
+            new ImageContent(photo.Content, photo.ContentType),
+        ];
+        chatHistory.AddUserMessage(messageItems);
+
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+        string response;
+        try
+        {
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+            response = result.Content ?? string.Empty;
+            activity?.SetTag("llm.response_length", response.Length);
+            activity?.SetTag("llm.model", result.ModelId);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogLlmCallFailed(ex.Message);
+            return ImportRecipeErrors.ExtractionFailed;
+        }
+
+        return ParseResponse(response);
+    }
+
+    private Result<RecognizedIngredientsResponseDto> ParseResponse(string response)
+    {
+        try
+        {
+            var json = LlmResponseParser.ExtractJson(response);
+            var parsed = JsonSerializer.Deserialize<RecognizedIngredientsResponseDto>(json, jsonOptions);
+            if (parsed is null)
+            {
+                LogParsingFailed("Deserialization returned null");
+                return ImportRecipeErrors.ExtractionFailed;
+            }
+
+            return parsed;
+        }
+        catch (JsonException ex)
+        {
+            LogParsingFailed(ex.Message);
+            return ImportRecipeErrors.ExtractionFailed;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Ingredient recognition LLM call failed: {Reason}")]
+    private partial void LogLlmCallFailed(string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Ingredient recognition response parsing failed: {Reason}")]
+    private partial void LogParsingFailed(string reason);
+}


### PR DESCRIPTION
## Summary

### Backend
- `IIngredientRecognitionService` interface in `Recipes.Application`
- `SemanticKernelIngredientRecognitionService` implementation reusing the kernel from photo import. New `IngredientRecognition` prompt with JSON schema (name, confidence 0-1, optional category)
- `RecognizeIngredientsCommand` + handler with size/format validation
- `POST /api/v1/recipes/recognize-ingredients` endpoint with `RecipeImport` rate limit
- `RecognizedIngredientDto` + `RecognizedIngredientsResponseDto`

### Frontend
- `RecipeApiService.recognizeIngredients(blob)` method
- `IngredientRecognitionService` in `shared/models` with case-insensitive merge keeping highest confidence + sort, and `confidenceLevel` classification (high ≥0.8, medium ≥0.5, low <0.5)
- `IngredientScannerComponent` in `libs/ui` — full-screen camera with results overlay, color-coded confidence chips (success/warning border), scan button with loading state, per-ingredient remove, confirm action, camera flip
- Dashboard "Scan ingredients" button next to "Scan recipe", recognized ingredients toast with chips after confirmation
- EN + DE translations
- Bumped shell component style budget to 20kb

## Tests
- **9 service tests**: merge logic (empty, dedup, confidence preservation, sorting), confidenceLevel buckets
- **14 component tests**: init/permission/error states, scan flow, ingredient management (remove, confirm), cancel/flip, cleanup
- **All 80 ui tests pass**, **203 shell tests pass**
- Total new tests: **23**

## Test plan
- [x] Backend builds: `dotnet build src/Yumney.Recipes.Extraction`
- [x] Frontend builds: all 4 apps compile
- [x] `nx test ui` — 80 tests pass
- [x] `nx test shell` — 203 tests pass
- [x] `vitest libs/shared/models` — 9 ingredient recognition tests pass
- [ ] Visual: scanner full-screen camera with chips overlay
- [ ] Visual: recognized ingredients toast with color-coded confidence
- [ ] Edge case: poor lighting → low confidence chips visible
- [ ] Edge case: nothing detected → helpful error message

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)