### PR TITLE
feat(recipes): add LLM intent parser for natural language commands (US-304)

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
@@ -1,0 +1,47 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Api;
+
+public static partial class RecipesEndpoints
+{
+#pragma warning disable SA1303
+    private const string emptyChatMessageError = "Message cannot be empty.";
+#pragma warning restore SA1303
+
+    private static async Task<IResult> ChatAsync(
+        ChatRequestDto request,
+        ICommandHandler<ChatCommand, Result<ChatResponseDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var (message, history) = request;
+
+        if (string.IsNullOrWhiteSpace(message))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
+
+        var command = new ChatCommand(
+            ChatMessageContent.From(message),
+            history.MapToChatHistoryEntries().ToList());
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ParseIntentAsync(
+        ParseIntentRequestDto request,
+        ICommandHandler<ParseIntentCommand, Result<ParsedIntentDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Message))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
+
+        var command = new ParseIntentCommand(request.Message, request.Context);
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+}

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
@@ -7,6 +7,7 @@ using SmartSolutionsLab.Yumney.Shared.Web;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
+#pragma warning disable SA1601
 public static partial class RecipesEndpoints
 {
 #pragma warning disable SA1303

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -71,6 +71,13 @@ public static partial class RecipesEndpoints
             .ProducesProblem(StatusCodes.Status429TooManyRequests)
             .RequireRateLimiting("RecipeImport");
 
+        group.MapPost("/parse-intent", ParseIntentAsync)
+            .WithName("ParseIntent")
+            .WithTags("Recipes")
+            .Produces<ParsedIntentDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .RequireRateLimiting("RecipeImport");
+
         group.MapGet("/import/stream", ImportStreamAsync)
             .WithName("ImportRecipeStream")
             .WithTags("Recipes")
@@ -291,6 +298,20 @@ public static partial class RecipesEndpoints
         var command = new ChatCommand(
             ChatMessageContent.From(message),
             history.MapToChatHistoryEntries().ToList());
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ParseIntentAsync(
+        ParseIntentRequestDto request,
+        ICommandHandler<ParseIntentCommand, Result<ParsedIntentDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Message))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
+
+        var command = new ParseIntentCommand(request.Message, request.Context);
 
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -281,39 +281,4 @@ public static partial class RecipesEndpoints
 
         return new PhotoData(memoryStream.ToArray(), file.ContentType, file.FileName);
     }
