### PR TITLE
feat(recipes): filter by tags, difficulty, and time (US-072)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -43,6 +43,21 @@
         "noResultsMessage": "Keine Rezepte für \"{{query}}\" gefunden. Versuche einen anderen Suchbegriff.",
         "clear": "Suche löschen"
       },
+      "filter": {
+        "toggle": "Filter",
+        "title": "Rezepte filtern",
+        "clear": "Alle löschen",
+        "tags": "Tags",
+        "difficulty": "Schwierigkeit",
+        "difficultyOption": {
+          "easy": "Einfach",
+          "medium": "Mittel",
+          "hard": "Schwer"
+        },
+        "maxPrepTime": "Max. Vorbereitung (Min.)",
+        "maxCookTime": "Max. Kochzeit (Min.)",
+        "minutesPlaceholder": "Min."
+      },
       "errors": {
         "generic": "Rezepte konnten nicht geladen werden. Bitte versuche es später erneut."
       }

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -43,6 +43,21 @@
         "noResultsMessage": "No recipes match \"{{query}}\". Try a different search term.",
         "clear": "Clear search"
       },
+      "filter": {
+        "toggle": "Filters",
+        "title": "Filter recipes",
+        "clear": "Clear all",
+        "tags": "Tags",
+        "difficulty": "Difficulty",
+        "difficultyOption": {
+          "easy": "Easy",
+          "medium": "Medium",
+          "hard": "Hard"
+        },
+        "maxPrepTime": "Max prep time (min)",
+        "maxCookTime": "Max cook time (min)",
+        "minutesPlaceholder": "min"
+      },
       "errors": {
         "generic": "Failed to load recipes. Please try again later."
       }

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -30,24 +30,46 @@
   </div>
 
   <div class="search-bar">
-    <input
-      type="search"
-      class="search-input"
-      [value]="searchQuery()"
-      (input)="onSearchInput($event)"
-      [placeholder]="t('recipes.list.search.placeholder')"
-      [attr.aria-label]="t('recipes.list.search.label')"
-    />
-    @if (searchQuery()) {
-      <button
-        class="search-clear"
-        (click)="onSearchClear()"
-        [attr.aria-label]="t('recipes.list.search.clear')"
-      >
-        &times;
-      </button>
-    }
+    <div class="search-input-wrapper">
+      <input
+        type="search"
+        class="search-input"
+        [value]="searchQuery()"
+        (input)="onSearchInput($event)"
+        [placeholder]="t('recipes.list.search.placeholder')"
+        [attr.aria-label]="t('recipes.list.search.label')"
+      />
+      @if (searchQuery()) {
+        <button
+          class="search-clear"
+          (click)="onSearchClear()"
+          [attr.aria-label]="t('recipes.list.search.clear')"
+        >
+          &times;
+        </button>
+      }
+    </div>
+    <button
+      type="button"
+      class="filter-toggle"
+      (click)="toggleFilterPanel()"
+      [attr.aria-expanded]="filterPanelOpen()"
+      [attr.aria-label]="t('recipes.list.filter.toggle')"
+    >
+      {{ t('recipes.list.filter.toggle') }}
+      @if (filterActiveCount() > 0) {
+        <span class="filter-toggle-count">{{ filterActiveCount() }}</span>
+      }
+    </button>
   </div>
+
+  @if (filterPanelOpen()) {
+    <yn-filter-panel
+      [value]="filter()"
+      [availableTags]="availableTags()"
+      (valueChange)="onFilterChange($event)"
+    />
+  }
 
   @if (serverError(); as error) {
     <div class="error-banner" role="alert">{{ t(error) }}</div>

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -102,7 +102,57 @@
 
 // ── Search bar with glass ──
 .search-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  margin-bottom: var(--yn-space-5);
+}
+
+.search-input-wrapper {
   position: relative;
+  flex: 1;
+}
+
+.filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-base);
+  white-space: nowrap;
+  cursor: pointer;
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+  transition:
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    background var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+}
+
+.filter-toggle-count {
+  display: inline-flex;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 var(--yn-space-2);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-primary);
+  color: var(--yn-on-primary, white);
+  font-size: var(--yn-text-xs);
+  font-weight: var(--yn-font-semibold);
+}
+
+yn-filter-panel {
+  display: block;
   margin-bottom: var(--yn-space-7);
 }
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -16,11 +16,18 @@ import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeListItem, GetRecipesParams } from '@yumney/shared/api-client';
 import { createAsyncState, ERROR_MAPS, ROUTES, UI } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
