### PR TITLE
refactor(shopping): polish ES model — fix 8 code review issues (US-311)

### DIFF
--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -149,11 +149,11 @@ public static class ShoppingEndpoints
         if (string.IsNullOrWhiteSpace(request.Name))
             return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Item name is required.");
 
-        var command = new AddManualItemCommand(request.Name.Trim(), request.Quantity, request.Unit);
+        var command = new AddManualItemCommand(ItemName.From(request.Name.Trim()), request.Quantity, request.Unit);
 
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.IsSuccess
-            ? Results.Created($"/shopping-lists/items/{result.Value.TransactionIdentifier}", result.Value)
+            ? Results.Created($"/shopping-lists/items/{result.Value.LedgerIdentifier}", result.Value)
             : result.ToOk();
     }
 

--- a/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
@@ -1,10 +1,11 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
 public sealed record AddManualItemCommand(
-    string ItemName,
+    ItemName ItemName,
     decimal? Quantity,
     string? Unit) : ICommand<Result<AddedItemDto>>;

--- a/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
@@ -3,6 +3,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
 
@@ -15,26 +16,27 @@ public sealed partial class AddManualItemCommandHandler(
     public async Task<Result<AddedItemDto>> HandleAsync(AddManualItemCommand command, CancellationToken cancellationToken = default)
     {
         var (itemName, explicitQuantity, explicitUnit) = command;
+        var name = itemName.Value;
         var ownerId = currentUser.UserId;
 
-        LogAddManualItem(ownerId, itemName);
+        LogAddManualItem(ownerId, name);
 
-        var resolved = ResolveQuantity(itemName, explicitQuantity, explicitUnit);
-        var category = IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other;
+        var resolved = ResolveQuantity(name, explicitQuantity, explicitUnit);
+        var category = IngredientCategoryResolver.Resolve(name) ?? IngredientCategory.Other;
 
         var ledger = await eventStore.LoadAsync(ownerId, cancellationToken)
             ?? ShoppingLedger.Create(ownerId);
 
-        ledger.AddItem(itemName, resolved.Quantity, resolved.Unit, "manual");
+        ledger.AddItem(name, resolved.Quantity, resolved.Unit, ItemSources.Manual);
 
         await eventStore.SaveAsync(ledger, cancellationToken);
 
         return new AddedItemDto(
-            itemName,
+            name,
             resolved.Quantity,
             resolved.Unit,
             category.Value,
-            "manual",
+            ItemSources.Manual,
             ledger.Id);
     }
 

--- a/src/Yumney.Shopping.Application/DTOs/AddedItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/AddedItemDto.cs
@@ -6,4 +6,4 @@ public sealed record AddedItemDto(
     string? Unit,
     string Category,
     string Source,
-    Guid TransactionIdentifier);
+    Guid LedgerIdentifier);

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ItemSources.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ItemSources.cs
@@ -1,0 +1,10 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+/// <summary>
+/// Constants for item source tracking.
+/// </summary>
+public static class ItemSources
+{
+    /// <summary>Gets the source value for manually added items.</summary>
+    public const string Manual = "manual";
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
@@ -87,26 +88,33 @@ public sealed class ShoppingLedger
 
     public void AddItem(string itemName, decimal quantity, string? unit, string source)
     {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
+        Ensure.That(source).IsNotNullOrWhiteSpace();
         RaiseEvent(new ShoppingItemAdded(itemName, quantity, unit, source));
     }
 
     public void MarkBought(string itemName, decimal quantity, string? unit)
     {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
         RaiseEvent(new ShoppingItemBought(itemName, quantity, unit));
     }
 
     public void MarkConsumed(string itemName, decimal quantity, string? unit, string source)
     {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
+        Ensure.That(source).IsNotNullOrWhiteSpace();
         RaiseEvent(new ShoppingItemConsumed(itemName, quantity, unit, source));
     }
 
     public void RemoveItem(string itemName, decimal quantity, string? unit, string? reason = null)
     {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
         RaiseEvent(new ShoppingItemRemoved(itemName, quantity, unit, reason));
     }
 
     public void AdjustQuantity(string itemName, decimal newQuantity, string? unit)
     {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
         RaiseEvent(new ShoppingItemQuantityAdjusted(itemName, newQuantity, unit));
     }
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
@@ -109,7 +109,7 @@ public sealed partial class EfCoreShoppingEventStore(
 
         ledger.MarkCommitted();
 
-        await PublishEventsAsync(uncommitted, cancellationToken);
+        await PublishEventsAsync(ledger.OwnerId, uncommitted, cancellationToken);
 
         LogEventsSaved(ledger.OwnerId, uncommitted.Count, ledger.Version);
     }
@@ -139,20 +139,20 @@ public sealed partial class EfCoreShoppingEventStore(
         }
     }
 
