### PR TITLE
test(shopping): backfill shopping mode tests + fix pending tracking (US-315)

### DIFF
--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -164,9 +164,11 @@ public sealed class ShoppingLedger
                 break;
             case ShoppingItemRemoved e:
                 GetOrCreateItem(e.ItemName, e.Unit).Removed += e.Quantity;
+                if (IsInShoppingMode) PendingChangesCount++;
                 break;
             case ShoppingItemQuantityAdjusted e:
                 GetOrCreateItem(e.ItemName, e.Unit).OnList = e.NewQuantity;
+                if (IsInShoppingMode) PendingChangesCount++;
                 break;
             case ShoppingModeStarted e:
                 IsInShoppingMode = true;

--- a/tests/Yumney.Shopping.Application.Tests/Commands/ShoppingModeCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/ShoppingModeCommandHandlerTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Commands;
+
+public class ShoppingModeCommandHandlerTests
+{
+    private readonly IShoppingEventStore eventStore = Substitute.For<IShoppingEventStore>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+
+    public ShoppingModeCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+    }
+
+    [Fact]
+    public async Task StartShoppingMode_WithExistingLedger_SavesEvent()
+    {
+        var handler = new StartShoppingModeCommandHandler(eventStore, currentUser);
+        var ledger = ShoppingLedger.Create("user-123");
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns(ledger);
+
+        var result = await handler.HandleAsync(new StartShoppingModeCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartShoppingMode_NoLedgerExists_CreatesAndSaves()
+    {
+        var handler = new StartShoppingModeCommandHandler(eventStore, currentUser);
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns((ShoppingLedger?)null);
+
+        var result = await handler.HandleAsync(new StartShoppingModeCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EndShoppingMode_WithExistingLedger_SavesEvent()
+    {
+        var handler = new EndShoppingModeCommandHandler(eventStore, currentUser);
+        var ledger = ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+        ledger.MarkCommitted();
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns(ledger);
+
+        var result = await handler.HandleAsync(new EndShoppingModeCommand(true));
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EndShoppingMode_NoLedger_ReturnsSuccess()
+    {
+        var handler = new EndShoppingModeCommandHandler(eventStore, currentUser);
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns((ShoppingLedger?)null);
+
+        var result = await handler.HandleAsync(new EndShoppingModeCommand(false));
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.DidNotReceive().SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EndShoppingMode_PassesAcceptFlag()
+    {
+        var handler = new EndShoppingModeCommandHandler(eventStore, currentUser);
+        var ledger = ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+        ledger.MarkCommitted();
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns(ledger);
+
+        await handler.HandleAsync(new EndShoppingModeCommand(AcceptPendingChanges: true));
+
+        ledger.IsInShoppingMode.Should().BeFalse();
+    }
+}

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -317,4 +317,106 @@ public class ShoppingLedgerTests
 
         ledger.PendingChangesCount.Should().Be(0);
     }
+
+    [Fact]
+    public void RemoveItem_WhileInShoppingMode_IncrementsPendingChanges()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 2, "L", "manual");
+        ledger.StartShoppingMode();
+
+        ledger.RemoveItem("Milk", 1, "L");
+
+        ledger.PendingChangesCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AdjustQuantity_WhileInShoppingMode_IncrementsPendingChanges()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 2, "L", "manual");
+        ledger.StartShoppingMode();
+
+        ledger.AdjustQuantity("Milk", 5, "L");
+
+        ledger.PendingChangesCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void MarkBought_WhileInShoppingMode_DoesNotIncrementPendingChanges()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 2, "L", "manual");
+        ledger.StartShoppingMode();
+
+        ledger.MarkBought("Milk", 2, "L");
+
+        ledger.PendingChangesCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void AddItem_NotInShoppingMode_DoesNotTrackPending()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        ledger.AddItem("Milk", 1, "L", "manual");
+
+        ledger.PendingChangesCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void FromEvents_RebuildShoppingModeState()
+    {
+        var original = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        original.AddItem("Milk", 1, "L", "manual");
+        original.StartShoppingMode();
+        original.AddItem("Eggs", 6, "pc", "manual");
+
+        var events = original.UncommittedEvents.ToList();
+        var rebuilt = Domain.ShoppingLedger.ShoppingLedger.FromEvents(original.Id, "user-123", events);
+
+        rebuilt.IsInShoppingMode.Should().BeTrue();
+        rebuilt.ShoppingModeStartedAt.Should().NotBeNull();
+        rebuilt.PendingChangesCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void FromEvents_RebuildEndedShoppingMode()
+    {
+        var original = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        original.StartShoppingMode();
+        original.AddItem("Eggs", 6, "pc", "manual");
+        original.EndShoppingMode(acceptPendingChanges: true);
+
+        var events = original.UncommittedEvents.ToList();
+        var rebuilt = Domain.ShoppingLedger.ShoppingLedger.FromEvents(original.Id, "user-123", events);
+
+        rebuilt.IsInShoppingMode.Should().BeFalse();
+        rebuilt.PendingChangesCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void StartShoppingMode_RaisesCorrectEvent()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        ledger.StartShoppingMode();
+
+        ledger.UncommittedEvents.Should().HaveCount(1);
+        ledger.UncommittedEvents.First().Should().BeOfType<ShoppingModeStarted>();
+    }
+
+    [Fact]
+    public void EndShoppingMode_RaisesCorrectEvent()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.StartShoppingMode();
+
+        ledger.EndShoppingMode(acceptPendingChanges: false);
+
+        ledger.UncommittedEvents.Should().HaveCount(2);
+        var endEvent = ledger.UncommittedEvents.Last() as ShoppingModeEnded;
+        endEvent.Should().NotBeNull();
+        endEvent!.AcceptedPendingChanges.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- Fix: `RemoveItem` and `AdjustQuantity` now increment `PendingChangesCount` during shopping mode
- 8 new domain tests covering pending tracking for all mutation types, event replay, and event type verification
- 5 new handler tests for `StartShoppingModeCommandHandler` and `EndShoppingModeCommandHandler`

Follow-up to #207

## Test plan
- [x] All 108 Shopping domain tests pass (8 new)
- [x] All 47 Shopping application tests pass (5 new)
- [x] Build passes with TreatWarningsAsErrors=true