-import { InfiniteScrollDirective, staggerFadeIn, prefersReducedMotion } from '@yumney/ui';
+import {
+  EMPTY_FILTER,
+  FilterPanelComponent,
+  InfiniteScrollDirective,
+  prefersReducedMotion,
+  type RecipeFilterValue,
+  staggerFadeIn,
+} from '@yumney/ui';
 
 @Component({
   selector: 'yn-recipe-list',
-  imports: [TranslocoModule, RouterLink, InfiniteScrollDirective],
+  imports: [TranslocoModule, RouterLink, InfiniteScrollDirective, FilterPanelComponent],
   templateUrl: './recipe-list.component.html',
   styleUrl: './recipe-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -103,6 +110,9 @@ export class RecipeListComponent implements OnInit {
   serverError = this.asyncState.serverError;
   searchQuery = signal('');
   activeSearch = signal('');
+  filter = signal<RecipeFilterValue>({ ...EMPTY_FILTER });
+  filterPanelOpen = signal(false);
+  availableTags = signal<string[]>([]);
 
   hasMore = computed(() => this.recipes().length < this.totalCount());
   sortMenuOpen = signal(false);
@@ -177,14 +187,40 @@ export class RecipeListComponent implements OnInit {
     this.loadRecipes(true);
   }
 
+  toggleFilterPanel(): void {
+    this.filterPanelOpen.update((open) => !open);
+  }
+
+  onFilterChange(value: RecipeFilterValue): void {
+    this.filter.set(value);
+    this.currentPage.set(1);
+    this.recipes.set([]);
+    this.totalCount.set(0);
+    this.loadRecipes(false);
+  }
+
+  filterActiveCount = computed(() => {
+    const f = this.filter();
+    let count = f.tags.length;
+    if (f.difficulty !== null) count += 1;
+    if (f.maxPrepTime !== null) count += 1;
+    if (f.maxCookTime !== null) count += 1;
+    return count;
+  });
+
   private loadRecipes(append: boolean): void {
     const search = this.activeSearch();
+    const f = this.filter();
     const params: GetRecipesParams = {
       page: this.currentPage(),
       pageSize: this.pageSize(),
       sortBy: this.sortBy(),
       sortDirection: this.sortDirection(),
       ...(search !== '' && { search }),
+      ...(f.tags.length > 0 && { tags: f.tags }),
+      ...(f.difficulty !== null && { difficulty: f.difficulty }),
+      ...(f.maxPrepTime !== null && { maxPrepTime: f.maxPrepTime }),
+      ...(f.maxCookTime !== null && { maxCookTime: f.maxCookTime }),
     };
 
     this.asyncState.execute(
@@ -197,7 +233,18 @@ export class RecipeListComponent implements OnInit {
         } else {
           this.recipes.set(response.items);
         }
+        this.collectAvailableTags(response.items);
       },
     );
+  }
+
+  private collectAvailableTags(items: RecipeListItem[]): void {
+    const existing = new Set(this.availableTags());
+    for (const item of items) {
+      if (Array.isArray(item.tags)) {
+        for (const tag of item.tags) existing.add(tag);
+      }
+    }
+    this.availableTags.set([...existing].sort((a, b) => a.localeCompare(b)));
   }
 }

--- a/client/libs/shared/api-client/src/lib/get-recipes-params.ts
+++ b/client/libs/shared/api-client/src/lib/get-recipes-params.ts
@@ -1,6 +1,12 @@
 import type { PaginationParams } from '@yumney/shared/models';
 
