### PR TITLE
feat(shopping): add two-phase shopping mode (US-315)

### DIFF
--- a/src/Yumney.Shopping.Api/Requests/EndShoppingModeRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/EndShoppingModeRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record EndShoppingModeRequest(bool AcceptPendingChanges = false);

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -57,6 +57,16 @@ public static class ShoppingEndpoints
             .WithTags("Shopping")
             .Produces<MergedShoppingListDto>();
 
+        group.MapPost("/shopping-mode/start", StartShoppingModeAsync)
+            .WithName("StartShoppingMode")
+            .WithTags("Shopping")
+            .Produces(StatusCodes.Status204NoContent);
+
+        group.MapPost("/shopping-mode/end", EndShoppingModeAsync)
+            .WithName("EndShoppingMode")
+            .WithTags("Shopping")
+            .Produces(StatusCodes.Status204NoContent);
+
         return app;
     }
 
@@ -164,5 +174,22 @@ public static class ShoppingEndpoints
         var query = new GetMergedShoppingListQuery();
         var result = await handler.HandleAsync(query, cancellationToken);
         return result.ToOk();
+    }
+
+    private static async Task<IResult> StartShoppingModeAsync(
+        ICommandHandler<StartShoppingModeCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(new StartShoppingModeCommand(), cancellationToken);
+        return result.ToNoContent();
+    }
+
+    private static async Task<IResult> EndShoppingModeAsync(
+        EndShoppingModeRequest request,
+        ICommandHandler<EndShoppingModeCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(new EndShoppingModeCommand(request.AcceptPendingChanges), cancellationToken);
+        return result.ToNoContent();
     }
 }

--- a/src/Yumney.Shopping.Application/Commands/EndShoppingModeCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/EndShoppingModeCommand.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record EndShoppingModeCommand(bool AcceptPendingChanges) : ICommand<Result>;

