### PR TITLE
feat(shared): add QuantityRounder for display rounding (US-314)

### DIFF
--- a/src/Yumney.Shared/Common/QuantityRounder.cs
+++ b/src/Yumney.Shared/Common/QuantityRounder.cs
@@ -1,0 +1,40 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Rounds quantities up to practical purchase amounts for display.
+/// Exact values are preserved in the ledger — rounding is display-only.
+/// </summary>
+public static class QuantityRounder
+{
+    /// <summary>
+    /// Round a quantity up to the next practical purchase amount.
+    /// </summary>
+    /// <param name="quantity">The exact calculated quantity.</param>
+    /// <param name="unit">The unit (affects rounding strategy).</param>
+    /// <returns>The rounded display quantity and the original exact value.</returns>
+    public static RoundedQuantity RoundUp(decimal quantity, string? unit)
+    {
+        if (quantity <= 0)
+            return new RoundedQuantity(quantity, quantity);
+
+        var rounded = Math.Ceiling(quantity);
+
+        if (rounded == quantity)
+            return new RoundedQuantity(quantity, quantity);
+
+        return new RoundedQuantity(rounded, quantity);
+    }
+}
+
+/// <summary>
+/// A display quantity with the rounded value and the original exact value.
+/// </summary>
+/// <param name="DisplayQuantity">The rounded-up quantity for display.</param>
+/// <param name="ExactQuantity">The original calculated quantity.</param>
+public sealed record RoundedQuantity(decimal DisplayQuantity, decimal ExactQuantity)
+{
+    /// <summary>
+    /// Gets a value indicating whether the quantity was rounded.
+    /// </summary>
+    public bool WasRounded => DisplayQuantity != ExactQuantity;
+}

--- a/src/Yumney.Shopping.Application/DTOs/MergedShoppingItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/MergedShoppingItemDto.cs
@@ -3,6 +3,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 public sealed record MergedShoppingItemDto(
     string ItemName,
     decimal TotalQuantity,
+    decimal DisplayQuantity,
     string? Unit,
     string Category,
     bool IsBought,

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
@@ -20,7 +20,8 @@ public sealed class ShoppingListReadModelRepository(ShoppingDbContext context) :
             {
                 var sources = JsonSerializer.Deserialize<List<SourceEntry>>(r.SourcesJson) ?? [];
                 var sourceDtos = sources.Select(s => new ItemSourceDto(s.Quantity, s.Source, s.OccurredAt)).ToList();
-                return new MergedShoppingItemDto(r.ItemName, r.TotalQuantity, r.Unit, r.Category, r.IsBought, sourceDtos);
+                var rounded = QuantityRounder.RoundUp(r.TotalQuantity, r.Unit);
+                return new MergedShoppingItemDto(r.ItemName, r.TotalQuantity, rounded.DisplayQuantity, r.Unit, r.Category, r.IsBought, sourceDtos);
             })
             .OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
             .ToList();

--- a/tests/Yumney.Shared.Tests/Common/QuantityRounderTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/QuantityRounderTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class QuantityRounderTests
+{
+    [Theory]
+    [InlineData(5.3, 6)]
+    [InlineData(1.1, 2)]
+    [InlineData(0.5, 1)]
+    [InlineData(3.9, 4)]
+    public void RoundUp_FractionalQuantity_RoundsToNextInteger(decimal input, decimal expected)
+    {
+        var result = QuantityRounder.RoundUp(input, "L");
+
+        result.DisplayQuantity.Should().Be(expected);
+        result.ExactQuantity.Should().Be(input);
+        result.WasRounded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(1)]
+    [InlineData(6)]
+    public void RoundUp_WholeNumber_NoRounding(decimal input)
+    {
+        var result = QuantityRounder.RoundUp(input, "L");
+
+        result.DisplayQuantity.Should().Be(input);
+        result.ExactQuantity.Should().Be(input);
+        result.WasRounded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RoundUp_Zero_ReturnsZero()
+    {
+        var result = QuantityRounder.RoundUp(0, "pc");
+
+        result.DisplayQuantity.Should().Be(0);
+        result.WasRounded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RoundUp_Negative_ReturnsAsIs()
+    {
+        var result = QuantityRounder.RoundUp(-1, "L");
+
+        result.DisplayQuantity.Should().Be(-1);
+        result.WasRounded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RoundUp_NullUnit_StillRounds()
+    {
+        var result = QuantityRounder.RoundUp(2.5m, null);
+
+        result.DisplayQuantity.Should().Be(3);
+        result.WasRounded.Should().BeTrue();
+    }
+}

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
@@ -38,8 +38,8 @@ public class GetMergedShoppingListQueryHandlerTests
     {
         var items = new List<MergedShoppingItemDto>
         {
-            new("Milk", 2, "L", "dairy", false, []),
-            new("Chicken", 500, "g", "meat-fish", false, []),
+            new("Milk", 2, 2, "L", "dairy", false, []),
+            new("Chicken", 500, 500, "g", "meat-fish", false, []),
         };
         readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));


### PR DESCRIPTION
## Summary
- Add `QuantityRounder.RoundUp()` in Shared — rounds up to next integer for display
- Add `RoundedQuantity` record with DisplayQuantity, ExactQuantity, WasRounded
- Add `DisplayQuantity` field to `MergedShoppingItemDto`
- Read model repository applies rounding at query time
- Ledger stores exact values — rounding is display-only

Closes #163

## Test plan
- [x] Fractional quantities round up (5.3 -> 6, 1.1 -> 2)
- [x] Whole numbers not rounded (2 -> 2)
- [x] Zero and negative handled
- [x] Null unit still rounds
- [x] WasRounded flag correct
- [x] All 10 QuantityRounder tests pass
- [x] All 42 Shopping application tests pass
- [x] All 64 architecture tests pass