### PR TITLE
feat(mealplan): add extended meal planning with multi-slot days (US-321)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -52,6 +52,7 @@ public static class MealPlanEndpoints
             request.Day,
             request.RecipeIdentifier,
             request.RecipeTitle,
+            request.MealType,
             request.Servings);
 
         var result = await handler.HandleAsync(command, cancellationToken);

--- a/src/Yumney.MealPlan.Api/Requests/AssignRecipeRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AssignRecipeRequest.cs
@@ -1,7 +1,10 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
 public sealed record AssignRecipeRequest(
     DayOfWeek Day,
     Guid RecipeIdentifier,
     string RecipeTitle,
+    MealType MealType = MealType.Dinner,
     int? Servings = null);

--- a/src/Yumney.MealPlan.Application/Commands/AssignRecipeCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/AssignRecipeCommand.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 
@@ -10,4 +11,5 @@ public sealed record AssignRecipeCommand(
     DayOfWeek Day,
     Guid RecipeIdentifier,
     string RecipeTitle,
-    int? Servings) : ICommand<Result<WeeklyPlanDto>>;
+    MealType MealType = MealType.Dinner,
+    int? Servings = null) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
@@ -18,21 +18,22 @@ public sealed class AssignRecipeCommandHandler(
         if (plan is null)
         {
             plan = WeeklyPlan.Create(owner, week);
-            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.Servings);
+            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.MealType, command.Servings);
             await plans.AddAsync(plan, cancellationToken);
         }
         else
         {
             plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
-            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.Servings);
+            plan.AssignRecipe(command.Day, command.RecipeIdentifier, command.RecipeTitle, command.MealType, command.Servings);
             await plans.SaveChangesAsync(cancellationToken);
         }
 
-        var slots = plan.Slots
+        var visibleSlots = plan.GetVisibleSlots()
             .OrderBy(s => s.Day)
-            .Select(s => new MealSlotDto(s.Day.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
+            .ThenBy(s => s.MealType)
+            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
             .ToList();
 
-        return new WeeklyPlanDto(week.Value, slots);
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
     }
 }

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
@@ -1,5 +1,5 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public sealed record MealSlotDto(string Day, Guid? RecipeIdentifier, string? RecipeTitle, int Servings, bool IsEmpty);
+public sealed record MealSlotDto(string Day, string MealType, Guid? RecipeIdentifier, string? RecipeTitle, int Servings, bool IsEmpty);
 
