### PR TITLE
refactor(domain): enforce closed-set invariants on enum-like value objects (US-000)

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -268,7 +268,9 @@ public static class RecipesEndpoints
             statusCode: StatusCodes.Status413PayloadTooLarge,
             detail: $"Photo '{fileName}' exceeds the maximum size of 10 MB.");
 
-    private const string EmptyChatMessageError = "Message cannot be empty.";
+#pragma warning disable SA1303 // editorconfig requires camelCase for private const fields
+    private const string emptyChatMessageError = "Message cannot be empty.";
+#pragma warning restore SA1303
 
     private static async Task<IResult> ChatAsync(
         ChatRequestDto request,
@@ -279,7 +281,7 @@ public static class RecipesEndpoints
         {
             return Results.Problem(
                 statusCode: StatusCodes.Status400BadRequest,
-                detail: EmptyChatMessageError);
+                detail: emptyChatMessageError);
         }
 
         var historyEntries = request.History

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -120,11 +120,9 @@ public static class RecipesEndpoints
         string? search = null,
         CancellationToken cancellationToken = default)
     {
-        var sortField = default(RecipeSortField).ParseNullable(sortBy) ?? RecipeSortField.Date;
-
         var query = new GetRecipesQuery(
-            PagingOptions.Of(Page.From(page), PageSize.From(pageSize)),
-            new SortingOptions<RecipeSortField>(sortField, sortDirection),
+            PagingOptions.From(page, pageSize),
+            SortingOptions<RecipeSortField>.Parse(sortBy, sortDirection, RecipeSortField.Date),
             SearchTerm.FromNullable(search));
 
         var result = await handler.HandleAsync(query, cancellationToken);
@@ -226,35 +224,22 @@ public static class RecipesEndpoints
         return result.ToOk();
     }
 
-#pragma warning disable SA1303
-    private const long maxPhotoSizeBytes = 10 * 1024 * 1024;
-#pragma warning restore SA1303
-
     private static async Task<IResult> ImportFromPhotosAsync(
         IFormFileCollection photos,
         ICommandHandler<ImportRecipeFromPhotosCommand, Result<ExtractedRecipeDto>> handler,
         CancellationToken cancellationToken)
     {
-        List<PhotoData> photoDataList = [];
+        var oversized = photos.FirstOrDefault(p => p.Length > PhotoValidator.MaxPhotoSizeBytes);
+        if (oversized is not null) return PhotoTooLargeProblem(oversized.FileName);
 
+        List<PhotoData> photoDataList = [];
         foreach (var file in photos)
         {
-            if (file.Length > maxPhotoSizeBytes)
-            {
-                return Results.Problem(
-                    statusCode: StatusCodes.Status413PayloadTooLarge,
-                    detail: $"Photo '{file.FileName}' exceeds the maximum size of 10 MB.");
-            }
-
-            using var memoryStream = new MemoryStream((int)file.Length);
-            await file.CopyToAsync(memoryStream, cancellationToken);
-            photoDataList.Add(new PhotoData(memoryStream.ToArray(), file.ContentType, file.FileName));
+            photoDataList.Add(await LoadPhotoDataAsync(file, cancellationToken));
         }
 
         var command = new ImportRecipeFromPhotosCommand(photoDataList);
-
         var result = await handler.HandleAsync(command, cancellationToken);
-
         return result.ToOk();
     }
 
@@ -263,22 +248,27 @@ public static class RecipesEndpoints
         ICommandHandler<RecognizeIngredientsCommand, Result<RecognizedIngredientsResponseDto>> handler,
         CancellationToken cancellationToken)
     {
-        if (photo.Length > maxPhotoSizeBytes)
-        {
-            return Results.Problem(
-                statusCode: StatusCodes.Status413PayloadTooLarge,
-                detail: $"Photo exceeds the maximum size of 10 MB.");
-        }
+        if (photo.Length > PhotoValidator.MaxPhotoSizeBytes) return PhotoTooLargeProblem(photo.FileName);
 
-        using var memoryStream = new MemoryStream((int)photo.Length);
-        await photo.CopyToAsync(memoryStream, cancellationToken);
-        var photoData = new PhotoData(memoryStream.ToArray(), photo.ContentType, photo.FileName);
-
+        var photoData = await LoadPhotoDataAsync(photo, cancellationToken);
         var command = new RecognizeIngredientsCommand(photoData);
         var result = await handler.HandleAsync(command, cancellationToken);
-
         return result.ToOk();
     }
+
+    private static async Task<PhotoData> LoadPhotoDataAsync(IFormFile file, CancellationToken cancellationToken)
+    {
+        using var memoryStream = new MemoryStream((int)file.Length);
+        await file.CopyToAsync(memoryStream, cancellationToken);
+        return new PhotoData(memoryStream.ToArray(), file.ContentType, file.FileName);
+    }
+
+    private static IResult PhotoTooLargeProblem(string fileName) =>
+        Results.Problem(
+            statusCode: StatusCodes.Status413PayloadTooLarge,
+            detail: $"Photo '{fileName}' exceeds the maximum size of 10 MB.");
+
+    private const string EmptyChatMessageError = "Message cannot be empty.";
 
     private static async Task<IResult> ChatAsync(
         ChatRequestDto request,
@@ -289,7 +279,7 @@ public static class RecipesEndpoints
         {
             return Results.Problem(
                 statusCode: StatusCodes.Status400BadRequest,
-                detail: "Message cannot be empty.");
+                detail: EmptyChatMessageError);
         }
 
         var historyEntries = request.History
