### PR TITLE
fix(infra): wire mealplan-api into AppHost, Gateway, and deploy pipeline (US-320)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -121,6 +121,7 @@ if (!options.DatabaseOnly)
         recipesApi.WithContainerRegistry(registry);
         shoppingApi.WithContainerRegistry(registry);
         usersApi.WithContainerRegistry(registry);
+        mealplanApi.WithContainerRegistry(registry);
     }
 #pragma warning restore ASPIRECOMPUTE003
 
@@ -167,6 +168,7 @@ if (!options.DatabaseOnly)
     recipesApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 10, 20));
     shoppingApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 5, 50));
     usersApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
+    mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
     migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
 
     if (isRunMode)
@@ -200,11 +202,13 @@ if (!options.DatabaseOnly)
             .WithReference(recipesApi)
             .WithReference(shoppingApi)
             .WithReference(usersApi)
+            .WithReference(mealplanApi)
             .WithReference(shell)
             .WithReference(keycloak)
             .WaitFor(recipesApi)
             .WaitFor(shoppingApi)
             .WaitFor(usersApi)
+            .WaitFor(mealplanApi)
             .WaitFor(shell)
             .WaitFor(recipesMfe)
             .WaitFor(shoppingMfe)
@@ -230,6 +234,7 @@ if (!options.DatabaseOnly)
                 yarp.AddRoute("/api/v1/recipes/{**catch-all}", recipesApi);
                 yarp.AddRoute("/api/v1/shopping-lists/{**catch-all}", shoppingApi);
                 yarp.AddRoute("/api/v1/auth/{**catch-all}", usersApi);
+                yarp.AddRoute("/api/v1/meal-plans/{**catch-all}", mealplanApi);
                 yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
             })
             .WithExternalHttpEndpoints();

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -29,6 +29,12 @@
           "Path": "/api/v1/auth/{**remainder}"
         }
       },
+      "mealplan-route": {
+        "ClusterId": "mealplan-api",
+        "Match": {
+          "Path": "/api/v1/meal-plans/{**remainder}"
+        }
+      },
       "shell-route": {
         "ClusterId": "shell",
         "Order": 1000,
@@ -64,6 +70,13 @@
         "Destinations": {
           "primary": {
             "Address": "https+http://users-api"
+          }
+        }
+      },
+      "mealplan-api": {
+        "Destinations": {
+          "primary": {
+            "Address": "https+http://mealplan-api"
           }
         }
       },


### PR DESCRIPTION
## Summary
Fix staging deploy failure (backchannel error) caused by incomplete MealPlan API integration.

| Fix | What |
|-----|------|
| Container Registry | Add mealplanApi to GHCR push |
| ACA Publishing | Add PublishAsAzureContainerApp (0 min, 3 max, 50 concurrent) |
| Gateway run mode | Add WithReference + WaitFor for mealplanApi |
| Gateway YARP publish | Add route /api/v1/meal-plans/ |
| Gateway appsettings | Add mealplan-api route + cluster for run mode |

## Test plan
- [x] Build passes with TreatWarningsAsErrors=true
- [x] No code logic changes — infrastructure wiring only