+export type RecipeDifficulty = 'easy' | 'medium' | 'hard';
+
 export interface GetRecipesParams extends PaginationParams {
   sortBy?: 'Name' | 'Date';
   search?: string;
+  tags?: string[];
+  difficulty?: RecipeDifficulty;
+  maxPrepTime?: number;
+  maxCookTime?: number;
 }

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -148,6 +148,10 @@ export class RecipeApiService {
         ...(params.sortBy != null && { sortBy: params.sortBy }),
         ...(params.sortDirection != null && { sortDirection: params.sortDirection }),
         ...(params.search != null && params.search !== '' && { search: params.search }),
+        ...(params.tags != null && params.tags.length > 0 && { tags: params.tags.join(',') }),
+        ...(params.difficulty != null && { difficulty: params.difficulty }),
+        ...(params.maxPrepTime != null && { maxPrepTime: params.maxPrepTime }),
+        ...(params.maxCookTime != null && { maxCookTime: params.maxCookTime }),
       },
     });
   }

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -25,6 +25,12 @@ export { IngredientScannerComponent } from './lib/ingredient-scanner/ingredient-
 export { ChatPanelComponent } from './lib/chat-panel/chat-panel.component';
 export { ShareToastComponent } from './lib/share-toast/share-toast.component';
 export { IngredientsToastComponent } from './lib/ingredients-toast/ingredients-toast.component';
