### PR TITLE
feat: conversational AI recipe chat (US-230)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -79,7 +79,8 @@
       "navigation": "Hauptnavigation",
       "switchLanguage": "Sprache wechseln",
       "languageDe": "DE",
-      "languageEn": "EN"
+      "languageEn": "EN",
+      "openChat": "Rezept-Chat öffnen"
     },
     "offlineIndicator": {
       "offline": "Du bist offline. Einige Funktionen sind nicht verfügbar.",
@@ -361,6 +362,25 @@
       "captureFailed": "Bild konnte nicht aufgenommen werden",
       "recognitionFailed": "Zutaten konnten nicht erkannt werden. Bitte erneut versuchen.",
       "nothingDetected": "Keine Zutaten erkannt. Bessere Beleuchtung oder näher rangehen."
+    }
+  },
+  "chat": {
+    "title": "Rezept-Chat",
+    "welcome": "Frag mich alles über Rezepte — was du heute kochen sollst, Ernährungsalternativen, Zutatenersatz und mehr.",
+    "examples": {
+      "1": "Was kann ich aus Hähnchen und Reis machen?",
+      "2": "Zeig mir vegetarische Gerichte unter 30 Minuten",
+      "3": "Ich habe Eier und Mehl — welche Kekse kann ich backen?"
+    },
+    "placeholder": "Frag nach Rezepten…",
+    "inputLabel": "Chat-Eingabe",
+    "send": "Senden",
+    "close": "Chat schließen",
+    "clear": "Löschen",
+    "clearHistory": "Verlauf löschen",
+    "errors": {
+      "offline": "Chat benötigt eine Internetverbindung.",
+      "failed": "Chat-Dienst nicht erreichbar. Bitte erneut versuchen."
     }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -79,7 +79,8 @@
       "navigation": "Main navigation",
       "switchLanguage": "Switch language",
       "languageDe": "DE",
-      "languageEn": "EN"
+      "languageEn": "EN",
+      "openChat": "Open recipe chat"
     },
     "offlineIndicator": {
       "offline": "You are offline. Some features may be unavailable.",
@@ -361,6 +362,25 @@
       "captureFailed": "Failed to capture frame",
       "recognitionFailed": "Could not recognize ingredients. Please try again.",
       "nothingDetected": "No ingredients detected. Try better lighting or move closer."
+    }
+  },
+  "chat": {
+    "title": "Recipe Chat",
+    "welcome": "Ask me anything about recipes — what to cook tonight, dietary swaps, ingredient substitutions, and more.",
+    "examples": {
+      "1": "What can I make with chicken and rice?",
+      "2": "Show me 30-minute vegetarian meals",
+      "3": "I have eggs and flour — what cookies can I bake?"
+    },
+    "placeholder": "Ask about recipes…",
+    "inputLabel": "Chat input",
+    "send": "Send",
+    "close": "Close chat",
+    "clear": "Clear",
+    "clearHistory": "Clear conversation history",
+    "errors": {
+      "offline": "Chat requires an internet connection.",
+      "failed": "Could not reach the chat service. Please try again."
     }
   }
 }

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -31,3 +31,10 @@ export type {
   RecognizedIngredient,
   RecognizedIngredientsResponse,
 } from './lib/recognized-ingredient';