-    private async Task PublishEventsAsync(List<IDomainEvent> events, CancellationToken cancellationToken)
+    private async Task PublishEventsAsync(string ownerId, List<IDomainEvent> events, CancellationToken cancellationToken)
     {
         foreach (var @event in events)
         {
             if (@event is ShoppingItemAdded added)
-                await eventBus.PublishAsync(new ShoppingItemAddedIntegrationEvent(added), cancellationToken);
+                await eventBus.PublishAsync(new ShoppingItemAddedIntegrationEvent(ownerId, added), cancellationToken);
             else if (@event is ShoppingItemBought bought)
-                await eventBus.PublishAsync(new ShoppingItemBoughtIntegrationEvent(bought), cancellationToken);
+                await eventBus.PublishAsync(new ShoppingItemBoughtIntegrationEvent(ownerId, bought), cancellationToken);
             else if (@event is ShoppingItemConsumed consumed)
-                await eventBus.PublishAsync(new ShoppingItemConsumedIntegrationEvent(consumed), cancellationToken);
+                await eventBus.PublishAsync(new ShoppingItemConsumedIntegrationEvent(ownerId, consumed), cancellationToken);
             else if (@event is ShoppingItemRemoved removed)
-                await eventBus.PublishAsync(new ShoppingItemRemovedIntegrationEvent(removed), cancellationToken);
+                await eventBus.PublishAsync(new ShoppingItemRemovedIntegrationEvent(ownerId, removed), cancellationToken);
             else if (@event is ShoppingItemQuantityAdjusted adjusted)
-                await eventBus.PublishAsync(new ShoppingItemQuantityAdjustedIntegrationEvent(adjusted), cancellationToken);
+                await eventBus.PublishAsync(new ShoppingItemQuantityAdjustedIntegrationEvent(ownerId, adjusted), cancellationToken);
         }
     }
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingIntegrationEvents.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingIntegrationEvents.cs
@@ -4,13 +4,12 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 #pragma warning disable SA1649
+public sealed record ShoppingItemAddedIntegrationEvent(string OwnerId, ShoppingItemAdded Inner) : IntegrationEvent;
 
-public sealed record ShoppingItemAddedIntegrationEvent(ShoppingItemAdded Inner) : IntegrationEvent;
+public sealed record ShoppingItemBoughtIntegrationEvent(string OwnerId, ShoppingItemBought Inner) : IntegrationEvent;
 
-public sealed record ShoppingItemBoughtIntegrationEvent(ShoppingItemBought Inner) : IntegrationEvent;
+public sealed record ShoppingItemConsumedIntegrationEvent(string OwnerId, ShoppingItemConsumed Inner) : IntegrationEvent;
 
-public sealed record ShoppingItemConsumedIntegrationEvent(ShoppingItemConsumed Inner) : IntegrationEvent;
+public sealed record ShoppingItemRemovedIntegrationEvent(string OwnerId, ShoppingItemRemoved Inner) : IntegrationEvent;
 
-public sealed record ShoppingItemRemovedIntegrationEvent(ShoppingItemRemoved Inner) : IntegrationEvent;
-
-public sealed record ShoppingItemQuantityAdjustedIntegrationEvent(ShoppingItemQuantityAdjusted Inner) : IntegrationEvent;
+public sealed record ShoppingItemQuantityAdjustedIntegrationEvent(string OwnerId, ShoppingItemQuantityAdjusted Inner) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
@@ -2,12 +2,10 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
-#pragma warning disable SA1204
 /// <summary>
 /// Async projection handler — rebuilds the read model from shopping events.
 /// Subscribes to integration events published by the event store.
@@ -15,16 +13,15 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel
 public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     : IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>,
       IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>,