+export {
+  FilterPanelComponent,
+  type RecipeFilterValue,
+  type RecipeDifficulty,
+  EMPTY_FILTER,
+} from './lib/filter-panel/filter-panel.component';
 
 // Directives
 export { InfiniteScrollDirective } from './lib/directives/infinite-scroll.directive';

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.html
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.html
@@ -1,0 +1,79 @@
+<div class="filter-panel" *transloco="let t">
+  <div class="filter-header">
+    <h3 class="filter-title">
+      {{ t('recipes.list.filter.title') }}
+      @if (activeCount() > 0) {
+        <span class="filter-count">({{ activeCount() }})</span>
+      }
+    </h3>
+    @if (activeCount() > 0) {
+      <button type="button" class="clear-button" (click)="clearAll()">
+        {{ t('recipes.list.filter.clear') }}
+      </button>
+    }
+  </div>
+
+  @if (availableTags().length > 0) {
+    <div class="filter-group">
+      <label class="filter-label">{{ t('recipes.list.filter.tags') }}</label>
+      <div class="chip-row">
+        @for (tag of availableTags(); track tag) {
+          <button
+            type="button"
+            class="filter-chip"
+            [class.active]="isTagActive(tag)"
+            (click)="toggleTag(tag)"
+          >
+            {{ tag }}
+          </button>
+        }
+      </div>
+    </div>
+  }
+
+  <div class="filter-group">
+    <label class="filter-label">{{ t('recipes.list.filter.difficulty') }}</label>
+    <div class="chip-row">
+      @for (option of difficultyOptions; track option) {
+        <button
+          type="button"
+          class="filter-chip"
+          [class.active]="value().difficulty === option"
+          (click)="toggleDifficulty(option)"
+        >
+          {{ t('recipes.list.filter.difficultyOption.' + option) }}
+        </button>
+      }
+    </div>
+  </div>
+
+  <div class="filter-group time-group">
+    <label class="filter-label" for="filter-max-prep">
+      {{ t('recipes.list.filter.maxPrepTime') }}
+    </label>
+    <input
+      id="filter-max-prep"
+      type="number"
+      class="time-input"
+      min="1"
+      [value]="value().maxPrepTime ?? ''"
+      (change)="onPrepTimeChange($event)"
+      [placeholder]="t('recipes.list.filter.minutesPlaceholder')"
+    />
+  </div>
+
+  <div class="filter-group time-group">
+    <label class="filter-label" for="filter-max-cook">
+      {{ t('recipes.list.filter.maxCookTime') }}
+    </label>
+    <input
+      id="filter-max-cook"
+      type="number"
+      class="time-input"
+      min="1"
+      [value]="value().maxCookTime ?? ''"
+      (change)="onCookTimeChange($event)"
+      [placeholder]="t('recipes.list.filter.minutesPlaceholder')"
+    />
+  </div>
+</div>

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.scss
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.scss
@@ -1,0 +1,112 @@
+.filter-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-4);
+  padding: var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-lg);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+}
+
+.filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.filter-title {
+  margin: 0;
+  font-size: var(--yn-text-lg);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+}
+
+.filter-count {
+  margin-left: var(--yn-space-2);
+  color: var(--yn-primary);
+  font-weight: var(--yn-font-medium);
+}
+
+.clear-button {
+  padding: var(--yn-space-2) var(--yn-space-3);
+  border: none;
+  background: transparent;
+  color: var(--yn-primary);
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.filter-label {
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  color: var(--yn-text-muted);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-2);
+}
+
+.filter-chip {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: transparent;
+  color: var(--yn-text);
+  font-size: var(--yn-text-sm);
+  cursor: pointer;
+  transition:
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    color var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+
+  &.active {
+    background: var(--yn-primary);
+    border-color: var(--yn-primary);
+    color: var(--yn-on-primary, white);
+  }
+}
+
+.time-group {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--yn-space-3);
+
+  .filter-label {
+    flex: 1;
+  }
+}
+
+.time-input {
+  width: 6rem;
+  padding: var(--yn-space-2) var(--yn-space-3);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-md);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-base);
+
+  &:focus {
+    outline: none;
+    border-color: var(--yn-primary);
+  }
+}

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.ts
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+export type RecipeDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface RecipeFilterValue {
+  tags: string[];
+  difficulty: RecipeDifficulty | null;
+  maxPrepTime: number | null;
+  maxCookTime: number | null;
+}
+
+export const EMPTY_FILTER: RecipeFilterValue = {
+  tags: [],
+  difficulty: null,
+  maxPrepTime: null,
+  maxCookTime: null,
+};
+
+const DIFFICULTY_OPTIONS: RecipeDifficulty[] = ['easy', 'medium', 'hard'];
+
+@Component({
+  selector: 'yn-filter-panel',
+  standalone: true,
+  imports: [TranslocoModule],
+  templateUrl: './filter-panel.component.html',
+  styleUrl: './filter-panel.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FilterPanelComponent {
+  value = input.required<RecipeFilterValue>();
+  availableTags = input<string[]>([]);
+  valueChange = output<RecipeFilterValue>();
+
+  protected readonly difficultyOptions = DIFFICULTY_OPTIONS;
+
+  protected activeCount = computed(() => {
+    const v = this.value();
+    let count = v.tags.length;
+    if (v.difficulty !== null) count += 1;
+    if (v.maxPrepTime !== null) count += 1;
+    if (v.maxCookTime !== null) count += 1;
+    return count;
+  });
+
+  protected isTagActive(tag: string): boolean {
+    return this.value().tags.includes(tag);
+  }
+
+  protected toggleTag(tag: string): void {
+    const current = this.value();
+    const tags = current.tags.includes(tag)
+      ? current.tags.filter((t) => t !== tag)
+      : [...current.tags, tag];
+    this.valueChange.emit({ ...current, tags });
+  }
+
+  protected toggleDifficulty(difficulty: RecipeDifficulty): void {
+    const current = this.value();
+    const next = current.difficulty === difficulty ? null : difficulty;
+    this.valueChange.emit({ ...current, difficulty: next });
+  }
+
+  protected onPrepTimeChange(event: Event): void {
+    const raw = (event.target as HTMLInputElement).value;
+    const parsed = raw === '' ? null : Number(raw);
+    this.valueChange.emit({
+      ...this.value(),
+      maxPrepTime: parsed !== null && !Number.isNaN(parsed) && parsed > 0 ? parsed : null,
+    });
+  }
+
+  protected onCookTimeChange(event: Event): void {
+    const raw = (event.target as HTMLInputElement).value;
+    const parsed = raw === '' ? null : Number(raw);
+    this.valueChange.emit({
+      ...this.value(),
+      maxCookTime: parsed !== null && !Number.isNaN(parsed) && parsed > 0 ? parsed : null,
+    });
+  }
+
+  protected clearAll(): void {
+    this.valueChange.emit({ ...EMPTY_FILTER });
+  }
+}

--- a/src/Yumney.Recipes.Api/RecipeFilterParser.cs
+++ b/src/Yumney.Recipes.Api/RecipeFilterParser.cs
@@ -1,0 +1,33 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Api;
+
+internal static class RecipeFilterParser
+{
+    public static RecipeFilter? Build(string? tags, string? difficulty, int? maxPrepTime, int? maxCookTime)
+    {
+        var tagList = ParseTags(tags);
+        var difficultyVo = Difficulty.FromNullable(difficulty);
+        var maxPrep = PreparationTime.FromNullable(maxPrepTime);
+        var maxCook = CookingTime.FromNullable(maxCookTime);
+
+        if (tagList is null && difficultyVo is null && maxPrep is null && maxCook is null)
+        {
+            return null;
+        }
+
+        return new RecipeFilter(tagList, difficultyVo, maxPrep, maxCook);
+    }
+
+    private static List<RecipeTag>? ParseTags(string? tags)
+    {
+        if (string.IsNullOrWhiteSpace(tags)) return null;
+
+        var parsed = tags
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(RecipeTag.From)
+            .ToList();
+
+        return parsed.Count == 0 ? null : parsed;
+    }
+}

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -120,12 +120,17 @@ public static partial class RecipesEndpoints
         string sortBy = "Date",
         SortDirection sortDirection = SortDirection.Descending,
         string? search = null,
+        string? tags = null,
+        string? difficulty = null,
+        int? maxPrepTime = null,
+        int? maxCookTime = null,
         CancellationToken cancellationToken = default)
     {
         var query = new GetRecipesQuery(
             PagingOptions.From(page, pageSize),
             SortingOptions<RecipeSortField>.Parse(sortBy, sortDirection, RecipeSortField.Date),
-            SearchTerm.FromNullable(search));
+            SearchTerm.FromNullable(search),
+            RecipeFilterParser.Build(tags, difficulty, maxPrepTime, maxCookTime));
 
         var result = await handler.HandleAsync(query, cancellationToken);
         return result.ToOk();
