### PR TITLE
feat(shopping): add shopping list export as formatted text (US-316)

### DIFF
--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -67,6 +67,11 @@ public static class ShoppingEndpoints
             .WithTags("Shopping")
             .Produces(StatusCodes.Status204NoContent);
 
+        group.MapGet("/export", ExportAsync)
+            .WithName("ExportShoppingList")
+            .WithTags("Shopping")
+            .Produces<string>(contentType: "text/plain");
+
         return app;
     }
 
@@ -191,5 +196,16 @@ public static class ShoppingEndpoints
     {
         var result = await handler.HandleAsync(new EndShoppingModeCommand(request.AcceptPendingChanges), cancellationToken);
         return result.ToNoContent();
+    }
+
+    private static async Task<IResult> ExportAsync(
+        IQueryHandler<ExportShoppingListQuery, Result<string>> handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(new ExportShoppingListQuery(), cancellationToken);
+        if (result.IsFailure)
+            return result.ToOk();
+
+        return Results.Text(result.Value, "text/plain");
     }
 }

--- a/src/Yumney.Shopping.Application/Queries/ExportShoppingListQuery.cs
+++ b/src/Yumney.Shopping.Application/Queries/ExportShoppingListQuery.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries;
+
+public sealed record ExportShoppingListQuery : IQuery<Result<string>>;

--- a/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using System.Text;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+
+/// <summary>
+/// Exports the shopping list as formatted text grouped by category.
+/// Only includes unbought items. Does not change any item state.
+/// </summary>
+public sealed class ExportShoppingListQueryHandler(
+    IShoppingListReadModelRepository readModel,
+    ICurrentUser currentUser) : IQueryHandler<ExportShoppingListQuery, Result<string>>
+{
+#pragma warning disable SA1311
+    private static readonly Dictionary<string, string> categoryEmojis = new()
+    {
+        ["produce"] = "\U0001F966",
+        ["dairy"] = "\U0001F95B",
+        ["meat-fish"] = "\U0001F969",
+        ["bakery"] = "\U0001F35E",
+        ["frozen"] = "\u2744\uFE0F",
+        ["beverages"] = "\U0001F964",
+        ["pantry"] = "\U0001F3E0",
+        ["household"] = "\U0001F9F9",
+        ["other"] = "\U0001F4E6",
+    };
+
+    private static readonly Dictionary<string, string> categoryLabels = new()
+    {
+        ["produce"] = "Produce",
+        ["dairy"] = "Dairy",
+        ["meat-fish"] = "Meat & Fish",
+        ["bakery"] = "Bakery",
+        ["frozen"] = "Frozen",
+        ["beverages"] = "Beverages",
+        ["pantry"] = "Pantry",
+        ["household"] = "Household",
+        ["other"] = "Other",
+    };
+#pragma warning restore SA1311
+
+    /// <inheritdoc />
+    public async Task<Result<string>> HandleAsync(ExportShoppingListQuery query, CancellationToken cancellationToken = default)
+    {
+        var list = await readModel.GetByOwnerAsync(currentUser.UserId, cancellationToken);
+
+        var openItems = list.Items.Where(i => !i.IsBought).ToList();
+        if (openItems.Count == 0)
+            return string.Empty;
+
+        var grouped = openItems
+            .GroupBy(i => i.Category)
+            .OrderBy(g => IngredientCategory.From(g.Key).DisplayOrder);
+
+        var sb = new StringBuilder();
+
+        foreach (var group in grouped)
+        {
+            var emoji = categoryEmojis.GetValueOrDefault(group.Key, "\U0001F4E6");
+            var label = categoryLabels.GetValueOrDefault(group.Key, "Other");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"{emoji} {label}:");
+
+            foreach (var item in group)
+            {
+                var qty = QuantityRounder.RoundUp(item.TotalQuantity, item.Unit);
+                var unitSuffix = item.Unit is not null ? $" {item.Unit}" : string.Empty;
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  \u2610 {qty.DisplayQuantity}{unitSuffix} {item.ItemName}");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
+using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
+
+public class ExportShoppingListQueryHandlerTests
+{
+    private readonly IShoppingListReadModelRepository readModel = Substitute.For<IShoppingListReadModelRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ExportShoppingListQueryHandler handler;
+
+    public ExportShoppingListQueryHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new ExportShoppingListQueryHandler(readModel, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoItems_ReturnsEmptyString()
+    {
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto([]));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_AllBought_ReturnsEmptyString()
+    {
+        var items = new List<MergedShoppingItemDto>
+        {
+            new("Milk", 2, 2, "L", "dairy", true, []),
+        };
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto(items));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OpenItems_FormatsGroupedByCategory()
+    {
+        var items = new List<MergedShoppingItemDto>
+        {
+            new("Chicken", 500, 500, "g", "meat-fish", false, []),
+            new("Milk", 2, 2, "L", "dairy", false, []),
+            new("Onion", 3, 3, "pc", "produce", false, []),
+        };
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto(items));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Contain("Produce");
+        result.Value.Should().Contain("Dairy");
+        result.Value.Should().Contain("Meat & Fish");
+        result.Value.Should().Contain("Onion");
+        result.Value.Should().Contain("Milk");
+        result.Value.Should().Contain("Chicken");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExcludesBoughtItems()
+    {
+        var items = new List<MergedShoppingItemDto>
+        {
+            new("Milk", 2, 2, "L", "dairy", true, []),
+            new("Eggs", 6, 6, "pc", "dairy", false, []),
+        };
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto(items));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        result.Value.Should().Contain("Eggs");
+        result.Value.Should().NotContain("Milk");
+    }
+
+    [Fact]
+    public async Task HandleAsync_RoundsQuantities()
+    {
+        var items = new List<MergedShoppingItemDto>
+        {
+            new("Milk", 5.3m, 6, "L", "dairy", false, []),
+        };
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto(items));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        result.Value.Should().Contain("6 L Milk");
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderedByCategoryDisplayOrder()
+    {
+        var items = new List<MergedShoppingItemDto>
+        {
+            new("Soap", 1, 1, "pc", "household", false, []),
+            new("Onion", 1, 1, "pc", "produce", false, []),
+        };
+        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+            .Returns(new MergedShoppingListDto(items));
+
+        var result = await handler.HandleAsync(new ExportShoppingListQuery());
+
+        var produceIndex = result.Value.IndexOf("Produce", StringComparison.Ordinal);
+        var householdIndex = result.Value.IndexOf("Household", StringComparison.Ordinal);
+        produceIndex.Should().BeLessThan(householdIndex);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ExportShoppingListQuery` + handler that formats shopping list as text
- Only unbought items included, grouped by category with emoji headers
- Quantities rounded for display via `QuantityRounder`
- Endpoint: `GET /api/v1/shopping-lists/export` returns `text/plain`
- Does NOT change any item state (read-only)

Closes #165

## Test plan
- [x] No items → empty string
- [x] All bought → empty string
- [x] Open items formatted and grouped by category
- [x] Bought items excluded from export
- [x] Quantities rounded (5.3L → 6L)
- [x] Categories ordered by display order (produce before household)
- [x] All 53 Shopping application tests pass (6 new)
- [x] All 64 architecture tests pass