### PR TITLE
feat(users): add DietaryProfile to user profile (US-301)

### DIFF
--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
@@ -14,6 +14,8 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
 
     public DefaultServings DefaultServings { get; private set; } = DefaultServings.Default;
 
+    public DietaryProfile DietaryProfile { get; private set; } = DietaryProfile.Empty;
+
     private AppUserProfile()
     {
     }
@@ -46,5 +48,10 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
     public void AdjustDefaultServingsTo(DefaultServings defaultServings)
     {
         DefaultServings = defaultServings;
+    }
+
+    public void UpdateDietaryProfile(DietaryProfile dietaryProfile)
+    {
+        DietaryProfile = dietaryProfile;
     }
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/CookingEffortPreference.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/CookingEffortPreference.cs
@@ -1,0 +1,35 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+#pragma warning disable SA1311
+public sealed record CookingEffortPreference : IValueObject<string>
+{
+    public const int MaxLength = 25;
+
+#pragma warning disable SA1202
+    private static readonly string[] allowedValues =
+        ["quick-weekdays", "balanced", "elaborate-weekends"];
+
+    public static readonly CookingEffortPreference QuickWeekdays = new("quick-weekdays");
+    public static readonly CookingEffortPreference Balanced = new("balanced");
+    public static readonly CookingEffortPreference ElaborateWeekends = new("elaborate-weekends");
+#pragma warning restore SA1202
+
+    public string Value { get; }
+
+    private CookingEffortPreference(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .IsOneOf(allowedValues)
+            .AndReturn();
+    }
+
+    public static CookingEffortPreference From(string value) => new(value);
+
+    public static implicit operator string(CookingEffortPreference obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryProfile.cs
@@ -1,0 +1,43 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+public sealed record DietaryProfile : IValueObject
+{
+    public DietaryType? DietaryType { get; }
+
+    public IReadOnlyList<DietaryRestriction> Restrictions { get; }
+
+    public WeeklyBalanceGoals BalanceGoals { get; }
+
+    public CookingEffortPreference? CookingEffort { get; }
+
+    private DietaryProfile()
+    {
+        Restrictions = [];
+        BalanceGoals = WeeklyBalanceGoals.None;
+    }
+
+    private DietaryProfile(
+        DietaryType? dietaryType,
+        IReadOnlyList<DietaryRestriction> restrictions,
+        WeeklyBalanceGoals balanceGoals,
+        CookingEffortPreference? cookingEffort)
+    {
+        DietaryType = dietaryType;
+        Restrictions = restrictions;
+        BalanceGoals = balanceGoals;
+        CookingEffort = cookingEffort;
+    }
+
+    public static DietaryProfile From(
+        DietaryType? dietaryType,
+        IReadOnlyList<DietaryRestriction> restrictions,
+        WeeklyBalanceGoals balanceGoals,
+        CookingEffortPreference? cookingEffort) =>
+        new(dietaryType, restrictions, balanceGoals, cookingEffort);
+
+    public static readonly DietaryProfile Empty = new(null, [], WeeklyBalanceGoals.None, null);
+
+    public bool IsEmpty => DietaryType is null && Restrictions.Count == 0 && BalanceGoals.IsEmpty && CookingEffort is null;
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryProfile.cs
@@ -40,4 +40,24 @@ public sealed record DietaryProfile : IValueObject
     public static readonly DietaryProfile Empty = new(null, [], WeeklyBalanceGoals.None, null);
 
     public bool IsEmpty => DietaryType is null && Restrictions.Count == 0 && BalanceGoals.IsEmpty && CookingEffort is null;
+
+    public bool Equals(DietaryProfile? other)
+    {
+        if (other is null) return false;
+        return DietaryType == other.DietaryType
+            && Restrictions.SequenceEqual(other.Restrictions)
+            && BalanceGoals == other.BalanceGoals
+            && CookingEffort == other.CookingEffort;
+    }
+
+    public override int GetHashCode()
+    {
+        HashCode hash = default;
+        hash.Add(DietaryType);
+        foreach (var restriction in Restrictions)
+            hash.Add(restriction);
+        hash.Add(BalanceGoals);
+        hash.Add(CookingEffort);
+        return hash.ToHashCode();
+    }
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryRestriction.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryRestriction.cs
@@ -1,0 +1,42 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+#pragma warning disable SA1311
+public sealed record DietaryRestriction : IValueObject<string>
+{
+    public const int MaxLength = 30;
+
+#pragma warning disable SA1202
+    private static readonly string[] allowedValues =
+        ["gluten-free", "lactose-free", "nut-allergy", "egg-free", "soy-free", "shellfish-allergy", "halal", "kosher"];
+
+    public static readonly DietaryRestriction GlutenFree = new("gluten-free");
+    public static readonly DietaryRestriction LactoseFree = new("lactose-free");
+    public static readonly DietaryRestriction NutAllergy = new("nut-allergy");
+    public static readonly DietaryRestriction EggFree = new("egg-free");
+    public static readonly DietaryRestriction SoyFree = new("soy-free");
+    public static readonly DietaryRestriction ShellfishAllergy = new("shellfish-allergy");
+    public static readonly DietaryRestriction Halal = new("halal");
+    public static readonly DietaryRestriction Kosher = new("kosher");
+#pragma warning restore SA1202
+
+    public string Value { get; }
+
+    private DietaryRestriction(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .IsOneOf(allowedValues)
+            .AndReturn();
+    }
+
+    public static DietaryRestriction From(string value) => new(value);
+
+    public static IReadOnlyList<string> AllowedValues => allowedValues;
+
+    public static implicit operator string(DietaryRestriction obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryType.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryType.cs
@@ -1,0 +1,37 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+#pragma warning disable SA1311
+public sealed record DietaryType : IValueObject<string>
+{
+    public const int MaxLength = 20;
+
+#pragma warning disable SA1202
+    private static readonly string[] allowedValues =
+        ["omnivore", "vegetarian", "vegan", "pescatarian", "flexitarian"];
+
+    public static readonly DietaryType Omnivore = new("omnivore");
+    public static readonly DietaryType Vegetarian = new("vegetarian");
+    public static readonly DietaryType Vegan = new("vegan");
+    public static readonly DietaryType Pescatarian = new("pescatarian");
+    public static readonly DietaryType Flexitarian = new("flexitarian");
+#pragma warning restore SA1202
+
+    public string Value { get; }
+
+    private DietaryType(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .IsOneOf(allowedValues)
+            .AndReturn();
+    }
+
+    public static DietaryType From(string value) => new(value);
+
+    public static implicit operator string(DietaryType obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/WeeklyBalanceGoals.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/WeeklyBalanceGoals.cs
@@ -1,0 +1,37 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+public sealed record WeeklyBalanceGoals : IValueObject
+{
+    public const int MinMeals = 0;
+    public const int MaxMeals = 7;
+
+    public int? MinVeggieMeals { get; }
+
+    public int? MaxRedMeatMeals { get; }
+
+    private WeeklyBalanceGoals()
+    {
+    }
+
+    private WeeklyBalanceGoals(int? minVeggieMeals, int? maxRedMeatMeals)
+    {
+        if (minVeggieMeals.HasValue)
+            Ensure.That(minVeggieMeals.Value).IsInRange(MinMeals, MaxMeals);
+
+        if (maxRedMeatMeals.HasValue)
+            Ensure.That(maxRedMeatMeals.Value).IsInRange(MinMeals, MaxMeals);
+
+        MinVeggieMeals = minVeggieMeals;
+        MaxRedMeatMeals = maxRedMeatMeals;
+    }
+
+    public static WeeklyBalanceGoals From(int? minVeggieMeals, int? maxRedMeatMeals) =>
+        new(minVeggieMeals, maxRedMeatMeals);
+
+    public static readonly WeeklyBalanceGoals None = new(null, null);
+
+    public bool IsEmpty => !MinVeggieMeals.HasValue && !MaxRedMeatMeals.HasValue;
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
@@ -39,6 +39,33 @@ internal sealed class AppUserProfileConfiguration : IEntityTypeConfiguration<App
             .HasDefaultValue(DefaultServings.Default)
             .IsRequired();
 
+        entity.OwnsOne(e => e.DietaryProfile, dietary =>
+        {
+            dietary.Property(d => d.DietaryType)
+                .HasConversion<DietaryTypeConverter>()
+                .HasMaxLength(DietaryType.MaxLength)
+                .HasColumnName("DietaryType");
+
+            dietary.Property(d => d.Restrictions)
+                .HasConversion<DietaryRestrictionsConverter>()
+                .HasMaxLength(500)
+                .HasColumnName("DietaryRestrictions");
+
+            dietary.Property(d => d.CookingEffort)
+                .HasConversion<CookingEffortPreferenceConverter>()
+                .HasMaxLength(CookingEffortPreference.MaxLength)
+                .HasColumnName("CookingEffort");
+
+            dietary.OwnsOne(d => d.BalanceGoals, goals =>
+            {
+                goals.Property(g => g.MinVeggieMeals)
+                    .HasColumnName("MinVeggieMeals");
+
+                goals.Property(g => g.MaxRedMeatMeals)
+                    .HasColumnName("MaxRedMeatMeals");
+            });
+        });
+
         entity.HasIndex(e => e.KeycloakUserId).IsUnique();
         entity.Ignore(e => e.DomainEvents);
     }

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/CookingEffortPreferenceConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/CookingEffortPreferenceConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class CookingEffortPreferenceConverter()
+    : ValueConverter<CookingEffortPreference, string>(v => v.Value, v => CookingEffortPreference.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryRestrictionsConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryRestrictionsConverter.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class DietaryRestrictionsConverter()
+    : ValueConverter<IReadOnlyList<DietaryRestriction>, string>(
+        v => string.Join(',', v.Select(r => r.Value)),
+        v => ConvertFromString(v))
+{
+    private static IReadOnlyList<DietaryRestriction> ConvertFromString(string value) =>
+        string.IsNullOrEmpty(value)
+            ? Array.Empty<DietaryRestriction>()
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(DietaryRestriction.From).ToList();
+}

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryTypeConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryTypeConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class DietaryTypeConverter()
+    : ValueConverter<DietaryType, string>(v => v.Value, v => DietaryType.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409200433_AddDietaryProfile.Designer.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409200433_AddDietaryProfile.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409200433_AddDietaryProfile")]
+    partial class AddDietaryProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -26,11 +29,6 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
                 {
                     b.Property<Guid>("Id")
                         .HasColumnType("uuid");
-
-                    b.Property<int>("DefaultServings")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasDefaultValue(4);
 
                     b.Property<string>("DisplayName")
                         .IsRequired()

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409200433_AddDietaryProfile.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260409200433_AddDietaryProfile.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDietaryProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CookingEffort",
+                table: "AppUserProfiles",
+                type: "character varying(25)",
+                maxLength: 25,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DietaryRestrictions",
+                table: "AppUserProfiles",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DietaryType",
+                table: "AppUserProfiles",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxRedMeatMeals",
+                table: "AppUserProfiles",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinVeggieMeals",
+                table: "AppUserProfiles",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CookingEffort",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "DietaryRestrictions",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "DietaryType",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "MaxRedMeatMeals",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "MinVeggieMeals",
+                table: "AppUserProfiles");
+        }
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
@@ -103,4 +103,31 @@ public class AppUserProfileTests
 
         profile.DefaultServings.Should().Be(newServings);
     }
+
+    [Fact]
+    public void Create_ValidParameters_SetsEmptyDietaryProfile()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+
+        profile.DietaryProfile.Should().Be(DietaryProfile.Empty);
+        profile.DietaryProfile.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateDietaryProfile_NewProfile_UpdatesDietaryProfile()
+    {
+        var profile = Domain.AppUserProfile.AppUserProfile.Create(TestKeycloakUserId, TestDisplayName);
+        var dietary = DietaryProfile.From(
+            DietaryType.Vegetarian,
+            [DietaryRestriction.GlutenFree],
+            WeeklyBalanceGoals.From(3, 1),
+            CookingEffortPreference.QuickWeekdays);
+
+        profile.UpdateDietaryProfile(dietary);
+
+        profile.DietaryProfile.DietaryType.Should().Be(DietaryType.Vegetarian);
+        profile.DietaryProfile.Restrictions.Should().HaveCount(1);
+        profile.DietaryProfile.BalanceGoals.MinVeggieMeals.Should().Be(3);
+        profile.DietaryProfile.CookingEffort.Should().Be(CookingEffortPreference.QuickWeekdays);
+    }
 }

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/CookingEffortPreferenceTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/CookingEffortPreferenceTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class CookingEffortPreferenceTests
+{
+    [Theory]
+    [InlineData("quick-weekdays")]
+    [InlineData("balanced")]
+    [InlineData("elaborate-weekends")]
+    public void From_ValidValue_CreatesInstance(string value)
+    {
+        var pref = CookingEffortPreference.From(value);
+
+        pref.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => CookingEffortPreference.From(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData("Quick-Weekdays")]
+    [InlineData("lazy")]
+    [InlineData("always-elaborate")]
+    public void From_UnsupportedValue_ThrowsGuardException(string value)
+    {
+        var act = () => CookingEffortPreference.From(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void StaticInstances_HaveCorrectValues()
+    {
+        CookingEffortPreference.QuickWeekdays.Value.Should().Be("quick-weekdays");
+        CookingEffortPreference.Balanced.Value.Should().Be("balanced");
+        CookingEffortPreference.ElaborateWeekends.Value.Should().Be("elaborate-weekends");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var p1 = CookingEffortPreference.From("balanced");
+        var p2 = CookingEffortPreference.From("balanced");
+
+        p1.Should().Be(p2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryProfileTests.cs
@@ -76,4 +76,21 @@ public class DietaryProfileTests
 
         p1.Should().Be(p2);
     }
+
+    [Fact]
+    public void Equality_SameRestrictions_AreEqual()
+    {
+        var p1 = DietaryProfile.From(
+            DietaryType.Vegetarian,
+            [DietaryRestriction.GlutenFree, DietaryRestriction.LactoseFree],
+            WeeklyBalanceGoals.From(2, 3),
+            CookingEffortPreference.Balanced);
+        var p2 = DietaryProfile.From(
+            DietaryType.Vegetarian,
+            [DietaryRestriction.GlutenFree, DietaryRestriction.LactoseFree],
+            WeeklyBalanceGoals.From(2, 3),
+            CookingEffortPreference.Balanced);
+
+        p1.Should().Be(p2);
+    }
 }

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryProfileTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class DietaryProfileTests
+{
+    [Fact]
+    public void Empty_StaticInstance_IsEmpty()
+    {
+        DietaryProfile.Empty.IsEmpty.Should().BeTrue();
+        DietaryProfile.Empty.DietaryType.Should().BeNull();
+        DietaryProfile.Empty.Restrictions.Should().BeEmpty();
+        DietaryProfile.Empty.BalanceGoals.IsEmpty.Should().BeTrue();
+        DietaryProfile.Empty.CookingEffort.Should().BeNull();
+    }
+
+    [Fact]
+    public void From_AllValues_CreatesInstance()
+    {
+        var profile = DietaryProfile.From(
+            DietaryType.Vegetarian,
+            [DietaryRestriction.GlutenFree, DietaryRestriction.LactoseFree],
+            WeeklyBalanceGoals.From(3, 0),
+            CookingEffortPreference.QuickWeekdays);
+
+        profile.DietaryType.Should().Be(DietaryType.Vegetarian);
+        profile.Restrictions.Should().HaveCount(2);
+        profile.BalanceGoals.MinVeggieMeals.Should().Be(3);
+        profile.CookingEffort.Should().Be(CookingEffortPreference.QuickWeekdays);
+        profile.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void From_OnlyDietaryType_IsNotEmpty()
+    {
+        var profile = DietaryProfile.From(
+            DietaryType.Vegan,
+            [],
+            WeeklyBalanceGoals.None,
+            null);
+
+        profile.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void From_OnlyRestrictions_IsNotEmpty()
+    {
+        var profile = DietaryProfile.From(
+            null,
+            [DietaryRestriction.NutAllergy],
+            WeeklyBalanceGoals.None,
+            null);
+
+        profile.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void From_OnlyBalanceGoals_IsNotEmpty()
+    {
+        var profile = DietaryProfile.From(
+            null,
+            [],
+            WeeklyBalanceGoals.From(2, null),
+            null);
+
+        profile.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var p1 = DietaryProfile.From(DietaryType.Omnivore, [], WeeklyBalanceGoals.None, null);
+        var p2 = DietaryProfile.From(DietaryType.Omnivore, [], WeeklyBalanceGoals.None, null);
+
+        p1.Should().Be(p2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryRestrictionTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryRestrictionTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class DietaryRestrictionTests
+{
+    [Theory]
+    [InlineData("gluten-free")]
+    [InlineData("lactose-free")]
+    [InlineData("nut-allergy")]
+    [InlineData("egg-free")]
+    [InlineData("soy-free")]
+    [InlineData("shellfish-allergy")]
+    [InlineData("halal")]
+    [InlineData("kosher")]
+    public void From_ValidValue_CreatesInstance(string value)
+    {
+        var restriction = DietaryRestriction.From(value);
+
+        restriction.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => DietaryRestriction.From(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData("Gluten-Free")]
+    [InlineData("sugar-free")]
+    [InlineData("dairy-free")]
+    public void From_UnsupportedValue_ThrowsGuardException(string value)
+    {
+        var act = () => DietaryRestriction.From(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void AllowedValues_ContainsAllStaticInstances()
+    {
+        DietaryRestriction.AllowedValues.Should().HaveCount(8);
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var r1 = DietaryRestriction.From("gluten-free");
+        var r2 = DietaryRestriction.From("gluten-free");
+
+        r1.Should().Be(r2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryTypeTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/DietaryTypeTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class DietaryTypeTests
+{
+    [Theory]
+    [InlineData("omnivore")]
+    [InlineData("vegetarian")]
+    [InlineData("vegan")]
+    [InlineData("pescatarian")]
+    [InlineData("flexitarian")]
+    public void From_ValidValue_CreatesInstance(string value)
+    {
+        var type = DietaryType.From(value);
+
+        type.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+    {
+        var act = () => DietaryType.From(value!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData("Vegan")]
+    [InlineData("OMNIVORE")]
+    [InlineData("keto")]
+    [InlineData("paleo")]
+    public void From_UnsupportedValue_ThrowsGuardException(string value)
+    {
+        var act = () => DietaryType.From(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void StaticInstances_HaveCorrectValues()
+    {
+        DietaryType.Omnivore.Value.Should().Be("omnivore");
+        DietaryType.Vegetarian.Value.Should().Be("vegetarian");
+        DietaryType.Vegan.Value.Should().Be("vegan");
+        DietaryType.Pescatarian.Value.Should().Be("pescatarian");
+        DietaryType.Flexitarian.Value.Should().Be("flexitarian");
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var t1 = DietaryType.From("vegan");
+        var t2 = DietaryType.From("vegan");
+
+        t1.Should().Be(t2);
+    }
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/WeeklyBalanceGoalsTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/WeeklyBalanceGoalsTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class WeeklyBalanceGoalsTests
+{
+    [Fact]
+    public void From_ValidValues_CreatesInstance()
+    {
+        var goals = WeeklyBalanceGoals.From(2, 3);
+
+        goals.MinVeggieMeals.Should().Be(2);
+        goals.MaxRedMeatMeals.Should().Be(3);
+    }
+
+    [Fact]
+    public void From_NullValues_CreatesEmptyInstance()
+    {
+        var goals = WeeklyBalanceGoals.From(null, null);
+
+        goals.MinVeggieMeals.Should().BeNull();
+        goals.MaxRedMeatMeals.Should().BeNull();
+        goals.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void From_PartialValues_CreatesInstance()
+    {
+        var goals = WeeklyBalanceGoals.From(3, null);
+
+        goals.MinVeggieMeals.Should().Be(3);
+        goals.MaxRedMeatMeals.Should().BeNull();
+        goals.IsEmpty.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(8)]
+    public void From_MinVeggieOutOfRange_ThrowsGuardException(int value)
+    {
+        var act = () => WeeklyBalanceGoals.From(value, null);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(8)]
+    public void From_MaxRedMeatOutOfRange_ThrowsGuardException(int value)
+    {
+        var act = () => WeeklyBalanceGoals.From(null, value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void From_BoundaryValues_CreatesInstance()
+    {
+        var goals = WeeklyBalanceGoals.From(0, 7);
+
+        goals.MinVeggieMeals.Should().Be(0);
+        goals.MaxRedMeatMeals.Should().Be(7);
+    }
+
+    [Fact]
+    public void None_StaticInstance_IsEmpty()
+    {
+        WeeklyBalanceGoals.None.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var g1 = WeeklyBalanceGoals.From(2, 3);
+        var g2 = WeeklyBalanceGoals.From(2, 3);
+
+        g1.Should().Be(g2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DietaryProfile` composite value object to `AppUserProfile` with four components:
  - `DietaryType` — omnivore, vegetarian, vegan, pescatarian, flexitarian
  - `DietaryRestriction` — gluten-free, lactose-free, nut-allergy, egg-free, soy-free, shellfish-allergy, halal, kosher
  - `WeeklyBalanceGoals` — min veggie meals / max red meat meals per week (0–7)
  - `CookingEffortPreference` — quick-weekdays, balanced, elaborate-weekends
- All fields optional — existing users start with empty profile
- EF Core `OwnsOne` mapping with nested `OwnsOne` for balance goals
- Restrictions stored as comma-separated string column

Closes #152

## Test plan
- [x] All value objects validate allowed values and reject invalid input
- [x] `DietaryProfile.Empty` is truly empty, `IsEmpty` returns true
- [x] Composite creation with all/partial/no values works correctly
- [x] `AppUserProfile.UpdateDietaryProfile()` updates the profile
- [x] Build passes with `TreatWarningsAsErrors=true` (0 warnings)
- [x] All 144 Users domain tests pass (44 new)
- [x] All 64 architecture tests pass