### PR TITLE
feat(shared): add ingredient category system with LLM fallback (US-310)

### DIFF
--- a/src/Yumney.Recipes.Application/Interfaces/IIngredientCategoryService.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IIngredientCategoryService.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+public interface IIngredientCategoryService
+{
+    /// <summary>
+    /// Categorize an ingredient. Uses static lookup first, then LLM for unknown items.
+    /// </summary>
+    /// <param name="itemName">The ingredient or item name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved category (never null — defaults to Other).</returns>
+    Task<IngredientCategory> CategorizeAsync(string itemName, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ExtractionServiceCollectionExtensions
         services.AddScoped<IIngredientRecognitionService, SemanticKernelIngredientRecognitionService>();
         services.AddScoped<IChatService, SemanticKernelChatService>();
         services.AddScoped<IIntentParserService, SemanticKernelIntentParserService>();
+        services.AddScoped<IIngredientCategoryService, SemanticKernelIngredientCategoryService>();
 
         var skOptions = configuration
             .GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
@@ -11,7 +11,8 @@ public sealed partial class SemanticKernelIngredientCategoryService(
     Kernel kernel,
     ILogger<SemanticKernelIngredientCategoryService> logger) : IIngredientCategoryService
 {
-    private const string SystemPrompt = """
+#pragma warning disable SA1303
+    private const string systemPrompt = """
         You are a grocery item categorizer. Given an item name, respond with exactly one of these categories:
         produce, dairy, meat-fish, bakery, frozen, beverages, pantry, household, other
 
@@ -24,6 +25,7 @@ public sealed partial class SemanticKernelIngredientCategoryService(
         "Alufolie" → household
         "Tiefkühlerbsen" → frozen
         """;
+#pragma warning restore SA1303
 
     public async Task<IngredientCategory> CategorizeAsync(string itemName, CancellationToken cancellationToken = default)
     {
@@ -34,7 +36,7 @@ public sealed partial class SemanticKernelIngredientCategoryService(
         try
         {
             var chatHistory = new ChatHistory();
-            chatHistory.AddSystemMessage(SystemPrompt);
+            chatHistory.AddSystemMessage(systemPrompt);
             chatHistory.AddUserMessage(itemName);
 
             var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+
+#pragma warning disable SA1601
+public sealed partial class SemanticKernelIngredientCategoryService(
+    Kernel kernel,
+    ILogger<SemanticKernelIngredientCategoryService> logger) : IIngredientCategoryService
+{
+    private const string SystemPrompt = """
+        You are a grocery item categorizer. Given an item name, respond with exactly one of these categories:
+        produce, dairy, meat-fish, bakery, frozen, beverages, pantry, household, other
+
+        Respond with only the category value, nothing else. No explanation, no punctuation.
+        The item may be in English or German.
+
+        Examples:
+        "tahini" → pantry
+        "Tofu" → produce
+        "Alufolie" → household
+        "Tiefkühlerbsen" → frozen
+        """;
+
+    public async Task<IngredientCategory> CategorizeAsync(string itemName, CancellationToken cancellationToken = default)
+    {
+        var staticResult = IngredientCategoryResolver.Resolve(itemName);
+        if (staticResult is not null)
+            return staticResult;
+
+        try
+        {
+            var chatHistory = new ChatHistory();
+            chatHistory.AddSystemMessage(SystemPrompt);
+            chatHistory.AddUserMessage(itemName);
+
+            var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+            var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+            var response = result.Content?.Trim().ToLowerInvariant() ?? string.Empty;
+
+            return ParseCategory(response, itemName);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogCategorizationFailed(itemName, ex.Message);
+            return IngredientCategory.Other;
+        }
+    }
+
+    private IngredientCategory ParseCategory(string response, string itemName)
+    {
+        try
+        {
+            return IngredientCategory.From(response);
+        }
+        catch
+        {
+            LogUnrecognizedCategory(itemName, response);
+            return IngredientCategory.Other;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "LLM categorization failed for '{ItemName}': {Reason}")]
+    private partial void LogCategorizationFailed(string itemName, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "LLM returned unrecognized category for '{ItemName}': '{Response}'")]
+    private partial void LogUnrecognizedCategory(string itemName, string response);
+}

--- a/src/Yumney.Shared/Common/IngredientCategory.cs
+++ b/src/Yumney.Shared/Common/IngredientCategory.cs
@@ -1,0 +1,46 @@
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+#pragma warning disable SA1311
+public sealed record IngredientCategory : IValueObject<string>
+{
+    public const int MaxLength = 30;
+
+#pragma warning disable SA1202
+    private static readonly string[] allowedValues =
+        ["produce", "dairy", "meat-fish", "bakery", "frozen", "beverages", "pantry", "household", "other"];
+
+    public static readonly IngredientCategory Produce = new("produce");
+    public static readonly IngredientCategory Dairy = new("dairy");
+    public static readonly IngredientCategory MeatFish = new("meat-fish");
+    public static readonly IngredientCategory Bakery = new("bakery");
+    public static readonly IngredientCategory Frozen = new("frozen");
+    public static readonly IngredientCategory Beverages = new("beverages");
+    public static readonly IngredientCategory Pantry = new("pantry");
+    public static readonly IngredientCategory Household = new("household");
+    public static readonly IngredientCategory Other = new("other");
+#pragma warning restore SA1202
+
+    public string Value { get; }
+
+    public int DisplayOrder { get; }
+
+    private IngredientCategory(string value)
+    {
+        Value = Ensure.That(value)
+            .IsNotNullOrWhiteSpace()
+            .HasMaxLength(MaxLength)
+            .IsOneOf(allowedValues)
+            .AndReturn();
+        DisplayOrder = Array.IndexOf(allowedValues, Value);
+    }
+
+    public static IngredientCategory From(string value) => new(value);
+
+    public static IReadOnlyList<IngredientCategory> All { get; } =
+        [Produce, Dairy, MeatFish, Bakery, Frozen, Beverages, Pantry, Household, Other];
+
+    public static implicit operator string(IngredientCategory obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Shared/Common/IngredientCategoryResolver.cs
+++ b/src/Yumney.Shared/Common/IngredientCategoryResolver.cs
@@ -1,0 +1,125 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Resolves ingredient categories from known item names (EN + DE).
+/// Returns null for unknown items — callers should fall back to LLM or default to Other.
+/// </summary>
+public static class IngredientCategoryResolver
+{
+#pragma warning disable SA1311
+    private static readonly Dictionary<string, IngredientCategory> itemCategories = BuildItemCategories();
+#pragma warning restore SA1311
+
+    /// <summary>
+    /// Try to resolve the category for an item by name.
+    /// </summary>
+    /// <param name="itemName">The item name (EN or DE).</param>
+    /// <returns>The category if known, or null if the item is not recognized.</returns>
+    public static IngredientCategory? Resolve(string itemName)
+    {
+        if (string.IsNullOrWhiteSpace(itemName))
+            return null;
+
+        var normalized = itemName.Trim().ToLowerInvariant();
+
+        if (itemCategories.TryGetValue(normalized, out var category))
+            return category;
+
+        // Basic English plural normalization
+        if (normalized.Length > 3 && normalized.EndsWith('s') && !normalized.EndsWith("ss", StringComparison.Ordinal))
+        {
+            var singular = normalized[..^1];
+            if (itemCategories.TryGetValue(singular, out var singularCategory))
+                return singularCategory;
+        }
+
+        return null;
+    }
+
+#pragma warning disable SA1117
+    private static Dictionary<string, IngredientCategory> BuildItemCategories()
+    {
+        var map = new Dictionary<string, IngredientCategory>(StringComparer.OrdinalIgnoreCase);
+
+        Add(map, IngredientCategory.Produce,
+            "onion", "zwiebel", "garlic", "knoblauch",
+            "potato", "kartoffel", "tomato", "tomate",
+            "carrot", "karotte", "moehre", "möhre",
+            "cucumber", "gurke", "lettuce", "salat",
+            "pepper", "paprika", "zucchini", "broccoli", "brokkoli",
+            "spinach", "spinat", "mushroom", "pilz", "champignon",
+            "celery", "sellerie", "leek", "lauch",
+            "lemon", "zitrone", "lime", "limette",
+            "apple", "apfel", "banana", "banane",
+            "orange", "grape", "traube", "berry", "beere",
+            "avocado", "ginger", "ingwer", "herbs", "kräuter");
+
+        Add(map, IngredientCategory.Dairy,
+            "milk", "milch", "cream", "sahne", "schlagsahne",
+            "butter", "cheese", "käse", "kaese",
+            "yogurt", "joghurt", "sour cream", "schmand", "saure sahne",
+            "quark", "cottage cheese", "mozzarella", "parmesan",
+            "egg", "eggs", "ei", "eier");
+
+        Add(map, IngredientCategory.MeatFish,
+            "chicken", "hähnchen", "haehnchen", "huhn",
+            "beef", "rindfleisch", "rind",
+            "pork", "schweinefleisch", "schwein",
+            "ground beef", "hackfleisch", "gehacktes",
+            "salmon", "lachs", "fish", "fisch",
+            "shrimp", "garnelen", "garnele",
+            "tuna", "thunfisch", "sausage", "wurst", "bratwurst",
+            "bacon", "speck", "ham", "schinken",
+            "turkey", "truthahn", "pute", "lamb", "lamm");
+
+        Add(map, IngredientCategory.Bakery,
+            "bread", "brot", "rolls", "brötchen", "broetchen",
+            "baguette", "croissant", "toast", "pretzel", "brezel");
+
+        Add(map, IngredientCategory.Frozen,
+            "ice cream", "eis", "frozen pizza", "tiefkühlpizza",
+            "frozen vegetables", "tiefkühlgemüse",
+            "fish sticks", "fischstäbchen", "fischstaebchen");
+
+        Add(map, IngredientCategory.Beverages,
+            "juice", "saft", "water", "wasser",
+            "beer", "bier", "wine", "wein",
+            "coffee", "kaffee", "tea", "tee",
+            "soda", "limonade", "limo");
+
+        Add(map, IngredientCategory.Pantry,
+            "flour", "mehl", "sugar", "zucker",
+            "rice", "reis", "pasta", "nudeln",
+            "oil", "öl", "oel", "olive oil", "olivenöl", "olivenoel",
+            "vegetable oil", "pflanzenöl", "pflanzenoel",
+            "salt", "salz", "pepper", "pfeffer",
+            "baking powder", "backpulver", "yeast", "hefe",
+            "vinegar", "essig", "soy sauce", "sojasoße", "sojasauce",
+            "honey", "honig", "mustard", "senf",
+            "ketchup", "mayonnaise", "mayo",
+            "canned tomatoes", "dosentomaten", "tomato paste", "tomatenmark",
+            "broth", "brühe", "bruehe", "stock", "fond",
+            "nuts", "nüsse", "nuesse", "almonds", "mandeln",
+            "chocolate", "schokolade", "cocoa", "kakao",
+            "oats", "haferflocken", "cornstarch", "speisestärke");
+
+        Add(map, IngredientCategory.Household,
+            "toilet paper", "toilettenpapier",
+            "dish soap", "spülmittel", "spuelmittel",
+            "paper towels", "küchentücher", "kuechentuecher",
+            "trash bags", "müllbeutel", "muellbeutel",
+            "sponge", "schwamm", "aluminum foil", "alufolie",
+            "plastic wrap", "frischhaltefolie",
+            "laundry detergent", "waschmittel",
+            "hand soap", "handseife");
+
+        return map;
+    }
+#pragma warning restore SA1117
+
+    private static void Add(Dictionary<string, IngredientCategory> dict, IngredientCategory category, params string[] names)
+    {
+        foreach (var name in names)
+            dict.TryAdd(name, category);
+    }
+}

--- a/tests/Yumney.Shared.Tests/Common/IngredientCategoryResolverTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/IngredientCategoryResolverTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class IngredientCategoryResolverTests
+{
+    [Theory]
+    [InlineData("onion", "produce")]
+    [InlineData("tomato", "produce")]
+    [InlineData("apple", "produce")]
+    [InlineData("spinach", "produce")]
+    public void Resolve_EnglishProduce_ReturnsProduce(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("zwiebel", "produce")]
+    [InlineData("kartoffel", "produce")]
+    [InlineData("knoblauch", "produce")]
+    public void Resolve_GermanProduce_ReturnsProduce(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("milk", "dairy")]
+    [InlineData("cheese", "dairy")]
+    [InlineData("egg", "dairy")]
+    [InlineData("milch", "dairy")]
+    [InlineData("käse", "dairy")]
+    [InlineData("eier", "dairy")]
+    public void Resolve_Dairy_ReturnsDairy(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("chicken", "meat-fish")]
+    [InlineData("salmon", "meat-fish")]
+    [InlineData("hähnchen", "meat-fish")]
+    [InlineData("lachs", "meat-fish")]
+    [InlineData("hackfleisch", "meat-fish")]
+    public void Resolve_MeatFish_ReturnsMeatFish(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("bread", "bakery")]
+    [InlineData("brot", "bakery")]
+    [InlineData("croissant", "bakery")]
+    public void Resolve_Bakery_ReturnsBakery(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("juice", "beverages")]
+    [InlineData("coffee", "beverages")]
+    [InlineData("kaffee", "beverages")]
+    [InlineData("bier", "beverages")]
+    public void Resolve_Beverages_ReturnsBeverages(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("flour", "pantry")]
+    [InlineData("rice", "pantry")]
+    [InlineData("pasta", "pantry")]
+    [InlineData("mehl", "pantry")]
+    [InlineData("reis", "pantry")]
+    [InlineData("nudeln", "pantry")]
+    public void Resolve_Pantry_ReturnsPantry(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("toilet paper", "household")]
+    [InlineData("dish soap", "household")]
+    [InlineData("toilettenpapier", "household")]
+    [InlineData("spülmittel", "household")]
+    public void Resolve_Household_ReturnsHousehold(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ice cream", "frozen")]
+    [InlineData("fish sticks", "frozen")]
+    public void Resolve_Frozen_ReturnsFrozen(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("onions", "produce")]
+    [InlineData("carrots", "produce")]
+    [InlineData("lemons", "produce")]
+    public void Resolve_EnglishPlural_NormalizesToSingular(string item, string expected)
+    {
+        var result = IngredientCategoryResolver.Resolve(item);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_UnknownItem_ReturnsNull()
+    {
+        var result = IngredientCategoryResolver.Resolve("tahini");
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_EmptyInput_ReturnsNull(string? item)
+    {
+        var result = IngredientCategoryResolver.Resolve(item!);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_CaseInsensitive_MatchesItem()
+    {
+        var result = IngredientCategoryResolver.Resolve("MILK");
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be("dairy");
+    }
+
+    [Fact]
+    public void Resolve_TrimmedInput_MatchesItem()
+    {
+        var result = IngredientCategoryResolver.Resolve("  chicken  ");
+
+        result.Should().NotBeNull();
+        result!.Value.Should().Be("meat-fish");
+    }
+}

--- a/tests/Yumney.Shared.Tests/Common/IngredientCategoryTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/IngredientCategoryTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class IngredientCategoryTests
+{
+    [Theory]
+    [InlineData("produce")]
+    [InlineData("dairy")]
+    [InlineData("meat-fish")]
+    [InlineData("bakery")]
+    [InlineData("frozen")]
+    [InlineData("beverages")]
+    [InlineData("pantry")]
+    [InlineData("household")]
+    [InlineData("other")]
+    public void From_ValidValue_CreatesInstance(string value)
+    {
+        var category = IngredientCategory.From(value);
+
+        category.Value.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("Produce")]
+    [InlineData("DAIRY")]
+    [InlineData("invalid")]
+    public void From_InvalidValue_ThrowsGuardException(string value)
+    {
+        var act = () => IngredientCategory.From(value);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void All_Contains9Categories()
+    {
+        IngredientCategory.All.Should().HaveCount(9);
+    }
+
+    [Fact]
+    public void DisplayOrder_ProduceIsFirst()
+    {
+        IngredientCategory.Produce.DisplayOrder.Should().Be(0);
+    }
+
+    [Fact]
+    public void DisplayOrder_OtherIsLast()
+    {
+        IngredientCategory.Other.DisplayOrder.Should().Be(8);
+    }
+
+    [Fact]
+    public void DisplayOrder_IsConsecutive()
+    {
+        for (var i = 0; i < IngredientCategory.All.Count; i++)
+        {
+            IngredientCategory.All[i].DisplayOrder.Should().Be(i);
+        }
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var c1 = IngredientCategory.From("dairy");
+        var c2 = IngredientCategory.From("dairy");
+
+        c1.Should().Be(c2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IngredientCategory` value object with 9 predefined categories and display ordering
- Add `IngredientCategoryResolver` with 100+ known item-to-category mappings (EN + DE) and plural normalization
- Add `IIngredientCategoryService` interface with `SemanticKernelIngredientCategoryService` implementation — static lookup first, LLM fallback for unknown items, defaults to Other on failure
- Categories: Produce, Dairy, Meat & Fish, Bakery, Frozen, Beverages, Pantry & Dry Goods, Household, Other

Closes #159

## Test plan
- [x] All 9 category values create valid instances
- [x] Invalid/uppercase values throw GuardException
- [x] DisplayOrder is consecutive (0-8), Produce first, Other last
- [x] EN items resolve correctly across all categories
- [x] DE items resolve correctly across all categories
- [x] English plurals normalize to singular
- [x] Unknown items return null (caller decides fallback)
- [x] Case-insensitive and whitespace-trimmed matching
- [x] All 217 Shared tests pass (63 new)
- [x] All 64 architecture tests pass