### PR TITLE
feat(recipes): voice-guided cook mode (US-240)

### DIFF
--- a/client/apps/account/public/assets/i18n/de.json
+++ b/client/apps/account/public/assets/i18n/de.json
@@ -7,7 +7,9 @@
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
       "navigation": "Hauptnavigation",
-      "switchLanguage": "Sprache wechseln"
+      "switchLanguage": "Sprache wechseln",
+      "switchToDark": "Zu dunklem Modus wechseln",
+      "switchToLight": "Zu hellem Modus wechseln"
     }
   },
   "account": {

--- a/client/apps/account/public/assets/i18n/en.json
+++ b/client/apps/account/public/assets/i18n/en.json
@@ -7,7 +7,9 @@
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
       "navigation": "Main navigation",
-      "switchLanguage": "Switch language"
+      "switchLanguage": "Switch language",
+      "switchToDark": "Switch to dark mode",
+      "switchToLight": "Switch to light mode"
     }
   },
   "account": {

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -7,7 +7,9 @@
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
       "navigation": "Hauptnavigation",
-      "switchLanguage": "Sprache wechseln"
+      "switchLanguage": "Sprache wechseln",
+      "switchToDark": "Zu dunklem Modus wechseln",
+      "switchToLight": "Zu hellem Modus wechseln"
     }
   },
   "shared": {
@@ -86,7 +88,8 @@
       "actions": {
         "edit": "Bearbeiten",
         "delete": "Löschen",
-        "shoppingList": "Einkaufsliste"
+        "shoppingList": "Einkaufsliste",
+        "startCooking": "Kochmodus starten"
       },
       "loading": "Rezept wird geladen...",
       "notFound": "Rezept nicht gefunden.",
@@ -108,6 +111,28 @@
       },
       "errors": {
         "generic": "Rezept konnte nicht geladen werden. Bitte versuche es später erneut."
+      }
+    },
+    "cook": {
+      "loading": "Rezept wird geladen...",
+      "exit": "Beenden",
+      "previous": "Zurück",
+      "next": "Weiter",
+      "repeat": "Wiederholen",
+      "ingredients": "Zutaten",
+      "mute": "Stumm",
+      "unmute": "Ton an",
+      "voiceToggle": "Sprachsteuerung umschalten",
+      "voiceListening": "Höre zu...",
+      "voiceTapToTalk": "Zum Sprechen tippen",
+      "stepProgress": "Schritt {{current}} von {{total}}",
+      "timer": {
+        "defaultName": "Timer",
+        "cancel": "Abbrechen",
+        "done": "Timer fertig"
+      },
+      "errors": {
+        "notFound": "Rezept nicht gefunden."
       }
     }
   },
@@ -135,7 +160,8 @@
         "titleMaxLength": "Titel darf maximal 200 Zeichen lang sein.",
         "ingredientNameRequired": "Zutatname ist erforderlich.",
         "stepDescriptionRequired": "Schrittbeschreibung ist erforderlich."
-      }
+      },
+      "clearUnit": "Einheit l�schen"
     },
     "save": {
       "saving": "Wird gespeichert..."

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -7,7 +7,9 @@
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
       "navigation": "Main navigation",
-      "switchLanguage": "Switch language"
+      "switchLanguage": "Switch language",
+      "switchToDark": "Switch to dark mode",
+      "switchToLight": "Switch to light mode"
     }
   },
   "shared": {
@@ -86,7 +88,8 @@
       "actions": {
         "edit": "Edit",
         "delete": "Delete",
-        "shoppingList": "Shopping List"
+        "shoppingList": "Shopping List",
+        "startCooking": "Start Cooking"
       },
       "loading": "Loading recipe...",
       "notFound": "Recipe not found.",
@@ -108,6 +111,28 @@
       },
       "errors": {
         "generic": "Failed to load recipe. Please try again later."
+      }
+    },
+    "cook": {
+      "loading": "Loading recipe...",
+      "exit": "Exit",
+      "previous": "Previous",
+      "next": "Next",
+      "repeat": "Repeat",
+      "ingredients": "Ingredients",
+      "mute": "Mute",
+      "unmute": "Unmute",
+      "voiceToggle": "Toggle voice control",
+      "voiceListening": "Listening...",
+      "voiceTapToTalk": "Tap to talk",
+      "stepProgress": "Step {{current}} of {{total}}",
+      "timer": {
+        "defaultName": "Timer",
+        "cancel": "Cancel",
+        "done": "Timer done"
+      },
+      "errors": {
+        "notFound": "Recipe not found."
       }
     }
   },
@@ -135,7 +160,8 @@
         "titleMaxLength": "Title must not exceed 200 characters.",
         "ingredientNameRequired": "Ingredient name is required.",
         "stepDescriptionRequired": "Step description is required."