+export { ChatApiService } from './lib/chat-api.service';
+export type {
+  ChatMessage,
+  ChatRecipeSuggestion,
+  ChatRequest,
+  ChatResponse,
+} from './lib/chat-message';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -8,6 +8,7 @@ export const API_ENDPOINTS = {
       `${API_BASE}/recipes/import/stream?url=${encodeURIComponent(url)}`,
     importFromPhotos: `${API_BASE}/recipes/import-from-photos`,
     recognizeIngredients: `${API_BASE}/recipes/recognize-ingredients`,
+    chat: `${API_BASE}/recipes/chat`,
     byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
   },
   shoppingLists: {

--- a/client/libs/shared/api-client/src/lib/chat-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/chat-api.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
+import type { ChatRequest, ChatResponse } from './chat-message';
+
+@Injectable({ providedIn: 'root' })
+export class ChatApiService {
+  private http = inject(HttpClient);
+
+  send(request: ChatRequest): Observable<ChatResponse> {
+    return this.http.post<ChatResponse>(API_ENDPOINTS.recipes.chat, request);
+  }
+}

--- a/client/libs/shared/api-client/src/lib/chat-message.ts
+++ b/client/libs/shared/api-client/src/lib/chat-message.ts
@@ -1,0 +1,20 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatRecipeSuggestion {
+  recipeIdentifier: string | null;
+  title: string;
+  reason: string | null;
+}
+
+export interface ChatRequest {
+  message: string;
+  history: ChatMessage[];
+}
+
+export interface ChatResponse {
+  reply: string;
+  suggestions: ChatRecipeSuggestion[];
+}

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -28,3 +28,4 @@ export { ROUTES } from './lib/route-paths';
 export { ThemeService, type Theme } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
 export { IngredientRecognitionService } from './lib/ingredient-recognition.service';
+export { ChatStateService } from './lib/chat-state.service';

--- a/client/libs/shared/models/src/lib/chat-state.service.spec.ts
+++ b/client/libs/shared/models/src/lib/chat-state.service.spec.ts
@@ -1,0 +1,72 @@
+import { ChatStateService } from './chat-state.service';
+import type { ChatMessage } from '@yumney/shared/api-client';
+
+describe('ChatStateService', () => {
+  let service: ChatStateService;
+
+  beforeEach(() => {
+    service = new ChatStateService();
+  });
+
+  describe('isOpen state', () => {
+    it('should default to closed', () => {
+      expect(service.isOpen()).toBe(false);
+    });
+
+    it('should open the chat', () => {
+      service.open();
+      expect(service.isOpen()).toBe(true);
+    });
+
+    it('should close the chat', () => {
+      service.open();
+      service.close();
+      expect(service.isOpen()).toBe(false);
+    });
+
+    it('should toggle the chat', () => {
+      service.toggle();
+      expect(service.isOpen()).toBe(true);
+      service.toggle();
+      expect(service.isOpen()).toBe(false);
+    });
+  });
+
+  describe('messages', () => {
+    it('should default to empty messages', () => {
+      expect(service.messages()).toEqual([]);
+    });
+
+    it('should add a message', () => {
+      const msg: ChatMessage = { role: 'user', content: 'Hello' };
+      service.addMessage(msg);
+      expect(service.messages()).toEqual([msg]);
+    });
+
+    it('should preserve message order when adding multiple', () => {
+      service.addMessage({ role: 'user', content: 'A' });
+      service.addMessage({ role: 'assistant', content: 'B' });
+      service.addMessage({ role: 'user', content: 'C' });
+      expect(service.messages().map((m) => m.content)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should clear messages', () => {
+      service.addMessage({ role: 'user', content: 'Hello' });
+      service.clear();
+      expect(service.messages()).toEqual([]);
+    });
+  });
+
+  describe('thinking indicator', () => {
+    it('should default to not thinking', () => {
+      expect(service.isThinking()).toBe(false);
+    });
+
+    it('should set thinking state', () => {
+      service.setThinking(true);
+      expect(service.isThinking()).toBe(true);
+      service.setThinking(false);
+      expect(service.isThinking()).toBe(false);
+    });
+  });
+});

--- a/client/libs/shared/models/src/lib/chat-state.service.ts
+++ b/client/libs/shared/models/src/lib/chat-state.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, signal } from '@angular/core';
+import type { ChatMessage } from '@yumney/shared/api-client';
+
+@Injectable({ providedIn: 'root' })
+export class ChatStateService {
+  readonly isOpen = signal(false);
+  readonly messages = signal<ChatMessage[]>([]);
+  readonly isThinking = signal(false);
+
+  open(): void {
+    this.isOpen.set(true);
+  }
+
+  close(): void {
+    this.isOpen.set(false);
+  }
+
+  toggle(): void {
+    this.isOpen.update((v) => !v);
+  }
+
+  addMessage(message: ChatMessage): void {
+    this.messages.update((list) => [...list, message]);
+  }
+
+  setThinking(value: boolean): void {
+    this.isThinking.set(value);
+  }
+
+  clear(): void {
+    this.messages.set([]);
+  }
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -35,3 +35,4 @@ export {
 
 export { CameraCaptureComponent } from './lib/camera-capture/camera-capture.component';
 export { IngredientScannerComponent } from './lib/ingredient-scanner/ingredient-scanner.component';
+export { ChatPanelComponent } from './lib/chat-panel/chat-panel.component';

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.html
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.html
@@ -4,3 +4,4 @@
 <main>
   <router-outlet />
 </main>
+<yn-chat-panel />

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.ts
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.ts
@@ -2,10 +2,11 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { IS_STANDALONE } from '@yumney/shared/models';
 import { HeaderComponent } from '../header/header.component';
+import { ChatPanelComponent } from '../chat-panel/chat-panel.component';
 
 @Component({
   selector: 'yn-app-layout',
-  imports: [RouterOutlet, HeaderComponent],
+  imports: [RouterOutlet, HeaderComponent, ChatPanelComponent],
   templateUrl: './app-layout.component.html',
   styleUrl: './app-layout.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -1,0 +1,88 @@
+@if (state.isOpen()) {
+  <div class="chat-panel" *transloco="let t" role="dialog" [attr.aria-label]="t('chat.title')">
+    <div class="chat-header">
+      <h2>{{ t('chat.title') }}</h2>
+      <div class="chat-header-actions">
+        @if (state.messages().length > 0) {
+          <button class="chat-clear" (click)="onClear()" [attr.aria-label]="t('chat.clearHistory')">
+            {{ t('chat.clear') }}
+          </button>
+        }
+        <button class="chat-close" (click)="onClose()" [attr.aria-label]="t('chat.close')">
+          &times;
+        </button>
+      </div>
+    </div>
+
+    <div #messages class="chat-messages">
+      @if (state.messages().length === 0) {
+        <div class="chat-welcome">
+          <p>{{ t('chat.welcome') }}</p>
+          <ul class="chat-examples">
+            <li>{{ t('chat.examples.1') }}</li>
+            <li>{{ t('chat.examples.2') }}</li>
+            <li>{{ t('chat.examples.3') }}</li>
+          </ul>
+        </div>
+      }
+
+      @for (msg of state.messages(); track $index) {
+        <div class="chat-message" [class]="'role-' + msg.role">
+          <div class="chat-bubble">{{ msg.content }}</div>
+        </div>
+      }
+
+      @if (state.isThinking()) {
+        <div class="chat-message role-assistant">
+          <div class="chat-bubble chat-thinking">
+            <span class="dot"></span>
+            <span class="dot"></span>
+            <span class="dot"></span>
+          </div>
+        </div>
+      }
+
+      @if (lastSuggestions().length > 0) {
+        <div class="chat-suggestions">
+          @for (s of lastSuggestions(); track s.title) {
+            @if (s.recipeIdentifier) {
+              <a
+                class="chat-suggestion-card"
+                [routerLink]="['/recipes', s.recipeIdentifier]"
+                (click)="onSuggestionClick()"
+              >
+                <strong>{{ s.title }}</strong>
+                @if (s.reason) {
+                  <span>{{ s.reason }}</span>
+                }
+              </a>
+            }
+          }
+        </div>
+      }
+
+      @if (error(); as err) {
+        <div class="chat-error" role="alert">{{ t(err) }}</div>
+      }
+    </div>
+
+    <form class="chat-input" (submit)="$event.preventDefault(); onSend()">
+      <textarea
+        [ngModel]="input()"
+        (ngModelChange)="input.set($event)"
+        (keydown)="onKeydown($event)"
+        [placeholder]="t('chat.placeholder')"
+        [attr.aria-label]="t('chat.inputLabel')"
+        rows="2"
+        name="chat-input"
+      ></textarea>
+      <button
+        type="submit"
+        class="chat-send btn-primary"
+        [disabled]="!input().trim() || state.isThinking()"
+      >
+        {{ t('chat.send') }}
+      </button>
+    </form>
+  </div>
+}

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
@@ -1,0 +1,302 @@
+@use 'buttons';
+@use 'glass';
+@use 'breakpoints' as bp;
+
+.chat-panel {
+  @include glass.glass-surface(2);
+  position: fixed;
+  z-index: var(--yn-z-modal);
+  display: flex;
+  flex-direction: column;
+  background: var(--yn-glass-bg-strong);
+  backdrop-filter: blur(var(--yn-glass-blur-strong));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-strong));
+
+  // Mobile: full-width slide up from bottom
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80vh;
+  max-height: 600px;
+  border-radius: var(--yn-radius-card-lg) var(--yn-radius-card-lg) 0 0;
+  animation: yn-slide-in-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+
+  @include bp.respond-to('md') {
+    // Desktop: side panel from right
+    bottom: var(--yn-space-5);
+    right: var(--yn-space-5);
+    left: auto;
+    width: 420px;
+    height: calc(100vh - 4rem);
+    max-height: 720px;
+    border-radius: var(--yn-radius-card-lg);
+    animation: yn-slide-in-right var(--yn-duration-normal) var(--yn-ease-spring) both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+// ── Header ──
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--yn-space-5);
+  border-bottom: 1px solid var(--yn-glass-border-subtle);
+
+  h2 {
+    margin: 0;
+    font-size: var(--yn-text-lg);
+    font-weight: var(--yn-font-semibold);
+    color: var(--yn-text);
+  }
+}
+
+.chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.chat-clear {
+  background: none;
+  border: none;
+  color: var(--yn-text-muted);
+  font-size: var(--yn-text-sm);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--yn-primary);
+  }
+}
+
+.chat-close {
+  background: none;
+  border: none;
+  font-size: var(--yn-text-3xl);
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  line-height: var(--yn-leading-none);
+  padding: 0 var(--yn-space-2);
+
+  &:hover {
+    color: var(--yn-text);
+  }
+}
+
+// ── Messages ──
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--yn-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-4);
+}
+
+.chat-welcome {
+  text-align: center;
+  color: var(--yn-text-muted);
+  padding: var(--yn-space-7) 0;
+
+  p {
+    margin: 0 0 var(--yn-space-4);
+    font-size: var(--yn-text-base);
+  }
+}
+
+.chat-examples {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+
+  li {
+    @include glass.glass-surface(0);
+    padding: var(--yn-space-3) var(--yn-space-4);
+    border-radius: var(--yn-radius-badge);
+    font-size: var(--yn-text-sm);
+    font-style: italic;
+  }
+}
+
+.chat-message {
+  display: flex;
+
+  &.role-user {
+    justify-content: flex-end;
+
+    .chat-bubble {
+      background: var(--yn-primary);
+      color: var(--yn-text-inverse);
+      border-bottom-right-radius: var(--yn-radius-sm);
+    }
+  }
+
+  &.role-assistant {
+    justify-content: flex-start;
+
+    .chat-bubble {
+      background: var(--yn-glass-bg-elevated);
+      border: 1px solid var(--yn-glass-border-subtle);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      color: var(--yn-text);
+      border-bottom-left-radius: var(--yn-radius-sm);
+    }
+  }
+}
+
+.chat-bubble {
+  max-width: 85%;
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-radius: var(--yn-radius-card);
+  font-size: var(--yn-text-base);
+  line-height: var(--yn-leading-relaxed);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+// ── Thinking dots ──
+.chat-thinking {
+  display: flex;
+  gap: var(--yn-space-2);
+  padding: var(--yn-space-4) var(--yn-space-5);
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--yn-radius-circle);
+    background: var(--yn-text-muted);
+    animation: chat-thinking-bounce 1.2s infinite ease-in-out both;
+
+    &:nth-child(1) {
+      animation-delay: -0.32s;
+    }
+
+    &:nth-child(2) {
+      animation-delay: -0.16s;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dot {
+      animation: none;
+      opacity: 0.6;
+    }
+  }
+}
+
+@keyframes chat-thinking-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+// ── Recipe suggestions ──
+.chat-suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
+}
+
+.chat-suggestion-card {
+  @include glass.glass-surface(0);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-1);
+  padding: var(--yn-space-4);
+  border-radius: var(--yn-radius-card);
+  border-left: 3px solid var(--yn-primary);
+  text-decoration: none;
+  color: var(--yn-text);
+  transition:
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    transform var(--yn-duration-fast) var(--yn-ease-spring);
+
+  &:hover {
+    background: var(--yn-glass-bg-elevated);
+    transform: translateX(2px);
+  }
+
+  strong {
+    font-size: var(--yn-text-base);
+    font-weight: var(--yn-font-semibold);
+  }
+
+  span {
+    font-size: var(--yn-text-sm);
+    color: var(--yn-text-muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+}
+
+// ── Error ──
+.chat-error {
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-radius: var(--yn-radius-button);
+  background: var(--yn-danger-light);
+  border-left: 3px solid var(--yn-danger);
+  color: var(--yn-danger);
+  font-size: var(--yn-text-sm);
+}
+
+// ── Input ──
+.chat-input {
+  display: flex;
+  gap: var(--yn-space-3);
+  padding: var(--yn-space-5);
+  border-top: 1px solid var(--yn-glass-border-subtle);
+
+  textarea {
+    flex: 1;
+    padding: var(--yn-space-3) var(--yn-space-4);
+    border: 1px solid var(--yn-glass-border);
+    border-radius: var(--yn-radius-input);
+    background: var(--yn-glass-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    font-family: inherit;
+    font-size: var(--yn-text-base);
+    color: var(--yn-text);
+    resize: none;
+    outline: none;
+    box-sizing: border-box;
+
+    &:focus {
+      border-color: var(--yn-primary);
+      box-shadow: var(--yn-ring-primary);
+    }
+
+    &::placeholder {
+      color: var(--yn-text-placeholder);
+    }
+  }
+}
+
+.chat-send {
+  align-self: flex-end;
+}

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -1,0 +1,184 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { of, throwError } from 'rxjs';
+import { ChatPanelComponent } from './chat-panel.component';
+import { ChatApiService } from '@yumney/shared/api-client';
+import { ChatStateService } from '@yumney/shared/models';
+
+const en = {
+  chat: {
+    title: 'Recipe Chat',
+    welcome: 'Ask me anything about recipes',
+    examples: { 1: 'Quick meals', 2: 'Vegetarian', 3: 'Cookies' },
+    placeholder: 'Ask…',
+    inputLabel: 'Chat input',
+    send: 'Send',
+    close: 'Close',
+    clear: 'Clear',
+    clearHistory: 'Clear history',
+    errors: { offline: 'Offline', failed: 'Failed' },
+  },
+};
+
+describe('ChatPanelComponent', () => {
+  let fixture: ComponentFixture<ChatPanelComponent>;
+  let chatState: ChatStateService;
+  let chatApiMock: { send: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    chatApiMock = {
+      send: vi.fn().mockReturnValue(of({ reply: 'Hello!', suggestions: [] })),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ChatPanelComponent,
+        TranslocoTestingModule.forRoot({
+          langs: { en },
+          translocoConfig: { availableLangs: ['en'], defaultLang: 'en' },
+        }),
+      ],
+      providers: [
+        provideRouter([]),
+        { provide: ChatApiService, useValue: chatApiMock },
+        ChatStateService,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatPanelComponent);
+    chatState = TestBed.inject(ChatStateService);
+  });
+
+  afterEach(() => {
+    chatState.clear();
+    chatState.close();
+  });
+
+  it('should create the component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should not render panel when closed', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.chat-panel')).toBeFalsy();
+  });
+
+  it('should render panel when opened', () => {
+    chatState.open();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.chat-panel')).toBeTruthy();
+  });
+
+  it('should show welcome message when no history', () => {
+    chatState.open();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.chat-welcome')).toBeTruthy();
+  });
+
+  it('should send message and add user message to state', async () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Hello');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(chatApiMock.send).toHaveBeenCalled();
+    expect(chatState.messages().length).toBeGreaterThanOrEqual(1);
+    expect(chatState.messages()[0]).toEqual({ role: 'user', content: 'Hello' });
+  });
+
+  it('should add assistant reply on successful response', async () => {
+    chatApiMock.send = vi.fn().mockReturnValue(of({ reply: 'Try pasta!', suggestions: [] }));
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Suggest something');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(chatState.messages().length).toBe(2);
+    expect(chatState.messages()[1]).toEqual({ role: 'assistant', content: 'Try pasta!' });
+    expect(chatState.isThinking()).toBe(false);
+  });
+
+  it('should show error when request fails', async () => {
+    chatApiMock.send = vi.fn().mockReturnValue(throwError(() => new Error('fail')));
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Hello');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(fixture.componentInstance['error']()).toBe('chat.errors.failed');
+    expect(chatState.isThinking()).toBe(false);
+  });
+
+  it('should not send empty message', () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('   ');
+    fixture.componentInstance['onSend']();
+
+    expect(chatApiMock.send).not.toHaveBeenCalled();
+  });
+
+  it('should clear input after sending', async () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Hello');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(fixture.componentInstance['input']()).toBe('');
+  });
+
+  it('should close panel when close button clicked', () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    const closeBtn = fixture.nativeElement.querySelector('.chat-close');
+    closeBtn.click();
+    fixture.detectChanges();
+
+    expect(chatState.isOpen()).toBe(false);
+  });
+
+  it('should clear messages when clear button clicked', async () => {
+    chatState.open();
+    chatState.addMessage({ role: 'user', content: 'Hello' });
+    fixture.detectChanges();
+
+    const clearBtn = fixture.nativeElement.querySelector('.chat-clear');
+    clearBtn.click();
+    fixture.detectChanges();
+
+    expect(chatState.messages().length).toBe(0);
+  });
+
+  it('should send on Enter key without shift', () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Hello');
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    fixture.componentInstance['onKeydown'](event);
+
+    expect(chatApiMock.send).toHaveBeenCalled();
+  });
+
+  it('should not send on Shift+Enter (allow newline)', () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('Hello');
+    const event = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true });
+    fixture.componentInstance['onKeydown'](event);
+
+    expect(chatApiMock.send).not.toHaveBeenCalled();
+  });
+});

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -1,0 +1,104 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ElementRef,
+  inject,
+  signal,
+  viewChild,
+  effect,
+  AfterViewInit,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { ChatApiService, type ChatRecipeSuggestion } from '@yumney/shared/api-client';
+import { ChatStateService } from '@yumney/shared/models';
+
+@Component({
+  selector: 'yn-chat-panel',
+  standalone: true,
+  imports: [FormsModule, RouterLink, TranslocoModule],
+  templateUrl: './chat-panel.component.html',
+  styleUrl: './chat-panel.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChatPanelComponent implements AfterViewInit {
+  protected state = inject(ChatStateService);
+  private chatApi = inject(ChatApiService);
+
+  protected input = signal('');
+  protected error = signal<string | null>(null);
+  protected lastSuggestions = signal<ChatRecipeSuggestion[]>([]);
+
+  messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messages');
+
+  constructor() {
+    // Auto-scroll on new messages
+    effect(() => {
+      this.state.messages();
+      this.state.isThinking();
+      queueMicrotask(() => this.scrollToBottom());
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this.scrollToBottom();
+  }
+
+  protected onClose(): void {
+    this.state.close();
+  }
+
+  protected onSend(): void {
+    const message = this.input().trim();
+    if (!message || this.state.isThinking()) return;
+
+    if (!navigator.onLine) {
+      this.error.set('chat.errors.offline');
+      return;
+    }
+
+    this.error.set(null);
+    this.input.set('');
+    this.state.addMessage({ role: 'user', content: message });
+    this.state.setThinking(true);
+
+    const history = this.state.messages().slice(0, -1);
+
+    this.chatApi.send({ message, history }).subscribe({
+      next: (response) => {
+        this.state.addMessage({ role: 'assistant', content: response.reply });
+        this.lastSuggestions.set(response.suggestions);
+        this.state.setThinking(false);
+      },
+      error: () => {
+        this.state.setThinking(false);
+        this.error.set('chat.errors.failed');
+      },
+    });
+  }
+
+  protected onClear(): void {
+    this.state.clear();
+    this.lastSuggestions.set([]);
+    this.error.set(null);
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.onSend();
+    }
+  }
+
+  protected onSuggestionClick(): void {
+    this.state.close();
+  }
+
+  private scrollToBottom(): void {
+    const el = this.messagesContainer()?.nativeElement;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -23,6 +23,15 @@
           {{ t('layout.header.login') }}
         </a>
       }
+      @if (authService.isAuthenticated()) {
+        <button
+          class="chat-toggle"
+          (click)="onToggleChat()"
+          [attr.aria-label]="t('layout.header.openChat')"
+        >
+          &#x1F4AC;
+        </button>
+      }
       <button
         class="theme-toggle"
         (click)="onToggleTheme()"

--- a/client/libs/ui/src/lib/header/header.component.scss
+++ b/client/libs/ui/src/lib/header/header.component.scss
@@ -116,3 +116,19 @@ nav {
     text-decoration: underline;
   }
 }
+
+.chat-toggle {
+  padding: var(--yn-space-1) var(--yn-space-3);
+  border: 1px solid var(--yn-border);
+  border-radius: var(--yn-radius-sm);
+  background: none;
+  font-size: var(--yn-text-lg);
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  line-height: var(--yn-leading-none);
+
+  &:hover {
+    background-color: var(--yn-background);
+    color: var(--yn-primary);
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.ts
+++ b/client/libs/ui/src/lib/header/header.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/c
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthService } from '@yumney/shared/auth';
-import { LanguageService, ThemeService } from '@yumney/shared/models';
+import { LanguageService, ThemeService, ChatStateService } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-header',
@@ -15,6 +15,7 @@ export class HeaderComponent {
   protected authService = inject(AuthService);
   protected languageService = inject(LanguageService);
   protected themeService = inject(ThemeService);
+  protected chatState = inject(ChatStateService);
 
   protected isDark = computed(() => this.themeService.theme() === 'dark');
 
@@ -33,5 +34,9 @@ export class HeaderComponent {
 
   onToggleTheme(): void {
     this.themeService.toggle();
+  }
+
+  onToggleChat(): void {
+    this.chatState.toggle();
   }
 }

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -67,6 +67,13 @@ public static class RecipesEndpoints
             .RequireRateLimiting("RecipeImport")
             .DisableAntiforgery();
 
+        group.MapPost("/chat", ChatAsync)
+            .WithName("RecipeChat")
+            .WithTags("Recipes")
+            .Produces<ChatResponseDto>()
+            .ProducesProblem(StatusCodes.Status429TooManyRequests)
+            .RequireRateLimiting("RecipeImport");
+
         group.MapGet("/import/stream", ImportStreamAsync)
             .WithName("ImportRecipeStream")
             .WithTags("Recipes")
@@ -269,6 +276,23 @@ public static class RecipesEndpoints
         var command = new RecognizeIngredientsCommand(photoData);
         var result = await handler.HandleAsync(command, cancellationToken);
 
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ChatAsync(
+        ChatRequestDto request,
+        ICommandHandler<ChatCommand, Result<ChatResponseDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Message))
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: "Message cannot be empty.");
+        }
+
+        var command = new ChatCommand(request.Message, request.History);
+        var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }
 

