### PR TITLE
feat(shared): add DefaultQuantityResolver for chat commands (US-307)

### DIFF
--- a/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
@@ -1,0 +1,88 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Resolves default quantities for items added without explicit amounts.
+/// Category-based lookup with a fallback of 1 piece for unknown items.
+/// </summary>
+public static class DefaultQuantityResolver
+{
+    private static readonly Dictionary<string, ResolvedQuantity> ItemDefaults =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Liquids → 1L
+            ["milk"] = new(1, "L"),
+            ["cream"] = new(1, "L"),
+            ["juice"] = new(1, "L"),
+            ["water"] = new(1, "L"),
+            ["broth"] = new(1, "L"),
+            ["stock"] = new(1, "L"),
+            ["oil"] = new(0.5m, "L"),
+            ["olive oil"] = new(0.5m, "L"),
+            ["vegetable oil"] = new(0.5m, "L"),
+
+            // Eggs → 6
+            ["eggs"] = new(6, "pc"),
+            ["egg"] = new(6, "pc"),
+
+            // Dairy → 250g
+            ["butter"] = new(250, "g"),
+            ["cheese"] = new(250, "g"),
+            ["yogurt"] = new(500, "g"),
+            ["sour cream"] = new(200, "g"),
+
+            // Meat / Fish → 500g
+            ["chicken"] = new(500, "g"),
+            ["beef"] = new(500, "g"),
+            ["pork"] = new(500, "g"),
+            ["ground beef"] = new(500, "g"),
+            ["salmon"] = new(500, "g"),
+            ["fish"] = new(500, "g"),
+            ["shrimp"] = new(500, "g"),
+
+            // Baking → common amounts
+            ["flour"] = new(1, "kg"),
+            ["sugar"] = new(1, "kg"),
+            ["baking powder"] = new(1, "pc"),
+            ["yeast"] = new(1, "pc"),
+
+            // Staples → 1 piece or pack
+            ["salt"] = new(1, "pc"),
+            ["pepper"] = new(1, "pc"),
+            ["rice"] = new(1, "kg"),
+            ["pasta"] = new(500, "g"),
+            ["bread"] = new(1, "pc"),
+        };
+
+    private static readonly Dictionary<string, ResolvedQuantity> CategoryDefaults =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["liquid"] = new(1, "L"),
+            ["dairy"] = new(250, "g"),
+            ["meat"] = new(500, "g"),
+            ["fish"] = new(500, "g"),
+            ["vegetable"] = new(1, "pc"),
+            ["fruit"] = new(1, "pc"),
+            ["baking"] = new(1, "pc"),
+            ["household"] = new(1, "pc"),
+        };
+
+    /// <summary>
+    /// Resolve the default quantity for an item. Returns the standard default
+    /// for known items, or falls back to 1 piece for unknown items.
+    /// </summary>
+    public static ResolvedQuantity Resolve(string itemName, string? category = null)
+    {
+        if (string.IsNullOrWhiteSpace(itemName))
+            return ResolvedQuantity.OnePiece;
+
+        var trimmed = itemName.Trim();
+
+        if (ItemDefaults.TryGetValue(trimmed, out var itemDefault))
+            return itemDefault;
+
+        if (category is not null && CategoryDefaults.TryGetValue(category, out var categoryDefault))
+            return categoryDefault;
+
+        return ResolvedQuantity.OnePiece;
+    }
+}

--- a/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
@@ -2,56 +2,13 @@ namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 /// <summary>
 /// Resolves default quantities for items added without explicit amounts.