-      }
+      },
+      "clearUnit": "Clear unit"
     },
     "save": {
       "saving": "Saving..."

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
@@ -1,0 +1,113 @@
+<div class="cook-mode" *transloco="let t">
+  @if (isLoading()) {
+    <yn-loading-spinner label="recipes.cook.loading" />
+  }
+
+  @if (serverError(); as error) {
+    <div class="error-banner" role="alert">{{ t(error) }}</div>
+  }
+
+  @if (recipe(); as r) {
+    <header class="cook-header">
+      <button type="button" class="exit-button" (click)="exit()">
+        {{ t('recipes.cook.exit') }}
+      </button>
+      <h1 class="cook-title">{{ r.title }}</h1>
+      <div class="header-actions">
+        <button
+          type="button"
+          class="header-action"
+          (click)="toggleMute()"
+          [attr.aria-pressed]="voice.muted()"
+        >
+          {{ voice.muted() ? t('recipes.cook.unmute') : t('recipes.cook.mute') }}
+        </button>
+        <button type="button" class="header-action" (click)="toggleIngredientsPanel()">
+          {{ t('recipes.cook.ingredients') }}
+        </button>
+      </div>
+    </header>
+
+    @if (currentStep(); as step) {
+      <yn-step-display
+        [stepNumber]="currentStepIndex() + 1"
+        [totalSteps]="totalSteps()"
+        [text]="step.description"
+      />
+    }
+
+    <div class="step-controls">
+      <button
+        type="button"
+        class="nav-button"
+        (click)="previous()"
+        [disabled]="currentStepIndex() === 0"
+      >
+        {{ t('recipes.cook.previous') }}
+      </button>
+      <button type="button" class="nav-button repeat" (click)="repeat()">
+        {{ t('recipes.cook.repeat') }}
+      </button>
+      <button
+        type="button"
+        class="nav-button"
+        (click)="next()"
+        [disabled]="currentStepIndex() >= totalSteps() - 1"
+      >
+        {{ t('recipes.cook.next') }}
+      </button>
+    </div>
+
+    @if (voice.sttSupported()) {
+      <button
+        type="button"
+        class="voice-toggle"
+        (click)="toggleListening()"
+        [attr.aria-label]="t('recipes.cook.voiceToggle')"
+      >
+        <yn-voice-indicator [listening]="voice.isListening()" />
+        <span>
+          {{
+            voice.isListening()
+              ? t('recipes.cook.voiceListening')
+              : t('recipes.cook.voiceTapToTalk')
+          }}
+        </span>
+      </button>
+    }
+
+    @if (timers.all().length > 0) {
+      <div class="timers-strip">
+        @for (timer of timers.all(); track timer.id) {
+          <yn-cooking-timer [timer]="timer" (cancel)="onCancelTimer($event)" />
+        }
+      </div>
+    }
+
+    @if (ingredientsPanelOpen()) {
+      <aside class="ingredients-panel" role="dialog">
+        <div class="panel-header">
+          <h2>{{ t('recipes.cook.ingredients') }}</h2>
+          <button type="button" class="panel-close" (click)="toggleIngredientsPanel()">
+            &times;
+          </button>
+        </div>
+        <ul class="ingredient-list">
+          @for (ingredient of r.ingredients; track $index) {
+            <li>
+              <span class="amount">
+                @if (ingredient.amount !== null) {
+                  {{ ingredient.amount }}
+                }
+                @if (ingredient.unit) {
+                  {{ ingredient.unit }}
+                }
+              </span>
+              <span class="name">{{ ingredient.name }}</span>
+            </li>
+          }
+        </ul>
+      </aside>
+    }
+  }
+</div>

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.scss
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.scss
@@ -1,0 +1,205 @@
+.cook-mode {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  padding: var(--yn-space-5);
+  gap: var(--yn-space-6);
+  background: var(--yn-bg);
+}
+
+.cook-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 800px;
+  gap: var(--yn-space-4);
+}
+
+.cook-title {
+  flex: 1;
+  margin: 0;
+  font-size: var(--yn-text-xl);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.exit-button,
+.header-action {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-sm);
+  cursor: pointer;
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+
+  &:hover {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--yn-space-2);
+}
+
+yn-step-display {
+  display: block;
+  width: 100%;
+  max-width: 800px;
+}
+
+.step-controls {
+  display: flex;
+  gap: var(--yn-space-3);
+  width: 100%;
+  max-width: 800px;
+  justify-content: center;
+}
+
+.nav-button {
+  flex: 1;
+  max-width: 12rem;
+  padding: var(--yn-space-4) var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-lg);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+  cursor: pointer;
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+
+  &:hover:not(:disabled) {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.repeat {
+    flex: 0 0 auto;
+  }
+}
+
+.voice-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-base);
+  cursor: pointer;
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+}
+
+.timers-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-4);
+  justify-content: center;
+  width: 100%;
+  max-width: 800px;
+}
+
+.ingredients-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(360px, 90vw);
+  height: 100vh;
+  padding: var(--yn-space-5);
+  overflow-y: auto;
+  border-left: 1px solid var(--yn-glass-border);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+  z-index: 100;
+  animation: slide-in var(--yn-duration-normal) var(--yn-ease-glass);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--yn-space-5);
+
+  h2 {
+    margin: 0;
+    font-size: var(--yn-text-lg);
+  }
+}
+
+.panel-close {
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: transparent;
+  font-size: var(--yn-text-2xl);
+  color: var(--yn-text);
+  cursor: pointer;
+}
+
+.ingredient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
+
+  li {
+    display: flex;
+    gap: var(--yn-space-3);
+    padding: var(--yn-space-2) 0;
+    border-bottom: 1px solid var(--yn-glass-border);
+    color: var(--yn-text);
+  }
+
+  .amount {
+    flex: 0 0 5rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--yn-text-muted);
+  }
+}
+
+.error-banner {
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border: 1px solid var(--yn-error);
+  border-radius: var(--yn-radius-md);
+  background: var(--yn-error-bg);
+  color: var(--yn-error);
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ingredients-panel {
+    animation: none;
+  }
+}

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -1,0 +1,206 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  HostListener,
+  inject,
+  OnDestroy,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { RecipeApiService, type RecipeDetail } from '@yumney/shared/api-client';
+import {
+  CookingTimerService,
+  createAsyncState,
+  ERROR_MAPS,
+  ROUTES,
+  type VoiceCommand,
+  VoiceService,
+  WakeLockService,
+} from '@yumney/shared/models';
+import {
+  CookingTimerComponent,
+  LoadingSpinnerComponent,
+  StepDisplayComponent,
+  VoiceIndicatorComponent,
+} from '@yumney/ui';
+
+const SWIPE_THRESHOLD = 50;
+
+@Component({
+  selector: 'yn-cook-mode',
+  imports: [
+    TranslocoModule,
+    StepDisplayComponent,
+    CookingTimerComponent,
+    VoiceIndicatorComponent,
+    LoadingSpinnerComponent,
+  ],
+  templateUrl: './cook-mode.component.html',
+  styleUrl: './cook-mode.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CookModeComponent implements OnInit, OnDestroy {
+  protected readonly ROUTES = ROUTES;
+
+  private recipeApi = inject(RecipeApiService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
+  private loadState = createAsyncState(this.destroyRef);
+  protected voice = inject(VoiceService);
+  protected timers = inject(CookingTimerService);
+  private wakeLock = inject(WakeLockService);
+  private transloco = inject(TranslocoService);
+
+  recipe = signal<RecipeDetail | null>(null);
+  currentStepIndex = signal(0);
+  ingredientsPanelOpen = signal(false);
+  isLoading = this.loadState.isLoading;
+  serverError = signal<string | null>(null);
+
+  totalSteps = computed(() => this.recipe()?.steps.length ?? 0);
+  currentStep = computed(() => {
+    const r = this.recipe();
+    return r?.steps[this.currentStepIndex()] ?? null;
+  });
+
+  private touchStartX: number | null = null;
+
+  constructor() {
+    effect(() => {
+      const step = this.currentStep();
+      if (step) {
+        this.voice.speak(step.description);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    const identifier = this.route.snapshot.paramMap.get('identifier');
+    if (!identifier) {
+      this.serverError.set('recipes.cook.errors.notFound');
+      return;
+    }
+
+    this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
+
+    this.loadState.execute(
+      this.recipeApi.getRecipeById(identifier),
+      ERROR_MAPS.recipes.detail,
+      (recipe) => this.recipe.set(recipe),
+      (error) => this.serverError.set(error),
+    );
+
+    void this.wakeLock.acquire();
+  }
+
+  ngOnDestroy(): void {
+    this.voice.stopSpeaking();
+    this.voice.stopListening();
+    this.timers.cancelAll();
+    void this.wakeLock.release();
+  }
+
+  next(): void {
+    if (this.currentStepIndex() < this.totalSteps() - 1) {
+      this.currentStepIndex.update((i) => i + 1);
+    }
+  }
+
+  previous(): void {
+    if (this.currentStepIndex() > 0) {
+      this.currentStepIndex.update((i) => i - 1);
+    }
+  }
+
+  repeat(): void {
+    const step = this.currentStep();
+    if (step) {
+      this.voice.speak(step.description);
+    }
+  }
+
+  toggleIngredientsPanel(): void {
+    this.ingredientsPanelOpen.update((open) => !open);
+  }
+
+  toggleListening(): void {
+    if (this.voice.isListening()) {
+      this.voice.stopListening();
+    } else {
+      this.voice.startListening((command) => this.handleCommand(command));
+    }
+  }
+
+  toggleMute(): void {
+    this.voice.setMuted(!this.voice.muted());
+  }
+
+  exit(): void {
+    const id = this.recipe()?.identifier;
+    if (id) {
+      void this.router.navigate([ROUTES.recipes.detail(id)]);
+    } else {
+      void this.router.navigate([ROUTES.recipes.list]);
+    }
+  }
+
+  onCancelTimer(id: string): void {
+    this.timers.cancel(id);
+  }
+
+  @HostListener('touchstart', ['$event'])
+  onTouchStart(event: TouchEvent): void {
+    this.touchStartX = event.touches[0]?.clientX ?? null;
+  }
+
+  @HostListener('touchend', ['$event'])
+  onTouchEnd(event: TouchEvent): void {
+    if (this.touchStartX === null) return;
+    const endX = event.changedTouches[0]?.clientX ?? this.touchStartX;
+    const delta = endX - this.touchStartX;
+    if (Math.abs(delta) >= SWIPE_THRESHOLD) {
+      if (delta < 0) this.next();
+      else this.previous();
+    }
+    this.touchStartX = null;
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowRight') this.next();
+    else if (event.key === 'ArrowLeft') this.previous();
+    else if (event.key === 'Escape') this.exit();
+  }
+
+  private handleCommand(command: VoiceCommand): void {
+    switch (command.type) {
+      case 'next':
+        this.next();
+        break;
+      case 'previous':
+        this.previous();
+        break;
+      case 'repeat':
+        this.repeat();
+        break;
+      case 'stop':
+        this.voice.stopSpeaking();
+        this.timers.cancelAll();
+        break;
+      case 'ingredients':
+        this.ingredientsPanelOpen.set(true);
+        break;
+      case 'timer': {
+        const name = this.transloco.translate('recipes.cook.timer.defaultName');
+        this.timers.start(name, command.minutes);
+        break;
+      }
+    }
+  }
+}

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -107,6 +107,9 @@
     }
 
     <div class="actions-bar">
+      <a class="btn-cook" [routerLink]="ROUTES.recipes.cook(recipe.identifier)">
+        {{ t('recipes.detail.actions.startCooking') }}
+      </a>
       <a class="btn-primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
       </a>

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -197,6 +197,35 @@
   }
 }
 
+.btn-cook {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--yn-space-3) var(--yn-space-6);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-primary);
+  color: var(--yn-on-primary, white);
+  font-weight: var(--yn-font-semibold);
+  text-decoration: none;
+  border: 1px solid var(--yn-primary);
+  cursor: pointer;
+  transition:
+    transform var(--yn-duration-fast) var(--yn-ease-spring),
+    box-shadow var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    transform: scale(1.02);
+    box-shadow: var(--yn-shadow-md);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+    &:hover {
+      transform: none;
+    }
+  }
+}
+
 // ── Floating action bar (mobile) ──
 .floating-actions {
   @include glass.glass-surface(2);

--- a/client/apps/recipes/src/app/recipes.routes.ts
+++ b/client/apps/recipes/src/app/recipes.routes.ts
@@ -8,6 +8,12 @@ export const recipesRoutes: Route[] = [
       import('./recipe-edit/recipe-edit.component').then((m) => m.RecipeEditComponent),
   },
   {
+    path: ':identifier/cook',
+    title: 'Cook Mode — Yumney',
+    loadComponent: () =>
+      import('./cook-mode/cook-mode.component').then((m) => m.CookModeComponent),
+  },
+  {
     path: ':identifier',
     title: 'Recipe — Yumney',
     loadComponent: () =>

--- a/client/apps/recipes/src/app/recipes.routes.ts
+++ b/client/apps/recipes/src/app/recipes.routes.ts
@@ -10,8 +10,7 @@ export const recipesRoutes: Route[] = [
   {
     path: ':identifier/cook',
     title: 'Cook Mode — Yumney',
-    loadComponent: () =>
-      import('./cook-mode/cook-mode.component').then((m) => m.CookModeComponent),
+    loadComponent: () => import('./cook-mode/cook-mode.component').then((m) => m.CookModeComponent),
   },
   {
     path: ':identifier',

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -80,7 +80,9 @@
       "switchLanguage": "Sprache wechseln",
       "languageDe": "DE",
       "languageEn": "EN",
-      "openChat": "Rezept-Chat öffnen"
+      "openChat": "Rezept-Chat öffnen",
+      "switchToDark": "Zu dunklem Modus wechseln",
+      "switchToLight": "Zu hellem Modus wechseln"
     },
     "offlineIndicator": {
       "offline": "Du bist offline. Einige Funktionen sind nicht verfügbar.",
@@ -267,13 +269,15 @@
         "titleMaxLength": "Titel darf maximal 200 Zeichen lang sein.",
         "ingredientNameRequired": "Zutatname ist erforderlich.",
         "stepDescriptionRequired": "Schrittbeschreibung ist erforderlich."
-      }
+      },
+      "clearUnit": "Einheit l�schen"
     },
     "suggestions": {
-      "title": "Vorschl�ge f�r dich"
+      "title": "Vorschläge für dich",
+      "prepTime": "{{minutes}} Min."
     },
     "quickActions": {
-      "breakfast_ideas": "Fr�hst�cksideen",
+      "breakfast_ideas": "Frühstücksideen",
       "quick_meals": "Schnelle Gerichte",
       "lunch_recipes": "Mittagsrezepte",
       "whats_for_dinner": "Was gibt es zum Abendessen?",
@@ -285,14 +289,14 @@
       "add_to_shopping_list": "Zur Einkaufsliste"
     },
     "recentActivity": {
-      "title": "Letzte Aktivit�t",
-      "empty": "Noch keine Aktivit�t. Importiere dein erstes Rezept!",
+      "title": "Letzte Aktivität",
+      "empty": "Noch keine Aktivität. Importiere dein erstes Rezept!",
       "unknownRecipe": "Unbekanntes Rezept",
       "types": {
         "recipe_imported": "Rezept importiert",
         "recipe_viewed": "Rezept angesehen",
         "recipe_edited": "Rezept bearbeitet",
-        "recipe_deleted": "Rezept gel�scht",
+        "recipe_deleted": "Rezept gelöscht",
         "shopping_list_created": "Einkaufsliste erstellt"
       }
     },

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -80,7 +80,9 @@
       "switchLanguage": "Switch language",
       "languageDe": "DE",
       "languageEn": "EN",
-      "openChat": "Open recipe chat"
+      "openChat": "Open recipe chat",
+      "switchToDark": "Switch to dark mode",
+      "switchToLight": "Switch to light mode"
     },
     "offlineIndicator": {
       "offline": "You are offline. Some features may be unavailable.",
@@ -267,10 +269,12 @@
         "titleMaxLength": "Title must not exceed 200 characters.",
         "ingredientNameRequired": "Ingredient name is required.",
         "stepDescriptionRequired": "Step description is required."
-      }
+      },
+      "clearUnit": "Clear unit"
     },
     "suggestions": {
-      "title": "Suggested for You"
+      "title": "Suggested for You",
+      "prepTime": "{{minutes}} min"
     },
     "quickActions": {
       "breakfast_ideas": "Breakfast ideas",

--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -7,7 +7,9 @@
       "myRecipes": "Meine Rezepte",
       "shoppingLists": "Einkaufslisten",
       "navigation": "Hauptnavigation",
-      "switchLanguage": "Sprache wechseln"
+      "switchLanguage": "Sprache wechseln",
+      "switchToDark": "Zu dunklem Modus wechseln",
+      "switchToLight": "Zu hellem Modus wechseln"
     }
   },
   "shopping": {

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -7,7 +7,9 @@
       "myRecipes": "My Recipes",
       "shoppingLists": "Shopping Lists",
       "navigation": "Main navigation",
-      "switchLanguage": "Switch language"
+      "switchLanguage": "Switch language",
+      "switchToDark": "Switch to dark mode",
+      "switchToLight": "Switch to light mode"
     }
   },
   "shopping": {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -32,3 +32,6 @@ export { ThemeService, type Theme } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
 export { IngredientRecognitionService } from './lib/ingredient-recognition.service';
 export { ChatStateService } from './lib/chat-state.service';
+export { VoiceService, type VoiceCommand } from './lib/voice.service';
+export { WakeLockService } from './lib/wake-lock.service';
+export { CookingTimerService, type CookingTimer } from './lib/cooking-timer.service';

--- a/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { CookingTimerService } from './cooking-timer.service';
+import { VoiceService } from './voice.service';
+
+describe('CookingTimerService', () => {
+  let service: CookingTimerService;
+  let voiceSpeak: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    voiceSpeak = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        CookingTimerService,
+        { provide: VoiceService, useValue: { speak: voiceSpeak } },
+      ],
+    });
+    service = TestBed.inject(CookingTimerService);
+  });
+
+  afterEach(() => {
+    service.cancelAll();
+    vi.useRealTimers();
+  });
+
+  it('should start a timer with correct totalSeconds', () => {
+    const id = service.start('Pasta', 1);
+    const timer = service.all().find((t) => t.id === id);
+
+    expect(timer?.totalSeconds).toBe(60);
+  });
+
+  it('should set initial remainingSeconds equal to totalSeconds', () => {
+    const id = service.start('Pasta', 2);
+    const timer = service.all().find((t) => t.id === id);
+
+    expect(timer?.remainingSeconds).toBe(120);
+  });
+
+  it('should mark hasActive true while a timer is running', () => {
+    service.start('Pasta', 1);
+
+    expect(service.hasActive()).toBe(true);
+  });
+
+  it('should decrement remainingSeconds each second', () => {
+    const id = service.start('Pasta', 1);
+
+    vi.advanceTimersByTime(3000);
+    const timer = service.all().find((t) => t.id === id);
+
+    expect(timer?.remainingSeconds).toBe(57);
+  });
+
+  it('should mark timer completed when countdown reaches zero', () => {
+    const id = service.start('Quick', 1 / 60); // 1 second
+
+    vi.advanceTimersByTime(1100);
+    const timer = service.all().find((t) => t.id === id);
+
+    expect(timer?.status).toBe('completed');
+  });
+
+  it('should announce completion via voice service', () => {
+    service.start('Quick', 1 / 60);
+
+    vi.advanceTimersByTime(1100);
+
+    expect(voiceSpeak).toHaveBeenCalledWith('Timer done');
+  });
+
+  it('should remove timer when canceled', () => {
+    const id = service.start('Pasta', 5);
+
+    service.cancel(id);
+
+    expect(service.all().find((t) => t.id === id)).toBeUndefined();
+  });
+
+  it('should cancel all timers via cancelAll', () => {
+    service.start('A', 1);
+    service.start('B', 1);
+
+    service.cancelAll();
+
+    expect(service.all()).toHaveLength(0);
+  });
+});

