### PR TITLE
feat(mealplan): add MealPlan module with WeeklyPlan aggregate (US-320)

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -1,5 +1,10 @@
 <Solution>
-  <Folder Name="/src/" />
+  <Folder Name="/src/">
+    <Project Path="src/Yumney.MealPlan.Api/Yumney.MealPlan.Api.csproj" />
+    <Project Path="src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj" />
+    <Project Path="src/Yumney.MealPlan.Domain/Yumney.MealPlan.Domain.csproj" />
+    <Project Path="src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj" />
+  </Folder>
   <Folder Name="/src/Host/">
     <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
     <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
@@ -35,7 +40,9 @@
     <Project Path="src/Yumney.Users.Infrastructure/Yumney.Users.Infrastructure.csproj" />
     <Project Path="src/Yumney.Users.Api/Yumney.Users.Api.csproj" />
   </Folder>
-  <Folder Name="/tests/" />
+  <Folder Name="/tests/">
+    <Project Path="tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj" />
+  </Folder>
   <Folder Name="/tests/Shared/">
     <Project Path="tests/Yumney.Shared.Tests/Yumney.Shared.Tests.csproj" />
     <Project Path="tests/Yumney.Shared.Guards.Tests/Yumney.Shared.Guards.Tests.csproj" />

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,7 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci', 'auth', 'e2e', 'frontend', 'test', 'domain', 'application'],
+      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci', 'auth', 'e2e', 'frontend', 'test', 'domain', 'application', 'mealplan'],
     ],
     'header-max-length': [2, 'always', 120],
     'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Yumney.Recipes.Api\Yumney.Recipes.Api.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Api\Yumney.Shopping.Api.csproj" />
     <ProjectReference Include="..\Yumney.Users.Api\Yumney.Users.Api.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Api\Yumney.MealPlan.Api.csproj" />
     <ProjectReference Include="..\Yumney.Gateway\Yumney.Gateway.csproj" />
     <ProjectReference Include="..\Yumney.MigrationRunner\Yumney.MigrationRunner.csproj" />
   </ItemGroup>

--- a/src/Yumney.MealPlan.Api/MealPlanApiServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanApiServiceCollectionExtensions.cs
@@ -1,0 +1,9 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Api;
+
+public static class MealPlanApiServiceCollectionExtensions
+{
+    public static IServiceCollection AddMealPlanApi(this IServiceCollection services)
+    {
+        return services;
+    }
+}

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -1,0 +1,60 @@
+using SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api;
+
+public static class MealPlanEndpoints
+{
+    public static IEndpointRouteBuilder MapMealPlanEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/meal-plans");
+
+        group.MapGet("/{year:int}/w/{weekNumber:int}", GetWeeklyPlanAsync)
+            .WithName("GetWeeklyPlan")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>();
+
+        group.MapPost("/{year:int}/w/{weekNumber:int}/slots", AssignRecipeAsync)
+            .WithName("AssignRecipe")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetWeeklyPlanAsync(
+        int year,
+        int weekNumber,
+        IQueryHandler<GetWeeklyPlanQuery, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetWeeklyPlanQuery(year, weekNumber);
+        var result = await handler.HandleAsync(query, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> AssignRecipeAsync(
+        int year,
+        int weekNumber,
+        AssignRecipeRequest request,
+        ICommandHandler<AssignRecipeCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new AssignRecipeCommand(
+            year,
+            weekNumber,
+            request.Day,
+            request.RecipeIdentifier,
+            request.RecipeTitle,
+            request.Servings);
+
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+}

--- a/src/Yumney.MealPlan.Api/Program.cs
+++ b/src/Yumney.MealPlan.Api/Program.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.MealPlan.Api;
+using SmartSolutionsLab.Yumney.MealPlan.Application;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddYumneyDefaults();
+
+builder.Services.AddMealPlanApi();
+builder.Services.AddMealPlanApplication();
+builder.Services.AddMealPlanInfrastructure(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseYumneyDefaults();
+
+app.MapGroup("/api/v1")
+    .RequireAuthorization()
+    .MapMealPlanEndpoints();
+
+app.Run();

--- a/src/Yumney.MealPlan.Api/Properties/launchSettings.json
+++ b/src/Yumney.MealPlan.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5124",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7027;http://localhost:5124",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Yumney.MealPlan.Api/Requests/AssignRecipeRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AssignRecipeRequest.cs
@@ -1,0 +1,7 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record AssignRecipeRequest(
+    DayOfWeek Day,
+    Guid RecipeIdentifier,
+    string RecipeTitle,
+    int? Servings = null);

--- a/src/Yumney.MealPlan.Api/Yumney.MealPlan.Api.csproj
+++ b/src/Yumney.MealPlan.Api/Yumney.MealPlan.Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Application\Yumney.MealPlan.Application.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Infrastructure\Yumney.MealPlan.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.MealPlan.Api/appsettings.Development.json
+++ b/src/Yumney.MealPlan.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore.Authentication": "Debug"
+    }
+  }
+}

--- a/src/Yumney.MealPlan.Api/appsettings.json
+++ b/src/Yumney.MealPlan.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Keycloak": {
+    "Realm": "yumney"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  }
+}