@@ -266,9 +271,7 @@ public static partial class RecipesEndpoints
     }
 
     private static IResult PhotoTooLargeProblem(string fileName) =>
-        Results.Problem(
-            statusCode: StatusCodes.Status413PayloadTooLarge,
-            detail: $"Photo '{fileName}' exceeds the maximum size of 10 MB.");
+        Results.Problem(statusCode: StatusCodes.Status413PayloadTooLarge, detail: $"Photo '{fileName}' exceeds the maximum size of 10 MB.");
 
 #pragma warning disable SA1303 // editorconfig requires camelCase for private const fields
     private const string emptyChatMessageError = "Message cannot be empty.";

--- a/src/Yumney.Recipes.Application/Queries/GetRecipesQuery.cs
+++ b/src/Yumney.Recipes.Application/Queries/GetRecipesQuery.cs
@@ -8,4 +8,5 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 public sealed record GetRecipesQuery(
     PagingOptions Paging,
     SortingOptions<RecipeSortField> Sorting,
-    SearchTerm? Search = null) : IQuery<Result<PagedResult<RecipeListItemDto>>>;
+    SearchTerm? Search = null,
+    RecipeFilter? Filter = null) : IQuery<Result<PagedResult<RecipeListItemDto>>>;

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
@@ -12,12 +12,12 @@ public sealed partial class GetRecipesQueryHandler(IRecipeRepository recipes, IC
 {
     public async Task<Result<PagedResult<RecipeListItemDto>>> HandleAsync(GetRecipesQuery query, CancellationToken cancellationToken = default)
     {
-        var (paging, sorting, search) = query;
+        var (paging, sorting, search, filter) = query;
         var owner = currentUser.AsOwner();
 
         LogGetRecipes(owner.Value, paging.Page.Value, paging.PageSize.Value, search?.Value);
 
-        var (items, totalCount) = await recipes.GetByOwnerAsync(owner, paging, sorting, search, cancellationToken);
+        var (items, totalCount) = await recipes.GetByOwnerAsync(owner, paging, sorting, search, filter, cancellationToken);
         var dtoItems = items.Select(r => r.ToListItemDto()).ToList();
 
         return PagedResultExtensions.With(dtoItems, totalCount, paging);

--- a/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
@@ -19,6 +19,7 @@ public interface IRecipeRepository
         PagingOptions paging,
         SortingOptions<RecipeSortField> sorting,
         SearchTerm? search = null,
+        RecipeFilter? filter = null,
         CancellationToken cancellationToken = default);
 
     Task UpdateAsync(Recipe recipe, CancellationToken cancellationToken = default);

--- a/src/Yumney.Recipes.Domain/Recipe/RecipeFilter.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/RecipeFilter.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+/// <summary>
+/// Optional filter criteria applied to <see cref="IRecipeRepository.GetByOwnerAsync"/>.
+/// All non-null values are combined with AND logic. Tags are matched as a
+/// "must contain all" set, not "must contain any".
+/// </summary>
+public sealed record RecipeFilter(
+    IReadOnlyList<RecipeTag>? Tags = null,
+    Difficulty? Difficulty = null,
+    PreparationTime? MaxPrepTime = null,
+    CookingTime? MaxCookTime = null)
+{
+    public bool IsEmpty =>
+        (Tags is null || Tags.Count == 0)
+        && Difficulty is null
+        && MaxPrepTime is null
+        && MaxCookTime is null;
+}

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -123,8 +123,9 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
             owner,
             paging,
             sorting,
-            null,
-            cancellationToken);
+            search: null,
+            filter: null,
+            cancellationToken: cancellationToken);
         return items;
     }
 

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -56,6 +56,7 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
         PagingOptions paging,
         SortingOptions<RecipeSortField> sorting,
         SearchTerm? search = null,