+/// Supports EN and DE item names with basic plural normalization.
 /// Category-based lookup with a fallback of 1 piece for unknown items.
 /// </summary>
 public static class DefaultQuantityResolver
 {
     private static readonly Dictionary<string, ResolvedQuantity> ItemDefaults =
-        new(StringComparer.OrdinalIgnoreCase)
-        {
-            // Liquids → 1L
-            ["milk"] = new(1, "L"),
-            ["cream"] = new(1, "L"),
-            ["juice"] = new(1, "L"),
-            ["water"] = new(1, "L"),
-            ["broth"] = new(1, "L"),
-            ["stock"] = new(1, "L"),
-            ["oil"] = new(0.5m, "L"),
-            ["olive oil"] = new(0.5m, "L"),
-            ["vegetable oil"] = new(0.5m, "L"),
-
-            // Eggs → 6
-            ["eggs"] = new(6, "pc"),
-            ["egg"] = new(6, "pc"),
-
-            // Dairy → 250g
-            ["butter"] = new(250, "g"),
-            ["cheese"] = new(250, "g"),
-            ["yogurt"] = new(500, "g"),
-            ["sour cream"] = new(200, "g"),
-
-            // Meat / Fish → 500g
-            ["chicken"] = new(500, "g"),
-            ["beef"] = new(500, "g"),
-            ["pork"] = new(500, "g"),
-            ["ground beef"] = new(500, "g"),
-            ["salmon"] = new(500, "g"),
-            ["fish"] = new(500, "g"),
-            ["shrimp"] = new(500, "g"),
-
-            // Baking → common amounts
-            ["flour"] = new(1, "kg"),
-            ["sugar"] = new(1, "kg"),
-            ["baking powder"] = new(1, "pc"),
-            ["yeast"] = new(1, "pc"),
-
-            // Staples → 1 piece or pack
-            ["salt"] = new(1, "pc"),
-            ["pepper"] = new(1, "pc"),
-            ["rice"] = new(1, "kg"),
-            ["pasta"] = new(500, "g"),
-            ["bread"] = new(1, "pc"),
-        };
+        BuildItemDefaults();
 
     private static readonly Dictionary<string, ResolvedQuantity> CategoryDefaults =
         new(StringComparer.OrdinalIgnoreCase)
@@ -75,14 +32,109 @@ public static class DefaultQuantityResolver
         if (string.IsNullOrWhiteSpace(itemName))
             return ResolvedQuantity.OnePiece;
 
-        var trimmed = itemName.Trim();
+        var normalized = Normalize(itemName);
 
-        if (ItemDefaults.TryGetValue(trimmed, out var itemDefault))
+        if (ItemDefaults.TryGetValue(normalized, out var itemDefault))
             return itemDefault;
 
         if (category is not null && CategoryDefaults.TryGetValue(category, out var categoryDefault))
             return categoryDefault;
 
         return ResolvedQuantity.OnePiece;
+    }
+
+    private static string Normalize(string input)
+    {
+        var trimmed = input.Trim().ToLowerInvariant();
+
+        // Basic English plural → singular (trailing 's' removal for simple cases)
+        if (trimmed.Length > 3 && trimmed.EndsWith('s') && !trimmed.EndsWith("ss", StringComparison.Ordinal))
+        {
+            var singular = trimmed[..^1];
+            if (ItemDefaults.ContainsKey(singular))
+                return singular;
+        }
+
+        return trimmed;
+    }
+
+#pragma warning disable SA1117 // Parameters should be on same line or each on its own line
+    private static Dictionary<string, ResolvedQuantity> BuildItemDefaults()
+    {
+        var defaults = new Dictionary<string, ResolvedQuantity>(StringComparer.OrdinalIgnoreCase);
+
+        // Liquids → 1L
+        AddWithAliases(defaults, new(1, "L"),
+            "milk", "milch",
+            "cream", "sahne", "schlagsahne",
+            "juice", "saft",
+            "water", "wasser",
+            "broth", "bruehe", "brühe",
+            "stock", "fond");
+        AddWithAliases(defaults, new(0.5m, "L"),
+            "oil", "oel", "öl",
+            "olive oil", "olivenoel", "olivenöl",
+            "vegetable oil", "pflanzenoel", "pflanzenöl");
+
+        // Eggs → 6
+        AddWithAliases(defaults, new(6, "pc"),
+            "egg", "eggs", "ei", "eier");
+
+        // Dairy → 250g
+        AddWithAliases(defaults, new(250, "g"),
+            "butter",
+            "cheese", "kaese", "käse");
+        AddWithAliases(defaults, new(500, "g"),
+            "yogurt", "joghurt");
+        AddWithAliases(defaults, new(200, "g"),
+            "sour cream", "schmand", "saure sahne");
+
+        // Meat / Fish → 500g
+        AddWithAliases(defaults, new(500, "g"),
+            "chicken", "haehnchen", "hähnchen", "huhn",
+            "beef", "rindfleisch", "rind",
+            "pork", "schweinefleisch", "schwein",
+            "ground beef", "hackfleisch", "gehacktes",
+            "salmon", "lachs",
+            "fish", "fisch",
+            "shrimp", "garnelen", "garnele");
+
+        // Baking
+        AddWithAliases(defaults, new(1, "kg"),
+            "flour", "mehl",
+            "sugar", "zucker");
+        AddWithAliases(defaults, new(1, "pc"),
+            "baking powder", "backpulver",
+            "yeast", "hefe");
+
+        // Staples
+        AddWithAliases(defaults, new(1, "pc"),
+            "salt", "salz",
+            "pepper", "pfeffer",
+            "bread", "brot");
+        AddWithAliases(defaults, new(1, "kg"),
+            "rice", "reis");
+        AddWithAliases(defaults, new(500, "g"),
+            "pasta", "nudeln");
+
+        // Common vegetables
+        AddWithAliases(defaults, new(1, "pc"),
+            "onion", "zwiebel",
+            "garlic", "knoblauch",
+            "potato", "kartoffel",
+            "tomato", "tomate",
+            "carrot", "karotte", "moehre", "möhre",
+            "cucumber", "gurke",
+            "lettuce", "salat",
+            "lemon", "zitrone");
+
+        return defaults;
+    }
+#pragma warning restore SA1117
+
+    private static void AddWithAliases(Dictionary<string, ResolvedQuantity> dict, ResolvedQuantity quantity, params string[] names)
+    {
+        foreach (var name in names)
+            dict.TryAdd(name, quantity);
     }
 }