--- a/src/Yumney.MealPlan.Application/Commands/AssignRecipeCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/AssignRecipeCommand.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record AssignRecipeCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek Day,
+    Guid RecipeIdentifier,
+    string RecipeTitle,
+    int? Servings) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
@@ -1,0 +1,38 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class AssignRecipeCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<AssignRecipeCommand, Result<WeeklyPlanDto>>
+{
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(AssignRecipeCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+        if (plan is null)
+        {
+            plan = WeeklyPlan.Create(owner, week);
+            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.Servings);
+            await plans.AddAsync(plan, cancellationToken);
+        }
+        else
+        {
+            plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.Servings);
+            await plans.SaveChangesAsync(cancellationToken);
+        }
+
+        var slots = plan.Slots
+            .OrderBy(s => s.Day)
+            .Select(s => new MealSlotDto(s.Day.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
+            .ToList();
+
+        return new WeeklyPlanDto(week.Value, slots);
+    }
+}

--- a/src/Yumney.MealPlan.Application/CurrentUserExtensions.cs
+++ b/src/Yumney.MealPlan.Application/CurrentUserExtensions.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application;
+
+public static class CurrentUserExtensions
+{
+    public static OwnerIdentifier AsOwner(this ICurrentUser currentUser) =>
+        OwnerIdentifier.From(currentUser.UserId);
+}

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
@@ -1,0 +1,5 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+public sealed record MealSlotDto(string Day, Guid? RecipeIdentifier, string? RecipeTitle, int Servings, bool IsEmpty);
+
+public sealed record WeeklyPlanDto(string Week, IReadOnlyList<MealSlotDto> Slots);

--- a/src/Yumney.MealPlan.Application/MealPlanApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Application/MealPlanApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application;
+
+public static class MealPlanApplicationServiceCollectionExtensions
+{
+    public static IServiceCollection AddMealPlanApplication(this IServiceCollection services)
+    {
+        services.AddHandlersFromAssemblyContaining<Queries.Handlers.GetWeeklyPlanQueryHandler>();
+        return services;
+    }
+}

