### PR TITLE
feat(shopping): auto-clear bought items after end of day (US-317)

### DIFF
--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListReadModelRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListReadModelRepository.cs
@@ -2,7 +2,17 @@ using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
+/// <summary>
+/// Read model repository for the shopping list projection.
+/// </summary>
 public interface IShoppingListReadModelRepository
 {
-    Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets the merged shopping list. By default, hides items bought before today.
+    /// </summary>
+    /// <param name="ownerId">The owner user identifier.</param>
+    /// <param name="includePastBought">If true, includes items bought before today.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The merged shopping list DTO.</returns>
+    Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, bool includePastBought = false, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
@@ -45,7 +45,7 @@ public sealed class ExportShoppingListQueryHandler(
     /// <inheritdoc />
     public async Task<Result<string>> HandleAsync(ExportShoppingListQuery query, CancellationToken cancellationToken = default)
     {
-        var list = await readModel.GetByOwnerAsync(currentUser.UserId, cancellationToken);
+        var list = await readModel.GetByOwnerAsync(currentUser.UserId, cancellationToken: cancellationToken);
 
         var openItems = list.Items.Where(i => !i.IsBought).ToList();
         if (openItems.Count == 0)

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
@@ -12,6 +12,6 @@ public sealed class GetMergedShoppingListQueryHandler(
     public async Task<Result<MergedShoppingListDto>> HandleAsync(GetMergedShoppingListQuery query, CancellationToken cancellationToken = default)
     {
         var ownerId = currentUser.UserId;
-        return await readModel.GetByOwnerAsync(ownerId, cancellationToken);
+        return await readModel.GetByOwnerAsync(ownerId, cancellationToken: cancellationToken);
     }
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260411120049_AddBoughtAtToReadModel.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260411120049_AddBoughtAtToReadModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411120049_AddBoughtAtToReadModel")]
+    partial class AddBoughtAtToReadModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260411120049_AddBoughtAtToReadModel.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260411120049_AddBoughtAtToReadModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBoughtAtToReadModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "BoughtAt",
+                table: "ShoppingListReadItems",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BoughtAt",
+                table: "ShoppingListReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
@@ -38,6 +38,7 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
         if (readItem is null) return;
 
         readItem.IsBought = true;
+        readItem.BoughtAt = DateTime.UtcNow;
         readItem.LastUpdated = DateTime.UtcNow;
 
         await context.SaveChangesAsync(cancellationToken);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadItem.cs
@@ -22,6 +22,8 @@ public sealed class ShoppingListReadItem
 
     public bool IsBought { get; set; }
 
+    public DateTime? BoughtAt { get; set; }
+
     /// <summary>
     /// Gets or sets the JSON-serialized list of sources (source label + quantity + timestamp).
     /// </summary>

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelRepository.cs
@@ -8,12 +8,21 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel
 
 public sealed class ShoppingListReadModelRepository(ShoppingDbContext context) : IShoppingListReadModelRepository
 {
-    public async Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public async Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, bool includePastBought = false, CancellationToken cancellationToken = default)
     {
-        var readItems = await context.ShoppingListReadItems
+        var today = DateTime.UtcNow.Date;
+
+        var query = context.ShoppingListReadItems
             .AsNoTracking()
-            .Where(r => r.OwnerId == ownerId)
-            .ToListAsync(cancellationToken);
+            .Where(r => r.OwnerId == ownerId);
+
+        if (!includePastBought)
+        {
+            query = query.Where(r => !r.IsBought || r.BoughtAt == null || r.BoughtAt >= today);
+        }
+
+        var readItems = await query.ToListAsync(cancellationToken);
 
         var dtoItems = readItems
             .Select(r =>

--- a/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
@@ -24,7 +24,7 @@ public class ExportShoppingListQueryHandlerTests
     [Fact]
     public async Task HandleAsync_NoItems_ReturnsEmptyString()
     {
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto([]));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -40,7 +40,7 @@ public class ExportShoppingListQueryHandlerTests
         {
             new("Milk", 2, 2, "L", "dairy", true, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -57,7 +57,7 @@ public class ExportShoppingListQueryHandlerTests
             new("Milk", 2, 2, "L", "dairy", false, []),
             new("Onion", 3, 3, "pc", "produce", false, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -79,7 +79,7 @@ public class ExportShoppingListQueryHandlerTests
             new("Milk", 2, 2, "L", "dairy", true, []),
             new("Eggs", 6, 6, "pc", "dairy", false, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -95,7 +95,7 @@ public class ExportShoppingListQueryHandlerTests
         {
             new("Milk", 5.3m, 6, "L", "dairy", false, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -111,7 +111,7 @@ public class ExportShoppingListQueryHandlerTests
             new("Soap", 1, 1, "pc", "household", false, []),
             new("Onion", 1, 1, "pc", "produce", false, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new ExportShoppingListQuery());

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
@@ -24,7 +24,7 @@ public class GetMergedShoppingListQueryHandlerTests
     [Fact]
     public async Task HandleAsync_EmptyReadModel_ReturnsEmptyList()
     {
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto([]));
 
         var result = await handler.HandleAsync(new GetMergedShoppingListQuery());
@@ -41,7 +41,7 @@ public class GetMergedShoppingListQueryHandlerTests
             new("Milk", 2, 2, "L", "dairy", false, []),
             new("Chicken", 500, 500, "g", "meat-fish", false, []),
         };
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto(items));
 
         var result = await handler.HandleAsync(new GetMergedShoppingListQuery());
@@ -53,11 +53,11 @@ public class GetMergedShoppingListQueryHandlerTests
     [Fact]
     public async Task HandleAsync_DelegatesToReadModel()
     {
-        readModel.GetByOwnerAsync("user-123", Arg.Any<CancellationToken>())
+        readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new MergedShoppingListDto([]));
 
         await handler.HandleAsync(new GetMergedShoppingListQuery());
 
-        await readModel.Received(1).GetByOwnerAsync("user-123", Arg.Any<CancellationToken>());
+        await readModel.Received(1).GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary
- Add `BoughtAt` timestamp to `ShoppingListReadItem` read model
- Default query filters out items bought before today (auto-clear next morning)
- `includePastBought` parameter on `GetByOwnerAsync` for showing history
- Projection handler sets `BoughtAt` when processing `ShoppingItemBought` events
- Ledger events never deleted — only the read model view changes

Closes #166

## Test plan
- [x] All 53 Shopping application tests pass (updated for new parameter)
- [x] All 64 architecture tests pass
- [x] Build passes with TreatWarningsAsErrors=true