-public sealed record WeeklyPlanDto(string Week, IReadOnlyList<MealSlotDto> Slots);
+public sealed record WeeklyPlanDto(string Week, bool IsExtendedMode, IReadOnlyList<MealSlotDto> Slots);

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
@@ -19,16 +19,23 @@ public sealed class GetWeeklyPlanQueryHandler(
         if (plan is null)
         {
             var emptySlots = Enumerable.Range(0, 7)
-                .Select(i => new MealSlotDto(((DayOfWeek)((i + 1) % 7)).ToString(), null, null, 4, true))
+                .Select(i => new MealSlotDto(
+                    ((DayOfWeek)((i + 1) % 7)).ToString(),
+                    MealType.Dinner.ToString(),
+                    null,
+                    null,
+                    4,
+                    true))
                 .ToList();
-            return new WeeklyPlanDto(week.Value, emptySlots);
+            return new WeeklyPlanDto(week.Value, false, emptySlots);
         }
 
-        var slots = plan.Slots
+        var visibleSlots = plan.GetVisibleSlots()
             .OrderBy(s => s.Day)
-            .Select(s => new MealSlotDto(s.Day.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
+            .ThenBy(s => s.MealType)
+            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
             .ToList();
 
-        return new WeeklyPlanDto(week.Value, slots);
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
     }
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
@@ -3,11 +3,14 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 /// <summary>
-/// A single meal slot within a weekly plan — one per day (default mode).
+/// A single meal slot within a weekly plan.
+/// Default mode: one Dinner slot per day. Extended mode: Breakfast + Lunch + Dinner.
 /// </summary>
 public sealed class MealSlot : Entity<MealSlotIdentifier>
 {
     public DayOfWeek Day { get; private set; }
+
+    public MealType MealType { get; private set; }
 
     public Guid? RecipeIdentifier { get; private set; }
 
@@ -21,12 +24,13 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
     {
     }
 
-    internal static MealSlot Create(DayOfWeek day, int defaultServings)
+    internal static MealSlot Create(DayOfWeek day, MealType mealType, int defaultServings)
     {
         return new MealSlot
         {
             Id = MealSlotIdentifier.New(),
             Day = day,
+            MealType = mealType,
             Servings = defaultServings,
         };
     }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealType.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealType.cs
@@ -1,0 +1,16 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// The type of meal for a slot.
+/// </summary>
+public enum MealType
+{
+    /// <summary>Dinner (default, always visible).</summary>
+    Dinner,
+
+    /// <summary>Breakfast (extended mode only).</summary>
+    Breakfast,
+
+    /// <summary>Lunch (extended mode only).</summary>
+    Lunch,
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -5,15 +5,21 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 /// <summary>
 /// A weekly meal plan — one per user per week.
-/// Contains 7 meal slots (one per day, default mode).
+/// Default mode: 7 Dinner slots. Extended mode: 21 slots (Breakfast + Lunch + Dinner).
 /// </summary>
+#pragma warning disable SA1311
 public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
 {
+    private static readonly DayOfWeek[] allDays =
+        [DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday];
+
     private readonly List<MealSlot> slots = [];
 
     public OwnerIdentifier Owner { get; private set; } = default!;
 
     public WeekIdentifier Week { get; private set; } = default!;
+
+    public bool IsExtendedMode { get; private set; }
 
     public IReadOnlyList<MealSlot> Slots => slots.AsReadOnly();
 
@@ -22,12 +28,12 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
     }
 
     /// <summary>
-    /// Create a new weekly plan with empty slots for each day.
+    /// Create a new weekly plan with Dinner slots for each day (default mode).
     /// </summary>
     /// <param name="owner">The user who owns this plan.</param>
     /// <param name="week">The week this plan covers.</param>
     /// <param name="defaultServings">Default servings per slot (from household profile).</param>
-    /// <returns>A new weekly plan with 7 empty slots.</returns>
+    /// <returns>A new weekly plan with 7 empty Dinner slots.</returns>
     public static WeeklyPlan Create(OwnerIdentifier owner, WeekIdentifier week, int defaultServings = 4)
     {
         var plan = new WeeklyPlan
@@ -37,50 +43,88 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
             Week = week,
         };
 
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Monday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Tuesday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Wednesday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Thursday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Friday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Saturday, defaultServings));
-        plan.slots.Add(MealSlot.Create(DayOfWeek.Sunday, defaultServings));
+        foreach (var day in allDays)
+            plan.slots.Add(MealSlot.Create(day, MealType.Dinner, defaultServings));
 
         return plan;
     }
 
     /// <summary>
-    /// Assign a recipe to a specific day's slot.
+    /// Enable extended mode — adds Breakfast and Lunch slots for each day.
+    /// Existing Dinner slots are preserved.
+    /// </summary>
+    /// <param name="defaultServings">Default servings for new slots.</param>
+    public void EnableExtendedMode(int defaultServings = 4)
+    {
+        if (IsExtendedMode) return;
+
+        foreach (var day in allDays)
+        {
+            if (!slots.Any(s => s.Day == day && s.MealType == MealType.Breakfast))
+                slots.Add(MealSlot.Create(day, MealType.Breakfast, defaultServings));
+            if (!slots.Any(s => s.Day == day && s.MealType == MealType.Lunch))
+                slots.Add(MealSlot.Create(day, MealType.Lunch, defaultServings));
+        }
+
+        IsExtendedMode = true;
+    }
+
+    /// <summary>
+    /// Disable extended mode — hides Breakfast and Lunch slots but preserves their data.
+    /// Only Dinner slots are visible in default mode.
+    /// </summary>
+    public void DisableExtendedMode()
+    {
+        IsExtendedMode = false;
+    }
+
+    /// <summary>
+    /// Get slots visible in the current mode.
+    /// </summary>
+    /// <returns>Dinner slots only in default mode, all slots in extended mode.</returns>
+    public IReadOnlyList<MealSlot> GetVisibleSlots()
+    {
+        return IsExtendedMode
+            ? slots.AsReadOnly()
+            : slots.Where(s => s.MealType == MealType.Dinner).ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Assign a recipe to a specific slot.
     /// </summary>
     /// <param name="day">The day of the week.</param>
     /// <param name="recipeIdentifier">The recipe identifier.</param>
     /// <param name="recipeTitle">The recipe title for display.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
     /// <param name="servings">Optional serving count override.</param>
-    public void AssignRecipe(DayOfWeek day, Guid recipeIdentifier, string recipeTitle, int? servings = null)
+    public void AssignRecipe(DayOfWeek day, Guid recipeIdentifier, string recipeTitle, MealType mealType = MealType.Dinner, int? servings = null)
     {
         Ensure.That(recipeTitle).IsNotNullOrWhiteSpace();
-        var slot = FindSlot(day);
+        var slot = FindSlot(day, mealType);
         slot.AssignRecipe(recipeIdentifier, recipeTitle, servings);
     }
 
     /// <summary>
-    /// Remove the recipe from a specific day's slot.
+    /// Remove the recipe from a specific slot.
     /// </summary>
     /// <param name="day">The day of the week.</param>
-    public void ClearSlot(DayOfWeek day)
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void ClearSlot(DayOfWeek day, MealType mealType = MealType.Dinner)
     {
-        var slot = FindSlot(day);
+        var slot = FindSlot(day, mealType);
         slot.ClearRecipe();
     }
 
     /// <summary>
-    /// Swap the meals between two days.
+    /// Swap the meals between two slots.
     /// </summary>
     /// <param name="day1">First day.</param>
     /// <param name="day2">Second day.</param>
-    public void SwapSlots(DayOfWeek day1, DayOfWeek day2)
+    /// <param name="mealType">The meal type to swap (defaults to Dinner).</param>
+    public void SwapSlots(DayOfWeek day1, DayOfWeek day2, MealType mealType = MealType.Dinner)
     {
-        var slot1 = FindSlot(day1);
-        var slot2 = FindSlot(day2);
+        var slot1 = FindSlot(day1, mealType);
+        var slot2 = FindSlot(day2, mealType);
 
         var tempRecipe = slot1.RecipeIdentifier;
         var tempTitle = slot1.RecipeTitle;
@@ -97,9 +141,10 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
             slot2.ClearRecipe();
     }
 
-    private MealSlot FindSlot(DayOfWeek day)
+    private MealSlot FindSlot(DayOfWeek day, MealType mealType)
     {
-        return slots.FirstOrDefault(s => s.Day == day)
-            ?? throw new EntityNotFoundException(nameof(MealSlot), day.ToString());
+        return slots.FirstOrDefault(s => s.Day == day && s.MealType == mealType)
+            ?? throw new EntityNotFoundException(nameof(MealSlot), $"{day}/{mealType}");
     }
 }
+#pragma warning restore SA1311

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
@@ -31,10 +31,13 @@ internal sealed class WeeklyPlanConfiguration : IEntityTypeConfiguration<WeeklyP
             slot.Property(s => s.Id)
                 .HasConversion<MealSlotIdentifierConverter>();
             slot.Property(s => s.Day).HasConversion<string>().HasMaxLength(10).IsRequired();
+            slot.Property(s => s.MealType).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.RecipeIdentifier);
             slot.Property(s => s.RecipeTitle).HasMaxLength(200);
             slot.Property(s => s.Servings).IsRequired();
         });
