### PR TITLE
feat(users): add DefaultServings to user profile (US-300)

### DIFF
--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
@@ -12,6 +12,8 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
 
     public PreferredUnitSystem PreferredUnitSystem { get; private set; } = PreferredUnitSystem.From("metric");
 
+    public DefaultServings DefaultServings { get; private set; } = DefaultServings.Default;
+
     private AppUserProfile()
     {
     }
@@ -39,5 +41,10 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
     public void RenameAs(DisplayName displayName)
     {
         DisplayName = displayName;
+    }
+
+    public void AdjustDefaultServingsTo(DefaultServings defaultServings)
+    {
+        DefaultServings = defaultServings;
     }
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/DefaultServings.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DefaultServings.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+public sealed record DefaultServings : IValueObject<int>
+{
+    public const int MinValue = 1;
+    public const int MaxValue = 12;
+    public const int DefaultValue = 4;
+
+    public static readonly DefaultServings Default = new(DefaultValue);
+
+    public int Value { get; }
+
+    private DefaultServings(int value)
+    {
+        Value = Ensure.That(value).IsInRange(MinValue, MaxValue).AndReturn();
+    }
+
+    public static DefaultServings From(int value) => new(value);
+
+    public static DefaultServings? FromNullable(int? value) =>
+        value.HasValue ? new DefaultServings(value.Value) : null;
+
+    public static implicit operator int(DefaultServings obj) => obj.Value;
+
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
@@ -4,5 +4,8 @@ public interface IAppUserProfileRepository
 {
     Task<AppUserProfile?> FindByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 
+    // Tracked fetch for update flows. Throws EntityNotFoundException if not found.
+    Task<AppUserProfile> GetByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
+
     Task AddAsync(AppUserProfile profile, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
@@ -10,6 +11,12 @@ public sealed class AppUserProfileRepository(UsersDbContext context) : IAppUserP
     public async Task<AppUserProfile?> FindByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
     {
         return await profiles.AsNoTracking().FirstOrDefaultAsync(p => p.KeycloakUserId == keycloakUserId, cancellationToken);
+    }
+
+    public async Task<AppUserProfile> GetByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
+    {
+        return await profiles.FirstOrDefaultAsync(p => p.KeycloakUserId == keycloakUserId, cancellationToken)
+            ?? throw new EntityNotFoundException(nameof(AppUserProfile), keycloakUserId.Value);
     }
 
     public async Task AddAsync(AppUserProfile profile, CancellationToken cancellationToken = default)

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
@@ -34,6 +34,11 @@ internal sealed class AppUserProfileConfiguration : IEntityTypeConfiguration<App
             .HasMaxLength(PreferredUnitSystem.MaxLength)
             .IsRequired();
 
+        entity.Property(e => e.DefaultServings)
+            .HasConversion<DefaultServingsConverter>()
+            .HasDefaultValue(DefaultServings.Default)
+            .IsRequired();
+
         entity.HasIndex(e => e.KeycloakUserId).IsUnique();
         entity.Ignore(e => e.DomainEvents);
     }

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/DefaultServingsConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/DefaultServingsConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class DefaultServingsConverter()
+    : ValueConverter<DefaultServings, int>(v => v.Value, v => DefaultServings.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409193950_AddDefaultServings.Designer.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409193950_AddDefaultServings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409193950_AddDefaultServings")]
+    partial class AddDefaultServings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409193950_AddDefaultServings.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409193950_AddDefaultServings.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultServings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DefaultServings",
+                table: "AppUserProfiles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 4);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultServings",
+                table: "AppUserProfiles");
+        }
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
@@ -83,4 +83,24 @@ public class AppUserProfileTests
 
         profile.PreferredUnitSystem.Should().Be(imperial);
     }
+
+    [Fact]
+    public void Create_ValidParameters_SetsDefaultServingsTo4()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.DefaultServings.Should().Be(DefaultServings.Default);
+        profile.DefaultServings.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void AdjustDefaultServingsTo_NewValue_UpdatesDefaultServings()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var newServings = DefaultServings.From(6);
+
+        profile.AdjustDefaultServingsTo(newServings);
+
+        profile.DefaultServings.Should().Be(newServings);
+    }
 }

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DefaultServingsTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DefaultServingsTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class DefaultServingsTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(12)]
+    public void From_ValidValue_CreatesInstance(int value)
+    {
+        var servings = DefaultServings.From(value);
+
+        servings.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(13)]
+    [InlineData(100)]
+    public void From_OutOfRange_ThrowsGuardException(int value)
+    {
+        var act = () => DefaultServings.From(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void Default_StaticInstance_HasValue4()
+    {
+        DefaultServings.Default.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void FromNullable_WithValue_CreatesInstance()
+    {
+        var servings = DefaultServings.FromNullable(4);
+
+        servings.Should().NotBeNull();
+        servings!.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void FromNullable_WithNull_ReturnsNull()
+    {
+        var servings = DefaultServings.FromNullable(null);
+
+        servings.Should().BeNull();
+    }
+
+    [Fact]
+    public void ImplicitConversion_ToInt_ReturnsValue()
+    {
+        var servings = DefaultServings.From(6);
+
+        int value = servings;
+
+        value.Should().Be(6);
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var s1 = DefaultServings.From(4);
+        var s2 = DefaultServings.From(4);
+
+        s1.Should().Be(s2);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValueAsString()
+    {
+        var servings = DefaultServings.From(6);
+
+        servings.ToString().Should().Be("6");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DefaultServings` value object (range 1–12, default 4) to `AppUserProfile` aggregate
- Add `AdjustDefaultServingsTo()` behavior method for updating household size
- Add `GetByKeycloakUserIdAsync` (non-nullable, tracked) to `IAppUserProfileRepository` alongside existing `Find` (nullable, untracked)
- EF Core migration adds `DefaultServings` column with default value 4 for existing users
- 10 new domain tests (8 for value object, 2 for aggregate behavior)

Closes #151

## Test plan
- [x] `DefaultServings.From()` validates range 1–12, rejects 0, negative, and >12
- [x] `DefaultServings.Default` is 4
- [x] `AppUserProfile.Create()` initializes with default servings
- [x] `AdjustDefaultServingsTo()` updates the value
- [x] Build passes with `TreatWarningsAsErrors=true` (0 warnings)
- [x] All 100 Users domain tests pass
- [x] All 64 architecture tests pass