--- a/src/Yumney.Recipes.Application/Commands/ChatCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ChatCommand.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record ChatCommand(string Message, IReadOnlyList<ChatMessageDto> History)
+    : ICommand<Result<ChatResponseDto>>;

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ChatCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ChatCommandHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class ChatCommandHandler(
+    IChatService chatService,
+    ICurrentUser currentUser,
+    ILogger<ChatCommandHandler> logger) : ICommandHandler<ChatCommand, Result<ChatResponseDto>>
+{
+    public async Task<Result<ChatResponseDto>> HandleAsync(
+        ChatCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var owner = OwnerIdentifier.From(currentUser.UserId);
+
+        LogChatRequest(owner.Value, command.Message.Length, command.History.Count);
+
+        return await chatService.ChatAsync(command.Message, command.History, owner, cancellationToken);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Chat request from {UserId}, message length {MessageLength}, history {HistoryCount}")]
+    private partial void LogChatRequest(string userId, int messageLength, int historyCount);
+}

--- a/src/Yumney.Recipes.Application/DTOs/ChatMessageDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ChatMessageDto.cs
@@ -1,0 +1,14 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+public sealed record ChatMessageDto(string Role, string Content);
+
+public sealed record ChatRequestDto(string Message, IReadOnlyList<ChatMessageDto> History);
+
+public sealed record ChatResponseDto(
+    string Reply,
+    IReadOnlyList<ChatRecipeSuggestionDto> Suggestions);
+
+public sealed record ChatRecipeSuggestionDto(
+    Guid? RecipeIdentifier,
+    string Title,
+    string? Reason);

--- a/src/Yumney.Recipes.Application/Interfaces/IChatService.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IChatService.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+public interface IChatService
+{
+    Task<Result<ChatResponseDto>> ChatAsync(
+        string message,
+        IReadOnlyList<ChatMessageDto> history,
+        OwnerIdentifier owner,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ExtractionServiceCollectionExtensions
             .AddStandardResilienceHandler();
         services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
         services.AddScoped<IIngredientRecognitionService, SemanticKernelIngredientRecognitionService>();
+        services.AddScoped<IChatService, SemanticKernelChatService>();
 
         var skOptions = configuration
             .GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -13,12 +13,13 @@ namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 #pragma warning disable SA1601
 #pragma warning disable SA1311
 #pragma warning disable SA1204
+#pragma warning disable SA1303
 public sealed partial class SemanticKernelChatService(
     Kernel kernel,
     IRecipeRepository recipes,
     ILogger<SemanticKernelChatService> logger) : IChatService
 {
-    private const int MaxRecipesToInclude = 20;
+    private const int maxRecipesToInclude = 20;
 
     public async Task<Result<ChatResponseDto>> ChatAsync(
         string message,
@@ -116,7 +117,7 @@ public sealed partial class SemanticKernelChatService(
         OwnerIdentifier owner,
         CancellationToken cancellationToken)
     {
-        var paging = PagingOptions.Of(Page.From(1), PageSize.From(MaxRecipesToInclude));
+        var paging = PagingOptions.Of(Page.From(1), PageSize.From(maxRecipesToInclude));
         var sorting = new SortingOptions<RecipeSortField>(RecipeSortField.Date, SortDirection.Descending);
         var (items, _) = await recipes.GetByOwnerAsync(owner, paging, sorting, cancellationToken: cancellationToken);
         return items;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+
+#pragma warning disable SA1601
+#pragma warning disable SA1311
+#pragma warning disable SA1204
+public sealed partial class SemanticKernelChatService(
+    Kernel kernel,
+    IRecipeRepository recipes,
+    ILogger<SemanticKernelChatService> logger) : IChatService
+{
+    private const int MaxRecipesToInclude = 20;
+
+    public async Task<Result<ChatResponseDto>> ChatAsync(
+        string message,
+        IReadOnlyList<ChatMessageDto> history,
+        OwnerIdentifier owner,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("chat.message");
+        activity?.SetTag("chat.history_length", history.Count);
+
+        var userRecipes = await LoadUserRecipeContextAsync(owner, cancellationToken);
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage(BuildSystemPrompt(userRecipes));
+
+        foreach (var msg in history)
+        {
+            if (msg.Role == "user")
+            {
+                chatHistory.AddUserMessage(msg.Content);
+            }
+            else if (msg.Role == "assistant")
+            {
+                chatHistory.AddAssistantMessage(msg.Content);
+            }
+        }
+
+        chatHistory.AddUserMessage(message);
+
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+        string reply;
+        try
+        {
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+            reply = result.Content ?? string.Empty;
+            activity?.SetTag("llm.response_length", reply.Length);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogChatFailed(ex.Message);
+            return ImportRecipeErrors.ExtractionFailed;
+        }
+
+        var suggestions = MatchRecipesByMention(reply, userRecipes);
+
+        return new ChatResponseDto(reply, suggestions);
+    }
+
+    private static string BuildSystemPrompt(IReadOnlyList<Recipe> userRecipes)
+    {
+        var recipeList = userRecipes.Count == 0
+            ? "(no recipes yet)"
+            : string.Join("\n", userRecipes.Select(r => $"- {r.Title.Value}"));
+
+        return $$"""
+            You are a friendly cooking assistant for the Yumney recipe app.
+            Help the user discover recipes from their collection or suggest new ones.
+            When suggesting recipes from their collection, mention the exact title in quotes.
+
+            The user's recipe collection contains:
+            {{recipeList}}
+
+            Be concise. Use natural language. If the user asks for something not in their
+            collection, suggest a general recipe idea or recommend they import one from a website.
+            """;
+    }
+
+    private static List<ChatRecipeSuggestionDto> MatchRecipesByMention(
+        string reply,
+        IReadOnlyList<Recipe> userRecipes)
+    {
+        var suggestions = new List<ChatRecipeSuggestionDto>();
+
+        foreach (var recipe in userRecipes)
+        {
+            if (reply.Contains(recipe.Title.Value, StringComparison.OrdinalIgnoreCase))
+            {
+                suggestions.Add(new ChatRecipeSuggestionDto(
+                    recipe.Id.Value,
+                    recipe.Title.Value,
+                    Reason: null));
+            }
+        }
+
+        return suggestions;
+    }
+
+    private async Task<IReadOnlyList<Recipe>> LoadUserRecipeContextAsync(
+        OwnerIdentifier owner,
+        CancellationToken cancellationToken)
+    {
+        var paging = PagingOptions.Of(Page.From(1), PageSize.From(MaxRecipesToInclude));
+        var sorting = new SortingOptions<RecipeSortField>(RecipeSortField.Date, SortDirection.Descending);
+        var (items, _) = await recipes.GetByOwnerAsync(owner, paging, sorting, cancellationToken: cancellationToken);
+        return items;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Chat LLM call failed: {Reason}")]
+    private partial void LogChatFailed(string reason);
+}


### PR DESCRIPTION
## Summary

### Backend
- `IChatService` + `SemanticKernelChatService` reusing the existing kernel
- Loads user's recent 20 recipes into system prompt for context
- Matches mentioned recipe titles back to IDs as suggestions
- `ChatCommand` + handler with current-user authorization
- `POST /api/v1/recipes/chat` endpoint with rate limiting
- DTOs: `ChatMessageDto`, `ChatRequestDto`, `ChatResponseDto`, `ChatRecipeSuggestionDto`

### Frontend
- `ChatApiService` for sending messages
- `ChatStateService` — signal-based state (isOpen, messages, isThinking)
- `ChatPanelComponent` — glass panel:
  - **Mobile**: slides up from bottom (80vh height)
  - **Desktop**: slides in from right (420px width)
  - User/assistant message bubbles with role-based styling
  - Animated thinking dots during AI processing
  - Recipe suggestion cards (clickable → recipe detail)
  - Welcome screen with example questions
  - Offline detection + error handling
  - Enter to send, Shift+Enter for newline
  - Clear history button
- Header chat toggle button (only when authenticated)
- Rendered in `AppLayoutComponent` so it persists across MFE navigation
- EN + DE translations

## Tests
- **10 ChatStateService tests**: open/close/toggle, message add/clear, thinking state
- **13 ChatPanelComponent tests**: render, send flow, error handling, clear, keyboard shortcuts, close action
- **Total new tests: 23**
- All 93 ui tests + 203 shell tests pass

## Test plan
- [x] Backend builds: `dotnet build src/Yumney.Recipes.Extraction`
- [x] Frontend builds: all 4 apps compile
- [x] `nx test ui` — 93 tests pass
- [x] `nx test shell` — 203 tests pass
- [x] `vitest libs/shared/models` — 10 chat-state tests pass
- [ ] Visual: chat slides up on mobile, in from right on desktop
- [ ] Visual: thinking dots animate while waiting
- [ ] Visual: clicking recipe suggestion navigates and closes chat
- [ ] Edge case: offline → "requires internet" message

Note: Used a custom glass chat panel instead of Deep Chat web component
to keep bundle size minimal and match the design system pixel-perfectly.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)