@@ -300,9 +290,28 @@ public static class RecipesEndpoints
         return result.ToOk();
     }
 
-#pragma warning disable SA1303
-    private const int maxStreamBufferLength = 100_000;
-#pragma warning restore SA1303
+    /// <summary>
+    /// Server-Sent Event types emitted by <see cref="ImportStreamAsync"/>.
+    /// Mirrored on the frontend in <c>libs/shared/api-client/import-stream-event.ts</c>.
+    /// </summary>
+    private static class SseEvent
+    {
+        public const string Status = "status";
+        public const string Chunk = "chunk";
+        public const string Done = "done";
+        public const string Fail = "fail";
+    }
+
+    private static class ImportStreaming
+    {
+        /// <summary>Hard cap on bytes buffered from the LLM stream before aborting.</summary>
+        public const int MaxBufferLength = 100_000;
+        public const string InvalidUrlMessage = "Invalid URL";
+        public const string FetchingStatusMessage = "Fetching page...";
+        public const string ExtractingStatusMessage = "Extracting recipe...";
+        public const string ResponseTooLargeMessage = "Response too large";
+        public const string ExtractionFailedMessage = "Extraction failed";
+    }
 
     private static async Task ImportStreamAsync(
         HttpContext httpContext,
@@ -329,34 +338,34 @@ public static class RecipesEndpoints
         }
         catch (GuardException)
         {
-            await WriteSseEventAsync("fail", "Invalid URL");
+            await WriteSseEventAsync(SseEvent.Fail, ImportStreaming.InvalidUrlMessage);
             return;
         }
 
-        await WriteSseEventAsync("status", "Fetching page...");
+        await WriteSseEventAsync(SseEvent.Status, ImportStreaming.FetchingStatusMessage);
 
         var scrapeResult = await scraper.ScrapeAsync(recipeUrl, cancellationToken);
         if (scrapeResult.IsFailure)
         {
-            await WriteSseEventAsync("fail", scrapeResult.Error!.Message);
+            await WriteSseEventAsync(SseEvent.Fail, scrapeResult.Error!.Message);
             return;
         }
 