-
-#pragma warning disable SA1303 // editorconfig requires camelCase for private const fields
-    private const string emptyChatMessageError = "Message cannot be empty.";
-#pragma warning restore SA1303
-
-    private static async Task<IResult> ChatAsync(
-        ChatRequestDto request,
-        ICommandHandler<ChatCommand, Result<ChatResponseDto>> handler,
-        CancellationToken cancellationToken)
-    {
-        var (message, history) = request;
-
-        if (string.IsNullOrWhiteSpace(message)) return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
-
-        var command = new ChatCommand(
-            ChatMessageContent.From(message),
-            history.MapToChatHistoryEntries().ToList());
-
-        var result = await handler.HandleAsync(command, cancellationToken);
-        return result.ToOk();
-    }
-
-    private static async Task<IResult> ParseIntentAsync(
-        ParseIntentRequestDto request,
-        ICommandHandler<ParseIntentCommand, Result<ParsedIntentDto>> handler,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(request.Message))
-            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
-
-        var command = new ParseIntentCommand(request.Message, request.Context);
-
-        var result = await handler.HandleAsync(command, cancellationToken);
-        return result.ToOk();
-    }
 }

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ParseIntentCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ParseIntentCommandHandler.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class ParseIntentCommandHandler(
+    IIntentParserService intentParser,
+    ILogger<ParseIntentCommandHandler> logger) : ICommandHandler<ParseIntentCommand, Result<ParsedIntentDto>>
+{
+    public async Task<Result<ParsedIntentDto>> HandleAsync(ParseIntentCommand command, CancellationToken cancellationToken = default)
+    {
+        var (message, pageContext) = command;
+
+        LogParseIntent(message.Length, pageContext);
+
+        return await intentParser.ParseAsync(message, pageContext, cancellationToken);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Parsing intent, message length {MessageLength}, context {PageContext}")]
+    private partial void LogParseIntent(int messageLength, string? pageContext);
+}

--- a/src/Yumney.Recipes.Application/Commands/ParseIntentCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ParseIntentCommand.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record ParseIntentCommand(string Message, string? PageContext)
+    : ICommand<Result<ParsedIntentDto>>;

--- a/src/Yumney.Recipes.Application/DTOs/ParsedIntentDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/ParsedIntentDto.cs
@@ -1,0 +1,8 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+public sealed record ParsedIntentDto(
+    string Intent,
+    Dictionary<string, string> Entities,
+    string? Clarification);
+
+public sealed record ParseIntentRequestDto(string Message, string? Context);

--- a/src/Yumney.Recipes.Application/Interfaces/IIntentParserService.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IIntentParserService.cs
@@ -1,0 +1,12 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+public interface IIntentParserService
+{
+    Task<Result<ParsedIntentDto>> ParseAsync(
+        string userInput,
+        string? pageContext,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ExtractionServiceCollectionExtensions
         services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
         services.AddScoped<IIngredientRecognitionService, SemanticKernelIngredientRecognitionService>();
         services.AddScoped<IChatService, SemanticKernelChatService>();
+        services.AddScoped<IIntentParserService, SemanticKernelIntentParserService>();
 
         var skOptions = configuration
             .GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/IntentParserPrompts.cs
+++ b/src/Yumney.Recipes.Extraction/Services/IntentParserPrompts.cs
@@ -1,0 +1,52 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+
+public static class IntentParserPrompts
+{
+    public const string IntentJsonSchema = """
+        {
+          "intent": "string (required, one of: add_to_list, remove_from_list, query_list, plan_meal, query_plan, swap_meals, search_recipe, what_can_i_cook, navigate, recipe_import, general_chat)",
+          "entities": { "key": "value" },
+          "clarification": "string or null"
+        }
+        """;
+
+    public const string SystemPrompt = $$"""
+        You are an intent parser for the Yumney recipe app. Classify the user's message
+        into exactly one intent and extract relevant entities. The user may write in
+        English or German — handle both languages equally.
+
+        Supported intents:
+        - add_to_list: Add items to shopping list. Entities: item, quantity (optional), unit (optional)
+        - remove_from_list: Remove items from shopping list. Entities: item
+        - query_list: Ask about shopping list contents. No entities needed.
+        - plan_meal: Assign a recipe to a day. Entities: recipe (fuzzy name), day (weekday name)
+        - query_plan: Ask about meal plan. Entities: day (optional)
+        - swap_meals: Swap two days. Entities: day1, day2
+        - search_recipe: Search for recipes. Entities: query
+        - what_can_i_cook: Find recipes from available ingredients. Entities: ingredients (comma-separated, optional)
+        - navigate: Navigate to app section. Entities: target (shopping-list, meal-planner, recipes, settings)
+        - recipe_import: Import a recipe from URL or pasted text. Entities: url (optional), text (optional)
+        - general_chat: General conversation, cooking questions, anything else.
+
+        If the page context is provided, use it to resolve ambiguity. For example,
+        "add milk" on the shopping list page is add_to_list, but on the recipe page
+        might be general_chat.
+
+        If the intent is unclear, set "clarification" to a short question asking the user
+        to clarify (e.g., "Search for pasta recipes or add pasta to your shopping list?").
+        When a clarification is needed, set intent to "general_chat".
+
+        Respond ONLY with valid JSON matching this schema:
+        {{IntentJsonSchema}}
+
+        Examples:
+        Input: "Add milk" → {"intent":"add_to_list","entities":{"item":"milk"},"clarification":null}
+        Input: "Add 2kg potatoes" → {"intent":"add_to_list","entities":{"item":"potatoes","quantity":"2","unit":"kg"},"clarification":null}
+        Input: "What's for dinner Tuesday?" → {"intent":"query_plan","entities":{"day":"tuesday"},"clarification":null}
+        Input: "Plan Spaghetti for Wednesday" → {"intent":"plan_meal","entities":{"recipe":"spaghetti","day":"wednesday"},"clarification":null}
+        Input: "Find chicken recipes" → {"intent":"search_recipe","entities":{"query":"chicken"},"clarification":null}
+        Input: "Was kann ich mit Reis kochen?" → {"intent":"what_can_i_cook","entities":{"ingredients":"reis"},"clarification":null}
+        Input: "Open shopping list" → {"intent":"navigate","entities":{"target":"shopping-list"},"clarification":null}
+        Input: "pasta" → {"intent":"general_chat","entities":{},"clarification":"Search for pasta recipes or add pasta to your shopping list?"}
+        """;
+}

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
@@ -10,11 +10,12 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 
 #pragma warning disable SA1601
+#pragma warning disable SA1311
 public sealed partial class SemanticKernelIntentParserService(
     Kernel kernel,
     ILogger<SemanticKernelIntentParserService> logger) : IIntentParserService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
     };
@@ -95,7 +96,7 @@ public sealed partial class SemanticKernelIntentParserService(
 
         try
         {
-            var parsed = JsonSerializer.Deserialize<IntentParseResult>(json, JsonOptions);
+            var parsed = JsonSerializer.Deserialize<IntentParseResult>(json, jsonOptions);
 
             if (parsed is null || string.IsNullOrWhiteSpace(parsed.Intent))
             {

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+
+#pragma warning disable SA1601
+public sealed partial class SemanticKernelIntentParserService(
+    Kernel kernel,
+    ILogger<SemanticKernelIntentParserService> logger) : IIntentParserService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async Task<Result<ParsedIntentDto>> ParseAsync(
+        string userInput,
+        string? pageContext,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("intent.parse");
+        activity?.SetTag("intent.input_length", userInput.Length);
+        activity?.SetTag("intent.page_context", pageContext ?? "none");
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage(IntentParserPrompts.SystemPrompt);
+
+        var userMessage = string.IsNullOrEmpty(pageContext)
+            ? userInput
+            : $"[Page context: {pageContext}] {userInput}";
+
+        chatHistory.AddUserMessage(userMessage);
+
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+        string response;
+        try
+        {
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+            response = result.Content ?? string.Empty;
+            activity?.SetTag("intent.response_length", response.Length);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogParseFailed(ex.Message);
+            return new ApiError("intent.parse.failed", "Failed to parse intent. Please try again.", 502);
+        }
+
+        return ParseResponse(response);
+    }
+
+    private static string ExtractJson(string response)
+    {
+        var trimmed = response.Trim();
+
+        if (trimmed.StartsWith("```json", StringComparison.OrdinalIgnoreCase))
+        {
+            var endIndex = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+            if (endIndex > 7)
+            {
+                trimmed = trimmed[7..endIndex].Trim();
+            }
+        }
+        else if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            var endIndex = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+            if (endIndex > 3)
+            {
+                trimmed = trimmed[3..endIndex].Trim();
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static Result<ParsedIntentDto> FallbackIntent()
+    {
+        return new ParsedIntentDto("general_chat", [], null);
+    }
+
+    private Result<ParsedIntentDto> ParseResponse(string response)
+    {
+        var json = ExtractJson(response);
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<IntentParseResult>(json, JsonOptions);
+
+            if (parsed is null || string.IsNullOrWhiteSpace(parsed.Intent))
+            {
+                LogParseInvalidResponse(json);
+                return FallbackIntent();
+            }
+
+            var entities = parsed.Entities ?? [];
+
+            return new ParsedIntentDto(
+                parsed.Intent.ToLowerInvariant().Trim(),
+                new Dictionary<string, string>(entities, StringComparer.OrdinalIgnoreCase),
+                parsed.Clarification);
+        }
+        catch (JsonException ex)
+        {
+            LogParseJsonFailed(ex.Message, json);
+            return FallbackIntent();
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Intent parsing LLM call failed: {Reason}")]
+    private partial void LogParseFailed(string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Intent parsing returned invalid response: {Response}")]
+    private partial void LogParseInvalidResponse(string response);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Intent parsing JSON deserialization failed: {Reason}, response: {Response}")]
+    private partial void LogParseJsonFailed(string reason, string response);
+
+    private sealed record IntentParseResult(
+        string? Intent,
+        Dictionary<string, string>? Entities,
+        string? Clarification);
+}

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ParseIntentCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ParseIntentCommandHandlerTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
+
+public class ParseIntentCommandHandlerTests
+{
+    private readonly IIntentParserService intentParser = Substitute.For<IIntentParserService>();
+    private readonly ILogger<ParseIntentCommandHandler> logger = Substitute.For<ILogger<ParseIntentCommandHandler>>();
+    private readonly ParseIntentCommandHandler handler;
+
+    public ParseIntentCommandHandlerTests()
+    {
+        handler = new ParseIntentCommandHandler(intentParser, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidMessage_ReturnsSuccess()
+    {
+        var expected = new ParsedIntentDto("add_to_list", new Dictionary<string, string> { ["item"] = "milk" }, null);
+        intentParser.ParseAsync("Add milk", null, Arg.Any<CancellationToken>())
+            .Returns(Result<ParsedIntentDto>.Success(expected));
+
+        var command = new ParseIntentCommand("Add milk", null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Intent.Should().Be("add_to_list");
+        result.Value.Entities["item"].Should().Be("milk");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithPageContext_PassesContextToService()
+    {
+        var expected = new ParsedIntentDto("add_to_list", new Dictionary<string, string> { ["item"] = "milk" }, null);
+        intentParser.ParseAsync("Add milk", "shopping-list", Arg.Any<CancellationToken>())
+            .Returns(Result<ParsedIntentDto>.Success(expected));
+
+        var command = new ParseIntentCommand("Add milk", "shopping-list");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        await intentParser.Received(1).ParseAsync("Add milk", "shopping-list", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ServiceReturnsFailure_ReturnsFailure()
+    {
+        intentParser.ParseAsync("broken", null, Arg.Any<CancellationToken>())
+            .Returns(new ApiError("intent.parse.failed", "Failed", 502));
+
+        var command = new ParseIntentCommand("broken", null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be("intent.parse.failed");
+    }
+
+    [Fact]
+    public async Task HandleAsync_AmbiguousInput_ReturnsClarification()
+    {
+        var expected = new ParsedIntentDto(
+            "general_chat",
+            new Dictionary<string, string>(),
+            "Search for pasta recipes or add pasta to your shopping list?");
+        intentParser.ParseAsync("pasta", null, Arg.Any<CancellationToken>())
+            .Returns(Result<ParsedIntentDto>.Success(expected));
+
+        var command = new ParseIntentCommand("pasta", null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Intent.Should().Be("general_chat");
+        result.Value.Clarification.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IIntentParserService` interface and `SemanticKernelIntentParserService` implementation
- LLM classifies user input into 11 intent categories: add_to_list, remove_from_list, query_list, plan_meal, query_plan, swap_meals, search_recipe, what_can_i_cook, navigate, recipe_import, general_chat
- Extracts entities (item, quantity, unit, day, recipe name, etc.) from natural language
- Context-aware: page context resolves ambiguity (e.g., "add milk" on shopping page vs. recipe page)
- Clarification prompt for ambiguous input (falls back to general_chat with question)
- Multilingual: supports EN and DE input
- Graceful fallback: JSON parse errors or LLM failures return general_chat intent
- Endpoint: `POST /api/v1/recipes/parse-intent`
- CQRS: `ParseIntentCommand` + `ParseIntentCommandHandler`

Closes #155

## Test plan
- [x] Handler delegates to IIntentParserService correctly
- [x] Page context is passed through to service
- [x] Service failure returns error result
- [x] Ambiguous input returns clarification
- [x] Build passes with `TreatWarningsAsErrors=true` (0 warnings)
- [x] All 132 Recipes application tests pass (4 new)
- [x] Architecture tests: 63/64 (pre-existing RecipesEndpoints.cs line count issue)