### PR TITLE
feat(shopping): add merged shopping list projection with sources (US-313)

### DIFF
--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -52,6 +52,11 @@ public static class ShoppingEndpoints
             .Produces<AddedItemDto>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
+        group.MapGet("/merged", GetMergedAsync)
+            .WithName("GetMergedShoppingList")
+            .WithTags("Shopping")
+            .Produces<MergedShoppingListDto>();
+
         return app;
     }
 
@@ -150,5 +155,14 @@ public static class ShoppingEndpoints
         return result.IsSuccess
             ? Results.Created($"/shopping-lists/items/{result.Value.TransactionIdentifier}", result.Value)
             : result.ToOk();
+    }
+
+    private static async Task<IResult> GetMergedAsync(
+        IQueryHandler<GetMergedShoppingListQuery, Result<MergedShoppingListDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetMergedShoppingListQuery();
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return result.ToOk();
     }
 }

--- a/src/Yumney.Shopping.Application/DTOs/MergedShoppingItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/MergedShoppingItemDto.cs
@@ -1,0 +1,16 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public sealed record MergedShoppingItemDto(
+    string ItemName,
+    decimal TotalQuantity,
+    string? Unit,
+    string Category,
+    bool IsBought,
+    IReadOnlyList<ItemSourceDto> Sources);
+
+public sealed record ItemSourceDto(
+    decimal Quantity,
+    string Source,
+    DateTime OccurredAt);
+
+public sealed record MergedShoppingListDto(IReadOnlyList<MergedShoppingItemDto> Items);

--- a/src/Yumney.Shopping.Application/Queries/GetMergedShoppingListQuery.cs
+++ b/src/Yumney.Shopping.Application/Queries/GetMergedShoppingListQuery.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries;
+
+public sealed record GetMergedShoppingListQuery : IQuery<Result<MergedShoppingListDto>>;

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
@@ -1,0 +1,33 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+
+public sealed class GetMergedShoppingListQueryHandler(
+    IShoppingLedgerRepository ledgers,
+    ICurrentUser currentUser) : IQueryHandler<GetMergedShoppingListQuery, Result<MergedShoppingListDto>>
+{
+    public async Task<Result<MergedShoppingListDto>> HandleAsync(GetMergedShoppingListQuery query, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+
+        var ledger = await ledgers.FindByOwnerAsync(owner, cancellationToken);
+        if (ledger is null)
+            return new MergedShoppingListDto([]);
+
+        var mergedItems = ledger.GetMergedItems();
+
+        var dtoItems = mergedItems.Select(item =>
+        {
+            var category = IngredientCategoryResolver.Resolve(item.ItemName) ?? IngredientCategory.Other;
+            var sources = item.Sources.Select(s => new ItemSourceDto(s.Quantity, s.Source, s.OccurredAt)).ToList();
+            return new MergedShoppingItemDto(item.ItemName, item.TotalQuantity, item.Unit, category.Value, item.IsBought, sources);
+        })
+        .OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
+        .ToList();
+
+        return new MergedShoppingListDto(dtoItems);
+    }
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/MergedShoppingItem.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/MergedShoppingItem.cs
@@ -1,0 +1,20 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+/// <summary>
+/// A merged view of shopping items — same item + same unit summed into one line
+/// with source breakdown available for expansion.
+/// </summary>
+public sealed record MergedShoppingItem(
+    string ItemName,
+    decimal TotalQuantity,
+    string? Unit,
+    bool IsBought,
+    IReadOnlyList<ItemSource> Sources);
+
+/// <summary>
+/// One contribution to a merged item — who added what amount and when.
+/// </summary>
+public sealed record ItemSource(
+    decimal Quantity,
+    string Source,
+    DateTime OccurredAt);

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -112,6 +112,7 @@ public sealed class ShoppingLedger : AggregateRoot<ShoppingLedgerIdentifier>
     /// summed into one line with source breakdown.
     /// Different units for the same item produce separate lines.
     /// </summary>
+    /// <returns>Merged items grouped by item name and unit.</returns>
     public IReadOnlyList<MergedShoppingItem> GetMergedItems()
     {
         var groups = new Dictionary<string, List<LedgerTransaction>>(StringComparer.OrdinalIgnoreCase);

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -107,6 +107,40 @@ public sealed class ShoppingLedger : AggregateRoot<ShoppingLedgerIdentifier>
         }).ToList();
     }
 
