### PR TITLE
feat(shopping): add manual item to shopping ledger (US-312)

### DIFF
--- a/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record AddManualItemRequest(string Name, decimal? Quantity = null, string? Unit = null);

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -46,6 +46,12 @@ public static class ShoppingEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapPost("/items", AddManualItemAsync)
+            .WithName("AddManualItem")
+            .WithTags("Shopping")
+            .Produces<AddedItemDto>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         return app;
     }
 
@@ -128,5 +134,21 @@ public static class ShoppingEndpoints
 
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToNoContent();
+    }
+
+    private static async Task<IResult> AddManualItemAsync(
+        AddManualItemRequest request,
+        ICommandHandler<AddManualItemCommand, Result<AddedItemDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Item name is required.");
+
+        var command = new AddManualItemCommand(request.Name.Trim(), request.Quantity, request.Unit);
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.IsSuccess
+            ? Results.Created($"/shopping-lists/items/{result.Value.TransactionIdentifier}", result.Value)
+            : result.ToOk();
     }
 }

--- a/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record AddManualItemCommand(
+    string ItemName,
+    decimal? Quantity,
+    string? Unit) : ICommand<Result<AddedItemDto>>;

--- a/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class AddManualItemCommandHandler(
+    IShoppingLedgerRepository ledgers,
+    ICurrentUser currentUser,
+    ILogger<AddManualItemCommandHandler> logger) : ICommandHandler<AddManualItemCommand, Result<AddedItemDto>>
+{
+    public async Task<Result<AddedItemDto>> HandleAsync(AddManualItemCommand command, CancellationToken cancellationToken = default)
+    {
+        var (itemName, explicitQuantity, explicitUnit) = command;
+        var owner = currentUser.AsOwner();
+
+        LogAddManualItem(owner.Value, itemName);
+
+        var resolved = ResolveQuantity(itemName, explicitQuantity, explicitUnit);
+        var category = IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other;
+
+        var ledger = await ledgers.FindByOwnerAsync(owner, cancellationToken);
+        if (ledger is null)
+        {
+            ledger = ShoppingLedger.Create(owner);
+            var tx = ledger.AddItem(ItemName.From(itemName), resolved.Quantity, resolved.Unit, TransactionSource.Manual);
+            await ledgers.AddAsync(ledger, cancellationToken);
+            return ToDto(itemName, resolved, category, tx);
+        }
+
+        var transaction = ledger.AddItem(ItemName.From(itemName), resolved.Quantity, resolved.Unit, TransactionSource.Manual);
+        await ledgers.SaveChangesAsync(cancellationToken);
+        return ToDto(itemName, resolved, category, transaction);
+    }
+
+    private static Result<AddedItemDto> ToDto(
+        string itemName,
+        (decimal Quantity, string? Unit) resolved,
+        IngredientCategory category,
+        LedgerTransaction tx)
+    {
+        return new AddedItemDto(itemName, resolved.Quantity, resolved.Unit, category.Value, tx.Source.Value, tx.Id.Value);
+    }
+
+    private static (decimal Quantity, string? Unit) ResolveQuantity(string itemName, decimal? explicitQuantity, string? explicitUnit)
+    {
+        if (explicitQuantity.HasValue)
+            return (explicitQuantity.Value, explicitUnit);
+
+        var defaultQty = DefaultQuantityResolver.Resolve(itemName);
+        return (defaultQty.Amount, defaultQty.Unit);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Adding manual item for owner {OwnerId}: {ItemName}")]
+    private partial void LogAddManualItem(string ownerId, string itemName);
+}

--- a/src/Yumney.Shopping.Application/DTOs/AddedItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/AddedItemDto.cs
@@ -1,0 +1,9 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public sealed record AddedItemDto(
+    string ItemName,
+    decimal Quantity,
+    string? Unit,
+    string Category,
+    string Source,
+    Guid TransactionIdentifier);

--- a/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Commands;
+
+public class AddManualItemCommandHandlerTests
+{
+    private readonly IShoppingLedgerRepository ledgers = Substitute.For<IShoppingLedgerRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ILogger<AddManualItemCommandHandler> logger = Substitute.For<ILogger<AddManualItemCommandHandler>>();
+    private readonly AddManualItemCommandHandler handler;
+
+    public AddManualItemCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new AddManualItemCommandHandler(ledgers, currentUser, logger);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithExplicitQuantity_UsesProvidedValues()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Potatoes", 2, "kg");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ItemName.Should().Be("Potatoes");
+        result.Value.Quantity.Should().Be(2);
+        result.Value.Unit.Should().Be("kg");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutQuantity_ResolvesDefault()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Milk", null, null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Quantity.Should().Be(1);
+        result.Value.Unit.Should().Be("L");
+    }
+
+    [Fact]
+    public async Task HandleAsync_KnownItem_ResolvesCategory()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Chicken", 500, "g");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Category.Should().Be("meat-fish");
+    }
+
+    [Fact]
+    public async Task HandleAsync_UnknownItem_CategoryDefaultsToOther()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Toilet Paper", 1, "pc");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Category.Should().Be("household");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoLedgerExists_CreatesNewLedger()
+    {
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((ShoppingLedger?)null);
+
+        var command = new AddManualItemCommand("Salt", null, null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        await ledgers.Received(1).AddAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_LedgerExists_SavesChanges()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Eggs", null, null);
+
+        await handler.HandleAsync(command);
+
+        await ledgers.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        await ledgers.DidNotReceive().AddAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_SourceIsManual()
+    {
+        var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+        ledgers.FindByOwnerAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existingLedger);
+
+        var command = new AddManualItemCommand("Bread", null, null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.Value.Source.Should().Be("manual");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AddManualItemCommand` + handler for adding items to the ShoppingLedger
- Auto-resolves default quantities when not specified (via `DefaultQuantityResolver`)
- Auto-categorizes items via `IngredientCategoryResolver` (static lookup, Other fallback)
- Creates ledger on first use (lazy initialization per user)
- Source tracked as "manual" in all transactions
- Endpoint: `POST /api/v1/shopping-lists/items` with `{ name, quantity?, unit? }`
- Returns `AddedItemDto` with resolved quantity, category, source, and transaction ID

Closes #161

## Test plan
- [x] Explicit quantity used when provided
- [x] Default quantity resolved for known items (milk → 1L)
- [x] Known items categorized correctly (chicken → meat-fish)
- [x] Household items categorized correctly (toilet paper → household)
- [x] New ledger created when none exists
- [x] Existing ledger reused with SaveChanges
- [x] Source is always "manual"
- [x] All 41 Shopping application tests pass (7 new)
- [x] All 64 architecture tests pass