+      IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>,
       IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>,
       IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>
 {
+    /// <inheritdoc />
     public async Task HandleAsync(ShoppingItemAddedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var ownerId = await ResolveOwnerAsync(inner.Source, cancellationToken);
-        if (ownerId is null) return;
-
-        var readItem = await FindOrCreateAsync(ownerId, inner.ItemName, inner.Unit, cancellationToken);
+        var readItem = await FindOrCreateAsync(@event.OwnerId, inner.ItemName, inner.Unit, cancellationToken);
         readItem.TotalQuantity += inner.Quantity;
         readItem.LastUpdated = DateTime.UtcNow;
 
@@ -33,13 +30,11 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
         await context.SaveChangesAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task HandleAsync(ShoppingItemBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var ownerId = await ResolveOwnerFromRecentEventsAsync(inner.ItemName, cancellationToken);
-        if (ownerId is null) return;
-
-        var readItem = await FindAsync(ownerId, inner.ItemName, inner.Unit, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit, cancellationToken);
         if (readItem is null) return;
 
         readItem.IsBought = true;
@@ -48,13 +43,22 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
         await context.SaveChangesAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task HandleAsync(ShoppingItemConsumedIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        var inner = @event.Inner;
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit, cancellationToken);
+        if (readItem is null) return;
+
+        readItem.LastUpdated = DateTime.UtcNow;
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task HandleAsync(ShoppingItemRemovedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var ownerId = await ResolveOwnerFromRecentEventsAsync(inner.ItemName, cancellationToken);
-        if (ownerId is null) return;
-
-        var readItem = await FindAsync(ownerId, inner.ItemName, inner.Unit, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit, cancellationToken);
         if (readItem is null) return;
 
         readItem.TotalQuantity = Math.Max(0, readItem.TotalQuantity - inner.Quantity);
@@ -66,13 +70,11 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
         await context.SaveChangesAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task HandleAsync(ShoppingItemQuantityAdjustedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var ownerId = await ResolveOwnerFromRecentEventsAsync(inner.ItemName, cancellationToken);
-        if (ownerId is null) return;
-
-        var readItem = await FindAsync(ownerId, inner.ItemName, inner.Unit, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit, cancellationToken);
         if (readItem is null) return;
 
         readItem.TotalQuantity = inner.NewQuantity;
@@ -111,22 +113,7 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
                 cancellationToken);
     }
 
-    private async Task<string?> ResolveOwnerAsync(string source, CancellationToken cancellationToken)
-    {
-        // For now, resolve from the most recent aggregate metadata
-        return await ResolveOwnerFromRecentEventsAsync(string.Empty, cancellationToken);
-    }
-
-    private async Task<string?> ResolveOwnerFromRecentEventsAsync(string itemName, CancellationToken cancellationToken)
-    {
-        var metadata = await context.Set<AggregateMetadata>()
-            .AsNoTracking()
-            .OrderByDescending(m => m.AggregateId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return metadata?.OwnerId;
-    }
-
+#pragma warning disable SA1204
     private static void AppendSource(ShoppingListReadItem readItem, decimal quantity, string source)
     {
         var sources = JsonSerializer.Deserialize<List<SourceEntry>>(readItem.SourcesJson) ?? [];

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadItem.cs
@@ -1,3 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
 /// <summary>
@@ -16,7 +18,7 @@ public sealed class ShoppingListReadItem
 
     public string? Unit { get; set; }
 
-    public string Category { get; set; } = "other";
+    public string Category { get; set; } = IngredientCategory.Other.Value;
 
     public bool IsBought { get; set; }
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
@@ -13,15 +13,17 @@ public sealed class ShoppingListReadModelRepository(ShoppingDbContext context) :
         var readItems = await context.ShoppingListReadItems
             .AsNoTracking()
             .Where(r => r.OwnerId == ownerId)
-            .OrderBy(r => IngredientCategory.From(r.Category).DisplayOrder)
             .ToListAsync(cancellationToken);
 
-        var dtoItems = readItems.Select(r =>
-        {
-            var sources = JsonSerializer.Deserialize<List<SourceEntry>>(r.SourcesJson) ?? [];
-            var sourceDtos = sources.Select(s => new ItemSourceDto(s.Quantity, s.Source, s.OccurredAt)).ToList();
-            return new MergedShoppingItemDto(r.ItemName, r.TotalQuantity, r.Unit, r.Category, r.IsBought, sourceDtos);
-        }).ToList();
+        var dtoItems = readItems
+            .Select(r =>
+            {
+                var sources = JsonSerializer.Deserialize<List<SourceEntry>>(r.SourcesJson) ?? [];
+                var sourceDtos = sources.Select(s => new ItemSourceDto(s.Quantity, s.Source, s.OccurredAt)).ToList();
+                return new MergedShoppingItemDto(r.ItemName, r.TotalQuantity, r.Unit, r.Category, r.IsBought, sourceDtos);
+            })
+            .OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
+            .ToList();
 
         return new MergedShoppingListDto(dtoItems);
     }

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
         services.AddScoped<ShoppingListProjectionHandler>();
         services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
         services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();
+        services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingListProjectionHandler>();
         services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingListProjectionHandler>();
         services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingListProjectionHandler>();
         services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");

--- a/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Commands;
@@ -29,7 +30,7 @@ public class AddManualItemCommandHandlerTests
         eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>())
             .Returns(existingLedger);
 
-        var command = new AddManualItemCommand("Potatoes", 2, "kg");
+        var command = new AddManualItemCommand(ItemName.From("Potatoes"), 2, "kg");
 
         var result = await handler.HandleAsync(command);
 
@@ -46,7 +47,7 @@ public class AddManualItemCommandHandlerTests
         eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>())
             .Returns(existingLedger);
 
-        var command = new AddManualItemCommand("Milk", null, null);
+        var command = new AddManualItemCommand(ItemName.From("Milk"), null, null);
 
         var result = await handler.HandleAsync(command);
 
@@ -62,7 +63,7 @@ public class AddManualItemCommandHandlerTests
         eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>())
             .Returns(existingLedger);
 
-        var command = new AddManualItemCommand("Chicken", 500, "g");
+        var command = new AddManualItemCommand(ItemName.From("Chicken"), 500, "g");
 
         var result = await handler.HandleAsync(command);
 
@@ -76,7 +77,7 @@ public class AddManualItemCommandHandlerTests
         eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>())
             .Returns((ShoppingLedger?)null);
 