--- a/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shared/Common/DefaultQuantityResolver.cs
@@ -5,12 +5,13 @@ namespace SmartSolutionsLab.Yumney.Shared.Common;
 /// Supports EN and DE item names with basic plural normalization.
 /// Category-based lookup with a fallback of 1 piece for unknown items.
 /// </summary>
+#pragma warning disable SA1311
 public static class DefaultQuantityResolver
 {
-    private static readonly Dictionary<string, ResolvedQuantity> ItemDefaults =
-        BuildItemDefaults();
+    private static readonly Dictionary<string, ResolvedQuantity> itemDefaults =
+        BuilditemDefaults();
 
-    private static readonly Dictionary<string, ResolvedQuantity> CategoryDefaults =
+    private static readonly Dictionary<string, ResolvedQuantity> categoryDefaults =
         new(StringComparer.OrdinalIgnoreCase)
         {
             ["liquid"] = new(1, "L"),
@@ -27,6 +28,9 @@ public static class DefaultQuantityResolver
     /// Resolve the default quantity for an item. Returns the standard default
     /// for known items, or falls back to 1 piece for unknown items.
     /// </summary>
+    /// <param name="itemName">The item name (EN or DE).</param>
+    /// <param name="category">Optional category hint for unknown items.</param>
+    /// <returns>The resolved default quantity.</returns>
     public static ResolvedQuantity Resolve(string itemName, string? category = null)
     {
         if (string.IsNullOrWhiteSpace(itemName))
@@ -34,10 +38,10 @@ public static class DefaultQuantityResolver
 
         var normalized = Normalize(itemName);
 
-        if (ItemDefaults.TryGetValue(normalized, out var itemDefault))
+        if (itemDefaults.TryGetValue(normalized, out var itemDefault))
             return itemDefault;
 
-        if (category is not null && CategoryDefaults.TryGetValue(category, out var categoryDefault))
+        if (category is not null && categoryDefaults.TryGetValue(category, out var categoryDefault))
             return categoryDefault;
 
         return ResolvedQuantity.OnePiece;
@@ -51,7 +55,7 @@ public static class DefaultQuantityResolver
         if (trimmed.Length > 3 && trimmed.EndsWith('s') && !trimmed.EndsWith("ss", StringComparison.Ordinal))
         {
             var singular = trimmed[..^1];
-            if (ItemDefaults.ContainsKey(singular))
+            if (itemDefaults.ContainsKey(singular))
                 return singular;
         }
 
@@ -59,7 +63,7 @@ public static class DefaultQuantityResolver
     }
 
 #pragma warning disable SA1117 // Parameters should be on same line or each on its own line
-    private static Dictionary<string, ResolvedQuantity> BuildItemDefaults()
+    private static Dictionary<string, ResolvedQuantity> BuilditemDefaults()
     {
         var defaults = new Dictionary<string, ResolvedQuantity>(StringComparer.OrdinalIgnoreCase);
 
@@ -138,3 +142,4 @@ public static class DefaultQuantityResolver
             dict.TryAdd(name, quantity);
     }
 }
+#pragma warning restore SA1311

--- a/src/Yumney.Shared/Common/ResolvedQuantity.cs
+++ b/src/Yumney.Shared/Common/ResolvedQuantity.cs
@@ -1,0 +1,8 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+public sealed record ResolvedQuantity(decimal Amount, string Unit)
+{
+    public static readonly ResolvedQuantity OnePiece = new(1, "pc");
+
+    public override string ToString() => $"{Amount} {Unit}";
+}

--- a/tests/Yumney.Shared.Tests/Common/DefaultQuantityResolverTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/DefaultQuantityResolverTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class DefaultQuantityResolverTests
+{
+    [Theory]
+    [InlineData("milk", 1, "L")]
+    [InlineData("cream", 1, "L")]
+    [InlineData("juice", 1, "L")]
+    [InlineData("oil", 0.5, "L")]
+    public void Resolve_Liquid_ReturnsLiters(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData("eggs", 6)]
+    [InlineData("egg", 6)]
+    public void Resolve_Eggs_Returns6Pieces(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("pc");
+    }
+
+    [Theory]
+    [InlineData("butter", 250)]
+    [InlineData("cheese", 250)]
+    public void Resolve_Dairy_Returns250Grams(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("g");
+    }
+
+    [Theory]
+    [InlineData("chicken", 500)]
+    [InlineData("beef", 500)]
+    [InlineData("salmon", 500)]
+    public void Resolve_MeatFish_Returns500Grams(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("g");
+    }
+
+    [Fact]
+    public void Resolve_UnknownItem_ReturnsFallback()
+    {
+        var result = DefaultQuantityResolver.Resolve("toilet paper");
+
+        result.Should().Be(ResolvedQuantity.OnePiece);
+    }
+
+    [Fact]
+    public void Resolve_UnknownItemWithCategory_UsesCategoryDefault()
+    {
+        var result = DefaultQuantityResolver.Resolve("coconut milk", "liquid");
+
+        result.Amount.Should().Be(1);
+        result.Unit.Should().Be("L");
+    }
+
+    [Fact]
+    public void Resolve_UnknownItemWithUnknownCategory_ReturnsFallback()
+    {
+        var result = DefaultQuantityResolver.Resolve("mystery item", "unknown-category");
+
+        result.Should().Be(ResolvedQuantity.OnePiece);
+    }
+
+    [Fact]
+    public void Resolve_CaseInsensitive_MatchesItem()
+    {
+        var result = DefaultQuantityResolver.Resolve("MILK");
+
+        result.Amount.Should().Be(1);
+        result.Unit.Should().Be("L");
+    }
+
+    [Theory]
+    [InlineData("  milk  ", 1, "L")]
+    [InlineData("  chicken  ", 500, "g")]
+    public void Resolve_TrimmedInput_MatchesItem(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_EmptyInput_ReturnsFallback(string? item)
+    {
+        var result = DefaultQuantityResolver.Resolve(item!);
+
+        result.Should().Be(ResolvedQuantity.OnePiece);
+    }
+
+    [Fact]
+    public void Resolve_Pasta_Returns500Grams()
+    {
+        var result = DefaultQuantityResolver.Resolve("pasta");
+
+        result.Amount.Should().Be(500);
+        result.Unit.Should().Be("g");
+    }
+
+    [Fact]
+    public void Resolve_Flour_Returns1Kg()
+    {
+        var result = DefaultQuantityResolver.Resolve("flour");
+
+        result.Amount.Should().Be(1);
+        result.Unit.Should().Be("kg");
+    }
+
+    [Fact]
+    public void ResolvedQuantity_ToString_FormatsCorrectly()
+    {
+        var qty = new ResolvedQuantity(1, "L");
+
+        qty.ToString().Should().Be("1 L");
+    }
+}

--- a/tests/Yumney.Shared.Tests/Common/DefaultQuantityResolverTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/DefaultQuantityResolverTests.cs
@@ -11,7 +11,7 @@ public class DefaultQuantityResolverTests
     [InlineData("cream", 1, "L")]
     [InlineData("juice", 1, "L")]
     [InlineData("oil", 0.5, "L")]
-    public void Resolve_Liquid_ReturnsLiters(string item, decimal amount, string unit)
+    public void Resolve_EnglishLiquid_ReturnsLiters(string item, decimal amount, string unit)
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
@@ -22,7 +22,7 @@ public class DefaultQuantityResolverTests
     [Theory]
     [InlineData("eggs", 6)]
     [InlineData("egg", 6)]
-    public void Resolve_Eggs_Returns6Pieces(string item, decimal amount)
+    public void Resolve_EnglishEggs_Returns6Pieces(string item, decimal amount)
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
@@ -33,7 +33,7 @@ public class DefaultQuantityResolverTests
     [Theory]
     [InlineData("butter", 250)]
     [InlineData("cheese", 250)]
-    public void Resolve_Dairy_Returns250Grams(string item, decimal amount)
+    public void Resolve_EnglishDairy_Returns250Grams(string item, decimal amount)
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
@@ -45,12 +45,116 @@ public class DefaultQuantityResolverTests
     [InlineData("chicken", 500)]
     [InlineData("beef", 500)]
     [InlineData("salmon", 500)]
-    public void Resolve_MeatFish_Returns500Grams(string item, decimal amount)
+    public void Resolve_EnglishMeatFish_Returns500Grams(string item, decimal amount)
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
         result.Amount.Should().Be(amount);
         result.Unit.Should().Be("g");
+    }
+
+    [Theory]
+    [InlineData("onion", 1, "pc")]
+    [InlineData("potato", 1, "pc")]
+    [InlineData("tomato", 1, "pc")]
+    [InlineData("carrot", 1, "pc")]
+    public void Resolve_EnglishVegetable_Returns1Piece(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData("milch", 1, "L")]
+    [InlineData("sahne", 1, "L")]
+    [InlineData("saft", 1, "L")]
+    [InlineData("wasser", 1, "L")]
+    [InlineData("olivenöl", 0.5, "L")]
+    public void Resolve_GermanLiquid_ReturnsLiters(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData("ei", 6)]
+    [InlineData("eier", 6)]
+    public void Resolve_GermanEggs_Returns6Pieces(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("pc");
+    }
+
+    [Theory]
+    [InlineData("käse", 250)]
+    [InlineData("kaese", 250)]
+    public void Resolve_GermanDairy_Returns250Grams(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("g");
+    }
+
+    [Theory]
+    [InlineData("hähnchen", 500)]
+    [InlineData("rindfleisch", 500)]
+    [InlineData("hackfleisch", 500)]
+    [InlineData("lachs", 500)]
+    [InlineData("fisch", 500)]
+    public void Resolve_GermanMeatFish_Returns500Grams(string item, decimal amount)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be("g");
+    }
+
+    [Theory]
+    [InlineData("zwiebel", 1, "pc")]
+    [InlineData("kartoffel", 1, "pc")]
+    [InlineData("tomate", 1, "pc")]
+    [InlineData("karotte", 1, "pc")]
+    [InlineData("knoblauch", 1, "pc")]
+    public void Resolve_GermanVegetable_Returns1Piece(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData("mehl", 1, "kg")]
+    [InlineData("zucker", 1, "kg")]
+    [InlineData("reis", 1, "kg")]
+    [InlineData("nudeln", 500, "g")]
+    public void Resolve_GermanStaples_ReturnsCorrectAmount(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
+    }
+
+    [Theory]
+    [InlineData("onions", 1, "pc")]
+    [InlineData("potatoes", 1, "pc")]
+    [InlineData("tomatoes", 1, "pc")]
+    [InlineData("carrots", 1, "pc")]
+    [InlineData("lemons", 1, "pc")]
+    public void Resolve_EnglishPlural_NormalizesToSingular(string item, decimal amount, string unit)
+    {
+        var result = DefaultQuantityResolver.Resolve(item);
+
+        result.Amount.Should().Be(amount);
+        result.Unit.Should().Be(unit);
     }
 
     [Fact]