+
+        entity.Property(e => e.IsExtendedMode).IsRequired();
 
         entity.HasIndex(e => new { e.Owner, e.Week }).IsUnique();
         entity.Ignore(e => e.DomainEvents);

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.Designer.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MealPlanDbContext))]
-    partial class MealPlanDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412060256_AddExtendedMealPlanMode")]
+    partial class AddExtendedMealPlanMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExtendedMealPlanMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsExtendedMode",
+                table: "WeeklyPlans",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MealType",
+                table: "MealSlots",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsExtendedMode",
+                table: "WeeklyPlans");
+
+            migrationBuilder.DropColumn(
+                name: "MealType",
+                table: "MealSlots");
+        }
+    }
+}

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/AssignRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/AssignRecipeCommandHandlerTests.cs
@@ -26,7 +26,7 @@ public class AssignRecipeCommandHandlerTests
         plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
             .Returns((WeeklyPlan?)null);
 
-        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Pasta", null);
+        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
 
         var result = await handler.HandleAsync(command);
 
@@ -47,7 +47,7 @@ public class AssignRecipeCommandHandlerTests
         plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
             .Returns(existing);
 
-        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Wednesday, Guid.NewGuid(), "Steak", 6);
+        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Wednesday, Guid.NewGuid(), "Steak", Servings: 6);
 
         var result = await handler.HandleAsync(command);
 
