### PR TITLE
fix(shell): render chat panel in the shell app (US-230)

### DIFF
--- a/client/apps/shell/src/app/app.html
+++ b/client/apps/shell/src/app/app.html
@@ -3,3 +3,4 @@
 <main>
   <router-outlet></router-outlet>
 </main>
+<yn-chat-panel />

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -1,12 +1,12 @@
 import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { RouterModule } from '@angular/router';
-import { HeaderComponent } from '@yumney/ui';
+import { ChatPanelComponent, HeaderComponent } from '@yumney/ui';
 import { OfflineIndicatorComponent } from './layout/offline-indicator/offline-indicator.component';
 import { filter } from 'rxjs';
 
 @Component({
-  imports: [RouterModule, HeaderComponent, OfflineIndicatorComponent],
+  imports: [RouterModule, HeaderComponent, ChatPanelComponent, OfflineIndicatorComponent],
   selector: 'yn-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.html
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.html
@@ -4,4 +4,6 @@
 <main>
   <router-outlet />
 </main>
-<yn-chat-panel />
+@if (isStandalone) {
+  <yn-chat-panel />
+}


### PR DESCRIPTION
## Summary
- The shell's `app.html` never included `<yn-chat-panel />`, so the header toggle button flipped the signal with nothing to render. Chat appeared to do nothing.
- Added `<yn-chat-panel />` to the shell + imported `ChatPanelComponent`.
- Guarded the chat panel in `AppLayoutComponent` with `@if (isStandalone)` to prevent double-render when MFEs run inside the shell.

## Test plan
- [x] `yarn nx run-many -t test` — 199 tests pass
- [x] `yarn nx run-many -t build` — all 4 apps build
- [ ] Manual: click chat toggle on dashboard → panel slides in
- [ ] Manual: click chat toggle on recipe list (MFE route) → single panel, no duplicate