--- a/src/Yumney.Shopping.Application/Commands/Handlers/EndShoppingModeCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/EndShoppingModeCommandHandler.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+public sealed class EndShoppingModeCommandHandler(
+    IShoppingEventStore eventStore,
+    ICurrentUser currentUser) : ICommandHandler<EndShoppingModeCommand, Result>
+{
+    public async Task<Result> HandleAsync(EndShoppingModeCommand command, CancellationToken cancellationToken = default)
+    {
+        var ledger = await eventStore.LoadAsync(currentUser.UserId, cancellationToken);
+        if (ledger is null)
+            return Result.Success();
+
+        ledger.EndShoppingMode(command.AcceptPendingChanges);
+
+        await eventStore.SaveAsync(ledger, cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Yumney.Shopping.Application/Commands/Handlers/StartShoppingModeCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/StartShoppingModeCommandHandler.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+public sealed class StartShoppingModeCommandHandler(
+    IShoppingEventStore eventStore,
+    ICurrentUser currentUser) : ICommandHandler<StartShoppingModeCommand, Result>
+{
+    public async Task<Result> HandleAsync(StartShoppingModeCommand command, CancellationToken cancellationToken = default)
+    {
+        var ledger = await eventStore.LoadAsync(currentUser.UserId, cancellationToken)
+            ?? ShoppingLedger.Create(currentUser.UserId);
+
+        ledger.StartShoppingMode();
+
+        await eventStore.SaveAsync(ledger, cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Yumney.Shopping.Application/Commands/StartShoppingModeCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/StartShoppingModeCommand.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record StartShoppingModeCommand : ICommand<Result>;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingModeEnded.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingModeEnded.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+/// <summary>
+/// Raised when user exits shopping mode.
+/// </summary>
+public sealed record ShoppingModeEnded(bool AcceptedPendingChanges) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingModeStarted.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingModeStarted.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+/// <summary>
+/// Raised when user enters shopping mode — list becomes a snapshot.
+/// </summary>
+public sealed record ShoppingModeStarted(DateTime SnapshotTakenAt) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -24,6 +24,12 @@ public sealed class ShoppingLedger
 
     public IReadOnlyDictionary<string, ShoppingItemState> Items => items;
 
+    public bool IsInShoppingMode { get; private set; }
+
+    public DateTime? ShoppingModeStartedAt { get; private set; }
+
+    public int PendingChangesCount { get; private set; }
+
     private ShoppingLedger()
     {
     }
@@ -118,6 +124,18 @@ public sealed class ShoppingLedger
         RaiseEvent(new ShoppingItemQuantityAdjusted(itemName, newQuantity, unit));
     }
 
+    public void StartShoppingMode()
+    {
+        if (IsInShoppingMode) return;
+        RaiseEvent(new ShoppingModeStarted(DateTime.UtcNow));
+    }
+
+    public void EndShoppingMode(bool acceptPendingChanges)
+    {
+        if (!IsInShoppingMode) return;
+        RaiseEvent(new ShoppingModeEnded(acceptPendingChanges));
+    }
+
     public void MarkCommitted()
     {
         uncommittedEvents.Clear();
@@ -136,6 +154,7 @@ public sealed class ShoppingLedger
         {
             case ShoppingItemAdded e:
                 GetOrCreateItem(e.ItemName, e.Unit).OnList += e.Quantity;
+                if (IsInShoppingMode) PendingChangesCount++;
                 break;
             case ShoppingItemBought e:
                 GetOrCreateItem(e.ItemName, e.Unit).Bought += e.Quantity;
@@ -148,6 +167,16 @@ public sealed class ShoppingLedger
                 break;
             case ShoppingItemQuantityAdjusted e:
                 GetOrCreateItem(e.ItemName, e.Unit).OnList = e.NewQuantity;
+                break;
+            case ShoppingModeStarted e:
+                IsInShoppingMode = true;
+                ShoppingModeStartedAt = e.SnapshotTakenAt;
+                PendingChangesCount = 0;
+                break;
+            case ShoppingModeEnded:
+                IsInShoppingMode = false;
+                ShoppingModeStartedAt = null;
+                PendingChangesCount = 0;
                 break;
         }
     }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
@@ -29,6 +29,8 @@ public sealed partial class EfCoreShoppingEventStore(
         [nameof(ShoppingItemConsumed)] = typeof(ShoppingItemConsumed),
         [nameof(ShoppingItemRemoved)] = typeof(ShoppingItemRemoved),
         [nameof(ShoppingItemQuantityAdjusted)] = typeof(ShoppingItemQuantityAdjusted),
+        [nameof(ShoppingModeStarted)] = typeof(ShoppingModeStarted),
+        [nameof(ShoppingModeEnded)] = typeof(ShoppingModeEnded),
     };
 #pragma warning restore SA1311
 

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -245,4 +245,76 @@ public class ShoppingLedgerTests
 
         act.Should().Throw<GuardException>();
     }
+
+    [Fact]
+    public void StartShoppingMode_SetsIsInShoppingMode()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        ledger.StartShoppingMode();
+
+        ledger.IsInShoppingMode.Should().BeTrue();
+        ledger.ShoppingModeStartedAt.Should().NotBeNull();
+        ledger.PendingChangesCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void StartShoppingMode_AlreadyInMode_NoOp()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+        var version = ledger.Version;
+
+        ledger.StartShoppingMode();
+
+        ledger.Version.Should().Be(version);
+    }
+
+    [Fact]
+    public void EndShoppingMode_ClearsShoppingState()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+
+        ledger.EndShoppingMode(acceptPendingChanges: true);
+
+        ledger.IsInShoppingMode.Should().BeFalse();
+        ledger.ShoppingModeStartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void EndShoppingMode_NotInMode_NoOp()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        var version = ledger.Version;
+
+        ledger.EndShoppingMode(acceptPendingChanges: false);
+
+        ledger.Version.Should().Be(version);
+    }
+
+    [Fact]
+    public void AddItem_WhileInShoppingMode_IncrementsPendingChanges()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 1, "L", "manual");
+        ledger.StartShoppingMode();
+
+        ledger.AddItem("Eggs", 6, "pc", "manual");
+        ledger.AddItem("Bread", 1, "pc", "manual");
+
+        ledger.PendingChangesCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void EndShoppingMode_ResetsPendingChanges()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+        ledger.AddItem("Eggs", 6, "pc", "manual");
+
+        ledger.EndShoppingMode(acceptPendingChanges: false);
+
+        ledger.PendingChangesCount.Should().Be(0);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ShoppingModeStarted`/`ShoppingModeEnded` domain events
- `StartShoppingMode()` snapshots the list state, `EndShoppingMode(bool)` accepts or discards pending
- `PendingChangesCount` tracks items added while in shopping mode
- Idempotent: starting while already in mode is a no-op
- Endpoints: `POST .../shopping-mode/start` and `POST .../shopping-mode/end`
- Event store updated with new event type mappings

Closes #164

## Test plan
- [x] StartShoppingMode sets IsInShoppingMode and timestamp
- [x] StartShoppingMode while already in mode is no-op
- [x] EndShoppingMode clears state
- [x] EndShoppingMode while not in mode is no-op
- [x] AddItem during shopping mode increments pending count
- [x] EndShoppingMode resets pending count
- [x] All 100 Shopping domain tests pass (6 new)
- [x] All 42 application + 64 architecture tests pass