### PR TITLE
feat(shopping): add ShoppingLedger aggregate with transaction model (US-311)

### DIFF
--- a/src/Yumney.Shopping.Domain/ShoppingLedger/IShoppingLedgerRepository.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/IShoppingLedgerRepository.cs
@@ -1,0 +1,15 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public interface IShoppingLedgerRepository
+{
+    Task<ShoppingLedger?> FindByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
+
+    // Tracked fetch for update flows. Throws EntityNotFoundException if not found.
+    Task<ShoppingLedger> GetByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
+
+    Task AddAsync(ShoppingLedger ledger, CancellationToken cancellationToken = default);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ItemBalance.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ItemBalance.cs
@@ -1,0 +1,6 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed record ItemBalance(string ItemName, decimal OnList, decimal Bought, decimal Consumed, decimal AtHome)
+{
+    public decimal Remaining => OnList - Bought;
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerAction.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerAction.cs
@@ -1,11 +1,25 @@
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 
+/// <summary>
+/// Actions that can occur on a shopping ledger item.
+/// </summary>
 public enum LedgerAction
 {
+    /// <summary>Item added to shopping list.</summary>
     Added,
+
+    /// <summary>Item marked as bought/purchased.</summary>
     Bought,
+
+    /// <summary>Item consumed (used in cooking).</summary>
     Consumed,
+
+    /// <summary>Item removed from tracking.</summary>
     Removed,
+
+    /// <summary>Item quantity adjusted.</summary>
     Adjusted,
+
+    /// <summary>Previous transaction rolled back.</summary>
     RolledBack,
 }

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerAction.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerAction.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public enum LedgerAction
+{
+    Added,
+    Bought,
+    Consumed,
+    Removed,
+    Adjusted,
+    RolledBack,
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerTransaction.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerTransaction.cs
@@ -1,0 +1,42 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed class LedgerTransaction : Entity<LedgerTransactionIdentifier>
+{
+    public ItemName ItemName { get; private set; } = default!;
+
+    public LedgerAction Action { get; private set; }
+
+    public decimal Quantity { get; private set; }
+
+    public string? Unit { get; private set; }
+
+    public TransactionSource Source { get; private set; } = default!;
+
+    public DateTime OccurredAt { get; private set; }
+
+    private LedgerTransaction()
+    {
+    }
+
+    internal static LedgerTransaction Create(
+        ItemName itemName,
+        LedgerAction action,
+        decimal quantity,
+        string? unit,
+        TransactionSource source)
+    {
+        return new LedgerTransaction
+        {
+            Id = LedgerTransactionIdentifier.New(),
+            ItemName = itemName,
+            Action = action,
+            Quantity = quantity,
+            Unit = unit,
+            Source = source,
+            OccurredAt = DateTime.UtcNow,
+        };
+    }
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerTransactionIdentifier.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/LedgerTransactionIdentifier.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed record LedgerTransactionIdentifier : IValueObject
+{
+    public Guid Value { get; }
+
+    private LedgerTransactionIdentifier(Guid value)
+    {
+        Value = Ensure.That(value).IsNotEmpty().AndReturn();
+    }
+
+    public static LedgerTransactionIdentifier New() => new(Guid.CreateVersion7());
+
+    public static LedgerTransactionIdentifier From(Guid value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -1,0 +1,132 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed class ShoppingLedger : AggregateRoot<ShoppingLedgerIdentifier>
+{
+    private readonly List<LedgerTransaction> transactions = [];
+
+    public OwnerIdentifier Owner { get; private set; } = default!;
+
+    public IReadOnlyList<LedgerTransaction> Transactions => transactions.AsReadOnly();
+
+    private ShoppingLedger()
+    {
+    }
+
+    public static ShoppingLedger Create(OwnerIdentifier owner)
+    {
+        return new ShoppingLedger
+        {
+            Id = ShoppingLedgerIdentifier.New(),
+            Owner = owner,
+        };
+    }
+
+    public LedgerTransaction AddItem(ItemName itemName, decimal quantity, string? unit, TransactionSource source)
+    {
+        var transaction = LedgerTransaction.Create(itemName, LedgerAction.Added, quantity, unit, source);
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public LedgerTransaction MarkBought(ItemName itemName, decimal quantity, string? unit)
+    {
+        var transaction = LedgerTransaction.Create(itemName, LedgerAction.Bought, quantity, unit, TransactionSource.Manual);
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public LedgerTransaction MarkConsumed(ItemName itemName, decimal quantity, string? unit, TransactionSource source)
+    {
+        var transaction = LedgerTransaction.Create(itemName, LedgerAction.Consumed, quantity, unit, source);
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public LedgerTransaction RemoveItem(ItemName itemName, decimal quantity, string? unit, string? reason = null)
+    {
+        var source = reason is not null ? TransactionSource.From($"removed:{reason}") : TransactionSource.Manual;
+        var transaction = LedgerTransaction.Create(itemName, LedgerAction.Removed, quantity, unit, source);
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public LedgerTransaction AdjustQuantity(ItemName itemName, decimal newQuantity, string? unit)
+    {
+        var transaction = LedgerTransaction.Create(itemName, LedgerAction.Adjusted, newQuantity, unit, TransactionSource.Manual);
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public LedgerTransaction Rollback(LedgerTransactionIdentifier transactionId)
+    {
+        var original = transactions.FirstOrDefault(t => t.Id == transactionId)
+            ?? throw new EntityNotFoundException(nameof(LedgerTransaction), transactionId.Value);
+
+        var transaction = LedgerTransaction.Create(
+            original.ItemName,
+            LedgerAction.RolledBack,
+            original.Quantity,
+            original.Unit,
+            TransactionSource.From($"rollback:{transactionId.Value}"));
+        transactions.Add(transaction);
+        return transaction;
+    }
+
+    public IReadOnlyList<ItemBalance> CalculateBalance()
+    {
+        var balances = new Dictionary<string, (decimal OnList, decimal Bought, decimal Consumed, decimal Removed)>(
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tx in transactions)
+        {
+            var key = tx.ItemName.Value;
+            if (!balances.ContainsKey(key))
+                balances[key] = (0, 0, 0, 0);
+
+            var current = balances[key];
+            balances[key] = tx.Action switch
+            {
+                LedgerAction.Added => (current.OnList + tx.Quantity, current.Bought, current.Consumed, current.Removed),
+                LedgerAction.Bought => (current.OnList, current.Bought + tx.Quantity, current.Consumed, current.Removed),
+                LedgerAction.Consumed => (current.OnList, current.Bought, current.Consumed + tx.Quantity, current.Removed),
+                LedgerAction.Removed => (current.OnList, current.Bought, current.Consumed, current.Removed + tx.Quantity),
+                LedgerAction.Adjusted => (tx.Quantity, current.Bought, current.Consumed, current.Removed),
+                LedgerAction.RolledBack => ReverseTransaction(current, tx, key),
+                _ => current,
+            };
+        }
+
+        return balances.Select(kvp =>
+        {
+            var (onList, bought, consumed, removed) = kvp.Value;
+            var atHome = bought - consumed - removed;
+            return new ItemBalance(kvp.Key, onList, bought, consumed, Math.Max(0, atHome));
+        }).ToList();
+    }
+
+    private (decimal OnList, decimal Bought, decimal Consumed, decimal Removed) ReverseTransaction(
+        (decimal OnList, decimal Bought, decimal Consumed, decimal Removed) current,
+        LedgerTransaction rollbackTx,
+        string key)
+    {
+        var originalId = rollbackTx.Source.Value.Replace("rollback:", string.Empty);
+        if (!Guid.TryParse(originalId, out var guid))
+            return current;
+
+        var original = transactions.FirstOrDefault(t => t.Id == LedgerTransactionIdentifier.From(guid));
+        if (original is null)
+            return current;
+
+        return original.Action switch
+        {
+            LedgerAction.Added => (current.OnList - rollbackTx.Quantity, current.Bought, current.Consumed, current.Removed),
+            LedgerAction.Bought => (current.OnList, current.Bought - rollbackTx.Quantity, current.Consumed, current.Removed),
+            LedgerAction.Consumed => (current.OnList, current.Bought, current.Consumed - rollbackTx.Quantity, current.Removed),
+            LedgerAction.Removed => (current.OnList, current.Bought, current.Consumed, current.Removed - rollbackTx.Quantity),
+            _ => current,
+        };
+    }
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedgerIdentifier.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedgerIdentifier.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed record ShoppingLedgerIdentifier : IValueObject
+{
+    public Guid Value { get; }
+
+    private ShoppingLedgerIdentifier(Guid value)
+    {
+        Value = Ensure.That(value).IsNotEmpty().AndReturn();
+    }
+
+    public static ShoppingLedgerIdentifier New() => new(Guid.CreateVersion7());
+
+    public static ShoppingLedgerIdentifier From(Guid value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/TransactionSource.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/TransactionSource.cs
@@ -1,0 +1,32 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+public sealed record TransactionSource : IValueObject<string>
+{
+    public const int MaxLength = 500;
+    public const string ManualValue = "manual";
+
+    public static readonly TransactionSource Manual = new(ManualValue);
+
+    public string Value { get; }
+
+    private TransactionSource(string value)
+    {
+        Value = value;
+    }
+
+    public static TransactionSource FromRecipe(Guid recipeIdentifier, string? mealSlot = null)
+    {
+        var source = $"recipe:{recipeIdentifier}";
+        if (mealSlot is not null)
+            source += $"|slot:{mealSlot}";
+        return new TransactionSource(source);
+    }
+
+    public static TransactionSource From(string value) => new(value);
+
+    public bool IsManual => Value == ManualValue;
+
+    public static implicit operator string(TransactionSource obj) => obj.Value;
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerConfiguration.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingLedgerConfiguration : IEntityTypeConfiguration<ShoppingLedger>
+{
+    public void Configure(EntityTypeBuilder<ShoppingLedger> entity)
+    {
+        entity.ToTable("ShoppingLedgers");
+        entity.HasKey(e => e.Id);
+        entity.Property(e => e.Id)
+            .HasConversion<ShoppingLedgerIdentifierConverter>();
+
+        entity.Property(e => e.Owner)
+            .HasConversion<ShoppingOwnerIdentifierConverter>()
+            .HasMaxLength(255)
+            .IsRequired();
+
+        entity.OwnsMany(e => e.Transactions, tx =>
+        {
+            tx.ToTable("LedgerTransactions");
+            tx.WithOwner().HasForeignKey("ShoppingLedgerId");
+
+            tx.Property(t => t.Id)
+                .HasConversion<LedgerTransactionIdentifierConverter>();
+
+            tx.Property(t => t.ItemName)
+                .HasConversion<ItemNameConverter>()
+                .HasMaxLength(200)
+                .IsRequired();
+
+            tx.Property(t => t.Action)
+                .HasConversion<string>()
+                .HasMaxLength(20)
+                .IsRequired();
+
+            tx.Property(t => t.Quantity).IsRequired();
+
+            tx.Property(t => t.Unit).HasMaxLength(20);
+
+            tx.Property(t => t.Source)
+                .HasConversion<TransactionSourceConverter>()
+                .HasMaxLength(500)
+                .IsRequired();
+
+            tx.Property(t => t.OccurredAt).IsRequired();
+
+            tx.HasIndex(t => t.OccurredAt);
+        });
+
+        entity.HasIndex(e => e.Owner).IsUnique();
+        entity.Ignore(e => e.DomainEvents);
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/LedgerTransactionIdentifierConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/LedgerTransactionIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class LedgerTransactionIdentifierConverter()
+    : ValueConverter<LedgerTransactionIdentifier, Guid>(v => v.Value, v => LedgerTransactionIdentifier.From(v));

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingLedgerIdentifierConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingLedgerIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingLedgerIdentifierConverter()
+    : ValueConverter<ShoppingLedgerIdentifier, Guid>(v => v.Value, v => ShoppingLedgerIdentifier.From(v));

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/TransactionSourceConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/TransactionSourceConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class TransactionSourceConverter()
+    : ValueConverter<TransactionSource, string>(v => v.Value, v => TransactionSource.From(v));

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260410145134_AddShoppingLedger.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260410145134_AddShoppingLedger.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410145134_AddShoppingLedger")]
+    partial class AddShoppingLedger
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260410145134_AddShoppingLedger.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260410145134_AddShoppingLedger.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingLedger : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingLedgers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Owner = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingLedgers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LedgerTransactions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ShoppingLedgerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ItemName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Action = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Quantity = table.Column<decimal>(type: "numeric", nullable: false),
+                    Unit = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    Source = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LedgerTransactions", x => new { x.ShoppingLedgerId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_LedgerTransactions_ShoppingLedgers_ShoppingLedgerId",
+                        column: x => x.ShoppingLedgerId,
+                        principalTable: "ShoppingLedgers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LedgerTransactions_OccurredAt",
+                table: "LedgerTransactions",
+                column: "OccurredAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingLedgers_Owner",
+                table: "ShoppingLedgers",
+                column: "Owner",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LedgerTransactions");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingLedgers");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -6,6 +7,8 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 public sealed class ShoppingDbContext(DbContextOptions<ShoppingDbContext> options) : DbContext(options)
 {
     public DbSet<ShoppingList> ShoppingLists => Set<ShoppingList>();
+
+    public DbSet<ShoppingLedger> ShoppingLedgers => Set<ShoppingLedger>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingLedgerRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingLedgerRepository.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+
+public sealed class ShoppingLedgerRepository(ShoppingDbContext context) : IShoppingLedgerRepository
+{
+#pragma warning disable SA1311
+    private readonly DbSet<ShoppingLedger> ledgers = context.ShoppingLedgers;
+#pragma warning restore SA1311
+
+    public async Task<ShoppingLedger?> FindByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
+    {
+        return await ledgers
+            .AsNoTracking()
+            .Include(l => l.Transactions)
+            .FirstOrDefaultAsync(l => l.Owner == owner, cancellationToken);
+    }
+
+    public async Task<ShoppingLedger> GetByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
+    {
+        return await ledgers
+            .Include(l => l.Transactions)
+            .FirstOrDefaultAsync(l => l.Owner == owner, cancellationToken)
+            ?? throw new EntityNotFoundException(nameof(ShoppingLedger), owner.Value);
+    }
+
+    public async Task AddAsync(ShoppingLedger ledger, CancellationToken cancellationToken = default)
+    {
+        await ledgers.AddAsync(ledger, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
@@ -25,6 +26,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
         });
 
         services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+        services.AddScoped<IShoppingLedgerRepository, ShoppingLedgerRepository>();
         services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
         return services;

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -1,0 +1,243 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingLedger;
+
+public class ShoppingLedgerTests
+{
+    private static readonly OwnerIdentifier TestOwner = OwnerIdentifier.From("user-123");
+
+    [Fact]
+    public void Create_ValidOwner_ReturnsEmptyLedger()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+
+        ledger.Owner.Should().Be(TestOwner);
+        ledger.Transactions.Should().BeEmpty();
+        ledger.Id.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddItem_RecordsTransaction()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+
+        var tx = ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        ledger.Transactions.Should().HaveCount(1);
+        tx.Action.Should().Be(LedgerAction.Added);
+        tx.ItemName.Value.Should().Be("Milk");
+        tx.Quantity.Should().Be(1);
+        tx.Unit.Should().Be("L");
+        tx.Source.IsManual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddItem_FromRecipe_TracksSource()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var recipeId = Guid.NewGuid();
+        var source = TransactionSource.FromRecipe(recipeId, "monday-dinner");
+
+        var tx = ledger.AddItem(ItemName.From("Chicken"), 500, "g", source);
+
+        tx.Source.Value.Should().Contain(recipeId.ToString());
+        tx.Source.Value.Should().Contain("monday-dinner");
+        tx.Source.IsManual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MarkBought_RecordsTransaction()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+
+        var tx = ledger.MarkBought(ItemName.From("Milk"), 2, "L");
+
+        tx.Action.Should().Be(LedgerAction.Bought);
+        ledger.Transactions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void MarkConsumed_RecordsTransaction()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var source = TransactionSource.FromRecipe(Guid.NewGuid());
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", source);
+        ledger.MarkBought(ItemName.From("Milk"), 2, "L");
+
+        var tx = ledger.MarkConsumed(ItemName.From("Milk"), 1, "L", source);
+
+        tx.Action.Should().Be(LedgerAction.Consumed);
+    }
+
+    [Fact]
+    public void RemoveItem_RecordsTransactionWithReason()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        var tx = ledger.RemoveItem(ItemName.From("Milk"), 1, "L", "spoiled");
+
+        tx.Action.Should().Be(LedgerAction.Removed);
+        tx.Source.Value.Should().Contain("spoiled");
+    }
+
+    [Fact]
+    public void AdjustQuantity_RecordsTransaction()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        var tx = ledger.AdjustQuantity(ItemName.From("Milk"), 3, "L");
+
+        tx.Action.Should().Be(LedgerAction.Adjusted);
+        tx.Quantity.Should().Be(3);
+    }
+
+    [Fact]
+    public void Rollback_ExistingTransaction_RecordsRollback()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var addTx = ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        var rollbackTx = ledger.Rollback(addTx.Id);
+
+        rollbackTx.Action.Should().Be(LedgerAction.RolledBack);
+        rollbackTx.Source.Value.Should().Contain(addTx.Id.Value.ToString());
+        ledger.Transactions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Rollback_NonExistingTransaction_ThrowsEntityNotFoundException()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+
+        var act = () => ledger.Rollback(LedgerTransactionIdentifier.New());
+
+        act.Should().Throw<EntityNotFoundException>();
+    }
+
+    [Fact]
+    public void CalculateBalance_AddedItem_ShowsOnList()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+
+        var balance = ledger.CalculateBalance();
+
+        balance.Should().HaveCount(1);
+        balance[0].ItemName.Should().Be("Milk");
+        balance[0].OnList.Should().Be(2);
+        balance[0].Bought.Should().Be(0);
+        balance[0].AtHome.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateBalance_BoughtItem_ShowsAtHome()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+        ledger.MarkBought(ItemName.From("Milk"), 2, "L");
+
+        var balance = ledger.CalculateBalance();
+
+        balance[0].Bought.Should().Be(2);
+        balance[0].AtHome.Should().Be(2);
+        balance[0].Remaining.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateBalance_ConsumedItem_ReducesAtHome()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var source = TransactionSource.FromRecipe(Guid.NewGuid());
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", source);
+        ledger.MarkBought(ItemName.From("Milk"), 2, "L");
+        ledger.MarkConsumed(ItemName.From("Milk"), 1, "L", source);
+
+        var balance = ledger.CalculateBalance();
+
+        balance[0].AtHome.Should().Be(1);
+    }
+
+    [Fact]
+    public void CalculateBalance_MultipleAddsOfSameItem_Sums()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.FromRecipe(Guid.NewGuid()));
+
+        var balance = ledger.CalculateBalance();
+
+        balance.Should().HaveCount(1);
+        balance[0].OnList.Should().Be(3);
+    }
+
+    [Fact]
+    public void CalculateBalance_MultipleItems_TrackedSeparately()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("Eggs"), 6, "pc", TransactionSource.Manual);
+
+        var balance = ledger.CalculateBalance();
+
+        balance.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CalculateBalance_AtHomeNeverNegative()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+        ledger.MarkConsumed(ItemName.From("Milk"), 5, "L", TransactionSource.Manual);
+
+        var balance = ledger.CalculateBalance();
+
+        balance[0].AtHome.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateBalance_RollbackReversesPrevious()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var addTx = ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+        ledger.Rollback(addTx.Id);
+
+        var balance = ledger.CalculateBalance();
+
+        balance[0].OnList.Should().Be(0);
+    }
+
+    [Fact]
+    public void TransactionSource_Manual_IsManual()
+    {
+        TransactionSource.Manual.IsManual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TransactionSource_FromRecipe_IsNotManual()
+    {
+        var source = TransactionSource.FromRecipe(Guid.NewGuid());
+
+        source.IsManual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AllTransactions_PreservedInOrder()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+        ledger.MarkBought(ItemName.From("Milk"), 1, "L");
+        ledger.MarkConsumed(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        ledger.Transactions.Should().HaveCount(3);
+        ledger.Transactions[0].Action.Should().Be(LedgerAction.Added);
+        ledger.Transactions[1].Action.Should().Be(LedgerAction.Bought);
+        ledger.Transactions[2].Action.Should().Be(LedgerAction.Consumed);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ShoppingLedger` aggregate — one per user, event-sourced-style transaction log
- `LedgerTransaction` entity tracks: item name, action, quantity, unit, source, timestamp
- 6 actions: Added, Bought, Consumed, Removed, Adjusted, RolledBack
- `TransactionSource` tracks origin: manual or recipe (with optional meal slot)
- `CalculateBalance()` projects on-list, bought, consumed, at-home per item
- `Rollback()` reverses any previous transaction
- EF Core `OwnsMany` in `LedgerTransactions` table with FK cascade
- Unique owner constraint (one ledger per user)

Closes #160

## Test plan
- [x] Create empty ledger with owner
- [x] AddItem records transaction with correct action and source
- [x] Recipe source tracking includes recipe ID and meal slot
- [x] MarkBought, MarkConsumed, RemoveItem record correct actions
- [x] RemoveItem includes reason in source
- [x] AdjustQuantity records adjusted value
- [x] Rollback creates RolledBack transaction referencing original
- [x] Rollback of non-existing transaction throws EntityNotFoundException
- [x] Balance: added items show on-list
- [x] Balance: bought items show at-home
- [x] Balance: consumed items reduce at-home
- [x] Balance: multiple adds of same item sum correctly
- [x] Balance: different items tracked separately
- [x] Balance: at-home never negative
- [x] Balance: rollback reverses previous transaction in projection
- [x] Transactions preserved in order
- [x] All 90 Shopping domain tests pass (19 new)
- [x] All 64 architecture tests pass