--- a/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
@@ -10,10 +10,7 @@ describe('CookingTimerService', () => {
     vi.useFakeTimers();
     voiceSpeak = vi.fn();
     TestBed.configureTestingModule({
-      providers: [
-        CookingTimerService,
-        { provide: VoiceService, useValue: { speak: voiceSpeak } },
-      ],
+      providers: [CookingTimerService, { provide: VoiceService, useValue: { speak: voiceSpeak } }],
     });
     service = TestBed.inject(CookingTimerService);
   });

--- a/client/libs/shared/models/src/lib/cooking-timer.service.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, signal, computed, inject } from '@angular/core';
+import { VoiceService } from './voice.service';
+
+export interface CookingTimer {
+  id: string;
+  name: string;
+  totalSeconds: number;
+  remainingSeconds: number;
+  status: 'running' | 'completed';
+}
+
+const VIBRATION_PATTERN = [200, 100, 200, 100, 200];
+
+@Injectable({ providedIn: 'root' })
+export class CookingTimerService {
+  private readonly timers = signal<CookingTimer[]>([]);
+  private readonly intervals = new Map<string, ReturnType<typeof setInterval>>();
+  private voice = inject(VoiceService);
+
+  readonly all = computed(() => this.timers());
+  readonly hasActive = computed(() => this.timers().some((t) => t.status === 'running'));
+
+  start(name: string, minutes: number): string {
+    const id = `timer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const totalSeconds = Math.max(1, Math.floor(minutes * 60));
+    const timer: CookingTimer = {
+      id,
+      name,
+      totalSeconds,
+      remainingSeconds: totalSeconds,
+      status: 'running',
+    };
+    this.timers.update((list) => [...list, timer]);
+
+    const interval = setInterval(() => this.tick(id), 1000);
+    this.intervals.set(id, interval);
+    return id;
+  }
+
+  cancel(id: string): void {
+    this.clearInterval(id);
+    this.timers.update((list) => list.filter((t) => t.id !== id));
+  }
+
+  cancelAll(): void {
+    for (const id of this.intervals.keys()) {
+      this.clearInterval(id);
+    }
+    this.timers.set([]);
+  }
+
+  private tick(id: string): void {
+    const current = this.timers().find((t) => t.id === id);
+    if (!current || current.status === 'completed') return;
+
+    const next = current.remainingSeconds - 1;
+    if (next <= 0) {
+      this.complete(id);
+    } else {
+      this.timers.update((list) =>
+        list.map((t) => (t.id === id ? { ...t, remainingSeconds: next } : t)),
+      );
+    }
+  }
+
+  private complete(id: string): void {
+    this.clearInterval(id);
+    this.timers.update((list) =>
+      list.map((t) =>
+        t.id === id ? { ...t, remainingSeconds: 0, status: 'completed' as const } : t,
+      ),
+    );
+    this.triggerHaptics();
+    this.voice.speak('Timer done');
+  }
+
+  private clearInterval(id: string): void {
+    const handle = this.intervals.get(id);
+    if (handle !== undefined) {
+      clearInterval(handle);
+      this.intervals.delete(id);
+    }
+  }
+
+  private triggerHaptics(): void {
+    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+      try {
+        navigator.vibrate(VIBRATION_PATTERN);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/client/libs/shared/models/src/lib/route-paths.ts
+++ b/client/libs/shared/models/src/lib/route-paths.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
     list: '/recipes',
     detail: (identifier: string) => `/recipes/${identifier}`,
     edit: (identifier: string) => `/recipes/${identifier}/edit`,
+    cook: (identifier: string) => `/recipes/${identifier}/cook`,
   },
   shopping: {
     list: '/shopping',

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -1,0 +1,67 @@
+import { VoiceService } from './voice.service';
+
+describe('VoiceService.parseCommand', () => {
+  it('should parse "next step" as next command', () => {
+    expect(VoiceService.parseCommand('next step')).toEqual({ type: 'next' });
+  });
+
+  it('should parse German "nächster schritt" as next command', () => {
+    expect(VoiceService.parseCommand('nächster schritt')).toEqual({ type: 'next' });
+  });
+
+  it('should parse "previous step" as previous command', () => {
+    expect(VoiceService.parseCommand('previous step')).toEqual({ type: 'previous' });
+  });
+
+  it('should parse German "vorheriger schritt" as previous command', () => {
+    expect(VoiceService.parseCommand('vorheriger schritt')).toEqual({ type: 'previous' });
+  });
+
+  it('should parse "repeat" as repeat command', () => {
+    expect(VoiceService.parseCommand('repeat')).toEqual({ type: 'repeat' });
+  });
+
+  it('should parse "stop" as stop command', () => {
+    expect(VoiceService.parseCommand('stop')).toEqual({ type: 'stop' });
+  });
+
+  it('should parse German "stopp" as stop command', () => {
+    expect(VoiceService.parseCommand('stopp')).toEqual({ type: 'stop' });
+  });
+
+  it('should parse "ingredients" as ingredients command', () => {
+    expect(VoiceService.parseCommand('ingredients')).toEqual({ type: 'ingredients' });
+  });
+
+  it('should parse German "zutaten" as ingredients command', () => {
+    expect(VoiceService.parseCommand('zutaten')).toEqual({ type: 'ingredients' });
+  });
+
+  it('should parse "timer 5 minutes" as timer command with minutes', () => {
+    expect(VoiceService.parseCommand('timer 5 minutes')).toEqual({ type: 'timer', minutes: 5 });
+  });
+
+  it('should parse German "timer 10 minuten" as timer command with minutes', () => {
+    expect(VoiceService.parseCommand('timer 10 minuten')).toEqual({ type: 'timer', minutes: 10 });
+  });
+
+  it('should parse "5 minute timer" as timer command', () => {
+    expect(VoiceService.parseCommand('5 minute timer')).toEqual({ type: 'timer', minutes: 5 });
+  });
+
+  it('should be case-insensitive', () => {
+    expect(VoiceService.parseCommand('NEXT STEP')).toEqual({ type: 'next' });
+  });
+
+  it('should ignore surrounding whitespace', () => {
+    expect(VoiceService.parseCommand('  next step  ')).toEqual({ type: 'next' });
+  });
+
+  it('should return null for unknown phrases', () => {
+    expect(VoiceService.parseCommand('do something random')).toBeNull();
+  });
+
+  it('should return null for empty input', () => {
+    expect(VoiceService.parseCommand('')).toBeNull();
+  });
+});

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, signal } from '@angular/core';
+
+export type VoiceCommand =
+  | { type: 'next' }
+  | { type: 'previous' }
+  | { type: 'repeat' }
+  | { type: 'stop' }
+  | { type: 'ingredients' }
+  | { type: 'timer'; minutes: number };
+
+const COMMAND_PATTERNS: Array<{
+  match: RegExp;
+  build: (groups: RegExpMatchArray) => VoiceCommand;
+}> = [
+  { match: /^(next step|next|nächster schritt|weiter)$/i, build: () => ({ type: 'next' }) },
+  {
+    match: /^(previous step|previous|back|vorheriger schritt|zurück)$/i,
+    build: () => ({ type: 'previous' }),
+  },
+  { match: /^(repeat|wiederhole|wiederholen)$/i, build: () => ({ type: 'repeat' }) },
+  { match: /^(stop|stopp|stop it|halt)$/i, build: () => ({ type: 'stop' }) },
+  { match: /^(ingredients|zutaten)$/i, build: () => ({ type: 'ingredients' }) },
+  {
+    match: /^timer\s+(\d{1,3})\s*(?:minutes?|min|minuten|minute)$/i,
+    build: (m) => ({ type: 'timer', minutes: Number(m[1]) }),
+  },
+  {
+    match: /^(\d{1,3})\s*(?:minute|minuten|min)\s+timer$/i,
+    build: (m) => ({ type: 'timer', minutes: Number(m[1]) }),
+  },
+];
+
+interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+  onerror: ((event: { error: string }) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike;
+}
+
+@Injectable({ providedIn: 'root' })
+export class VoiceService {
+  readonly ttsSupported = signal(this.detectTtsSupport());
+  readonly sttSupported = signal(this.detectSttSupport());
+  readonly isListening = signal(false);
+  readonly isSpeaking = signal(false);
+  readonly muted = signal(false);
+
+  private recognition: SpeechRecognitionLike | null = null;
+  private currentLang = 'en-US';
+
+  setLanguage(lang: 'en' | 'de'): void {
+    this.currentLang = lang === 'de' ? 'de-DE' : 'en-US';
+    if (this.recognition) {
+      this.recognition.lang = this.currentLang;
+    }
+  }
+
+  speak(text: string): void {
+    if (!this.ttsSupported() || this.muted() || text.trim() === '') {
+      return;
+    }
+    const synth = window.speechSynthesis;
+    synth.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = this.currentLang;
+    utterance.onstart = () => this.isSpeaking.set(true);
+    utterance.onend = () => this.isSpeaking.set(false);
+    utterance.onerror = () => this.isSpeaking.set(false);
+    synth.speak(utterance);
+  }
+
+  stopSpeaking(): void {
+    if (this.ttsSupported()) {
+      window.speechSynthesis.cancel();
+      this.isSpeaking.set(false);
+    }
+  }
+
+  setMuted(muted: boolean): void {
+    this.muted.set(muted);
+    if (muted) {
+      this.stopSpeaking();
+    }
+  }
+
+  startListening(onCommand: (command: VoiceCommand) => void): void {
+    if (!this.sttSupported() || this.isListening()) {
+      return;
+    }
+    const recognition = this.createRecognition();
+    if (!recognition) return;
+
+    recognition.lang = this.currentLang;
+    recognition.continuous = true;
+    recognition.interimResults = false;
+    recognition.onresult = (event) => {
+      const last = event.results[event.results.length - 1];
+      const transcript = last[0]?.transcript?.trim() ?? '';
+      const command = VoiceService.parseCommand(transcript);
+      if (command) {
+        onCommand(command);
+      }
+    };
+    recognition.onerror = () => {
+      this.isListening.set(false);
+    };
+    recognition.onend = () => {
+      this.isListening.set(false);
+    };
+
+    this.recognition = recognition;
+    recognition.start();
+    this.isListening.set(true);
+  }
+
+  stopListening(): void {
+    if (this.recognition && this.isListening()) {
+      this.recognition.stop();
+      this.isListening.set(false);
+    }
+  }
+
+  static parseCommand(transcript: string): VoiceCommand | null {
+    const normalized = transcript.trim().toLowerCase();
+    if (normalized === '') return null;
+    for (const pattern of COMMAND_PATTERNS) {
+      const match = normalized.match(pattern.match);
+      if (match) {
+        return pattern.build(match);
+      }
+    }
+    return null;
+  }
+
+  private createRecognition(): SpeechRecognitionLike | null {
+    const ctor =
+      (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor }).SpeechRecognition ??
+      (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor })
+        .webkitSpeechRecognition;
+    return ctor ? new ctor() : null;
+  }
+
+  private detectTtsSupport(): boolean {
+    return typeof window !== 'undefined' && 'speechSynthesis' in window;
+  }
+
+  private detectSttSupport(): boolean {
+    if (typeof window === 'undefined') return false;
+    return (
+      'SpeechRecognition' in window ||
+      'webkitSpeechRecognition' in (window as unknown as Record<string, unknown>)
+    );
+  }
+}

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -142,7 +142,8 @@ export class VoiceService {
 
   private createRecognition(): SpeechRecognitionLike | null {
     const ctor =
-      (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor }).SpeechRecognition ??
+      (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor })
+        .SpeechRecognition ??
       (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor })
         .webkitSpeechRecognition;
     return ctor ? new ctor() : null;

--- a/client/libs/shared/models/src/lib/wake-lock.service.spec.ts
+++ b/client/libs/shared/models/src/lib/wake-lock.service.spec.ts
@@ -1,0 +1,100 @@
+import { TestBed } from '@angular/core/testing';
+import { WakeLockService } from './wake-lock.service';
+
+interface FakeSentinel {
+  released: boolean;
+  release: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  triggerRelease(): void;
+}
+
+function createFakeSentinel(): FakeSentinel {
+  let releaseHandler: (() => void) | null = null;
+  return {
+    released: false,
+    release: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn((_type: string, handler: () => void) => {
+      releaseHandler = handler;
+    }),
+    triggerRelease() {
+      releaseHandler?.();
+    },
+  };
+}
+
+describe('WakeLockService', () => {
+  let service: WakeLockService;
+  let originalWakeLock: unknown;
+
+  beforeEach(() => {
+    originalWakeLock = (navigator as unknown as { wakeLock?: unknown }).wakeLock;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'wakeLock', {
+      configurable: true,
+      value: originalWakeLock,
+    });
+  });
+
+  it('should report unsupported when wakeLock is missing', () => {
+    Object.defineProperty(navigator, 'wakeLock', { configurable: true, value: undefined });
+    service = TestBed.runInInjectionContext(() => new WakeLockService());
+
+    expect(service.supported()).toBe(false);
+  });
+
+  it('should acquire and set active when supported', async () => {
+    const sentinel = createFakeSentinel();
+    Object.defineProperty(navigator, 'wakeLock', {
+      configurable: true,
+      value: { request: vi.fn().mockResolvedValue(sentinel) },
+    });
+    service = TestBed.runInInjectionContext(() => new WakeLockService());
+
+    await service.acquire();
+
+    expect(service.active()).toBe(true);
+  });
+
+  it('should release sentinel and clear active state', async () => {
+    const sentinel = createFakeSentinel();
+    Object.defineProperty(navigator, 'wakeLock', {
+      configurable: true,
+      value: { request: vi.fn().mockResolvedValue(sentinel) },
+    });
+    service = TestBed.runInInjectionContext(() => new WakeLockService());
+
+    await service.acquire();
+    await service.release();
+
+    expect(sentinel.release).toHaveBeenCalled();
+    expect(service.active()).toBe(false);
+  });
+
+  it('should clear active when sentinel emits release event', async () => {
+    const sentinel = createFakeSentinel();
+    Object.defineProperty(navigator, 'wakeLock', {
+      configurable: true,
+      value: { request: vi.fn().mockResolvedValue(sentinel) },
+    });
+    service = TestBed.runInInjectionContext(() => new WakeLockService());
+
+    await service.acquire();
+    sentinel.triggerRelease();
+
+    expect(service.active()).toBe(false);
+  });
+
+  it('should swallow errors during acquire', async () => {
+    Object.defineProperty(navigator, 'wakeLock', {
+      configurable: true,
+      value: { request: vi.fn().mockRejectedValue(new Error('blocked')) },
+    });
+    service = TestBed.runInInjectionContext(() => new WakeLockService());
+
+    await service.acquire();
+
+    expect(service.active()).toBe(false);
+  });
+});

--- a/client/libs/shared/models/src/lib/wake-lock.service.ts
+++ b/client/libs/shared/models/src/lib/wake-lock.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, signal } from '@angular/core';
+
+interface WakeLockSentinelLike {
+  released: boolean;
+  release(): Promise<void>;
+  addEventListener(type: 'release', listener: () => void): void;
+}
+
+interface WakeLockNavigator {
+  wakeLock?: { request(type: 'screen'): Promise<WakeLockSentinelLike> };
+}
+
+@Injectable({ providedIn: 'root' })
+export class WakeLockService {
+  readonly supported = signal(this.detectSupport());
+  readonly active = signal(false);
+
+  private sentinel: WakeLockSentinelLike | null = null;
+  private visibilityHandler: (() => void) | null = null;
+
+  async acquire(): Promise<void> {
+    if (!this.supported() || this.sentinel !== null) {
+      return;
+    }
+    try {
+      const nav = navigator as unknown as WakeLockNavigator;
+      const sentinel = await nav.wakeLock!.request('screen');
+      this.sentinel = sentinel;
+      this.active.set(true);
+      sentinel.addEventListener('release', () => {
+        this.active.set(false);
+        this.sentinel = null;
+      });
+      this.installVisibilityHandler();
+    } catch {
+      this.active.set(false);
+    }
+  }
+
+  async release(): Promise<void> {
+    if (this.sentinel) {
+      try {
+        await this.sentinel.release();
+      } catch {
+        /* ignore */
+      }
+      this.sentinel = null;
+    }
+    this.active.set(false);
+    this.removeVisibilityHandler();
+  }
+
+  private installVisibilityHandler(): void {
+    if (this.visibilityHandler || typeof document === 'undefined') return;
+    this.visibilityHandler = () => {
+      if (document.visibilityState === 'visible' && this.sentinel === null && this.active()) {
+        void this.acquire();
+      }
+    };
+    document.addEventListener('visibilitychange', this.visibilityHandler);
+  }
+
+  private removeVisibilityHandler(): void {
+    if (this.visibilityHandler && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
+  }
+
+  private detectSupport(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const nav = navigator as unknown as WakeLockNavigator;
+    return nav.wakeLock != null;
+  }
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -31,6 +31,9 @@ export {
   type RecipeDifficulty,
   EMPTY_FILTER,
 } from './lib/filter-panel/filter-panel.component';
+export { StepDisplayComponent } from './lib/step-display/step-display.component';
+export { CookingTimerComponent } from './lib/cooking-timer/cooking-timer.component';
+export { VoiceIndicatorComponent } from './lib/voice-indicator/voice-indicator.component';
 
 // Directives
 export { InfiniteScrollDirective } from './lib/directives/infinite-scroll.directive';

--- a/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.html
+++ b/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.html
@@ -1,0 +1,18 @@
+<div class="cooking-timer" [class.completed]="timer().status === 'completed'" *transloco="let t">
+  <svg class="timer-ring" viewBox="0 0 140 140" aria-hidden="true">
+    <circle class="ring-bg" cx="70" cy="70" [attr.r]="radius"></circle>
+    <circle
+      class="ring-fg"
+      cx="70"
+      cy="70"
+      [attr.r]="radius"
+      [attr.stroke-dasharray]="circumference"
+      [attr.stroke-dashoffset]="dashOffset()"
+    ></circle>
+  </svg>
+  <div class="timer-text">{{ displayText() }}</div>
+  <div class="timer-name">{{ timer().name }}</div>
+  <button type="button" class="timer-cancel" (click)="onCancel()">
+    {{ t('recipes.cook.timer.cancel') }}
+  </button>
+</div>

--- a/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.scss
+++ b/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.scss
@@ -1,0 +1,94 @@
+.cooking-timer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--yn-space-2);
+  padding: var(--yn-space-5);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-lg);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+
+  &.completed {
+    border-color: var(--yn-primary);
+    animation: pulse 0.6s ease-out 3;
+  }
+}
+
+.timer-ring {
+  width: 140px;
+  height: 140px;
+  transform: rotate(-90deg);
+}
+
+.ring-bg {
+  fill: none;
+  stroke: var(--yn-glass-border);
+  stroke-width: 8;
+}
+
+.ring-fg {
+  fill: none;
+  stroke: var(--yn-primary);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1s linear;
+}
+
+.timer-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, calc(-50% - 24px));
+  font-size: var(--yn-text-2xl);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.timer-name {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  max-width: 8rem;
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.timer-cancel {
+  margin-top: var(--yn-space-2);
+  padding: var(--yn-space-2) var(--yn-space-3);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: transparent;
+  color: var(--yn-text);
+  font-size: var(--yn-text-xs);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-fg {
+    transition: none;
+  }
+  .cooking-timer.completed {
+    animation: none;
+  }
+}

--- a/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.ts
+++ b/client/libs/ui/src/lib/cooking-timer/cooking-timer.component.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import type { CookingTimer } from '@yumney/shared/models';
+
+const RADIUS = 60;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+@Component({
+  selector: 'yn-cooking-timer',
+  standalone: true,
+  imports: [TranslocoModule],
+  templateUrl: './cooking-timer.component.html',
+  styleUrl: './cooking-timer.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CookingTimerComponent {
+  timer = input.required<CookingTimer>();
+  cancel = output<string>();
+
+  protected readonly radius = RADIUS;
+  protected readonly circumference = CIRCUMFERENCE;
+
+  protected readonly displayText = computed(() => {
+    const t = this.timer();
+    const minutes = Math.floor(t.remainingSeconds / 60);
+    const seconds = t.remainingSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  });
+
+  protected readonly dashOffset = computed(() => {
+    const t = this.timer();
+    if (t.totalSeconds === 0) return 0;
+    const progress = t.remainingSeconds / t.totalSeconds;
+    return CIRCUMFERENCE * (1 - progress);
+  });
+
+  protected onCancel(): void {
+    this.cancel.emit(this.timer().id);
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -35,7 +35,9 @@
       <button
         class="theme-toggle"
         (click)="onToggleTheme()"
-        [attr.aria-label]="isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
+        [attr.aria-label]="
+          isDark() ? t('layout.header.switchToLight') : t('layout.header.switchToDark')
+        "
       >
         {{ isDark() ? '☀' : '☾' }}
       </button>

--- a/client/libs/ui/src/lib/step-display/step-display.component.html
+++ b/client/libs/ui/src/lib/step-display/step-display.component.html
@@ -1,0 +1,6 @@
+<div class="step-display" *transloco="let t">
+  <div class="step-progress">
+    {{ t('recipes.cook.stepProgress', { current: stepNumber(), total: totalSteps() }) }}
+  </div>
+  <p class="step-text">{{ text() }}</p>
+</div>

--- a/client/libs/ui/src/lib/step-display/step-display.component.scss
+++ b/client/libs/ui/src/lib/step-display/step-display.component.scss
@@ -1,0 +1,31 @@
+.step-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--yn-space-6);
+  padding: var(--yn-space-8) var(--yn-space-6);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-xl);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur));
+  text-align: center;
+}
+
+.step-progress {
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-medium);
+  color: var(--yn-text-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.step-text {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  line-height: var(--yn-leading-relaxed);
+  color: var(--yn-text);
+  font-weight: var(--yn-font-medium);
+  max-width: 60ch;
+}

--- a/client/libs/ui/src/lib/step-display/step-display.component.ts
+++ b/client/libs/ui/src/lib/step-display/step-display.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'yn-step-display',
+  standalone: true,
+  imports: [TranslocoModule],
+  templateUrl: './step-display.component.html',
+  styleUrl: './step-display.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StepDisplayComponent {
+  stepNumber = input.required<number>();
+  totalSteps = input.required<number>();
+  text = input.required<string>();
+}

--- a/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
+++ b/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
@@ -8,7 +8,11 @@ import { ROUTES } from '@yumney/shared/models';
   standalone: true,
   imports: [RouterLink, TranslocoModule],
   template: `
-    <a class="suggestion-card" [routerLink]="ROUTES.recipes.detail(identifier())" *transloco="let t">
+    <a
+      class="suggestion-card"
+      [routerLink]="ROUTES.recipes.detail(identifier())"
+      *transloco="let t"
+    >
       @if (imageUrl()) {
         <img class="suggestion-image" [src]="imageUrl()!" [alt]="title()" loading="lazy" />
       } @else {

--- a/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
+++ b/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
@@ -1,13 +1,14 @@
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
 import { ROUTES } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-suggestion-card',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, TranslocoModule],
   template: `
-    <a class="suggestion-card" [routerLink]="ROUTES.recipes.detail(identifier())">
+    <a class="suggestion-card" [routerLink]="ROUTES.recipes.detail(identifier())" *transloco="let t">
       @if (imageUrl()) {
         <img class="suggestion-image" [src]="imageUrl()!" [alt]="title()" loading="lazy" />
       } @else {
@@ -16,7 +17,9 @@ import { ROUTES } from '@yumney/shared/models';
       <div class="suggestion-info">
         <h3 class="suggestion-title">{{ title() }}</h3>
         @if (prepTimeMinutes()) {
-          <span class="suggestion-time">{{ prepTimeMinutes() }} min</span>
+          <span class="suggestion-time">{{
+            t('dashboard.suggestions.prepTime', { minutes: prepTimeMinutes() })
+          }}</span>
         }
         <span class="suggestion-reason">{{ reason() }}</span>
       </div>

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.html
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.html
@@ -15,7 +15,12 @@
       }
     </span>
     @if (selectedValue()) {
-      <span class="unit-clear" (click)="clearSelection($event)" aria-label="Clear">&times;</span>
+      <span
+        class="unit-clear"
+        (click)="clearSelection($event)"
+        [attr.aria-label]="t('dashboard.preview.clearUnit')"
+        >&times;</span
+      >
     }
     <span class="unit-chevron" [class.open]="isOpen()">&#9662;</span>
   </button>

--- a/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.scss
+++ b/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.scss
@@ -1,0 +1,43 @@
+.voice-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 1px solid var(--yn-glass-border);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text-muted);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+  transition:
+    color var(--yn-duration-fast) var(--yn-ease-glass),
+    border-color var(--yn-duration-fast) var(--yn-ease-glass);
+
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  &.listening {
+    color: var(--yn-primary);
+    border-color: var(--yn-primary);
+    animation: pulse-ring 1.4s ease-in-out infinite;
+  }
+}
+
+@keyframes pulse-ring {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--yn-primary-light);
+  }
+  50% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-indicator.listening {
+    animation: none;
+  }
+}

--- a/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.ts
+++ b/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'yn-voice-indicator',
+  standalone: true,
+  template: `
+    <div class="voice-indicator" [class.listening]="listening()" [attr.aria-live]="'polite'">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3z"
+          fill="currentColor"
+        />
+        <path
+          d="M19 11a1 1 0 0 0-2 0 5 5 0 0 1-10 0 1 1 0 0 0-2 0 7 7 0 0 0 6 6.92V21h-2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2h-2v-3.08A7 7 0 0 0 19 11z"
+          fill="currentColor"
+        />
+      </svg>
+    </div>
+  `,
+  styleUrl: './voice-indicator.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VoiceIndicatorComponent {
+  listening = input.required<boolean>();
+}

--- a/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.ts
+++ b/client/libs/ui/src/lib/voice-indicator/voice-indicator.component.ts
@@ -6,10 +6,7 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
   template: `
     <div class="voice-indicator" [class.listening]="listening()" [attr.aria-live]="'polite'">
       <svg viewBox="0 0 24 24" aria-hidden="true">
-        <path
-          d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3z"
-          fill="currentColor"
-        />
+        <path d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3z" fill="currentColor" />
         <path
           d="M19 11a1 1 0 0 0-2 0 5 5 0 0 1-10 0 1 1 0 0 0-2 0 7 7 0 0 0 6 6.92V21h-2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2h-2v-3.08A7 7 0 0 0 19 11z"
           fill="currentColor"


### PR DESCRIPTION
## Summary
- New full-screen cook mode at \`/recipes/:id/cook\` with voice + swipe + tap + keyboard navigation, ingredient drawer, screen wake lock, multi-timer support with vibration + voice announcements on completion.
- Bilingual voice control (en + de): \"next/previous/repeat/stop/ingredients/timer N min\".
- 3 new services in \`libs/shared/models/\` (\`VoiceService\`, \`WakeLockService\`, \`CookingTimerService\`) — all browser-native APIs, no new dependencies.
- 3 new glass UI components in \`libs/ui/\` (\`yn-step-display\`, \`yn-cooking-timer\`, \`yn-voice-indicator\`).
- Start Cooking button on recipe detail.
- Closes the multimodal redesign plan (Phase 5 — last remaining redesign-flavored story).

## i18n cleanup (drive-by)
While auditing translations the user spotted missing labels in the recipe area. Fixed in this PR:
- New \`recipes.cook.*\` keys (en + de) including loading label
- \`suggestion-card\` " min" suffix → \`dashboard.suggestions.prepTime\`
- header dark/light toggle aria-labels → \`layout.header.switchToDark/Light\` (added to all 4 apps)
- \`unit-select\` clear aria-label → \`dashboard.preview.clearUnit\`
- **Repaired 5 corrupted German strings** in \`shell/de.json\` that had been saved with U+FFFD replacement chars instead of umlauts (Vorschläge / Frühstücksideen / Aktivität / gelöscht)

## Test plan
- [x] \`yarn nx run-many -t test\` — 199 frontend tests pass (incl. 29 new service unit tests)
- [x] \`yarn nx run-many -t lint\` — clean
- [x] \`yarn nx run-many -t build\` — all 4 client apps build
- [ ] Manual: open recipe detail → Start Cooking → verify TTS reads first step
- [ ] Manual: voice command \"next step\" / \"timer 5 minutes\" / \"ingredients\"
- [ ] Manual: swipe and arrow-key navigation
- [ ] Manual: verify German UI shows real umlauts on dashboard
- [ ] Manual: cook mode in dark mode

Closes US-240.