-        await WriteSseEventAsync("status", "Extracting recipe...");
+        await WriteSseEventAsync(SseEvent.Status, ImportStreaming.ExtractingStatusMessage);
 
         var buffer = new StringBuilder();
         try
         {
             await foreach (var chunk in extraction.StreamExtractAsync(scrapeResult.Value, cancellationToken))
             {
-                if (buffer.Length + chunk.Length > maxStreamBufferLength)
+                if (buffer.Length + chunk.Length > ImportStreaming.MaxBufferLength)
                 {
-                    await WriteSseEventAsync("fail", "Response too large");
+                    await WriteSseEventAsync(SseEvent.Fail, ImportStreaming.ResponseTooLargeMessage);
                     return;
                 }
 
                 buffer.Append(chunk);
-                await WriteSseEventAsync("chunk", chunk);
+                await WriteSseEventAsync(SseEvent.Chunk, chunk);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -365,11 +374,11 @@ public static class RecipesEndpoints
         }
         catch (Exception)
         {
-            await WriteSseEventAsync("fail", "Extraction failed");
+            await WriteSseEventAsync(SseEvent.Fail, ImportStreaming.ExtractionFailedMessage);
             return;
         }
 
         var json = CompactJson(LlmResponseParser.ExtractJson(buffer.ToString()));
-        await WriteSseEventAsync("done", json);
+        await WriteSseEventAsync(SseEvent.Done, json);
     }
 }

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ChatCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ChatCommandHandler.cs
@@ -16,7 +16,7 @@ public sealed partial class ChatCommandHandler(
     public async Task<Result<ChatResponseDto>> HandleAsync(ChatCommand command, CancellationToken cancellationToken = default)
     {
         var (message, history) = command;
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogChatRequest(owner.Value, message.Value.Length, history.Count);
 

--- a/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed partial class DeleteRecipeCommandHandler(
     public async Task<Result> HandleAsync(DeleteRecipeCommand command, CancellationToken cancellationToken = default)
     {
         var identifier = command.Identifier;
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogDeleteRecipe(identifier, owner.Value);
 

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromPhotosCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromPhotosCommandHandler.cs
@@ -7,17 +7,14 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 
 #pragma warning disable SA1601
-#pragma warning disable SA1303
 public sealed partial class ImportRecipeFromPhotosCommandHandler(IRecipeExtractionService extractionService, ILogger<ImportRecipeFromPhotosCommandHandler> logger)
     : ICommandHandler<ImportRecipeFromPhotosCommand, Result<ExtractedRecipeDto>>
 {
-    private const int maxPhotos = 10;
-
     public async Task<Result<ExtractedRecipeDto>> HandleAsync(ImportRecipeFromPhotosCommand command, CancellationToken cancellationToken = default)
     {
         var photos = command.Photos;
 
-        var validation = PhotoValidator.ValidateMany(photos, maxPhotos);
+        var validation = PhotoValidator.ValidateMany(photos, PhotoValidator.MaxPhotos);
         if (validation.IsFailure)
         {
             LogValidationFailed(validation.Error!.Code);

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -18,7 +18,7 @@ public sealed partial class SaveRecipeCommandHandler(
         var (title, ingredientCommands, stepCommands, description, servings, preparationTime, cookingTime, difficulty,
             imageUrl, language, sourceUrl, tags) = command;
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         if (sourceUrl is not null && await recipes.ExistsBySourceUrlAsync(sourceUrl, owner, cancellationToken))
         {

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -18,7 +18,7 @@ public sealed partial class UpdateRecipeCommandHandler(
         var (identifier, title, ingredientCommands, stepCommands, description, servings,
              preparationTime, cookingTime, difficulty, imageUrl, tags) = command;
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogUpdateRecipe(identifier, owner.Value);
 

--- a/src/Yumney.Recipes.Application/CurrentUserExtensions.cs
+++ b/src/Yumney.Recipes.Application/CurrentUserExtensions.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application;
+
+public static class CurrentUserExtensions
+{
+    public static OwnerIdentifier AsOwner(this ICurrentUser currentUser) =>
+        OwnerIdentifier.From(currentUser.UserId);
+}

--- a/src/Yumney.Recipes.Application/DTOs/PhotoValidator.cs
+++ b/src/Yumney.Recipes.Application/DTOs/PhotoValidator.cs
@@ -5,6 +5,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 public static class PhotoValidator
 {
     public const long MaxPhotoSizeBytes = 10 * 1024 * 1024;
+    public const int MaxPhotos = 10;
 
     public static readonly HashSet<string> AllowedContentTypes =
     [

--- a/src/Yumney.Recipes.Application/DTOs/ScrapedContent.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ScrapedContent.cs
@@ -2,4 +2,4 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 
-public sealed record ScrapedContent(string CleanedText, RecipeUrl SourceUrl);
+public sealed record ScrapedContent(string CleanedText, string SourceUrl);

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
@@ -13,7 +13,7 @@ public sealed partial class GetRecipeByIdQueryHandler(IRecipeRepository recipes,
     public async Task<Result<RecipeDetailDto>> HandleAsync(GetRecipeByIdQuery query, CancellationToken cancellationToken = default)
     {
         var identifier = query.Identifier;
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogGetRecipeById(identifier, owner.Value);
 

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
@@ -13,7 +13,7 @@ public sealed partial class GetRecipesQueryHandler(IRecipeRepository recipes, IC
     public async Task<Result<PagedResult<RecipeListItemDto>>> HandleAsync(GetRecipesQuery query, CancellationToken cancellationToken = default)
     {
         var (paging, sorting, search) = query;
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogGetRecipes(owner.Value, paging.Page.Value, paging.PageSize.Value, search?.Value);
 

--- a/src/Yumney.Recipes.Domain/Chat/ChatRole.cs
+++ b/src/Yumney.Recipes.Domain/Chat/ChatRole.cs
@@ -5,26 +5,24 @@ namespace SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
 
 public sealed record ChatRole : IValueObject<string>
 {
+#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
+    private static readonly string[] AllowedValues = ["user", "assistant"];
+
     public static readonly ChatRole User = new("user");
     public static readonly ChatRole Assistant = new("assistant");
+#pragma warning restore SA1202
 
     public string Value { get; }
 
     private ChatRole(string value)
     {
-        Value = Ensure.That(value).IsNotNullOrWhiteSpace().AndReturn();
+        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(AllowedValues).AndReturn();
     }
 
     public static ChatRole From(string value)
     {
         string validated = Ensure.That(value).IsNotNullOrWhiteSpace().AndReturn();
-        var normalized = validated.ToLowerInvariant();
-        return normalized switch
-        {
-            "user" => User,
-            "assistant" => Assistant,
-            _ => throw new ArgumentException($"Unknown chat role: {value}", nameof(value)),
-        };
+        return new ChatRole(validated.ToLowerInvariant());
     }
 
     public static implicit operator string(ChatRole role) => role.Value;

--- a/src/Yumney.Recipes.Domain/Chat/ChatRole.cs
+++ b/src/Yumney.Recipes.Domain/Chat/ChatRole.cs
@@ -3,10 +3,11 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
 
+#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record ChatRole : IValueObject<string>
 {
-#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
-    private static readonly string[] AllowedValues = ["user", "assistant"];
+#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
+    private static readonly string[] allowedValues = ["user", "assistant"];
 
     public static readonly ChatRole User = new("user");
     public static readonly ChatRole Assistant = new("assistant");
@@ -16,7 +17,7 @@ public sealed record ChatRole : IValueObject<string>
 
     private ChatRole(string value)
     {
-        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(AllowedValues).AndReturn();
+        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(allowedValues).AndReturn();
     }
 
     public static ChatRole From(string value)
@@ -27,3 +28,4 @@ public sealed record ChatRole : IValueObject<string>
 
     public static implicit operator string(ChatRole role) => role.Value;
 }
+#pragma warning restore SA1311

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -119,7 +119,12 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
         var paging = PagingOptions.Of(Page.From(1), PageSize.From(maxRecipesToInclude));
         var sorting = new SortingOptions<RecipeSortField>(RecipeSortField.Date, SortDirection.Descending);
 
-        var (items, _) = await recipes.GetByOwnerAsync(owner, paging, sorting, cancellationToken: cancellationToken);
+        var (items, _) = await recipes.GetByOwnerAsync(
+            owner,
+            paging,
+            sorting,
+            null,
+            cancellationToken);
         return items;
     }
 

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
@@ -13,9 +13,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 
 #pragma warning disable SA1601
 #pragma warning disable SA1311
-public sealed partial class SemanticKernelIngredientRecognitionService(
-    Kernel kernel,
-    ILogger<SemanticKernelIngredientRecognitionService> logger)
+public sealed partial class SemanticKernelIngredientRecognitionService(Kernel kernel, ILogger<SemanticKernelIngredientRecognitionService> logger)
     : IIngredientRecognitionService
 {
     private static readonly JsonSerializerOptions jsonOptions = new()
@@ -24,9 +22,7 @@ public sealed partial class SemanticKernelIngredientRecognitionService(
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    public async Task<Result<RecognizedIngredientsResponseDto>> RecognizeAsync(
-        PhotoData photo,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<RecognizedIngredientsResponseDto>> RecognizeAsync(PhotoData photo, CancellationToken cancellationToken = default)
     {
         using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("recognize.ingredients");
         activity?.SetTag("recognize.photo_size", photo.Content.Length);
@@ -46,6 +42,7 @@ public sealed partial class SemanticKernelIngredientRecognitionService(
         {
             var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
             response = result.Content ?? string.Empty;
+
             activity?.SetTag("llm.response_length", response.Length);
             activity?.SetTag("llm.model", result.ModelId);
         }

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
@@ -24,25 +24,25 @@ public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel,
 
     public async Task<Result<ExtractedRecipeDto>> ExtractAsync(ScrapedContent content, CancellationToken cancellationToken = default)
     {
-        using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("extract.recipe.url");
-        activity?.SetTag("extract.source", content.SourceUrl.Value);
-        activity?.SetTag("extract.content_length", content.CleanedText.Length);
+        var (cleanedText, sourceUrl) = content;
 
-        var sanitized = ContentSanitizer.Sanitize(content.CleanedText);
+        using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("extract.recipe.url");
+        activity?.SetTag("extract.source", sourceUrl);
+        activity?.SetTag("extract.content_length", cleanedText.Length);
+
+        var sanitized = ContentSanitizer.Sanitize(cleanedText);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddSystemMessage(ExtractionPrompts.WebExtraction);
         chatHistory.AddUserMessage(ExtractionPrompts.WrapInContentDelimiters(sanitized));
 
-        var result = await CallLlmAndParseAsync(chatHistory, content.SourceUrl.Value, cancellationToken);
+        var result = await CallLlmAndParseAsync(chatHistory, sourceUrl, cancellationToken);
         SetActivityResult(activity, result);
 
         return result;
     }
 
-    public async Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(
-        IReadOnlyList<PhotoData> photos,
-        CancellationToken cancellationToken = default)
+    public async Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(IReadOnlyList<PhotoData> photos, CancellationToken cancellationToken = default)
     {
         using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("extract.recipe.photos");
         activity?.SetTag("extract.photo_count", photos.Count);

--- a/src/Yumney.Shared.Guards/GuardExtensions.cs
+++ b/src/Yumney.Shared.Guards/GuardExtensions.cs
@@ -77,6 +77,18 @@ public static class GuardExtensions
 
             return guard;
         }
+
+        public GuardClause<string> IsOneOf(params string[] allowed)
+        {
+            if (guard.Value is null || !allowed.Contains(guard.Value))
+            {
+                throw new GuardException(
+                    guard.ParameterName,
+                    $"{guard.ParameterName} must be one of: {string.Join(", ", allowed)}.");
+            }
+
+            return guard;
+        }
     }
 
     extension(GuardClause<int> guard)

--- a/src/Yumney.Shared/Common/PagingOptions.cs
+++ b/src/Yumney.Shared/Common/PagingOptions.cs
@@ -20,10 +20,6 @@ public sealed record PagingOptions
 
     public static PagingOptions Of(Page page, PageSize pageSize) => new(page, pageSize);
 
-    /// <summary>
-    /// Convenience factory for endpoint query-parameter parsing — wraps the
-    /// raw page/pageSize ints in their value objects.
-    /// </summary>
     public static PagingOptions From(int page, int pageSize) =>
         new(Page.From(page), PageSize.From(pageSize));
 }

--- a/src/Yumney.Shared/Common/PagingOptions.cs
+++ b/src/Yumney.Shared/Common/PagingOptions.cs
@@ -19,4 +19,11 @@ public sealed record PagingOptions
     }
 
     public static PagingOptions Of(Page page, PageSize pageSize) => new(page, pageSize);
+
+    /// <summary>
+    /// Convenience factory for endpoint query-parameter parsing — wraps the
+    /// raw page/pageSize ints in their value objects.
+    /// </summary>
+    public static PagingOptions From(int page, int pageSize) =>
+        new(Page.From(page), PageSize.From(pageSize));
 }

--- a/src/Yumney.Shared/Common/SortingOptions.cs
+++ b/src/Yumney.Shared/Common/SortingOptions.cs
@@ -1,4 +1,18 @@
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed record SortingOptions<TSortField>(TSortField SortBy, SortDirection Direction)
-    where TSortField : struct, Enum;
+    where TSortField : struct, Enum
+{
+    /// <summary>
+    /// Parses a sort-by query string against the enum, falling back to the
+    /// supplied default when the value is missing or unknown.
+    /// </summary>
+    public static SortingOptions<TSortField> Parse(
+        string? sortBy,
+        SortDirection direction,
+        TSortField fallback)
+    {
+        var field = default(TSortField).ParseNullable(sortBy) ?? fallback;
+        return new SortingOptions<TSortField>(field, direction);
+    }
+}

--- a/src/Yumney.Shared/Common/SortingOptions.cs
+++ b/src/Yumney.Shared/Common/SortingOptions.cs
@@ -3,10 +3,6 @@ namespace SmartSolutionsLab.Yumney.Shared.Common;
 public sealed record SortingOptions<TSortField>(TSortField SortBy, SortDirection Direction)
     where TSortField : struct, Enum
 {
-    /// <summary>
-    /// Parses a sort-by query string against the enum, falling back to the
-    /// supplied default when the value is missing or unknown.
-    /// </summary>
     public static SortingOptions<TSortField> Parse(
         string? sortBy,
         SortDirection direction,

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -79,11 +79,9 @@ public static class ShoppingEndpoints
         SortDirection sortDirection = SortDirection.Descending,
         CancellationToken cancellationToken = default)
     {
-        var sortField = default(ShoppingListSortField).ParseNullable(sortBy) ?? ShoppingListSortField.Date;
-
         var query = new GetShoppingListsQuery(
-            PagingOptions.Of(Page.From(page), PageSize.From(pageSize)),
-            new SortingOptions<ShoppingListSortField>(sortField, sortDirection));
+            PagingOptions.From(page, pageSize),
+            SortingOptions<ShoppingListSortField>.Parse(sortBy, sortDirection, ShoppingListSortField.Date));
         var result = await handler.HandleAsync(query, cancellationToken);
 
         return result.ToOk();

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffAllItemsCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffAllItemsCommandHandler.cs
@@ -20,7 +20,7 @@ public sealed partial class CheckOffAllItemsCommandHandler(
 
         if (shoppingList is null) return Result.Failure(CheckOffItemErrors.ListNotFound);
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         if (shoppingList.Owner != owner) return Result.Failure(CheckOffItemErrors.AccessDenied);
 

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CheckOffItemCommandHandler.cs
@@ -20,7 +20,7 @@ public sealed partial class CheckOffItemCommandHandler(
 
         if (shoppingList is null) return Result.Failure(CheckOffItemErrors.ListNotFound);
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         if (shoppingList.Owner != owner) return Result.Failure(CheckOffItemErrors.AccessDenied);
 

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
@@ -17,7 +17,7 @@ public sealed partial class CreateShoppingListCommandHandler(
     {
         var (title, itemCommands, recipeReference) = command;
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         var items = itemCommands
             .Select(i => Domain.ShoppingList.ShoppingListItem.Create(i.Name, i.Quantity))

--- a/src/Yumney.Shopping.Application/CurrentUserExtensions.cs
+++ b/src/Yumney.Shopping.Application/CurrentUserExtensions.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application;
+
+public static class CurrentUserExtensions
+{
+    public static OwnerIdentifier AsOwner(this ICurrentUser currentUser) =>
+        OwnerIdentifier.From(currentUser.UserId);
+}

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -26,7 +26,7 @@ public sealed partial class GetShoppingListByIdQueryHandler(
 
         if (shoppingList is null) return GetShoppingListByIdErrors.NotFound;
 
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         if (shoppingList.Owner != owner) return GetShoppingListByIdErrors.AccessDenied;
 

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -18,7 +18,7 @@ public sealed partial class GetShoppingListsQueryHandler(
         CancellationToken cancellationToken = default)
     {
         var (paging, sorting) = query;
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogGetShoppingLists(owner.Value, paging.Page.Value, paging.PageSize.Value);
 

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -48,15 +48,13 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
     public void CheckOffItem(ShoppingListItemIdentifier itemId)
     {
-        var item = items.FirstOrDefault(i => i.Id == itemId)
-            ?? throw new GuardException(nameof(itemId), $"Item {itemId} not found in shopping list.");
+        var item = FindItem(itemId);
         item.Check();
     }
 
     public void UncheckItem(ShoppingListItemIdentifier itemId)
     {
-        var item = items.FirstOrDefault(i => i.Id == itemId)
-            ?? throw new GuardException(nameof(itemId), $"Item {itemId} not found in shopping list.");
+        var item = FindItem(itemId);
         item.Uncheck();
     }
 
@@ -74,5 +72,12 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
         {
             item.Uncheck();
         }
+    }
+
+    private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)
+    {
+        var item = items.FirstOrDefault(i => i.Id == itemId);
+        Ensure.That(item!).IsNotNull();
+        return item!;
     }
 }

--- a/src/Yumney.Users.Application/CurrentUserExtensions.cs
+++ b/src/Yumney.Users.Application/CurrentUserExtensions.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application;
+
+public static class CurrentUserExtensions
+{
+    public static OwnerIdentifier AsOwner(this ICurrentUser currentUser) =>
+        OwnerIdentifier.From(currentUser.UserId);
+}

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -16,7 +16,7 @@ public sealed partial class GetRecentActivityQueryHandler(
 {
     public async Task<Result<IReadOnlyList<UserActivityDto>>> HandleAsync(GetRecentActivityQuery query, CancellationToken cancellationToken = default)
     {
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogGetRecentActivity(owner.Value, query.Limit);
 

--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -14,7 +14,7 @@ public sealed partial class GetSuggestionsQueryHandler(
 {
     public async Task<Result<SuggestionsResponseDto>> HandleAsync(GetSuggestionsQuery query, CancellationToken cancellationToken = default)
     {
-        var owner = OwnerIdentifier.From(currentUser.UserId);
+        var owner = currentUser.AsOwner();
 
         LogGetSuggestions(owner.Value);
 
@@ -25,34 +25,24 @@ public sealed partial class GetSuggestionsQueryHandler(
         return Result.Success(new SuggestionsResponseDto(Suggestions: [], QuickActions: quickActions));
     }
 
+    private static class MealHours
+    {
+        public const int BreakfastStart = 5;
+        public const int BreakfastEnd = 11;
+        public const int LunchEnd = 15;
+        public const int DinnerEnd = 21;
+    }
+
+    private const int RecentImportLookbackHours = -1;
+    private const int MaxQuickActions = 4;
+
     private static List<string> BuildQuickActions(IReadOnlyList<UserActivity> recentActivities)
     {
-        var actions = new List<string>();
-        var hour = DateTime.UtcNow.Hour;
-        var dayOfWeek = DateTime.UtcNow.DayOfWeek;
+        var now = DateTime.UtcNow;
+        var hour = now.Hour;
+        var actions = new List<string>(BuildTimeOfDayActions(hour));
 
-        if (hour >= 5 && hour < 11)
-        {
-            actions.Add("breakfast_ideas");
-            actions.Add("quick_meals");
-        }
-        else if (hour >= 11 && hour < 15)
-        {
-            actions.Add("lunch_recipes");
-            actions.Add("quick_meals");
-        }
-        else if (hour >= 15 && hour < 21)
-        {
-            actions.Add("whats_for_dinner");
-            actions.Add("30_min_recipes");
-        }
-        else
-        {
-            actions.Add("snack_ideas");
-            actions.Add("meal_prep");
-        }
-
-        if (dayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+        if (now.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
         {
             actions.Add("meal_prep");
             actions.Add("try_something_new");
@@ -60,7 +50,7 @@ public sealed partial class GetSuggestionsQueryHandler(
 
         var hasRecentImport = recentActivities.Any(a =>
             a.Type == ActivityType.RecipeImported &&
-            a.OccurredAt > DateTime.UtcNow.AddHours(-1));
+            a.OccurredAt > now.AddHours(RecentImportLookbackHours));
 
         if (hasRecentImport)
         {
@@ -68,8 +58,16 @@ public sealed partial class GetSuggestionsQueryHandler(
             actions.Insert(1, "add_to_shopping_list");
         }
 
-        return actions.Distinct().Take(4).ToList();
+        return actions.Distinct().Take(MaxQuickActions).ToList();
     }
+
+    private static IEnumerable<string> BuildTimeOfDayActions(int hour) => hour switch
+    {
+        >= MealHours.BreakfastStart and < MealHours.BreakfastEnd => ["breakfast_ideas", "quick_meals"],
+        >= MealHours.BreakfastEnd and < MealHours.LunchEnd => ["lunch_recipes", "quick_meals"],
+        >= MealHours.LunchEnd and < MealHours.DinnerEnd => ["whats_for_dinner", "30_min_recipes"],
+        _ => ["snack_ideas", "meal_prep"],
+    };
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Getting suggestions for user {UserId}")]
     private partial void LogGetSuggestions(string userId);

--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -33,8 +33,10 @@ public sealed partial class GetSuggestionsQueryHandler(
         public const int DinnerEnd = 21;
     }
 
-    private const int RecentImportLookbackHours = -1;
-    private const int MaxQuickActions = 4;
+#pragma warning disable SA1303 // editorconfig requires camelCase for private const fields
+    private const int recentImportLookbackHours = -1;
+    private const int maxQuickActions = 4;
+#pragma warning restore SA1303
 
     private static List<string> BuildQuickActions(IReadOnlyList<UserActivity> recentActivities)
     {
@@ -50,7 +52,7 @@ public sealed partial class GetSuggestionsQueryHandler(
 
         var hasRecentImport = recentActivities.Any(a =>
             a.Type == ActivityType.RecipeImported &&
-            a.OccurredAt > now.AddHours(RecentImportLookbackHours));
+            a.OccurredAt > now.AddHours(recentImportLookbackHours));
 
         if (hasRecentImport)
         {
@@ -58,7 +60,7 @@ public sealed partial class GetSuggestionsQueryHandler(
             actions.Insert(1, "add_to_shopping_list");
         }
 
-        return actions.Distinct().Take(MaxQuickActions).ToList();
+        return actions.Distinct().Take(maxQuickActions).ToList();
     }
 
     private static IEnumerable<string> BuildTimeOfDayActions(int hour) => hour switch

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
@@ -3,12 +3,13 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
+#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record PreferredLanguage : IValueObject<string>
 {
     public const int MaxLength = 10;
 
-#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
-    private static readonly string[] AllowedValues = ["en", "de"];
+#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
+    private static readonly string[] allowedValues = ["en", "de"];
 
     public static readonly PreferredLanguage English = new("en");
     public static readonly PreferredLanguage German = new("de");
@@ -21,7 +22,7 @@ public sealed record PreferredLanguage : IValueObject<string>
         Value = Ensure.That(value)
             .IsNotNullOrWhiteSpace()
             .HasMaxLength(MaxLength)
-            .IsOneOf(AllowedValues)
+            .IsOneOf(allowedValues)
             .AndReturn();
     }
 
@@ -29,3 +30,4 @@ public sealed record PreferredLanguage : IValueObject<string>
 
     public static implicit operator string(PreferredLanguage obj) => obj.Value;
 }
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredLanguage.cs
@@ -7,6 +7,13 @@ public sealed record PreferredLanguage : IValueObject<string>
 {
     public const int MaxLength = 10;
 
+#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
+    private static readonly string[] AllowedValues = ["en", "de"];
+
+    public static readonly PreferredLanguage English = new("en");
+    public static readonly PreferredLanguage German = new("de");
+#pragma warning restore SA1202
+
     public string Value { get; }
 
     private PreferredLanguage(string value)
@@ -14,6 +21,7 @@ public sealed record PreferredLanguage : IValueObject<string>
         Value = Ensure.That(value)
             .IsNotNullOrWhiteSpace()
             .HasMaxLength(MaxLength)
+            .IsOneOf(AllowedValues)
             .AndReturn();
     }
 

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
@@ -7,6 +7,13 @@ public sealed record PreferredUnitSystem : IValueObject<string>
 {
     public const int MaxLength = 20;
 
+#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
+    private static readonly string[] AllowedValues = ["metric", "imperial"];
+
+    public static readonly PreferredUnitSystem Metric = new("metric");
+    public static readonly PreferredUnitSystem Imperial = new("imperial");
+#pragma warning restore SA1202
+
     public string Value { get; }
 
     private PreferredUnitSystem(string value)
@@ -14,6 +21,7 @@ public sealed record PreferredUnitSystem : IValueObject<string>
         Value = Ensure.That(value)
             .IsNotNullOrWhiteSpace()
             .HasMaxLength(MaxLength)
+            .IsOneOf(AllowedValues)
             .AndReturn();
     }
 

--- a/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/PreferredUnitSystem.cs
@@ -3,12 +3,13 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
+#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record PreferredUnitSystem : IValueObject<string>
 {
     public const int MaxLength = 20;
 
-#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
-    private static readonly string[] AllowedValues = ["metric", "imperial"];
+#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
+    private static readonly string[] allowedValues = ["metric", "imperial"];
 
     public static readonly PreferredUnitSystem Metric = new("metric");
     public static readonly PreferredUnitSystem Imperial = new("imperial");
@@ -21,7 +22,7 @@ public sealed record PreferredUnitSystem : IValueObject<string>
         Value = Ensure.That(value)
             .IsNotNullOrWhiteSpace()
             .HasMaxLength(MaxLength)
-            .IsOneOf(AllowedValues)
+            .IsOneOf(allowedValues)
             .AndReturn();
     }
 
@@ -29,3 +30,4 @@ public sealed record PreferredUnitSystem : IValueObject<string>
 
     public static implicit operator string(PreferredUnitSystem obj) => obj.Value;
 }
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -5,24 +5,31 @@ namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 public sealed record ActivityType : IValueObject<string>
 {
+#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
+    private static readonly string[] AllowedValues =
+    [
+        "recipe_imported",
+        "recipe_viewed",
+        "recipe_edited",
+        "recipe_deleted",
+        "shopping_list_created",
+    ];
+
     public static readonly ActivityType RecipeImported = new("recipe_imported");
     public static readonly ActivityType RecipeViewed = new("recipe_viewed");
     public static readonly ActivityType RecipeEdited = new("recipe_edited");
     public static readonly ActivityType RecipeDeleted = new("recipe_deleted");
     public static readonly ActivityType ShoppingListCreated = new("shopping_list_created");
+#pragma warning restore SA1202
 
     public string Value { get; }
 
     private ActivityType(string value)
     {
-        Value = Ensure.That(value).IsNotNullOrWhiteSpace().AndReturn();
+        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(AllowedValues).AndReturn();
     }
 
-    public static ActivityType From(string value)
-    {
-        Ensure.That(value).IsNotNullOrWhiteSpace();
-        return new ActivityType(value);
-    }
+    public static ActivityType From(string value) => new(value);
 
     public static implicit operator string(ActivityType type) => type.Value;
 }

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -3,10 +3,11 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
+#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record ActivityType : IValueObject<string>
 {
-#pragma warning disable SA1202 // AllowedValues must initialize before the public static instances
-    private static readonly string[] AllowedValues =
+#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
+    private static readonly string[] allowedValues =
     [
         "recipe_imported",
         "recipe_viewed",
@@ -26,10 +27,11 @@ public sealed record ActivityType : IValueObject<string>
 
     private ActivityType(string value)
     {
-        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(AllowedValues).AndReturn();
+        Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(allowedValues).AndReturn();
     }
 
     public static ActivityType From(string value) => new(value);
 
     public static implicit operator string(ActivityType type) => type.Value;
 }
+#pragma warning restore SA1311

--- a/tests/Yumney.Shared.Guards.Tests/EnsureTests.cs
+++ b/tests/Yumney.Shared.Guards.Tests/EnsureTests.cs
@@ -132,6 +132,35 @@ public class EnsureTests
         act.Should().Throw<GuardException>();
     }
 
+    [Theory]
+    [InlineData("en", new[] { "en", "de" })]
+    [InlineData("metric", new[] { "metric", "imperial" })]
+    public void IsOneOf_AllowedValue_DoesNotThrow(string value, string[] allowed)
+    {
+        var act = () => Ensure.That(value).IsOneOf(allowed);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("fr", new[] { "en", "de" })]
+    [InlineData("EN", new[] { "en", "de" })]
+    [InlineData("", new[] { "en", "de" })]
+    public void IsOneOf_DisallowedValue_ThrowsGuardException(string value, string[] allowed)
+    {
+        var act = () => Ensure.That(value).IsOneOf(allowed);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void IsOneOf_NullValue_ThrowsGuardException()
+    {
+        var act = () => Ensure.That((string?)null!).IsOneOf("a", "b");
+
+        act.Should().Throw<GuardException>();
+    }
+
     [Fact]
     public void IsNotNull_ValidReference_DoesNotThrow()
     {

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredLanguageTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredLanguageTests.cs
@@ -10,8 +10,7 @@ public class PreferredLanguageTests
     [Theory]
     [InlineData("en")]
     [InlineData("de")]
-    [InlineData("fr")]
-    public void Constructor_ValidValue_CreatesInstance(string value)
+    public void Constructor_SupportedValue_CreatesInstance(string value)
     {
         var language = PreferredLanguage.From(value);
 
@@ -29,20 +28,28 @@ public class PreferredLanguageTests
         act.Should().Throw<GuardException>();
     }
 
-    [Fact]
-    public void Constructor_AtMaxLength_CreatesInstance()
+    [Theory]
+    [InlineData("fr")]
+    [InlineData("EN")]
+    [InlineData("english")]
+    [InlineData("xx")]
+    public void Constructor_UnsupportedLanguage_ThrowsGuardException(string value)
     {
-        var language = PreferredLanguage.From(new string('a', 10));
+        var act = () => PreferredLanguage.From(value);
 
-        language.Value.Should().HaveLength(10);
+        act.Should().Throw<GuardException>();
     }
 
     [Fact]
-    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    public void English_StaticInstance_HasValueEn()
     {
-        var act = () => PreferredLanguage.From(new string('a', 11));
+        PreferredLanguage.English.Value.Should().Be("en");
+    }
 
-        act.Should().Throw<GuardException>();
+    [Fact]
+    public void German_StaticInstance_HasValueDe()
+    {
+        PreferredLanguage.German.Value.Should().Be("de");
     }
 
     [Fact]

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredUnitSystemTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/PreferredUnitSystemTests.cs
@@ -10,7 +10,7 @@ public class PreferredUnitSystemTests
     [Theory]
     [InlineData("metric")]
     [InlineData("imperial")]
-    public void Constructor_ValidValue_CreatesInstance(string value)
+    public void Constructor_SupportedValue_CreatesInstance(string value)
     {
         var unitSystem = PreferredUnitSystem.From(value);
 
@@ -28,20 +28,28 @@ public class PreferredUnitSystemTests
         act.Should().Throw<GuardException>();
     }
 
-    [Fact]
-    public void Constructor_AtMaxLength_CreatesInstance()
+    [Theory]
+    [InlineData("Metric")]
+    [InlineData("METRIC")]
+    [InlineData("us")]
+    [InlineData("uk")]
+    public void Constructor_UnsupportedValue_ThrowsGuardException(string value)
     {
-        var unitSystem = PreferredUnitSystem.From(new string('a', 20));
+        var act = () => PreferredUnitSystem.From(value);
 
-        unitSystem.Value.Should().HaveLength(20);
+        act.Should().Throw<GuardException>();
     }
 
     [Fact]
-    public void Constructor_ExceedsMaxLength_ThrowsGuardException()
+    public void Metric_StaticInstance_HasValueMetric()
     {
-        var act = () => PreferredUnitSystem.From(new string('a', 21));
+        PreferredUnitSystem.Metric.Value.Should().Be("metric");
+    }
 
-        act.Should().Throw<GuardException>();
+    [Fact]
+    public void Imperial_StaticInstance_HasValueImperial()
+    {
+        PreferredUnitSystem.Imperial.Value.Should().Be("imperial");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `IsOneOf(params string[])` guard extension to `Yumney.Shared.Guards`
- Lock down value objects that should accept only a fixed set:
  - **ChatRole** — was throwing bare `ArgumentException` for unknown values; now goes through `Ensure.That().IsOneOf()` so 400 Bad Request is returned consistently via the global exception handler
  - **ActivityType** — `From()` previously accepted ANY string and silently created a new instance outside the predefined set; now restricted to the 5 known activity types
  - **PreferredLanguage** — was accepting any 10-char string; now restricted to `en` / `de`
  - **PreferredUnitSystem** — was accepting any 20-char string; now restricted to `metric` / `imperial`
- Refactor `ShoppingList.CheckOffItem` / `UncheckItem` to use `Ensure.That()` via a private `FindItem` helper instead of bare `?? throw new GuardException`

## Test plan
- [x] +9 new `IsOneOf` tests in `EnsureTests`
- [x] `PreferredLanguageTests` and `PreferredUnitSystemTests` rewritten to exercise the closed set
- [x] All 1113 backend tests pass locally
- [x] `dotnet build` clean