### PR TITLE
feat(shopping): add corrections and rollback commands (US-318)

### DIFF
--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAddedAsAtHome.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAddedAsAtHome.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+/// <summary>
+/// Raised when an item is added directly as "at home" (already purchased, forgot to track).
+/// </summary>
+public sealed record ShoppingItemAddedAsAtHome(
+    string ItemName,
+    decimal Quantity,
+    string? Unit) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemUndoBought.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemUndoBought.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+/// <summary>
+/// Raised when a bought item is reverted to unbought.
+/// </summary>
+public sealed record ShoppingItemUndoBought(
+    string ItemName,
+    decimal Quantity,
+    string? Unit) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -124,6 +124,18 @@ public sealed class ShoppingLedger
         RaiseEvent(new ShoppingItemQuantityAdjusted(itemName, newQuantity, unit));
     }
 
+    public void UndoBought(string itemName, decimal quantity, string? unit)
+    {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
+        RaiseEvent(new ShoppingItemUndoBought(itemName, quantity, unit));
+    }
+
+    public void AddAsAtHome(string itemName, decimal quantity, string? unit)
+    {
+        Ensure.That(itemName).IsNotNullOrWhiteSpace();
+        RaiseEvent(new ShoppingItemAddedAsAtHome(itemName, quantity, unit));
+    }
+
     public void StartShoppingMode()
     {
         if (IsInShoppingMode) return;
@@ -169,6 +181,14 @@ public sealed class ShoppingLedger
             case ShoppingItemQuantityAdjusted e:
                 GetOrCreateItem(e.ItemName, e.Unit).OnList = e.NewQuantity;
                 if (IsInShoppingMode) PendingChangesCount++;
+                break;
+            case ShoppingItemUndoBought e:
+                var undoItem = GetOrCreateItem(e.ItemName, e.Unit);
+                undoItem.Bought = Math.Max(0, undoItem.Bought - e.Quantity);
+                break;
+            case ShoppingItemAddedAsAtHome e:
+                var atHomeItem = GetOrCreateItem(e.ItemName, e.Unit);
+                atHomeItem.Bought += e.Quantity;
                 break;
             case ShoppingModeStarted e:
                 IsInShoppingMode = true;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
@@ -29,6 +29,8 @@ public sealed partial class EfCoreShoppingEventStore(
         [nameof(ShoppingItemConsumed)] = typeof(ShoppingItemConsumed),
         [nameof(ShoppingItemRemoved)] = typeof(ShoppingItemRemoved),
         [nameof(ShoppingItemQuantityAdjusted)] = typeof(ShoppingItemQuantityAdjusted),
+        [nameof(ShoppingItemUndoBought)] = typeof(ShoppingItemUndoBought),
+        [nameof(ShoppingItemAddedAsAtHome)] = typeof(ShoppingItemAddedAsAtHome),
         [nameof(ShoppingModeStarted)] = typeof(ShoppingModeStarted),
         [nameof(ShoppingModeEnded)] = typeof(ShoppingModeEnded),
     };

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -419,4 +419,104 @@ public class ShoppingLedgerTests
         endEvent.Should().NotBeNull();
         endEvent!.AcceptedPendingChanges.Should().BeFalse();
     }
+
+    [Fact]
+    public void UndoBought_ReversesBoughtQuantity()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 2, "L", "manual");
+        ledger.MarkBought("Milk", 2, "L");
+
+        ledger.UndoBought("Milk", 2, "L");
+
+        var item = ledger.Items.Values.First();
+        item.Bought.Should().Be(0);
+        item.IsBought.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UndoBought_PartialUndo()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 3, "L", "manual");
+        ledger.MarkBought("Milk", 3, "L");
+
+        ledger.UndoBought("Milk", 1, "L");
+
+        ledger.Items.Values.First().Bought.Should().Be(2);
+    }
+
+    [Fact]
+    public void UndoBought_NeverNegative()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 1, "L", "manual");
+
+        ledger.UndoBought("Milk", 5, "L");
+
+        ledger.Items.Values.First().Bought.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void UndoBought_EmptyItemName_ThrowsGuardException(string? itemName)
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        var act = () => ledger.UndoBought(itemName!, 1, "L");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void AddAsAtHome_AddsDirectlyToBought()
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        ledger.AddAsAtHome("Butter", 250, "g");
+
+        var item = ledger.Items.Values.First();
+        item.Bought.Should().Be(250);
+        item.OnList.Should().Be(0);
+        item.AtHome.Should().Be(250);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AddAsAtHome_EmptyItemName_ThrowsGuardException(string? itemName)
+    {
+        var ledger = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+
+        var act = () => ledger.AddAsAtHome(itemName!, 1, "pc");
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void FromEvents_RebuildsUndoBoughtState()
+    {
+        var original = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        original.AddItem("Milk", 2, "L", "manual");
+        original.MarkBought("Milk", 2, "L");
+        original.UndoBought("Milk", 2, "L");
+
+        var events = original.UncommittedEvents.ToList();
+        var rebuilt = Domain.ShoppingLedger.ShoppingLedger.FromEvents(original.Id, "user-123", events);
+
+        rebuilt.Items.Values.First().Bought.Should().Be(0);
+    }
+
+    [Fact]
+    public void FromEvents_RebuildsAddAsAtHomeState()
+    {
+        var original = Domain.ShoppingLedger.ShoppingLedger.Create("user-123");
+        original.AddAsAtHome("Butter", 250, "g");
+
+        var events = original.UncommittedEvents.ToList();
+        var rebuilt = Domain.ShoppingLedger.ShoppingLedger.FromEvents(original.Id, "user-123", events);
+
+        rebuilt.Items.Values.First().AtHome.Should().Be(250);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `UndoBought` command — reverses bought status, partial undo supported, never goes negative
- Add `AddAsAtHome` command — adds item directly to "at home" balance (forgot to track)
- New events: `ShoppingItemUndoBought`, `ShoppingItemAddedAsAtHome`
- Event store type mappings updated
- Existing `RemoveItem` + `AdjustQuantity` already handle edit/remove with reasons

Closes #167

## Test plan
- [x] UndoBought reverses full bought quantity
- [x] UndoBought partial (3 bought, undo 1 → 2 remaining)
- [x] UndoBought never goes negative
- [x] UndoBought empty name throws GuardException
- [x] AddAsAtHome adds directly to bought/at-home
- [x] AddAsAtHome empty name throws GuardException
- [x] FromEvents rebuilds UndoBought state
- [x] FromEvents rebuilds AddAsAtHome state
- [x] All 118 Shopping domain tests pass (10 new)
- [x] All 64 architecture tests pass