+        RecipeFilter? filter = null,
         CancellationToken cancellationToken = default)
     {
         var query = recipes.AsNoTracking().Where(r => r.Owner == owner);
@@ -70,6 +71,7 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
                 r.Ingredients.Any(i => EF.Functions.ILike(i.Name, pattern)));
         }
 
+        query = ApplyFilter(query, filter);
         query = ApplySorting(query, sorting);
 
         var totalCount = await query.CountAsync(cancellationToken);
@@ -81,6 +83,40 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
             .ToListAsync(cancellationToken);
 
         return (items, ItemCount.From(totalCount));
+    }
+
+    private static IQueryable<Recipe> ApplyFilter(IQueryable<Recipe> query, RecipeFilter? filter)
+    {
+        if (filter is null || filter.IsEmpty) return query;
+
+        if (filter.Difficulty is not null)
+        {
+            query = query.Where(r => r.Difficulty == filter.Difficulty);
+        }
+
+        if (filter.MaxPrepTime is not null)
+        {
+            var maxPrep = filter.MaxPrepTime;
+            query = query.Where(r => r.PreparationTime != null && r.PreparationTime <= maxPrep);
+        }
+
+        if (filter.MaxCookTime is not null)
+        {
+            var maxCook = filter.MaxCookTime;
+            query = query.Where(r => r.CookingTime != null && r.CookingTime <= maxCook);
+        }
+
+        if (filter.Tags is not null && filter.Tags.Count > 0)
+        {
+            // AND logic: every requested tag must be present on the recipe.
+            foreach (var requiredTag in filter.Tags)
+            {
+                var tagValue = requiredTag.Value;
+                query = query.Where(r => r.Tags.Any(t => t.Value == tagValue));
+            }
+        }
+
+        return query;
     }
 
     private static IQueryable<Recipe> ApplySorting(IQueryable<Recipe> query, SortingOptions<RecipeSortField> sorting)

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
@@ -1,0 +1,211 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes;
+
+[Collection(AspireCollection.Name)]
+public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
+{
+    private static readonly PagingOptions DefaultPaging = PagingOptions.Of(Page.From(1), PageSize.From(20));
+    private static readonly SortingOptions<RecipeSortField> DefaultSorting = new(RecipeSortField.Date, SortDirection.Descending);
+
+    private readonly OwnerIdentifier owner = OwnerIdentifier.From($"filter-test-{Guid.NewGuid():N}");
+
+    public async Task InitializeAsync()
+    {
+        await fixture.SeedRecipesAsync(
+            BuildRecipe(
+                title: "Quick Vegan Salad",
+                tags: ["vegan", "quick", "salad"],
+                difficulty: "easy",
+                prepMinutes: 10,
+                cookMinutes: 0),
+            BuildRecipe(
+                title: "Vegan Curry",
+                tags: ["vegan", "indian"],
+                difficulty: "medium",
+                prepMinutes: 20,
+                cookMinutes: 40),
+            BuildRecipe(
+                title: "Beef Wellington",
+                tags: ["meat", "fancy"],
+                difficulty: "hard",
+                prepMinutes: 60,
+                cookMinutes: 90),
+            BuildRecipe(
+                title: "Plain Rice",
+                tags: null,
+                difficulty: null,
+                prepMinutes: null,
+                cookMinutes: null));
+    }
+
+    public Task DisposeAsync() => AspireFixture.CleanupAsync(
+        fixture.CreateRecipesDbContextAsync,
+        ctx => ctx.Recipes.Where(r => r.Owner == owner));
+
+    [Fact]
+    public async Task Filter_ByDifficulty_ReturnsOnlyMatching()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(Difficulty: Difficulty.From("easy"));
+
+        var (items, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(1);
+        items.Should().ContainSingle(r => r.Title.Value == "Quick Vegan Salad");
+    }
+
+    [Fact]
+    public async Task Filter_ByMaxPrepTime_ReturnsRecipesAtOrUnderLimit()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(MaxPrepTime: PreparationTime.From(20));
+
+        var (items, _) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        items.Select(r => r.Title.Value).Should()
+            .Contain("Quick Vegan Salad")
+            .And.Contain("Vegan Curry")
+            .And.NotContain("Beef Wellington")
+            .And.NotContain("Plain Rice");
+    }
+
+    [Fact]
+    public async Task Filter_ByMaxCookTime_ReturnsRecipesAtOrUnderLimit()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(MaxCookTime: CookingTime.From(45));
+
+        var (items, _) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        items.Select(r => r.Title.Value).Should()
+            .Contain("Quick Vegan Salad")
+            .And.Contain("Vegan Curry")
+            .And.NotContain("Beef Wellington");
+    }
+
+    [Fact]
+    public async Task Filter_BySingleTag_ReturnsRecipesWithTag()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(Tags: [RecipeTag.From("vegan")]);
+
+        var (items, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(2);
+        items.Select(r => r.Title.Value).Should()
+            .Contain("Quick Vegan Salad")
+            .And.Contain("Vegan Curry");
+    }
+
+    [Fact]
+    public async Task Filter_ByMultipleTags_RequiresAllTagsPresent()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(Tags: [RecipeTag.From("vegan"), RecipeTag.From("quick")]);
+
+        var (items, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(1);
+        items.Should().ContainSingle(r => r.Title.Value == "Quick Vegan Salad");
+    }
+
+    [Fact]
+    public async Task Filter_CombinesAllCriteria_WithAndLogic()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(
+            Tags: [RecipeTag.From("vegan")],
+            Difficulty: Difficulty.From("medium"),
+            MaxPrepTime: PreparationTime.From(30),
+            MaxCookTime: CookingTime.From(60));
+
+        var (items, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(1);
+        items.Should().ContainSingle(r => r.Title.Value == "Vegan Curry");
+    }
+
+    [Fact]
+    public async Task Filter_NullFilter_ReturnsAllRecipes()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+
+        var (_, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: null);
+
+        totalCount.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Filter_EmptyFilter_ReturnsAllRecipes()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter();
+
+        var (_, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Filter_NoMatch_ReturnsEmpty()
+    {
+        await using var context = await fixture.CreateRecipesDbContextAsync();
+        var recipes = new RecipeRepository(context);
+        var filter = new RecipeFilter(Tags: [RecipeTag.From("dessert")]);
+
+        var (items, totalCount) = await recipes.GetByOwnerAsync(
+            owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
+
+        totalCount.Value.Should().Be(0);
+        items.Should().BeEmpty();
+    }
+
+    private Recipe BuildRecipe(
+        string title,
+        IReadOnlyList<string>? tags,
+        string? difficulty,
+        int? prepMinutes,
+        int? cookMinutes)
+    {
+        var ingredients = new[]
+        {
+            Ingredient.Create(IngredientName.From("Test Ingredient"), Quantity.FromNullable(null, null)),
+        };
+        var steps = new[]
+        {
+            Step.Create(StepNumber.From(1), StepDescription.From("Test step")),
+        };
+
+        return Recipe.Create(
+            RecipeTitle.From(title),
+            owner,
+            ingredients,
+            steps,
+            preparationTime: PreparationTime.FromNullable(prepMinutes),
+            cookingTime: CookingTime.FromNullable(cookMinutes),
+            difficulty: Difficulty.FromNullable(difficulty),
+            tags: tags?.Select(RecipeTag.From).ToList());
+    }
+}

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipesQueryHandlerTests.cs
@@ -99,6 +99,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -115,6 +116,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Is<PagingOptions>(p => p.Skip == 20 && p.PageSize.Value == 10),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -131,6 +133,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Is<PagingOptions>(p => p.Skip == 0 && p.PageSize.Value == 20),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -147,6 +150,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Is<SortingOptions<RecipeSortField>>(s => s.SortBy == RecipeSortField.Name && s.Direction == SortDirection.Ascending),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -163,6 +167,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Is<SortingOptions<RecipeSortField>>(s => s.SortBy == RecipeSortField.Date && s.Direction == SortDirection.Descending),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -180,6 +185,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             cts.Token);
     }
 