@@ -62,7 +62,7 @@ public class AssignRecipeCommandHandlerTests
         plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
             .Returns((WeeklyPlan?)null);
 
-        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Friday, Guid.NewGuid(), "Fish", null);
+        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Friday, Guid.NewGuid(), "Fish");
 
         var result = await handler.HandleAsync(command);
 

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -49,7 +49,7 @@ public class WeeklyPlanTests
     {
         var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
 
-        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", 8);
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", servings: 8);
 
         plan.Slots.First(s => s.Day == DayOfWeek.Monday).Servings.Should().Be(8);
     }
@@ -176,5 +176,101 @@ public class WeeklyPlanTests
         days.Should().Contain(DayOfWeek.Friday);
         days.Should().Contain(DayOfWeek.Saturday);
         days.Should().Contain(DayOfWeek.Sunday);
+    }
+
+    [Fact]
+    public void Create_DefaultMode_AllSlotsDinner()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.IsExtendedMode.Should().BeFalse();
+        plan.Slots.Should().OnlyContain(s => s.MealType == MealType.Dinner);
+    }
+
+    [Fact]
+    public void EnableExtendedMode_Adds21Slots()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.EnableExtendedMode();
+
+        plan.IsExtendedMode.Should().BeTrue();
+        plan.Slots.Should().HaveCount(21);
+    }
+
+    [Fact]
+    public void EnableExtendedMode_PreservesDinnerRecipes()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        plan.EnableExtendedMode();
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday && s.MealType == MealType.Dinner).RecipeTitle.Should().Be("Pasta");
+    }
+
+    [Fact]
+    public void EnableExtendedMode_AlreadyExtended_NoOp()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+
+        plan.EnableExtendedMode();
+
+        plan.Slots.Should().HaveCount(21);
+    }
+
+    [Fact]
+    public void DisableExtendedMode_ShowsOnlyDinner()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+
+        plan.DisableExtendedMode();
+
+        plan.IsExtendedMode.Should().BeFalse();
+        plan.GetVisibleSlots().Should().HaveCount(7);
+        plan.GetVisibleSlots().Should().OnlyContain(s => s.MealType == MealType.Dinner);
+    }
+
+    [Fact]
+    public void DisableExtendedMode_PreservesAllData()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Cereal", MealType.Breakfast);
+
+        plan.DisableExtendedMode();
+
+        plan.Slots.Should().HaveCount(21);
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday && s.MealType == MealType.Breakfast).RecipeTitle.Should().Be("Cereal");
+    }
+
+    [Fact]
+    public void AssignRecipe_BreakfastSlot_InExtendedMode()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+
+        plan.AssignRecipe(DayOfWeek.Tuesday, Guid.NewGuid(), "Pancakes", MealType.Breakfast);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday && s.MealType == MealType.Breakfast).RecipeTitle.Should().Be("Pancakes");
+    }
+
+    [Fact]
+    public void GetVisibleSlots_ExtendedMode_ReturnsAll21()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+
+        plan.GetVisibleSlots().Should().HaveCount(21);
+    }
+
+    [Fact]
+    public void GetVisibleSlots_DefaultMode_Returns7()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.GetVisibleSlots().Should().HaveCount(7);
     }
 }


### PR DESCRIPTION
## Summary
- Add `MealType` enum (Breakfast, Lunch, Dinner) to `MealSlot`
- Default mode: 7 Dinner slots per week
- Extended mode: 21 slots (Breakfast + Lunch + Dinner per day)
- `EnableExtendedMode()` adds missing Breakfast/Lunch slots, preserves Dinner recipes
- `DisableExtendedMode()` hides non-Dinner slots but keeps all data
- `GetVisibleSlots()` returns mode-appropriate slots
- All commands accept optional `MealType` (defaults to Dinner for backward compatibility)

Closes #169

## Test plan
- [x] Default mode: all slots are Dinner
- [x] EnableExtendedMode creates 21 slots
- [x] EnableExtendedMode preserves existing Dinner recipes
- [x] EnableExtendedMode already extended is no-op
- [x] DisableExtendedMode shows only Dinner via GetVisibleSlots
- [x] DisableExtendedMode preserves all data (21 slots still exist)
- [x] Assign recipe to Breakfast slot in extended mode
- [x] GetVisibleSlots: 21 in extended, 7 in default
- [x] All 24 MealPlan domain tests pass (9 new)
- [x] All 5 application + 64 architecture tests pass