-        var command = new AddManualItemCommand("Salt", null, null);
+        var command = new AddManualItemCommand(ItemName.From("Salt"), null, null);
 
         var result = await handler.HandleAsync(command);
 
@@ -91,7 +92,7 @@ public class AddManualItemCommandHandlerTests
         eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>())
             .Returns(existingLedger);
 
-        var command = new AddManualItemCommand("Bread", null, null);
+        var command = new AddManualItemCommand(ItemName.From("Bread"), null, null);
 
         var result = await handler.HandleAsync(command);
 

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 using Xunit;
@@ -205,5 +206,43 @@ public class ShoppingLedgerTests
 
         ledger.Version.Should().Be(3);
         ledger.UncommittedEvents.Should().HaveCount(3);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddItem_EmptyItemName_ThrowsGuardException(string? itemName)
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        var act = () => ledger.AddItem(itemName!, 1, "L", "manual");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddItem_EmptySource_ThrowsGuardException(string? source)
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        var act = () => ledger.AddItem("Milk", 1, "L", source!);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void MarkBought_EmptyItemName_ThrowsGuardException(string? itemName)
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        var act = () => ledger.MarkBought(itemName!, 1, "L");
+
+        act.Should().Throw<GuardException>();
     }
 }


### PR DESCRIPTION
## Summary

Addresses 8 issues identified in the post-ES-refactor code review:

| # | Severity | Fix |
|---|----------|-----|
| 1 | CRITICAL | Fix LINQ translation bug — OrderBy with value object creation moved to in-memory after ToList |
| 2 | CRITICAL | Integration events carry OwnerId — projection handler no longer guesses from metadata |
| 3+4 | HIGH | AddManualItemCommand uses ItemName value object; aggregate methods validated with Ensure.That() |
| 5 | HIGH | Add 8 validation guard tests (null/empty item names and sources) |
| 6 | MEDIUM | Add ShoppingItemConsumed projection handler + DI registration |
| 7 | MEDIUM | Aggregate methods guarded with Ensure.That() |
| 8 | MEDIUM | Rename AddedItemDto.TransactionIdentifier to LedgerIdentifier |
| 9 | LOW | Extract magic strings to ItemSources.Manual + IngredientCategory.Other.Value |

## Test plan
- [x] All 94 Shopping domain tests pass (8 new validation guard tests)
- [x] All 42 Shopping application tests pass (updated for ItemName value object)
- [x] All 64 architecture tests pass
- [x] Build passes with TreatWarningsAsErrors=true