@@ -133,5 +237,14 @@ public class DefaultQuantityResolverTests
         var qty = new ResolvedQuantity(1, "L");
 
         qty.ToString().Should().Be("1 L");
+    }
+
+    [Fact]
+    public void Resolve_PluralDoesNotBreakDirectMatch()
+    {
+        // "eggs" is a direct match, not a plural normalization
+        var result = DefaultQuantityResolver.Resolve("eggs");
+
+        result.Amount.Should().Be(6);
     }
 }


### PR DESCRIPTION
## Summary
- Add `DefaultQuantityResolver` static service in `Yumney.Shared`
- Category-based defaults: liquids (1L), eggs (6pc), dairy (250g), meat/fish (500g), baking (1kg/pc), vegetables/fruit (1pc)
- Known item lookup (30+ items) with case-insensitive matching
- Category fallback for unknown items when category hint is provided
- 1 piece fallback for completely unknown items
- `ResolvedQuantity` record with `Amount` + `Unit` + `ToString()`

Closes #158

## Test plan
- [x] Liquids resolve to liters (milk, cream, juice, oil)
- [x] Eggs resolve to 6 pieces
- [x] Dairy resolves to 250g (butter, cheese)
- [x] Meat/fish resolves to 500g (chicken, beef, salmon)
- [x] Unknown items fall back to 1 piece
- [x] Unknown items with category hint use category default
- [x] Case-insensitive matching works
- [x] Whitespace trimming works
- [x] Null/empty input returns fallback
- [x] Build passes with `TreatWarningsAsErrors=true` (0 warnings)
- [x] All 121 Shared tests pass (15 new)
- [x] All 64 architecture tests pass