--- a/src/Yumney.MealPlan.Application/Queries/GetWeeklyPlanQuery.cs
+++ b/src/Yumney.MealPlan.Application/Queries/GetWeeklyPlanQuery.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+
+public sealed record GetWeeklyPlanQuery(int Year, int WeekNumber) : IQuery<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
@@ -1,0 +1,34 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
+
+public sealed class GetWeeklyPlanQueryHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : IQueryHandler<GetWeeklyPlanQuery, Result<WeeklyPlanDto>>
+{
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(GetWeeklyPlanQuery query, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(query.Year, query.WeekNumber);
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+
+        if (plan is null)
+        {
+            var emptySlots = Enumerable.Range(0, 7)
+                .Select(i => new MealSlotDto(((DayOfWeek)((i + 1) % 7)).ToString(), null, null, 4, true))
+                .ToList();
+            return new WeeklyPlanDto(week.Value, emptySlots);
+        }
+
+        var slots = plan.Slots
+            .OrderBy(s => s.Day)
+            .Select(s => new MealSlotDto(s.Day.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
+            .ToList();
+
+        return new WeeklyPlanDto(week.Value, slots);
+    }
+}

--- a/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
+++ b/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/IWeeklyPlanRepository.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/IWeeklyPlanRepository.cs
@@ -1,0 +1,40 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// Repository for weekly meal plans.
+/// </summary>
+public interface IWeeklyPlanRepository
+{
+    /// <summary>
+    /// Find a plan by owner and week. Returns null if none exists.
+    /// </summary>
+    /// <param name="owner">The owner identifier.</param>
+    /// <param name="week">The week identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The weekly plan, or null.</returns>
+    Task<WeeklyPlan?> FindByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get a tracked plan for updates. Throws if not found.
+    /// </summary>
+    /// <param name="owner">The owner identifier.</param>
+    /// <param name="week">The week identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tracked weekly plan.</returns>
+    Task<WeeklyPlan> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Add a new weekly plan.
+    /// </summary>
+    /// <param name="plan">The plan to add.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    Task AddAsync(WeeklyPlan plan, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Save changes to a tracked plan.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
@@ -1,0 +1,52 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// A single meal slot within a weekly plan — one per day (default mode).
+/// </summary>
+public sealed class MealSlot : Entity<MealSlotIdentifier>
+{
+    public DayOfWeek Day { get; private set; }
+
+    public Guid? RecipeIdentifier { get; private set; }
+
+    public string? RecipeTitle { get; private set; }
+
+    public int Servings { get; private set; }
+
+    public bool IsEmpty => RecipeIdentifier is null;
+
+    private MealSlot()
+    {
+    }
+
+    internal static MealSlot Create(DayOfWeek day, int defaultServings)
+    {
+        return new MealSlot
+        {
+            Id = MealSlotIdentifier.New(),
+            Day = day,
+            Servings = defaultServings,
+        };
+    }
+
+    internal void AssignRecipe(Guid recipeIdentifier, string recipeTitle, int? servings = null)
+    {
+        RecipeIdentifier = recipeIdentifier;
+        RecipeTitle = recipeTitle;
+        if (servings.HasValue)
+            Servings = servings.Value;
+    }
+
+    internal void ClearRecipe()
+    {
+        RecipeIdentifier = null;
+        RecipeTitle = null;
+    }
+
+    internal void AdjustServingsTo(int servings)
+    {
+        Servings = servings;
+    }
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlotIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlotIdentifier.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+public sealed record MealSlotIdentifier : IValueObject
+{
+    public Guid Value { get; }
+
+    private MealSlotIdentifier(Guid value)
+    {
+        Value = Ensure.That(value).IsNotEmpty().AndReturn();
+    }
+
+    public static MealSlotIdentifier New() => new(Guid.CreateVersion7());
+
+    public static MealSlotIdentifier From(Guid value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/OwnerIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/OwnerIdentifier.cs
@@ -1,0 +1,21 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+public sealed record OwnerIdentifier : IValueObject<string>
+{
+    public const int MaxLength = 255;
+
+    public string Value { get; }
+
+    private OwnerIdentifier(string value)
+    {
+        string validated = Ensure.That(value).IsNotNullOrWhiteSpace().HasMaxLength(MaxLength).AndReturn();
+        Value = validated.Trim();
+    }
+
+    public static OwnerIdentifier From(string value) => new(value);
+
+    public static implicit operator string(OwnerIdentifier obj) => obj.Value;
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeekIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeekIdentifier.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// Identifies a specific week by ISO year and week number.
+/// </summary>
+public sealed record WeekIdentifier : IValueObject<string>
+{
+    public int Year { get; }
+
+    public int WeekNumber { get; }
+
+    public string Value { get; }
+
+    private WeekIdentifier(int year, int weekNumber)
+    {
+        Ensure.That(year).IsInRange(2020, 2100);
+        Ensure.That(weekNumber).IsInRange(1, 53);
+        Year = year;
+        WeekNumber = weekNumber;
+        Value = $"{year}-W{weekNumber:D2}";
+    }
+
+    public static WeekIdentifier From(int year, int weekNumber) => new(year, weekNumber);
+
+    public static WeekIdentifier FromDate(DateOnly date)
+    {
+        var cal = CultureInfo.InvariantCulture.Calendar;
+        var week = cal.GetWeekOfYear(date.ToDateTime(TimeOnly.MinValue), CalendarWeekRule.FirstFourDayWeek, System.DayOfWeek.Monday);
+        var year = date.Year;
+        if (week == 1 && date.Month == 12) year++;
+        if (week >= 52 && date.Month == 1) year--;
+        return new WeekIdentifier(year, week);
+    }
+
+    /// <summary>
+    /// Gets the current week identifier.
+    /// </summary>
+    /// <returns>The week identifier for today.</returns>
+    public static WeekIdentifier Current() => FromDate(DateOnly.FromDateTime(DateTime.UtcNow));
+
+    public static implicit operator string(WeekIdentifier obj) => obj.Value;
+
+    public override string ToString() => Value;
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -1,0 +1,105 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// A weekly meal plan — one per user per week.
+/// Contains 7 meal slots (one per day, default mode).
+/// </summary>
+public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
+{
+    private readonly List<MealSlot> slots = [];
+
+    public OwnerIdentifier Owner { get; private set; } = default!;
+
+    public WeekIdentifier Week { get; private set; } = default!;
+
+    public IReadOnlyList<MealSlot> Slots => slots.AsReadOnly();
+
+    private WeeklyPlan()
+    {
+    }
+
+    /// <summary>
+    /// Create a new weekly plan with empty slots for each day.
+    /// </summary>
+    /// <param name="owner">The user who owns this plan.</param>
+    /// <param name="week">The week this plan covers.</param>
+    /// <param name="defaultServings">Default servings per slot (from household profile).</param>
+    /// <returns>A new weekly plan with 7 empty slots.</returns>
+    public static WeeklyPlan Create(OwnerIdentifier owner, WeekIdentifier week, int defaultServings = 4)
+    {
+        var plan = new WeeklyPlan
+        {
+            Id = WeeklyPlanIdentifier.New(),
+            Owner = owner,
+            Week = week,
+        };
+
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Monday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Tuesday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Wednesday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Thursday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Friday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Saturday, defaultServings));
+        plan.slots.Add(MealSlot.Create(DayOfWeek.Sunday, defaultServings));
+
+        return plan;
+    }
+
+    /// <summary>
+    /// Assign a recipe to a specific day's slot.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="recipeIdentifier">The recipe identifier.</param>
+    /// <param name="recipeTitle">The recipe title for display.</param>
+    /// <param name="servings">Optional serving count override.</param>
+    public void AssignRecipe(DayOfWeek day, Guid recipeIdentifier, string recipeTitle, int? servings = null)
+    {
+        Ensure.That(recipeTitle).IsNotNullOrWhiteSpace();
+        var slot = FindSlot(day);
+        slot.AssignRecipe(recipeIdentifier, recipeTitle, servings);
+    }
+
+    /// <summary>
+    /// Remove the recipe from a specific day's slot.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    public void ClearSlot(DayOfWeek day)
+    {
+        var slot = FindSlot(day);
+        slot.ClearRecipe();
+    }
+
+    /// <summary>
+    /// Swap the meals between two days.
+    /// </summary>
+    /// <param name="day1">First day.</param>
+    /// <param name="day2">Second day.</param>
+    public void SwapSlots(DayOfWeek day1, DayOfWeek day2)
+    {
+        var slot1 = FindSlot(day1);
+        var slot2 = FindSlot(day2);
+
+        var tempRecipe = slot1.RecipeIdentifier;
+        var tempTitle = slot1.RecipeTitle;
+        var tempServings = slot1.Servings;
+
+        if (slot2.RecipeIdentifier.HasValue)
+            slot1.AssignRecipe(slot2.RecipeIdentifier.Value, slot2.RecipeTitle!, slot2.Servings);
+        else
+            slot1.ClearRecipe();
+
+        if (tempRecipe.HasValue)
+            slot2.AssignRecipe(tempRecipe.Value, tempTitle!, tempServings);
+        else
+            slot2.ClearRecipe();
+    }
+
+    private MealSlot FindSlot(DayOfWeek day)
+    {
+        return slots.FirstOrDefault(s => s.Day == day)
+            ?? throw new EntityNotFoundException(nameof(MealSlot), day.ToString());
+    }
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlanIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlanIdentifier.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+public sealed record WeeklyPlanIdentifier : IValueObject
+{
+    public Guid Value { get; }
+
+    private WeeklyPlanIdentifier(Guid value)
+    {
+        Value = Ensure.That(value).IsNotEmpty().AndReturn();
+    }
+
+    public static WeeklyPlanIdentifier New() => new(Guid.CreateVersion7());
+
+    public static WeeklyPlanIdentifier From(Guid value) => new(value);
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/Yumney.MealPlan.Domain/Yumney.MealPlan.Domain.csproj
+++ b/src/Yumney.MealPlan.Domain/Yumney.MealPlan.Domain.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared\Yumney.Shared.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Guards\Yumney.Shared.Guards.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
+
+public static class MealPlanInfrastructureServiceCollectionExtensions
+{
+    public static IServiceCollection AddMealPlanInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<MealPlanDbContext>((sp, options) =>
+        {
+            var connectionString = configuration.GetConnectionString("mealplandb");
+            Action<NpgsqlDbContextOptionsBuilder> contextOptions = builder => builder
+                .MigrationsHistoryTable("__MealPlanMigrationsHistory")
+                .EnableRetryOnFailure();
+
+            options
+                .UseNpgsql(connectionString, contextOptions)
+                .AddInterceptors(sp.GetRequiredService<DomainEventDispatchInterceptor>());
+        });
+
+        services.AddScoped<IWeeklyPlanRepository, WeeklyPlanRepository>();
+        services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb");
+
+        return services;
+    }
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Configurations;
+
+internal sealed class WeeklyPlanConfiguration : IEntityTypeConfiguration<WeeklyPlan>
+{
+    public void Configure(EntityTypeBuilder<WeeklyPlan> entity)
+    {
+        entity.ToTable("WeeklyPlans");
+        entity.HasKey(e => e.Id);
+        entity.Property(e => e.Id)
+            .HasConversion<WeeklyPlanIdentifierConverter>();
+
+        entity.Property(e => e.Owner)
+            .HasConversion<OwnerIdentifierConverter>()
+            .HasMaxLength(OwnerIdentifier.MaxLength)
+            .IsRequired();
+
+        entity.Property(e => e.Week)
+            .HasConversion<WeekIdentifierConverter>()
+            .HasMaxLength(10)
+            .IsRequired();
+
+        entity.OwnsMany(e => e.Slots, slot =>
+        {
+            slot.ToTable("MealSlots");
+            slot.WithOwner().HasForeignKey("WeeklyPlanId");
+            slot.Property(s => s.Id)
+                .HasConversion<MealSlotIdentifierConverter>();
+            slot.Property(s => s.Day).HasConversion<string>().HasMaxLength(10).IsRequired();
+            slot.Property(s => s.RecipeIdentifier);
+            slot.Property(s => s.RecipeTitle).HasMaxLength(200);
+            slot.Property(s => s.Servings).IsRequired();
+        });
+
+        entity.HasIndex(e => new { e.Owner, e.Week }).IsUnique();
+        entity.Ignore(e => e.DomainEvents);
+    }
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/MealSlotIdentifierConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/MealSlotIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
+
+internal sealed class MealSlotIdentifierConverter()
+    : ValueConverter<MealSlotIdentifier, Guid>(v => v.Value, v => MealSlotIdentifier.From(v));

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/OwnerIdentifierConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/OwnerIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
+
+internal sealed class OwnerIdentifierConverter()
+    : ValueConverter<OwnerIdentifier, string>(v => v.Value, v => OwnerIdentifier.From(v));

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierConverter.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
 
+#pragma warning disable SA1601
 internal sealed partial class WeekIdentifierConverter()
     : ValueConverter<WeekIdentifier, string>(
         v => v.Value,

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierConverter.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
+
+internal sealed partial class WeekIdentifierConverter()
+    : ValueConverter<WeekIdentifier, string>(
+        v => v.Value,
+        v => ParseWeekIdentifier(v))
+{
+    private static WeekIdentifier ParseWeekIdentifier(string value)
+    {
+        var match = WeekPattern().Match(value);
+        return WeekIdentifier.From(
+            int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture),
+            int.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [GeneratedRegex(@"^(\d{4})-W(\d{2})$")]
+    private static partial Regex WeekPattern();
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeeklyPlanIdentifierConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeeklyPlanIdentifierConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converters;
+
+internal sealed class WeeklyPlanIdentifierConverter()
+    : ValueConverter<WeeklyPlanIdentifier, Guid>(v => v.Value, v => WeeklyPlanIdentifier.From(v));

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDbContext.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+
+public sealed class MealPlanDbContext(DbContextOptions<MealPlanDbContext> options) : DbContext(options)
+{
+    public DbSet<WeeklyPlan> WeeklyPlans => Set<WeeklyPlan>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(MealPlanDbContext).Assembly);
+    }
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/WeeklyPlanRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/WeeklyPlanRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+
+public sealed class WeeklyPlanRepository(MealPlanDbContext context) : IWeeklyPlanRepository
+{
+#pragma warning disable SA1311
+    private readonly DbSet<WeeklyPlan> plans = context.WeeklyPlans;
+#pragma warning restore SA1311
+
+    /// <inheritdoc />
+    public async Task<WeeklyPlan?> FindByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+    {
+        return await plans
+            .AsNoTracking()
+            .Include(p => p.Slots)
+            .FirstOrDefaultAsync(p => p.Owner == owner && p.Week == week, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<WeeklyPlan> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+    {
+        return await plans
+            .Include(p => p.Slots)
+            .FirstOrDefaultAsync(p => p.Owner == owner && p.Week == week, cancellationToken)
+            ?? throw new EntityNotFoundException(nameof(WeeklyPlan), $"{owner.Value}/{week.Value}");
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(WeeklyPlan plan, CancellationToken cancellationToken = default)
+    {
+        await plans.AddAsync(plan, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
+++ b/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.MealPlan.Application\Yumney.MealPlan.Application.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.MigrationRunner/Yumney.MigrationRunner.csproj
+++ b/src/Yumney.MigrationRunner/Yumney.MigrationRunner.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Yumney.Recipes.Infrastructure\Yumney.Recipes.Infrastructure.csproj" />
     <ProjectReference Include="..\Yumney.Users.Infrastructure\Yumney.Users.Infrastructure.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Infrastructure\Yumney.Shopping.Infrastructure.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Infrastructure\Yumney.MealPlan.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class WeeklyPlanTests
+{
+    private static readonly OwnerIdentifier TestOwner = OwnerIdentifier.From("user-123");
+
+    [Fact]
+    public void Create_ValidParams_Returns7EmptySlots()
+    {
+        var week = WeekIdentifier.From(2026, 15);
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, week);
+
+        plan.Owner.Should().Be(TestOwner);
+        plan.Week.Should().Be(week);
+        plan.Slots.Should().HaveCount(7);
+        plan.Slots.Should().OnlyContain(s => s.IsEmpty);
+    }
+
+    [Fact]
+    public void Create_SetsDefaultServings()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15), 6);
+
+        plan.Slots.Should().OnlyContain(s => s.Servings == 6);
+    }
+
+    [Fact]
+    public void AssignRecipe_FillsSlot()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        var recipeId = Guid.NewGuid();
+
+        plan.AssignRecipe(DayOfWeek.Monday, recipeId, "Spaghetti Bolognese");
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.IsEmpty.Should().BeFalse();
+        monday.RecipeIdentifier.Should().Be(recipeId);
+        monday.RecipeTitle.Should().Be("Spaghetti Bolognese");
+    }
+
+    [Fact]
+    public void AssignRecipe_WithServings_OverridesDefault()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", 8);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).Servings.Should().Be(8);
+    }
+
+    [Fact]
+    public void ClearSlot_RemovesRecipe()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Wednesday, Guid.NewGuid(), "Chicken");
+
+        plan.ClearSlot(DayOfWeek.Wednesday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Wednesday).IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SwapSlots_SwapsTwoMeals()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        var recipeA = Guid.NewGuid();
+        var recipeB = Guid.NewGuid();
+        plan.AssignRecipe(DayOfWeek.Monday, recipeA, "Pasta");
+        plan.AssignRecipe(DayOfWeek.Friday, recipeB, "Steak");
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Friday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).RecipeTitle.Should().Be("Steak");
+        plan.Slots.First(s => s.Day == DayOfWeek.Friday).RecipeTitle.Should().Be("Pasta");
+    }
+
+    [Fact]
+    public void SwapSlots_WithOneEmpty_MovesRecipe()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Tuesday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).IsEmpty.Should().BeTrue();
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).RecipeTitle.Should().Be("Pasta");
+    }
+
+    [Fact]
+    public void AssignRecipe_EmptyTitle_ThrowsGuardException()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), string.Empty);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void WeekIdentifier_CurrentReturnsValue()
+    {
+        var current = WeekIdentifier.Current();
+
+        current.Year.Should().BeGreaterThan(2024);
+        current.WeekNumber.Should().BeInRange(1, 53);
+    }
+
+    [Fact]
+    public void WeekIdentifier_FromDate_CorrectWeek()
+    {
+        var week = WeekIdentifier.FromDate(new DateOnly(2026, 4, 13));
+
+        week.Year.Should().Be(2026);
+        week.WeekNumber.Should().Be(16);
+    }
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj
+++ b/tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
New bounded context: `Yumney.MealPlan` — 4 projects following the established module pattern.

### Domain
- `WeeklyPlan` aggregate with 7 `MealSlot` entities (Monday–Sunday)
- `WeekIdentifier` value object (ISO year + week number, FromDate/Current)
- Commands: `AssignRecipe`, `ClearSlot`, `SwapSlots`
- Default servings per slot from household profile

### Application
- `GetWeeklyPlanQuery` — returns plan for a week (creates empty slots if no plan exists)
- `AssignRecipeCommand` — assigns recipe to a day slot (creates plan on first use)
- CQRS handlers registered via assembly scanning

### Infrastructure
- EF Core with PostgreSQL, `OwnsMany` for MealSlots
- Unique index on (Owner, Week)
- Repository with Find/Get pattern

### API
- `GET /api/v1/meal-plans/{year}/w/{weekNumber}` — get weekly plan
- `POST /api/v1/meal-plans/{year}/w/{weekNumber}/slots` — assign recipe

Closes #168

## Test plan
- [x] Create plan with 7 empty slots
- [x] Default servings applied to all slots
- [x] AssignRecipe fills slot with recipe + title
- [x] AssignRecipe with custom servings overrides default
- [x] ClearSlot removes recipe
- [x] SwapSlots swaps two meals
- [x] SwapSlots with one empty moves recipe
- [x] Empty recipe title throws GuardException
- [x] WeekIdentifier.Current() returns valid value
- [x] WeekIdentifier.FromDate() calculates correct ISO week
- [x] All 10 MealPlan domain tests pass
- [x] All 64 architecture tests pass