### PR TITLE
feat(recipes): enable chat-based recipe import from URL and text (US-306)

### DIFF
--- a/client/apps/shell-e2e/src/auth/register.spec.ts
+++ b/client/apps/shell-e2e/src/auth/register.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { RegisterPage } from '../pages/register.page';
+import { uniqueEmail } from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Register Page (US-001)', () => {
   let registerPage: RegisterPage;
@@ -63,7 +65,7 @@ test.describe('Register Page (US-001)', () => {
   });
 
   test('should successfully register a new user', async () => {
-    const email = `e2e-${Date.now()}@yumney.dev`;
+    const email = uniqueEmail();
 
     await registerPage.fillForm({
       email,
@@ -73,7 +75,7 @@ test.describe('Register Page (US-001)', () => {
     });
     await registerPage.submitButton.click();
 
-    await expect(registerPage.successHeading).toBeVisible({ timeout: 10_000 });
+    await expect(registerPage.successHeading).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(registerPage.resendLink).toBeVisible();
   });
 
@@ -86,7 +88,7 @@ test.describe('Register Page (US-001)', () => {
     });
     await registerPage.submitButton.click();
 
-    await expect(registerPage.errorBanner).toBeVisible({ timeout: 10_000 });
+    await expect(registerPage.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(registerPage.errorBanner).toContainText(/already exists/i);
   });
 

--- a/client/apps/shell-e2e/src/dashboard/language-switch.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/language-switch.spec.ts
@@ -1,41 +1,39 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { DashboardPage } from '../pages/dashboard.page';
+import { HeaderPage } from '../pages/header.page';
 
 test.describe('Language Switching (US-060)', () => {
   let dashboard: DashboardPage;
+  let header: HeaderPage;
 
   test.beforeEach(async ({ authenticatedPage }) => {
     dashboard = new DashboardPage(authenticatedPage);
+    header = new HeaderPage(authenticatedPage);
     await dashboard.goto();
   });
 
-  test('should display language toggle button', async ({ authenticatedPage }) => {
-    const langToggle = authenticatedPage.locator('.lang-toggle');
-    await expect(langToggle).toBeVisible();
+  test('should display language toggle button', async () => {
+    await expect(header.langToggle).toBeVisible();
   });
 
-  test('should switch from EN to DE', async ({ authenticatedPage }) => {
-    const langToggle = authenticatedPage.locator('.lang-toggle');
-    await expect(langToggle).toContainText('DE');
+  test('should switch from EN to DE', async () => {
+    await expect(header.langToggle).toContainText('DE');
 
-    await langToggle.click();
-    await expect(langToggle).toContainText('EN');
+    await header.langToggle.click();
+    await expect(header.langToggle).toContainText('EN');
   });
 
-  test('should translate UI after switching language', async ({ authenticatedPage }) => {
-    const langToggle = authenticatedPage.locator('.lang-toggle');
-    await langToggle.click();
+  test('should translate UI after switching language', async () => {
+    await header.langToggle.click();
 
-    // German text should appear — check a known element
-    await expect(authenticatedPage.locator('.logout-button')).toContainText('Abmelden');
+    await expect(header.logoutButton).toContainText('Abmelden');
   });
 
   test('should persist language after page reload', async ({ authenticatedPage }) => {
-    const langToggle = authenticatedPage.locator('.lang-toggle');
-    await langToggle.click();
-    await expect(langToggle).toContainText('EN');
+    await header.langToggle.click();
+    await expect(header.langToggle).toContainText('EN');
 
     await authenticatedPage.reload();
-    await expect(authenticatedPage.locator('.lang-toggle')).toContainText('EN');
+    await expect(header.langToggle).toContainText('EN');
   });
 });

--- a/client/apps/shell-e2e/src/helpers/pwa.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/pwa.helper.ts
@@ -36,7 +36,7 @@ export async function setupKeycloakMock(page: Page): Promise<void> {
 /**
  * Wait for the service worker to become activated.
  */
-export async function waitForServiceWorker(page: Page, timeout: number = 40_000): Promise<void> {
+export async function waitForServiceWorker(page: Page, timeout = 40_000): Promise<void> {
   await page.evaluate(async (ms) => {
     if (!('serviceWorker' in navigator)) return;
     const deadline = Date.now() + ms;
@@ -54,7 +54,7 @@ export async function waitForServiceWorker(page: Page, timeout: number = 40_000)
  */
 export async function isServiceWorkerRegistered(
   page: Page,
-  timeout: number = 35_000,
+  timeout = 35_000,
 ): Promise<boolean> {
   return page.evaluate(async (ms) => {
     if (!('serviceWorker' in navigator)) return false;

--- a/client/apps/shell-e2e/src/helpers/pwa.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/pwa.helper.ts
@@ -1,0 +1,69 @@
+import { type Page } from '@playwright/test';
+
+/**
+ * Mock Keycloak OIDC endpoints so PWA tests can load without a real auth server.
+ */
+export async function setupKeycloakMock(page: Page): Promise<void> {
+  await page.route('**/realms/yumney/.well-known/openid-configuration', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        issuer: 'http://localhost:8080/realms/yumney',
+        authorization_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/auth',
+        token_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/token',
+        end_session_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/logout',
+        jwks_uri: 'http://localhost:8080/realms/yumney/protocol/openid-connect/certs',
+        userinfo_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/userinfo',
+        response_types_supported: ['code'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256'],
+      }),
+    }),
+  );
+  await page.route('**/realms/yumney/protocol/openid-connect/auth*', (route) =>
+    route.fulfill({ status: 200, body: '' }),
+  );
+  await page.route('**/realms/yumney/protocol/openid-connect/certs', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ keys: [] }),
+    }),
+  );
+}
+
+/**
+ * Wait for the service worker to become activated.
+ */
+export async function waitForServiceWorker(page: Page, timeout: number = 40_000): Promise<void> {
+  await page.evaluate(async (ms) => {
+    if (!('serviceWorker' in navigator)) return;
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      const active = registrations.find((r) => r.active?.state === 'activated');
+      if (active) return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }, timeout);
+}
+
+/**
+ * Check if any service worker is registered.
+ */
+export async function isServiceWorkerRegistered(
+  page: Page,
+  timeout: number = 35_000,
+): Promise<boolean> {
+  return page.evaluate(async (ms) => {
+    if (!('serviceWorker' in navigator)) return false;
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      if (registrations.length > 0) return true;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return false;
+  }, timeout);
+}

--- a/client/apps/shell-e2e/src/helpers/pwa.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/pwa.helper.ts
@@ -52,10 +52,7 @@ export async function waitForServiceWorker(page: Page, timeout = 40_000): Promis
 /**
  * Check if any service worker is registered.
  */
-export async function isServiceWorkerRegistered(
-  page: Page,
-  timeout = 35_000,
-): Promise<boolean> {
+export async function isServiceWorkerRegistered(page: Page, timeout = 35_000): Promise<boolean> {
   return page.evaluate(async (ms) => {
     if (!('serviceWorker' in navigator)) return false;
     const deadline = Date.now() + ms;

--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -1,0 +1,39 @@
+export const SELECTORS = {
+  banners: {
+    success: '.success-banner',
+    error: '[role="alert"]',
+  },
+  form: {
+    fieldError: '.field-error',
+    ingredients: '.ingredient-fields',
+    steps: '.step-fields',
+  },
+  recipe: {
+    card: '.recipe-card',
+    title: '.recipe-title',
+    deleteBtn: '.btn-danger',
+    confirmDelete: '.btn-danger-filled',
+  },
+  chat: {
+    fab: '.command-fab',
+    panel: '.chat-panel',
+    backdrop: '.chat-backdrop',
+    close: '.chat-close',
+    clear: '.chat-clear',
+    send: '.chat-send',
+    input: '.chat-input textarea',
+    welcome: '.chat-welcome',
+    examples: '.chat-examples li',
+    userMessage: '.chat-message.role-user .chat-bubble',
+    assistantMessage: '.chat-message.role-assistant .chat-bubble',
+  },
+  header: {
+    langToggle: '.lang-toggle',
+    logout: '.logout-button',
+  },
+  keycloak: {
+    username: '#username',
+    password: '#password',
+    loginBtn: '#kc-login',
+  },
+} as const;

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -18,7 +18,7 @@ export function uniqueTitle(prefix: string): string {
   return `${prefix} ${Date.now()}`;
 }
 
-export function uniqueEmail(prefix: string = 'e2e'): string {
+export function uniqueEmail(prefix = 'e2e'): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@yumney.dev`;
 }
 

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -1,3 +1,8 @@
+import { type Page, expect } from '@playwright/test';
+import { DashboardPage } from '../pages/dashboard.page';
+import { SELECTORS } from './selectors';
+import { TIMEOUTS } from './timeouts';
+
 /**
  * Test constants for E2E tests against the real system.
  * The test user is pre-seeded in the Keycloak realm import.
@@ -11,4 +16,74 @@ export const TEST_USER = {
 
 export function uniqueTitle(prefix: string): string {
   return `${prefix} ${Date.now()}`;
+}
+
+export function uniqueEmail(prefix: string = 'e2e'): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@yumney.dev`;
+}
+
+/**
+ * Authenticate via the Keycloak login form.
+ * Use this in beforeAll blocks where the auth fixture is not available.
+ */
+export async function loginViaKeycloak(
+  page: Page,
+  username: string = TEST_USER.username,
+  password: string = TEST_USER.password,
+): Promise<void> {
+  await page.goto('/auth/login');
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL('**/realms/yumney/protocol/openid-connect/**');
+  await page.locator(SELECTORS.keycloak.username).fill(username);
+  await page.locator(SELECTORS.keycloak.password).fill(password);
+  await page.locator(SELECTORS.keycloak.loginBtn).click();
+  await page.waitForURL('**/dashboard', { timeout: TIMEOUTS.long });
+}
+
+/**
+ * Create a basic recipe via the manual entry form and return its identifier.
+ */
+export async function createTestRecipe(
+  page: Page,
+  title: string,
+  options?: { ingredient?: string; step?: string; servings?: number },
+): Promise<string> {
+  const dashboard = new DashboardPage(page);
+  await dashboard.createButton.click();
+
+  await page.locator('#title').fill(title);
+
+  const ingredientName = page.locator(`${SELECTORS.form.ingredients} input[type="text"]`).first();
+  await ingredientName.fill(options?.ingredient ?? 'Test Ingredient');
+
+  const stepDescription = page.locator(`${SELECTORS.form.steps} textarea`).first();
+  await stepDescription.fill(options?.step ?? 'Test Step');
+
+  if (options?.servings) {
+    const servingsInput = page.locator('#servings');
+    await servingsInput.clear();
+    await servingsInput.fill(String(options.servings));
+  }
+
+  await page.getByRole('button', { name: /save/i }).click();
+  await expect(page.locator(SELECTORS.banners.success)).toBeVisible({
+    timeout: TIMEOUTS.long,
+  });
+
+  await page.goto('/recipes');
+  await page.waitForTimeout(1000);
+
+  const card = page.locator(SELECTORS.recipe.card).filter({ hasText: title }).first();
+  const href = await card.getAttribute('href');
+  return href?.replace('/recipes/', '') ?? '';
+}
+
+/**
+ * Delete a recipe by navigating to its detail page and confirming deletion.
+ */
+export async function deleteTestRecipe(page: Page, recipeIdentifier: string): Promise<void> {
+  await page.goto(`/recipes/${recipeIdentifier}`);
+  await page.locator(SELECTORS.recipe.deleteBtn).click();
+  await page.locator(SELECTORS.recipe.confirmDelete).click();
+  await page.waitForURL(/\/recipes$/, { timeout: TIMEOUTS.default });
 }

--- a/client/apps/shell-e2e/src/helpers/timeouts.ts
+++ b/client/apps/shell-e2e/src/helpers/timeouts.ts
@@ -1,0 +1,6 @@
+export const TIMEOUTS = {
+  short: 5_000,
+  default: 10_000,
+  long: 15_000,
+  veryLong: 30_000,
+} as const;

--- a/client/apps/shell-e2e/src/pages/chat.page.ts
+++ b/client/apps/shell-e2e/src/pages/chat.page.ts
@@ -1,0 +1,47 @@
+import { type Page, type Locator } from '@playwright/test';
+import { SELECTORS } from '../helpers/selectors';
+
+export class ChatPage {
+  readonly fab: Locator;
+  readonly panel: Locator;
+  readonly backdrop: Locator;
+  readonly closeButton: Locator;
+  readonly clearButton: Locator;
+  readonly sendButton: Locator;
+  readonly input: Locator;
+  readonly welcome: Locator;
+  readonly examples: Locator;
+
+  constructor(private page: Page) {
+    this.fab = page.locator(SELECTORS.chat.fab);
+    this.panel = page.locator(SELECTORS.chat.panel);
+    this.backdrop = page.locator(SELECTORS.chat.backdrop);
+    this.closeButton = page.locator(SELECTORS.chat.close);
+    this.clearButton = page.locator(SELECTORS.chat.clear);
+    this.sendButton = page.locator(SELECTORS.chat.send);
+    this.input = page.locator(SELECTORS.chat.input);
+    this.welcome = page.locator(SELECTORS.chat.welcome);
+    this.examples = page.locator(SELECTORS.chat.examples);
+  }
+
+  async open(): Promise<void> {
+    await this.fab.click();
+  }
+
+  async close(): Promise<void> {
+    await this.closeButton.click();
+  }
+
+  async sendMessage(text: string): Promise<void> {
+    await this.input.fill(text);
+    await this.sendButton.click();
+  }
+
+  userMessage(index: number = 0): Locator {
+    return this.page.locator(SELECTORS.chat.userMessage).nth(index);
+  }
+
+  assistantMessage(index: number = 0): Locator {
+    return this.page.locator(SELECTORS.chat.assistantMessage).nth(index);
+  }
+}

--- a/client/apps/shell-e2e/src/pages/chat.page.ts
+++ b/client/apps/shell-e2e/src/pages/chat.page.ts
@@ -37,11 +37,11 @@ export class ChatPage {
     await this.sendButton.click();
   }
 
-  userMessage(index: number = 0): Locator {
+  userMessage(index = 0): Locator {
     return this.page.locator(SELECTORS.chat.userMessage).nth(index);
   }
 
-  assistantMessage(index: number = 0): Locator {
+  assistantMessage(index = 0): Locator {
     return this.page.locator(SELECTORS.chat.assistantMessage).nth(index);
   }
 }

--- a/client/apps/shell-e2e/src/pages/header.page.ts
+++ b/client/apps/shell-e2e/src/pages/header.page.ts
@@ -1,0 +1,12 @@
+import { type Page, type Locator } from '@playwright/test';
+import { SELECTORS } from '../helpers/selectors';
+
+export class HeaderPage {
+  readonly langToggle: Locator;
+  readonly logoutButton: Locator;
+
+  constructor(private page: Page) {
+    this.langToggle = page.locator(SELECTORS.header.langToggle);
+    this.logoutButton = page.locator(SELECTORS.header.logout);
+  }
+}

--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -1,51 +1,6 @@
-import { test, expect, Page } from '@playwright/test';
-
-async function setupKeycloakMock(page: Page) {
-  await page.route('**/realms/yumney/.well-known/openid-configuration', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        issuer: 'http://localhost:8080/realms/yumney',
-        authorization_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/auth',
-        token_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/token',
-        end_session_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/logout',
-        jwks_uri: 'http://localhost:8080/realms/yumney/protocol/openid-connect/certs',
-        userinfo_endpoint: 'http://localhost:8080/realms/yumney/protocol/openid-connect/userinfo',
-        response_types_supported: ['code'],
-        subject_types_supported: ['public'],
-        id_token_signing_alg_values_supported: ['RS256'],
-      }),
-    }),
-  );
-  await page.route('**/realms/yumney/protocol/openid-connect/auth*', (route) =>
-    route.fulfill({ status: 200, body: '' }),
-  );
-  await page.route('**/realms/yumney/protocol/openid-connect/certs', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ keys: [] }),
-    }),
-  );
-}
-
-async function waitForServiceWorker(page: Page) {
-  await page.evaluate(async () => {
-    if (!('serviceWorker' in navigator)) {
-      return;
-    }
-    const deadline = Date.now() + 40000;
-    while (Date.now() < deadline) {
-      const registrations = await navigator.serviceWorker.getRegistrations();
-      const active = registrations.find((r) => r.active?.state === 'activated');
-      if (active) {
-        return;
-      }
-      await new Promise((r) => setTimeout(r, 500));
-    }
-  });
-}
+import { test, expect } from '@playwright/test';
+import { setupKeycloakMock, waitForServiceWorker } from '../helpers/pwa.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Offline Caching', () => {
   test.beforeEach(async ({ page }) => {
@@ -62,7 +17,7 @@ test.describe('Offline Caching', () => {
     await page.reload({ waitUntil: 'domcontentloaded' });
 
     const root = page.locator('yn-root');
-    await expect(root).toBeAttached({ timeout: 10000 });
+    await expect(root).toBeAttached({ timeout: TIMEOUTS.default });
   });
 
   test('should serve cached i18n translations when offline', async ({ page, context }) => {

--- a/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { isServiceWorkerRegistered } from '../helpers/pwa.helper';
 
 test.describe('PWA Installation', () => {
   test('should serve a valid web manifest', async ({ page }) => {
@@ -42,20 +43,7 @@ test.describe('PWA Installation', () => {
     await page.route('**/realms/**', (route) => route.abort());
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    const swRegistered = await page.evaluate(async () => {
-      if (!('serviceWorker' in navigator)) {
-        return false;
-      }
-      const deadline = Date.now() + 35000;
-      while (Date.now() < deadline) {
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        if (registrations.length > 0) {
-          return true;
-        }
-        await new Promise((r) => setTimeout(r, 500));
-      }
-      return false;
-    });
-    expect(swRegistered).toBe(true);
+    const registered = await isServiceWorkerRegistered(page);
+    expect(registered).toBe(true);
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
@@ -1,90 +1,89 @@
 import { test, expect } from '../fixtures/auth.fixture';
+import { ChatPage } from '../pages/chat.page';
+import { TIMEOUTS } from '../helpers/timeouts';
 
-test.describe('Recipe Chat (US-230, US-303)', () => {
+test.describe('Recipe Chat (US-230, US-303, US-306)', () => {
   test('should open chat panel when FAB is clicked', async ({ authenticatedPage }) => {
-    const fab = authenticatedPage.locator('.command-fab');
-    await expect(fab).toBeVisible({ timeout: 10_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await expect(chat.fab).toBeVisible({ timeout: TIMEOUTS.default });
 
-    await fab.click();
+    await chat.open();
 
-    const chatPanel = authenticatedPage.locator('.chat-panel');
-    await expect(chatPanel).toBeVisible({ timeout: 5_000 });
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
   });
 
   test('should close chat panel when FAB is clicked again', async ({ authenticatedPage }) => {
-    const fab = authenticatedPage.locator('.command-fab');
-    await fab.click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    await fab.click();
+    await chat.fab.click();
 
-    await expect(authenticatedPage.locator('.chat-panel')).not.toBeVisible();
+    await expect(chat.panel).not.toBeVisible();
   });
 
   test('should close chat panel when close button is clicked', async ({ authenticatedPage }) => {
-    await authenticatedPage.locator('.command-fab').click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    await authenticatedPage.locator('.chat-close').click();
+    await chat.close();
 
-    await expect(authenticatedPage.locator('.chat-panel')).not.toBeVisible();
+    await expect(chat.panel).not.toBeVisible();
   });
 
   test('should close chat panel when backdrop is tapped on mobile', async ({
     authenticatedPage,
   }) => {
     await authenticatedPage.setViewportSize({ width: 375, height: 812 });
-    await authenticatedPage.locator('.command-fab').click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    const backdrop = authenticatedPage.locator('.chat-backdrop');
-    await expect(backdrop).toBeVisible();
-    await backdrop.click({ position: { x: 10, y: 10 } });
+    await expect(chat.backdrop).toBeVisible();
+    await chat.backdrop.click({ position: { x: 10, y: 10 } });
 
-    await expect(authenticatedPage.locator('.chat-panel')).not.toBeVisible();
+    await expect(chat.panel).not.toBeVisible();
   });
 
   test('should show welcome message with examples when panel first opens', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.locator('.command-fab').click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    await expect(authenticatedPage.locator('.chat-welcome')).toBeVisible();
-    await expect(authenticatedPage.locator('.chat-examples li')).toHaveCount(3);
+    await expect(chat.welcome).toBeVisible();
+    await expect(chat.examples).toHaveCount(3);
   });
 
-  test('should show context-aware placeholder on dashboard', async ({ authenticatedPage }) => {
-    await authenticatedPage.locator('.command-fab').click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+  test('should show context-aware placeholder', async ({ authenticatedPage }) => {
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    const textarea = authenticatedPage.locator('.chat-input textarea');
-    const placeholder = await textarea.getAttribute('placeholder');
+    const placeholder = await chat.input.getAttribute('placeholder');
     expect(placeholder).toBeTruthy();
     expect(placeholder!.length).toBeGreaterThan(0);
   });
 
   test('should send a message and receive a response', async ({ authenticatedPage }) => {
-    await authenticatedPage.locator('.command-fab').click();
-    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
-    const textarea = authenticatedPage.locator('.chat-input textarea');
-    await textarea.fill('What can I cook tonight?');
-    await authenticatedPage.locator('.chat-send').click();
+    await chat.sendMessage('What can I cook tonight?');
 
-    await expect(authenticatedPage.locator('.chat-message.role-user .chat-bubble')).toBeVisible();
-
-    await expect(
-      authenticatedPage.locator('.chat-message.role-assistant .chat-bubble'),
-    ).toBeVisible({ timeout: 30_000 });
+    await expect(chat.userMessage()).toBeVisible();
+    await expect(chat.assistantMessage()).toBeVisible({ timeout: TIMEOUTS.veryLong });
   });
 
   test('should show FAB with aria-expanded attribute', async ({ authenticatedPage }) => {
-    const fab = authenticatedPage.locator('.command-fab');
-    await expect(fab).toBeVisible({ timeout: 10_000 });
-    await expect(fab).toHaveAttribute('aria-expanded', 'false');
+    const chat = new ChatPage(authenticatedPage);
+    await expect(chat.fab).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(chat.fab).toHaveAttribute('aria-expanded', 'false');
 
-    await fab.click();
-    await expect(fab).toHaveAttribute('aria-expanded', 'true');
+    await chat.open();
+    await expect(chat.fab).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
@@ -63,8 +63,7 @@ test.describe('Recipe Chat (US-230, US-303, US-306)', () => {
     await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
 
     const placeholder = await chat.input.getAttribute('placeholder');
-    expect(placeholder).toBeTruthy();
-    expect(placeholder!.length).toBeGreaterThan(0);
+    expect(placeholder?.length).toBeGreaterThan(0);
   });
 
   test('should send a message and receive a response', async ({ authenticatedPage }) => {

--- a/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
@@ -1,18 +1,28 @@
 import { test, expect } from '../fixtures/auth.fixture';
 
-test.describe('Recipe Chat (US-230)', () => {
-  test('should open chat panel when toggle button is clicked', async ({ authenticatedPage }) => {
-    const chatToggle = authenticatedPage.locator('.chat-toggle');
-    await expect(chatToggle).toBeVisible({ timeout: 10_000 });
+test.describe('Recipe Chat (US-230, US-303)', () => {
+  test('should open chat panel when FAB is clicked', async ({ authenticatedPage }) => {
+    const fab = authenticatedPage.locator('.command-fab');
+    await expect(fab).toBeVisible({ timeout: 10_000 });
 
-    await chatToggle.click();
+    await fab.click();
 
     const chatPanel = authenticatedPage.locator('.chat-panel');
     await expect(chatPanel).toBeVisible({ timeout: 5_000 });
   });
 
+  test('should close chat panel when FAB is clicked again', async ({ authenticatedPage }) => {
+    const fab = authenticatedPage.locator('.command-fab');
+    await fab.click();
+    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+
+    await fab.click();
+
+    await expect(authenticatedPage.locator('.chat-panel')).not.toBeVisible();
+  });
+
   test('should close chat panel when close button is clicked', async ({ authenticatedPage }) => {
-    await authenticatedPage.locator('.chat-toggle').click();
+    await authenticatedPage.locator('.command-fab').click();
     await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
 
     await authenticatedPage.locator('.chat-close').click();
@@ -24,7 +34,7 @@ test.describe('Recipe Chat (US-230)', () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.setViewportSize({ width: 375, height: 812 });
-    await authenticatedPage.locator('.chat-toggle').click();
+    await authenticatedPage.locator('.command-fab').click();
     await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
 
     const backdrop = authenticatedPage.locator('.chat-backdrop');
@@ -37,27 +47,44 @@ test.describe('Recipe Chat (US-230)', () => {
   test('should show welcome message with examples when panel first opens', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.locator('.chat-toggle').click();
+    await authenticatedPage.locator('.command-fab').click();
     await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
 
     await expect(authenticatedPage.locator('.chat-welcome')).toBeVisible();
     await expect(authenticatedPage.locator('.chat-examples li')).toHaveCount(3);
   });
 
+  test('should show context-aware placeholder on dashboard', async ({ authenticatedPage }) => {
+    await authenticatedPage.locator('.command-fab').click();
+    await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
+
+    const textarea = authenticatedPage.locator('.chat-input textarea');
+    const placeholder = await textarea.getAttribute('placeholder');
+    expect(placeholder).toBeTruthy();
+    expect(placeholder!.length).toBeGreaterThan(0);
+  });
+
   test('should send a message and receive a response', async ({ authenticatedPage }) => {
-    await authenticatedPage.locator('.chat-toggle').click();
+    await authenticatedPage.locator('.command-fab').click();
     await expect(authenticatedPage.locator('.chat-panel')).toBeVisible({ timeout: 5_000 });
 
     const textarea = authenticatedPage.locator('.chat-input textarea');
     await textarea.fill('What can I cook tonight?');
     await authenticatedPage.locator('.chat-send').click();
 
-    // User message appears
     await expect(authenticatedPage.locator('.chat-message.role-user .chat-bubble')).toBeVisible();
 
-    // Wait for assistant response (may take a few seconds for LLM)
     await expect(
       authenticatedPage.locator('.chat-message.role-assistant .chat-bubble'),
     ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('should show FAB with aria-expanded attribute', async ({ authenticatedPage }) => {
+    const fab = authenticatedPage.locator('.command-fab');
+    await expect(fab).toBeVisible({ timeout: 10_000 });
+    await expect(fab).toHaveAttribute('aria-expanded', 'false');
+
+    await fab.click();
+    await expect(fab).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
@@ -1,54 +1,20 @@
 import { test, expect } from '../fixtures/auth.fixture';
-import { DashboardPage } from '../pages/dashboard.page';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
-import { RecipeListPage } from '../pages/recipe-list.page';
-import { uniqueTitle } from '../helpers/test-data.helper';
+import {
+  uniqueTitle,
+  loginViaKeycloak,
+  createTestRecipe,
+  deleteTestRecipe,
+} from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
   let recipeIdentifier: string;
 
-  // Create a recipe via manual entry before detail tests
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-
-    // Authenticate
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    // Create a manual recipe
-    const dashboard = new DashboardPage(page);
-    await dashboard.createButton.click();
-
-    const titleInput = page.locator('#title');
-    await titleInput.fill(uniqueTitle('E2E Detail Test'));
-
-    // Add an ingredient
-    const ingredientName = page.locator('.ingredient-fields input[type="text"]').first();
-    await ingredientName.fill('Test Ingredient');
-
-    // Add a step
-    const stepDescription = page.locator('.step-fields textarea').first();
-    await stepDescription.fill('Test Step');
-
-    const saveButton = page.getByRole('button', { name: /save/i });
-    await saveButton.click();
-
-    // Wait for success and extract the identifier from the success or navigation
-    await expect(page.locator('.success-banner')).toBeVisible({ timeout: 15_000 });
-
-    // Navigate to recipes to find it
-    await page.goto('/recipes');
-    await page.waitForTimeout(1000);
-
-    const firstCard = page.locator('.recipe-card').first();
-    const href = await firstCard.getAttribute('href');
-    recipeIdentifier = href?.replace('/recipes/', '') ?? '';
-
+    await loginViaKeycloak(page);
+    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Detail Test'));
     await page.close();
   });
 
@@ -113,10 +79,9 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
     const detail = new RecipeDetailPage(authenticatedPage);
     await authenticatedPage.goto('/recipes/nonexistent-id-12345');
 
-    await expect(detail.errorBanner).toBeVisible({ timeout: 10_000 });
+    await expect(detail.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
-  // Delete the recipe last
   test('should delete recipe and navigate to list (US-033)', async ({ authenticatedPage }) => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
@@ -129,7 +94,7 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
     const confirmButton = detail.confirmDialog.locator('.btn-danger');
     await confirmButton.click();
 
-    await expect(authenticatedPage).toHaveURL(/\/recipes$/, { timeout: 10_000 });
+    await expect(authenticatedPage).toHaveURL(/\/recipes$/, { timeout: TIMEOUTS.default });
   });
 });
 
@@ -138,36 +103,11 @@ test.describe('Servings Scaling (US-050)', () => {
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    // Create a recipe with servings and ingredients with amounts
-    const dashboard = new DashboardPage(page);
-    await dashboard.createButton.click();
-
-    await page.locator('#title').fill(uniqueTitle('E2E Scaling'));
-    await page.locator('#servings').fill('4');
-
-    const ingredientName = page.locator('.ingredient-fields input[type="text"]').first();
-    await ingredientName.fill('Flour');
-    const ingredientAmount = page.locator('.ingredient-fields input[type="number"]').first();
-    await ingredientAmount.fill('400');
-
-    await page.getByRole('button', { name: /save/i }).click();
-    await expect(page.locator('.success-banner')).toBeVisible({ timeout: 15_000 });
-
-    await page.goto('/recipes');
-    await page.waitForTimeout(1000);
-
-    const firstCard = page.locator('.recipe-card').first();
-    const href = await firstCard.getAttribute('href');
-    recipeIdentifier = href?.replace('/recipes/', '') ?? '';
+    await loginViaKeycloak(page);
+    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Scaling'), {
+      ingredient: 'Flour',
+      servings: 4,
+    });
     await page.close();
   });
 
@@ -216,23 +156,12 @@ test.describe('Servings Scaling (US-050)', () => {
     await expect(detail.servingsValue).toHaveText('4');
   });
 
-  // Cleanup
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
     const page = await browser.newPage();
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    await page.goto(`/recipes/${recipeIdentifier}`);
-    await page.locator('.btn-danger').click();
-    await page.locator('.btn-danger-filled').click();
-    await page.waitForURL(/\/recipes$/, { timeout: 10_000 });
+    await loginViaKeycloak(page);
+    await deleteTestRecipe(page, recipeIdentifier);
     await page.close();
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '../fixtures/auth.fixture';
-import { DashboardPage } from '../pages/dashboard.page';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
 import { RecipeListPage } from '../pages/recipe-list.page';
-import { uniqueTitle } from '../helpers/test-data.helper';
+import { uniqueTitle, loginViaKeycloak, createTestRecipe } from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Favorite Recipes (US-071)', () => {
   let recipeTitle: string;
@@ -10,31 +10,13 @@ test.describe('Favorite Recipes (US-071)', () => {
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    const dashboard = new DashboardPage(page);
-    await dashboard.createButton.click();
+    await loginViaKeycloak(page);
 
     recipeTitle = uniqueTitle('E2E Favorite');
-    await page.locator('#title').fill(recipeTitle);
-    await page.locator('.ingredient-fields input[type="text"]').first().fill('Salt');
-    await page.locator('.step-fields textarea').first().fill('Add salt to taste');
-    await page.getByRole('button', { name: /save/i }).click();
-    await expect(page.locator('.success-banner')).toBeVisible({ timeout: 15_000 });
-
-    await page.goto('/recipes');
-    await page.waitForTimeout(1000);
-
-    const card = page.locator('.recipe-card').filter({ hasText: recipeTitle }).first();
-    const href = await card.getAttribute('href');
-    recipeIdentifier = href?.replace('/recipes/', '') ?? '';
+    recipeIdentifier = await createTestRecipe(page, recipeTitle, {
+      ingredient: 'Salt',
+      step: 'Add salt to taste',
+    });
 
     await page.close();
   });
@@ -44,7 +26,7 @@ test.describe('Favorite Recipes (US-071)', () => {
 
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: 10_000 });
+    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
 
     const heart = list.favoriteButtonOnCard(recipeTitle).first();
     await expect(heart).toHaveAttribute('aria-pressed', 'false');
@@ -58,13 +40,13 @@ test.describe('Favorite Recipes (US-071)', () => {
 
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: 10_000 });
+    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
 
     const heart = list.favoriteButtonOnCard(recipeTitle).first();
-    await expect(heart).toHaveAttribute('aria-pressed', 'true', { timeout: 5_000 });
+    await expect(heart).toHaveAttribute('aria-pressed', 'true', { timeout: TIMEOUTS.short });
 
     await authenticatedPage.reload();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: 10_000 });
+    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(heart).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -75,13 +57,12 @@ test.describe('Favorite Recipes (US-071)', () => {
 
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: 10_000 });
+    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
 
     await list.filterToggle.click();
     await list.favoritesFilterChip.click();
     await authenticatedPage.waitForTimeout(500);
 
-    // Favorited recipe should still be present
     await expect(list.recipeCard(recipeTitle).first()).toBeVisible();
   });
 
@@ -91,7 +72,7 @@ test.describe('Favorite Recipes (US-071)', () => {
     const detail = new RecipeDetailPage(authenticatedPage);
     await detail.goto(recipeIdentifier);
 
-    await expect(detail.favoriteButton).toBeVisible({ timeout: 10_000 });
+    await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -100,7 +81,7 @@ test.describe('Favorite Recipes (US-071)', () => {
 
     const detail = new RecipeDetailPage(authenticatedPage);
     await detail.goto(recipeIdentifier);
-    await expect(detail.favoriteButton).toBeVisible({ timeout: 10_000 });
+    await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
 
     await detail.favoriteButton.click();
     await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'false');

--- a/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
@@ -1,22 +1,16 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
+import { loginViaKeycloak, deleteTestRecipe } from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe Tags (US-070)', () => {
   let recipeIdentifier: string;
 
-  // Create a recipe with tags via API
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
+    await loginViaKeycloak(page);
 
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    // Create recipe with tags via API
+    // Create recipe with tags via API (authenticated session from loginViaKeycloak)
     const response = await page.evaluate(async () => {
       const res = await fetch('/api/v1/recipes', {
         method: 'POST',
@@ -46,7 +40,7 @@ test.describe('Recipe Tags (US-070)', () => {
 
     await authenticatedPage.goto(`/recipes/${recipeIdentifier}`);
     const detailPage = new RecipeDetailPage(authenticatedPage);
-    await expect(detailPage.heading).toBeVisible({ timeout: 10_000 });
+    await expect(detailPage.title).toBeVisible({ timeout: TIMEOUTS.default });
 
     const tags = authenticatedPage.locator('.tag');
     await expect(tags).toHaveCount(3);
@@ -56,7 +50,9 @@ test.describe('Recipe Tags (US-070)', () => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
     await authenticatedPage.goto(`/recipes/${recipeIdentifier}`);
-    await expect(authenticatedPage.locator('.tag').first()).toBeVisible({ timeout: 10_000 });
+    await expect(authenticatedPage.locator('.tag').first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
     const tagTexts = await authenticatedPage.locator('.tag').allTextContents();
     expect(tagTexts).toContain('italian');
@@ -64,23 +60,12 @@ test.describe('Recipe Tags (US-070)', () => {
     expect(tagTexts).toContain('quick');
   });
 
-  // Cleanup
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
     const page = await browser.newPage();
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    await page.goto(`/recipes/${recipeIdentifier}`);
-    await page.locator('.btn-danger').click();
-    await page.locator('.btn-danger-filled').click();
-    await page.waitForURL(/\/recipes$/, { timeout: 10_000 });
+    await loginViaKeycloak(page);
+    await deleteTestRecipe(page, recipeIdentifier);
     await page.close();
   });
 });

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -1,43 +1,23 @@
 import { test, expect } from '../fixtures/auth.fixture';
-import { DashboardPage } from '../pages/dashboard.page';
 import { ShoppingCreatePage } from '../pages/shopping-create.page';
 import { ShoppingDetailPage } from '../pages/shopping-detail.page';
-import { uniqueTitle } from '../helpers/test-data.helper';
+import {
+  uniqueTitle,
+  loginViaKeycloak,
+  createTestRecipe,
+  deleteTestRecipe,
+} from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   let recipeIdentifier: string;
 
-  // Create a recipe to generate a shopping list from
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    const dashboard = new DashboardPage(page);
-    await dashboard.createButton.click();
-
-    await page.locator('#title').fill(uniqueTitle('E2E Shopping'));
-
-    const ingredientName = page.locator('.ingredient-fields input[type="text"]').first();
-    await ingredientName.fill('Butter');
-    const ingredientAmount = page.locator('.ingredient-fields input[type="number"]').first();
-    await ingredientAmount.fill('200');
-
-    await page.getByRole('button', { name: /save/i }).click();
-    await expect(page.locator('.success-banner')).toBeVisible({ timeout: 15_000 });
-
-    await page.goto('/recipes');
-    await page.waitForTimeout(1000);
-
-    const firstCard = page.locator('.recipe-card').first();
-    const href = await firstCard.getAttribute('href');
-    recipeIdentifier = href?.replace('/recipes/', '') ?? '';
+    await loginViaKeycloak(page);
+    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Shopping'), {
+      ingredient: 'Butter',
+    });
     await page.close();
   });
 
@@ -101,37 +81,32 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
 
     await createPage.createButton.click();
 
-    await expect(authenticatedPage).toHaveURL(/\/shopping\/.+/, { timeout: 10_000 });
-    // Should see the shopping list detail
+    await expect(authenticatedPage).toHaveURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
     await expect(authenticatedPage.locator('h1')).toBeVisible();
   });
 
   test('should display shopping lists on overview page', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping');
 
-    // Should have at least the list we just created
     const cards = authenticatedPage.locator('.list-card');
     const empty = authenticatedPage.locator('.empty-state');
-    await expect(cards.or(empty).first()).toBeVisible({ timeout: 10_000 });
+    await expect(cards.or(empty).first()).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
   test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
-    // Navigate to the most recently created shopping list
     await authenticatedPage.goto('/shopping');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
-    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
     const detailPage = new ShoppingDetailPage(authenticatedPage);
-    await expect(detailPage.items.first()).toBeVisible({ timeout: 10_000 });
+    await expect(detailPage.items.first()).toBeVisible({ timeout: TIMEOUTS.default });
 
-    // Check the first item
     const firstCheckbox = detailPage.itemCheckboxes.first();
     await firstCheckbox.check();
 
-    // Verify strikethrough (checked class)
     await expect(detailPage.checkedItems.first()).toBeVisible();
   });
 
@@ -141,19 +116,17 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     await authenticatedPage.goto('/shopping');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
-    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
     const detailPage = new ShoppingDetailPage(authenticatedPage);
-    await expect(detailPage.items.first()).toBeVisible({ timeout: 10_000 });
+    await expect(detailPage.items.first()).toBeVisible({ timeout: TIMEOUTS.default });
 
-    // Check all
     await detailPage.checkAllButton.click();
     const allItems = await detailPage.items.all();
     for (const item of allItems) {
       await expect(item).toHaveClass(/checked/);
     }
 
-    // Reset
     await detailPage.resetButton.click();
     for (const item of allItems) {
       await expect(item).not.toHaveClass(/checked/);
@@ -166,30 +139,19 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     await authenticatedPage.goto('/shopping');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
-    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: 10_000 });
+    await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
     const detailPage = new ShoppingDetailPage(authenticatedPage);
-    await expect(detailPage.progress).toBeVisible({ timeout: 10_000 });
+    await expect(detailPage.progress).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(detailPage.progress).toContainText('/');
   });
 
-  // Cleanup: delete the recipe (cascade should handle shopping list)
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
     const page = await browser.newPage();
-    await page.goto('/auth/login');
-    await page.getByRole('button', { name: /sign in/i }).click();
-    await page.waitForURL('**/realms/yumney/**');
-    await page.locator('#username').fill('testuser');
-    await page.locator('#password').fill('Test1234');
-    await page.locator('#kc-login').click();
-    await page.waitForURL('**/dashboard', { timeout: 15_000 });
-
-    await page.goto(`/recipes/${recipeIdentifier}`);
-    await page.locator('.btn-danger').click();
-    await page.locator('.btn-danger-filled').click();
-    await page.waitForURL(/\/recipes$/, { timeout: 10_000 });
+    await loginViaKeycloak(page);
+    await deleteTestRecipe(page, recipeIdentifier);
     await page.close();
   });
 });

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -9,6 +9,8 @@ export const API_ENDPOINTS = {
     importFromPhotos: `${API_BASE}/recipes/import-from-photos`,
     recognizeIngredients: `${API_BASE}/recipes/recognize-ingredients`,
     chat: `${API_BASE}/recipes/chat`,
+    parseIntent: `${API_BASE}/recipes/parse-intent`,
+    importFromText: `${API_BASE}/recipes/import-from-text`,
     byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
     favorite: (identifier: string) => `${API_BASE}/recipes/${identifier}/favorite`,
   },

--- a/client/libs/shared/api-client/src/lib/chat-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/chat-api.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { API_ENDPOINTS } from './api-endpoints';
 import type { ChatRequest, ChatResponse } from './chat-message';
+import type { ImportRecipeResponse } from './import-recipe-response';
 
 @Injectable({ providedIn: 'root' })
 export class ChatApiService {
@@ -10,5 +11,9 @@ export class ChatApiService {
 
   send(request: ChatRequest): Observable<ChatResponse> {
     return this.http.post<ChatResponse>(API_ENDPOINTS.recipes.chat, request);
+  }
+
+  importFromText(text: string): Observable<ImportRecipeResponse> {
+    return this.http.post<ImportRecipeResponse>(API_ENDPOINTS.recipes.importFromText, { text });
   }
 }

--- a/client/libs/shared/models/src/lib/chat-hint.service.spec.ts
+++ b/client/libs/shared/models/src/lib/chat-hint.service.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
 import { Router, provideRouter } from '@angular/router';
 import { ChatHintService } from './chat-hint.service';
+
+@Component({ template: '' })
+class DummyComponent {}
 
 describe('ChatHintService', () => {
   let service: ChatHintService;
@@ -8,17 +12,61 @@ describe('ChatHintService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([
+          { path: 'dashboard', component: DummyComponent },
+          { path: 'recipes', component: DummyComponent },
+          { path: 'shopping', component: DummyComponent },
+          { path: 'meal-planner', component: DummyComponent },
+          { path: 'account', component: DummyComponent },
+        ]),
+      ],
     });
     service = TestBed.inject(ChatHintService);
     router = TestBed.inject(Router);
   });
 
-  it('should return default hint for unknown routes', () => {
+  it('should return default hint for root route', () => {
     expect(service.hintKey()).toBe('commandBar.hints.default');
   });
 
-  it('should return undefined page context for unknown routes', () => {
+  it('should return undefined page context for root route', () => {
+    expect(service.pageContext()).toBeUndefined();
+  });
+
+  it('should return dashboard hint after navigating to /dashboard', async () => {
+    await router.navigateByUrl('/dashboard');
+    expect(service.hintKey()).toBe('commandBar.hints.dashboard');
+    expect(service.pageContext()).toBe('dashboard');
+  });
+
+  it('should return recipes hint after navigating to /recipes', async () => {
+    await router.navigateByUrl('/recipes');
+    expect(service.hintKey()).toBe('commandBar.hints.recipes');
+    expect(service.pageContext()).toBe('recipes');
+  });
+
+  it('should return shopping hint after navigating to /shopping', async () => {
+    await router.navigateByUrl('/shopping');
+    expect(service.hintKey()).toBe('commandBar.hints.shopping');
+    expect(service.pageContext()).toBe('shopping-list');
+  });
+
+  it('should return meal planner hint after navigating to /meal-planner', async () => {
+    await router.navigateByUrl('/meal-planner');
+    expect(service.hintKey()).toBe('commandBar.hints.mealPlanner');
+    expect(service.pageContext()).toBe('meal-planner');
+  });
+
+  it('should return account hint after navigating to /account', async () => {
+    await router.navigateByUrl('/account');
+    expect(service.hintKey()).toBe('commandBar.hints.account');
+    expect(service.pageContext()).toBe('account');
+  });
+
+  it('should return default hint for unknown routes', async () => {
+    await router.navigateByUrl('/some-unknown-page');
+    expect(service.hintKey()).toBe('commandBar.hints.default');
     expect(service.pageContext()).toBeUndefined();
   });
 });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -256,4 +256,58 @@ describe('ChatPanelComponent', () => {
     expect(liveRegion).toBeTruthy();
     expect(liveRegion.textContent.trim()).toBe('Try pasta!');
   });
+
+  // ── URL / text detection ──
+
+  it('should trigger URL import when input is a URL', async () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('https://example.com/recipe');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(recipeApiMock.importRecipe).toHaveBeenCalledWith({ url: 'https://example.com/recipe' });
+    expect(chatApiMock.send).not.toHaveBeenCalled();
+  });
+
+  it('should trigger text import when input is long recipe text', async () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    const longText =
+      'Pasta Carbonara\n200g spaghetti\n4 eggs\n100g guanciale\nBoil pasta, mix with eggs and cheese';
+    fixture.componentInstance['input'].set(longText);
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(chatApiMock.importFromText).toHaveBeenCalledWith(longText);
+    expect(chatApiMock.send).not.toHaveBeenCalled();
+  });
+
+  it('should send regular chat for short text input', async () => {
+    chatState.open();
+    fixture.detectChanges();
+
+    fixture.componentInstance['input'].set('What can I cook?');
+    fixture.componentInstance['onSend']();
+    await Promise.resolve();
+
+    expect(chatApiMock.send).toHaveBeenCalled();
+    expect(recipeApiMock.importRecipe).not.toHaveBeenCalled();
+    expect(chatApiMock.importFromText).not.toHaveBeenCalled();
+  });
+
+  it('should detect URL correctly', () => {
+    expect(fixture.componentInstance['looksLikeUrl']('https://example.com/recipe')).toBe(true);
+    expect(fixture.componentInstance['looksLikeUrl']('http://food.com/pasta')).toBe(true);
+    expect(fixture.componentInstance['looksLikeUrl']('not a url')).toBe(false);
+    expect(fixture.componentInstance['looksLikeUrl']('Check https://example.com')).toBe(false);
+  });
+
+  it('should detect recipe text correctly', () => {
+    expect(fixture.componentInstance['looksLikeRecipeText']('line1\nline2\nline3')).toBe(true);
+    expect(fixture.componentInstance['looksLikeRecipeText']('a '.repeat(30))).toBe(true);
+    expect(fixture.componentInstance['looksLikeRecipeText']('short text')).toBe(false);
+  });
 });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { ChatPanelComponent } from './chat-panel.component';
-import { ChatApiService } from '@yumney/shared/api-client';
+import { ChatApiService, RecipeApiService } from '@yumney/shared/api-client';
 import { ChatStateService, setupTranslocoTesting } from '@yumney/shared/models';
 
 const en = {
@@ -19,16 +19,26 @@ const en = {
     clearHistory: 'Clear history',
     errors: { offline: 'Offline', failed: 'Failed' },
   },
+  commandBar: {
+    hints: {
+      default: 'Ask me anything...',
+    },
+  },
 };
 
 describe('ChatPanelComponent', () => {
   let fixture: ComponentFixture<ChatPanelComponent>;
   let chatState: ChatStateService;
-  let chatApiMock: { send: ReturnType<typeof vi.fn> };
+  let chatApiMock: { send: ReturnType<typeof vi.fn>; importFromText: ReturnType<typeof vi.fn> };
+  let recipeApiMock: { importRecipe: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     chatApiMock = {
       send: vi.fn().mockReturnValue(of({ reply: 'Hello!', suggestions: [] })),
+      importFromText: vi.fn().mockReturnValue(of({ title: 'Test', ingredients: [], steps: [] })),
+    };
+    recipeApiMock = {
+      importRecipe: vi.fn().mockReturnValue(of({ title: 'Test', ingredients: [], steps: [] })),
     };
 
     await TestBed.configureTestingModule({
@@ -37,6 +47,7 @@ describe('ChatPanelComponent', () => {
         provideYumneyIcons(),
         provideRouter([]),
         { provide: ChatApiService, useValue: chatApiMock },
+        { provide: RecipeApiService, useValue: recipeApiMock },
         ChatStateService,
       ],
     }).compileComponents();

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -14,7 +14,11 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { ChatApiService, type ChatRecipeSuggestion } from '@yumney/shared/api-client';
+import {
+  ChatApiService,
+  RecipeApiService,
+  type ChatRecipeSuggestion,
+} from '@yumney/shared/api-client';
 import { ChatHintService, ChatStateService, ROUTES } from '@yumney/shared/models';
 
 @Component({
@@ -31,6 +35,7 @@ export class ChatPanelComponent implements AfterViewInit {
   protected state = inject(ChatStateService);
   protected hints = inject(ChatHintService);
   private chatApi = inject(ChatApiService);
+  private recipeApi = inject(RecipeApiService);
   private destroyRef = inject(DestroyRef);
 
   protected input = signal('');
@@ -74,6 +79,16 @@ export class ChatPanelComponent implements AfterViewInit {
     this.state.addMessage({ role: 'user', content: message });
     this.state.setThinking(true);
 
+    if (this.looksLikeUrl(message)) {
+      this.handleUrlImport(message);
+    } else if (this.looksLikeRecipeText(message)) {
+      this.handleTextImport(message);
+    } else {
+      this.handleChat(message);
+    }
+  }
+
+  private handleChat(message: string): void {
     const history = this.state.messages().slice(0, -1);
 
     this.chatApi
@@ -86,15 +101,63 @@ export class ChatPanelComponent implements AfterViewInit {
           this.lastAssistantMessage.set(response.reply);
           this.state.setThinking(false);
         },
-        error: (err) => {
-          this.state.setThinking(false);
-          if (err?.status === 0 || !navigator.onLine) {
-            this.error.set('chat.errors.offline');
-          } else {
-            this.error.set('chat.errors.failed');
-          }
-        },
+        error: (err) => this.handleError(err),
       });
+  }
+
+  private handleUrlImport(url: string): void {
+    this.recipeApi
+      .importRecipe({ url })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (recipe) => {
+          const reply = `I found a recipe: **${recipe.title}**\n${recipe.ingredients.length} ingredients, ${recipe.steps.length} steps.`;
+          this.state.addMessage({ role: 'assistant', content: reply });
+          this.lastSuggestions.set([
+            { recipeIdentifier: null, title: recipe.title, reason: 'Extracted from URL' },
+          ]);
+          this.lastAssistantMessage.set(reply);
+          this.state.setThinking(false);
+        },
+        error: (err) => this.handleError(err),
+      });
+  }
+
+  private handleTextImport(text: string): void {
+    this.chatApi
+      .importFromText(text)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (recipe) => {
+          const reply = `I found a recipe: **${recipe.title}**\n${recipe.ingredients.length} ingredients, ${recipe.steps.length} steps.`;
+          this.state.addMessage({ role: 'assistant', content: reply });
+          this.lastSuggestions.set([
+            { recipeIdentifier: null, title: recipe.title, reason: 'Extracted from text' },
+          ]);
+          this.lastAssistantMessage.set(reply);
+          this.state.setThinking(false);
+        },
+        error: (err) => this.handleError(err),
+      });
+  }
+
+  private handleError(err: { status?: number }): void {
+    this.state.setThinking(false);
+    if (err?.status === 0 || !navigator.onLine) {
+      this.error.set('chat.errors.offline');
+    } else {
+      this.error.set('chat.errors.failed');
+    }
+  }
+
+  private looksLikeUrl(text: string): boolean {
+    return /^https?:\/\/\S+$/i.test(text);
+  }
+
+  private looksLikeRecipeText(text: string): boolean {
+    const lines = text.split('\n').length;
+    const words = text.split(/\s+/).length;
+    return lines >= 3 || words >= 30;
   }
 
   protected onClear(): void {

--- a/client/libs/ui/src/lib/command-fab/command-fab.component.spec.ts
+++ b/client/libs/ui/src/lib/command-fab/command-fab.component.spec.ts
@@ -72,4 +72,17 @@ describe('CommandFabComponent', () => {
     fixture.detectChanges();
     expect(button.getAttribute('aria-expanded')).toBe('true');
   });
+
+  it('should show message-circle icon when closed', () => {
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('lucide-icon');
+    expect(icon.getAttribute('name')).toBe('message-circle');
+  });
+
+  it('should show x icon when open', () => {
+    chatState.open();
+    fixture.detectChanges();
+    const icon = fixture.nativeElement.querySelector('lucide-icon');
+    expect(icon.getAttribute('name')).toBe('x');
+  });
 });

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Chat.cs
@@ -1,3 +1,4 @@
+using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
@@ -41,6 +42,20 @@ public static partial class RecipesEndpoints
             return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
 
         var command = new ParseIntentCommand(request.Message, request.Context);
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ImportFromTextAsync(
+        ImportFromTextRequestDto request,
+        ICommandHandler<ImportRecipeFromTextCommand, Result<ExtractedRecipeDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: emptyChatMessageError);
+
+        var command = new ImportRecipeFromTextCommand(request.Text);
 
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -78,6 +78,14 @@ public static partial class RecipesEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .RequireRateLimiting("RecipeImport");
 
+        group.MapPost("/import-from-text", ImportFromTextAsync)
+            .WithName("ImportRecipeFromText")
+            .WithTags("Recipes")
+            .Produces<ExtractedRecipeDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
+            .RequireRateLimiting("RecipeImport");
+
         group.MapGet("/import/stream", ImportStreamAsync)
             .WithName("ImportRecipeStream")
             .WithTags("Recipes")

--- a/src/Yumney.Recipes.Api/Requests/ImportFromTextRequestDto.cs
+++ b/src/Yumney.Recipes.Api/Requests/ImportFromTextRequestDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
+
+public sealed record ImportFromTextRequestDto(string Text);

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromTextCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromTextCommandHandler.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class ImportRecipeFromTextCommandHandler(
+    IRecipeExtractionService extraction,
+    ILogger<ImportRecipeFromTextCommandHandler> logger)
+    : ICommandHandler<ImportRecipeFromTextCommand, Result<ExtractedRecipeDto>>
+{
+    public async Task<Result<ExtractedRecipeDto>> HandleAsync(ImportRecipeFromTextCommand command, CancellationToken cancellationToken = default)
+    {
+        var text = command.RecipeText;
+
+        LogTextImportAttempt(text.Length);
+
+        var content = new ScrapedContent(text, SourceUrl: string.Empty);
+        var extractResult = await extraction.ExtractAsync(content, cancellationToken);
+
+        if (extractResult.IsFailure)
+        {
+            LogTextExtractionFailed(extractResult.Error!.Code);
+            return extractResult.Error!;
+        }
+
+        LogTextImportSuccess(extractResult.Value.Title);
+        return extractResult;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe import from text requested, length {TextLength}")]
+    private partial void LogTextImportAttempt(int textLength);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Text extraction failed: {Error}")]
+    private partial void LogTextExtractionFailed(string error);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Recipe '{Title}' extracted from pasted text")]
+    private partial void LogTextImportSuccess(string title);
+}

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeFromTextCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeFromTextCommand.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+public sealed record ImportRecipeFromTextCommand(string RecipeText) : ICommand<Result<ExtractedRecipeDto>>;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
@@ -61,7 +61,7 @@ public sealed partial class SemanticKernelIntentParserService(
         return ParseResponse(response);
     }
 
-    private static string ExtractJson(string response)
+    internal static string ExtractJson(string response)
     {
         var trimmed = response.Trim();
 

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeFromTextCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeFromTextCommandHandlerTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
+
+public class ImportRecipeFromTextCommandHandlerTests
+{
+    private readonly IRecipeExtractionService extraction = Substitute.For<IRecipeExtractionService>();
+    private readonly ILogger<ImportRecipeFromTextCommandHandler> logger = Substitute.For<ILogger<ImportRecipeFromTextCommandHandler>>();
+    private readonly ImportRecipeFromTextCommandHandler handler;
+
+    public ImportRecipeFromTextCommandHandlerTests()
+    {
+        handler = new ImportRecipeFromTextCommandHandler(extraction, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidText_ReturnsExtractedRecipe()
+    {
+        var expected = new ExtractedRecipeDto("Pasta Carbonara", [], [], Description: "Classic Italian");
+        extraction.ExtractAsync(Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Success(expected));
+
+        var command = new ImportRecipeFromTextCommand("Pasta Carbonara\n200g spaghetti\nMix with eggs and cheese");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Pasta Carbonara");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExtractionFails_ReturnsFailure()
+    {
+        extraction.ExtractAsync(Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>())
+            .Returns(ImportRecipeErrors.ExtractionFailed);
+
+        var command = new ImportRecipeFromTextCommand("Not a recipe");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be("IMPORT_EXTRACTION_FAILED");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PassesTextAsScrapedContent()
+    {
+        var expected = new ExtractedRecipeDto("Test", [], []);
+        extraction.ExtractAsync(Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>())
+            .Returns(Result<ExtractedRecipeDto>.Success(expected));
+
+        var recipeText = "My recipe\nIngredients: flour, eggs";
+        var command = new ImportRecipeFromTextCommand(recipeText);
+
+        await handler.HandleAsync(command);
+
+        await extraction.Received(1).ExtractAsync(
+            Arg.Is<ScrapedContent>(c => c.CleanedText == recipeText && c.SourceUrl == string.Empty),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/IntentParserJsonTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/IntentParserJsonTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services;
+
+public class IntentParserJsonTests
+{
+    [Fact]
+    public void ExtractJson_PlainJson_ReturnsAsIs()
+    {
+        var input = """{"intent":"add_to_list","entities":{"item":"milk"},"clarification":null}""";
+
+        var result = SemanticKernelIntentParserService.ExtractJson(input);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void ExtractJson_MarkdownJsonFence_ExtractsContent()
+    {
+        var input = """
+            ```json
+            {"intent":"search_recipe","entities":{"query":"chicken"},"clarification":null}
+            ```
+            """;
+
+        var result = SemanticKernelIntentParserService.ExtractJson(input);
+
+        result.Should().Contain("search_recipe");
+        result.Should().NotContain("```");
+    }
+
+    [Fact]
+    public void ExtractJson_MarkdownPlainFence_ExtractsContent()
+    {
+        var input = """
+            ```
+            {"intent":"navigate","entities":{"target":"shopping-list"},"clarification":null}
+            ```
+            """;
+
+        var result = SemanticKernelIntentParserService.ExtractJson(input);
+
+        result.Should().Contain("navigate");
+        result.Should().NotContain("```");
+    }
+
+    [Fact]
+    public void ExtractJson_WhitespaceAroundJson_Trims()
+    {
+        var input = """
+
+            {"intent":"general_chat","entities":{},"clarification":null}
+
+            """;
+
+        var result = SemanticKernelIntentParserService.ExtractJson(input);
+
+        result.Should().StartWith("{");
+        result.Should().EndWith("}");
+    }
+
+    [Fact]
+    public void ExtractJson_EmptyString_ReturnsEmpty()
+    {
+        var result = SemanticKernelIntentParserService.ExtractJson(string.Empty);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractJson_JsonFenceCaseInsensitive_ExtractsContent()
+    {
+        var input = """
+            ```JSON
+            {"intent":"add_to_list"}
+            ```
+            """;
+
+        var result = SemanticKernelIntentParserService.ExtractJson(input);
+
+        result.Should().Contain("add_to_list");
+        result.Should().NotContain("```");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ImportRecipeFromTextCommand` + handler — accepts raw recipe text, extracts via existing LLM pipeline
- Endpoint: `POST /api/v1/recipes/import-from-text`
- Chat panel detects URLs (regex `^https?://`) → triggers existing URL import
- Chat panel detects long text (3+ lines or 30+ words) → triggers text import
- Extraction results shown inline in chat with recipe title and stats
- Frontend API client extended with `importFromText()` and `parseIntent` endpoints
- Chat panel spec updated with RecipeApiService mock

Closes #157

## Test plan
- [x] Text import handler extracts recipe from raw text
- [x] Handler returns failure on extraction error
- [x] Handler passes text as ScrapedContent with empty SourceUrl
- [x] All 135 Recipes application tests pass (3 new)
- [x] All 64 architecture tests pass
- [x] All 153 UI lib tests pass (existing chat tests updated)