### PR TITLE
feat(shell): add context-aware chat placeholder hints (US-305)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -440,6 +440,14 @@
     }
   },
   "commandBar": {
-    "toggle": "Kommandoleiste öffnen"
+    "toggle": "Kommandoleiste öffnen",
+    "hints": {
+      "default": "Frag mich alles, füge eine Rezept-URL ein oder sag mir, was du kochen willst...",
+      "dashboard": "Frag mich alles, füge eine Rezept-URL ein oder sag mir, was du kochen willst...",
+      "recipes": "Rezepte suchen, nach Kategorie filtern oder Vorschläge erhalten...",
+      "shopping": "Artikel hinzufügen, Einkaufsliste ansehen oder Einkauf verwalten...",
+      "mealPlanner": "Mahlzeiten planen, Tage tauschen, Rezepte für die Woche vorschlagen...",
+      "account": "Einstellungen, Ernährungsprofil oder Haushaltsgröße anpassen..."
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -440,6 +440,14 @@
     }
   },
   "commandBar": {
-    "toggle": "Open command bar"
+    "toggle": "Open command bar",
+    "hints": {
+      "default": "Ask me anything, paste a recipe URL, or tell me what to cook...",
+      "dashboard": "Ask me anything, paste a recipe URL, or tell me what to cook...",
+      "recipes": "Search recipes, filter by category, or ask for suggestions...",
+      "shopping": "Add items, ask what's on the list, or manage your shopping...",
+      "mealPlanner": "Plan meals, swap days, suggest recipes for the week...",
+      "account": "Update your preferences, dietary profile, or household settings..."
+    }
   }
 }

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -32,6 +32,7 @@ export { ThemeService, type Theme } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
 export { IngredientRecognitionService } from './lib/ingredient-recognition.service';
 export { ChatStateService } from './lib/chat-state.service';
+export { ChatHintService } from './lib/chat-hint.service';
 export { VoiceService, type VoiceCommand } from './lib/voice.service';
 export { WakeLockService } from './lib/wake-lock.service';
 export { CookingTimerService, type CookingTimer } from './lib/cooking-timer.service';

--- a/client/libs/shared/models/src/lib/chat-hint.service.spec.ts
+++ b/client/libs/shared/models/src/lib/chat-hint.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { ChatHintService } from './chat-hint.service';
+
+describe('ChatHintService', () => {
+  let service: ChatHintService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter([])],
+    });
+    service = TestBed.inject(ChatHintService);
+    router = TestBed.inject(Router);
+  });
+
+  it('should return default hint for unknown routes', () => {
+    expect(service.hintKey()).toBe('commandBar.hints.default');
+  });
+
+  it('should return undefined page context for unknown routes', () => {
+    expect(service.pageContext()).toBeUndefined();
+  });
+});

--- a/client/libs/shared/models/src/lib/chat-hint.service.ts
+++ b/client/libs/shared/models/src/lib/chat-hint.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject, computed } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map, startWith } from 'rxjs';
+
+const ROUTE_HINTS: Record<string, string> = {
+  '/dashboard': 'commandBar.hints.dashboard',
+  '/recipes': 'commandBar.hints.recipes',
+  '/shopping': 'commandBar.hints.shopping',
+  '/meal-planner': 'commandBar.hints.mealPlanner',
+  '/account': 'commandBar.hints.account',
+};
+
+const DEFAULT_HINT = 'commandBar.hints.default';
+
+@Injectable({ providedIn: 'root' })
+export class ChatHintService {
+  private router = inject(Router);
+
+  private currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => e.urlAfterRedirects),
+      startWith(this.router.url),
+    ),
+    { initialValue: this.router.url },
+  );
+
+  readonly hintKey = computed(() => {
+    const url = this.currentUrl();
+    const match = Object.keys(ROUTE_HINTS).find((route) => url.startsWith(route));
+    return match ? ROUTE_HINTS[match] : DEFAULT_HINT;
+  });
+
+  readonly pageContext = computed(() => {
+    const url = this.currentUrl();
+    if (url.startsWith('/shopping')) return 'shopping-list';
+    if (url.startsWith('/meal-planner')) return 'meal-planner';
+    if (url.startsWith('/recipes')) return 'recipes';
+    if (url.startsWith('/dashboard')) return 'dashboard';
+    if (url.startsWith('/account')) return 'account';
+    return undefined;
+  });
+}

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -76,7 +76,7 @@
         [ngModel]="input()"
         (ngModelChange)="input.set($event)"
         (keydown)="onKeydown($event)"
-        [placeholder]="t('chat.placeholder')"
+        [placeholder]="t(hints.hintKey())"
         [attr.aria-label]="t('chat.inputLabel')"
         rows="2"
         name="chat-input"

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -15,7 +15,7 @@ import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { ChatApiService, type ChatRecipeSuggestion } from '@yumney/shared/api-client';
-import { ChatStateService, ROUTES } from '@yumney/shared/models';
+import { ChatHintService, ChatStateService, ROUTES } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-chat-panel',
@@ -29,6 +29,7 @@ export class ChatPanelComponent implements AfterViewInit {
   protected readonly ROUTES = ROUTES;
 
   protected state = inject(ChatStateService);
+  protected hints = inject(ChatHintService);
   private chatApi = inject(ChatApiService);
   private destroyRef = inject(DestroyRef);
 


### PR DESCRIPTION
## Summary
- Add `ChatHintService` that resolves route-based placeholder text and page context
- Chat input placeholder dynamically changes per page (dashboard, recipes, shopping, meal planner, account)
- `pageContext` signal exposed for intent parser disambiguation (US-304)
- i18n keys for EN and DE with contextual hint messages

Closes #156

## Test plan
- [x] Default hint returned for unknown routes
- [x] Page context undefined for unknown routes
- [x] All 153 UI lib tests pass
- [x] All 198 shell tests pass