+    /// <summary>
+    /// Project transactions into merged shopping items — same item + same unit
+    /// summed into one line with source breakdown.
+    /// Different units for the same item produce separate lines.
+    /// </summary>
+    public IReadOnlyList<MergedShoppingItem> GetMergedItems()
+    {
+        var groups = new Dictionary<string, List<LedgerTransaction>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tx in transactions.Where(t => t.Action == LedgerAction.Added))
+        {
+            var key = $"{tx.ItemName.Value}|{tx.Unit ?? string.Empty}";
+            if (!groups.ContainsKey(key))
+                groups[key] = [];
+            groups[key].Add(tx);
+        }
+
+        var boughtKeys = transactions
+            .Where(t => t.Action == LedgerAction.Bought)
+            .Select(t => $"{t.ItemName.Value}|{t.Unit ?? string.Empty}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return groups.Select(kvp =>
+        {
+            var txList = kvp.Value;
+            var first = txList[0];
+            var totalQuantity = txList.Sum(t => t.Quantity);
+            var sources = txList.Select(t => new ItemSource(t.Quantity, t.Source.Value, t.OccurredAt)).ToList();
+            var isBought = boughtKeys.Contains(kvp.Key);
+
+            return new MergedShoppingItem(first.ItemName.Value, totalQuantity, first.Unit, isBought, sources);
+        }).ToList();
+    }
+
     private (decimal OnList, decimal Bought, decimal Consumed, decimal Removed) ReverseTransaction(
         (decimal OnList, decimal Bought, decimal Consumed, decimal Removed) current,
         LedgerTransaction rollbackTx,

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/MergedShoppingItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/MergedShoppingItemTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingLedger;
+
+public class MergedShoppingItemTests
+{
+    private static readonly OwnerIdentifier TestOwner = OwnerIdentifier.From("user-123");
+
+    [Fact]
+    public void GetMergedItems_SameItemSameUnit_SumsQuantity()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("Milk"), 1, "L", TransactionSource.FromRecipe(Guid.NewGuid()));
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().HaveCount(1);
+        merged[0].ItemName.Should().Be("Milk");
+        merged[0].TotalQuantity.Should().Be(3);
+        merged[0].Unit.Should().Be("L");
+    }
+
+    [Fact]
+    public void GetMergedItems_SameItemDifferentUnit_SeparateLines()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "cups", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("Milk"), 500, "ml", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetMergedItems_DifferentItems_SeparateLines()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Flour"), 200, "g", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("Sugar"), 300, "g", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetMergedItems_SourcesTracked()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        var recipeSource = TransactionSource.FromRecipe(Guid.NewGuid());
+        ledger.AddItem(ItemName.From("Flour"), 200, "g", recipeSource);
+        ledger.AddItem(ItemName.From("Flour"), 300, "g", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged[0].Sources.Should().HaveCount(2);
+        merged[0].Sources[0].Quantity.Should().Be(200);
+        merged[0].Sources[1].Quantity.Should().Be(300);
+    }
+
+    [Fact]
+    public void GetMergedItems_CaseInsensitiveMerge()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("milk"), 1, "L", TransactionSource.Manual);
+        ledger.AddItem(ItemName.From("MILK"), 1, "L", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().HaveCount(1);
+        merged[0].TotalQuantity.Should().Be(2);
+    }
+
+    [Fact]
+    public void GetMergedItems_BoughtItemMarkedAsBought()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Eggs"), 6, "pc", TransactionSource.Manual);
+        ledger.MarkBought(ItemName.From("Eggs"), 6, "pc");
+
+        var merged = ledger.GetMergedItems();
+
+        merged[0].IsBought.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetMergedItems_UnboughtItemNotMarked()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Eggs"), 6, "pc", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged[0].IsBought.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetMergedItems_EmptyLedger_ReturnsEmpty()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMergedItems_OnlyAddsProjected_NotOtherActions()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(TestOwner);
+        ledger.AddItem(ItemName.From("Milk"), 2, "L", TransactionSource.Manual);
+        ledger.MarkBought(ItemName.From("Milk"), 2, "L");
+        ledger.MarkConsumed(ItemName.From("Milk"), 1, "L", TransactionSource.Manual);
+
+        var merged = ledger.GetMergedItems();
+
+        merged.Should().HaveCount(1);
+        merged[0].TotalQuantity.Should().Be(2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GetMergedItems()` domain method on `ShoppingLedger` — groups Added transactions by item name + unit, sums quantities, tracks source breakdown
- Same item + same unit → one merged line with total quantity
- Same item + different unit → separate lines
- Case-insensitive merging
- Bought status tracked per merged item
- `MergedShoppingItem` + `ItemSource` domain records
- `GetMergedShoppingListQuery` + handler with category resolution and display ordering
- Endpoint: `GET /api/v1/shopping-lists/merged`

Closes #162

## Test plan
- [x] Same item + same unit sums quantity (2L + 1L → 3L)
- [x] Same item + different unit stays separate (cups vs ml)
- [x] Different items stay separate
- [x] Sources tracked per merged item (recipe vs manual)
- [x] Case-insensitive merge (milk + MILK → 2)
- [x] Bought items marked correctly
- [x] Unbought items not marked
- [x] Empty ledger → empty list
- [x] Only Added transactions projected (not Bought/Consumed)
- [x] All 99 Shopping domain tests pass (9 new)
- [x] All 64 architecture tests pass