@@ -197,6 +203,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Is<SearchTerm?>(s => s != null && s.Value == "pasta"),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -213,6 +220,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             null,
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -282,12 +290,56 @@ public class GetRecipesQueryHandlerTests
         result.Value.TotalCount.Should().Be(25);
     }
 
+    [Fact]
+    public async Task HandleAsync_WithFilter_ForwardsFilterToRepository()
+    {
+        SetupEmptyRepository();
+        var filter = new RecipeFilter(
+            Tags: [RecipeTag.From("vegan")],
+            Difficulty: Difficulty.From("easy"),
+            MaxPrepTime: PreparationTime.From(15),
+            MaxCookTime: CookingTime.From(30));
+
+        var query = CreateQuery(1, 20, RecipeSortField.Date, SortDirection.Descending, filter: filter);
+        await handler.HandleAsync(query);
+
+        await recipes.Received(1).GetByOwnerAsync(
+            Arg.Any<OwnerIdentifier>(),
+            Arg.Any<PagingOptions>(),
+            Arg.Any<SortingOptions<RecipeSortField>>(),
+            Arg.Any<SearchTerm?>(),
+            Arg.Is<RecipeFilter?>(f => f != null && ReferenceEquals(f, filter)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutFilter_PassesNullFilterToRepository()
+    {
+        SetupEmptyRepository();
+
+        var query = CreateQuery(1, 20, RecipeSortField.Date, SortDirection.Descending);
+        await handler.HandleAsync(query);
+
+        await recipes.Received(1).GetByOwnerAsync(
+            Arg.Any<OwnerIdentifier>(),
+            Arg.Any<PagingOptions>(),
+            Arg.Any<SortingOptions<RecipeSortField>>(),
+            Arg.Any<SearchTerm?>(),
+            (RecipeFilter?)null,
+            Arg.Any<CancellationToken>());
+    }
+
     private static GetRecipesQuery CreateQuery(
-        int page, int pageSize, RecipeSortField sortBy, SortDirection sortDirection, SearchTerm? search = null)
+        int page,
+        int pageSize,
+        RecipeSortField sortBy,
+        SortDirection sortDirection,
+        SearchTerm? search = null,
+        RecipeFilter? filter = null)
     {
         var paging = PagingOptions.Of(Page.From(page), PageSize.From(pageSize));
         var sorting = new SortingOptions<RecipeSortField>(sortBy, sortDirection);
-        return new GetRecipesQuery(paging, sorting, search);
+        return new GetRecipesQuery(paging, sorting, search, filter);
     }
 
     private void SetupEmptyRepository()
@@ -302,6 +354,7 @@ public class GetRecipesQueryHandlerTests
             Arg.Any<PagingOptions>(),
             Arg.Any<SortingOptions<RecipeSortField>>(),
             Arg.Any<SearchTerm?>(),
+            Arg.Any<RecipeFilter?>(),
             Arg.Any<CancellationToken>())
             .Returns((items, ItemCount.From(totalCount)));
     }


### PR DESCRIPTION
## Summary
- Adds optional filtering on `GET /recipes`: `tags`, `difficulty`, `maxPrepTime`, `maxCookTime`. Tags require all to be present (AND-match). Filters compose with existing search and sorting.
- New `RecipeFilter` value record on the domain repository contract; EF translation works around the value-converter `<=` issue by leveraging `PreparationTime`/`CookingTime` implicit-int conversion.
- New `FilterPanelComponent` in `libs/ui` (glass-styled, chip rows for tags + difficulty, number inputs for time caps, active-count badge); wired into `RecipeListComponent` behind a toggle button.
- En/de translations under `recipes.list.filter.*`.

## Test plan
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet test Yumney.slnx` — 991 tests pass (incl. 9 new integration + 2 new handler tests)
- [x] `dotnet format Yumney.slnx --verify-no-changes` clean (touched files)
- [x] `yarn nx run-many -t test` — all 5 projects pass
- [x] `yarn nx run-many -t lint` — clean
- [x] `yarn nx run-many -t build` — all 4 client apps build
- [ ] Manual: open recipes list, toggle filters, verify each criterion narrows results
- [ ] Manual: verify dark/light mode appearance of filter panel

Closes US-072.