### PR TITLE
fix(mealplan): add extended mode endpoint, migration fix, coverage (US-321)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -25,6 +25,11 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
+        group.MapPut("/{year:int}/w/{weekNumber:int}/extended-mode", ToggleExtendedModeAsync)
+            .WithName("ToggleExtendedMode")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>();
+
         return app;
     }
 
@@ -55,6 +60,18 @@ public static class MealPlanEndpoints
             request.MealType,
             request.Servings);
 
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ToggleExtendedModeAsync(
+        int year,
+        int weekNumber,
+        ToggleExtendedModeRequest request,
+        ICommandHandler<ToggleExtendedModeCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ToggleExtendedModeCommand(year, weekNumber, request.Enable);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Api/Requests/ToggleExtendedModeRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ToggleExtendedModeRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record ToggleExtendedModeRequest(bool Enable);

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
@@ -1,0 +1,43 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class ToggleExtendedModeCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<ToggleExtendedModeCommand, Result<WeeklyPlanDto>>
+{
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(ToggleExtendedModeCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+        if (plan is null)
+        {
+            plan = WeeklyPlan.Create(owner, week);
+            if (command.Enable)
+                plan.EnableExtendedMode();
+            await plans.AddAsync(plan, cancellationToken);
+        }
+        else
+        {
+            plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+            if (command.Enable)
+                plan.EnableExtendedMode();
+            else
+                plan.DisableExtendedMode();
+            await plans.SaveChangesAsync(cancellationToken);
+        }
+
+        var visibleSlots = plan.GetVisibleSlots()
+            .OrderBy(s => s.Day)
+            .ThenBy(s => s.MealType)
+            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
+            .ToList();
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
+    }
+}

--- a/src/Yumney.MealPlan.Application/Commands/ToggleExtendedModeCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/ToggleExtendedModeCommand.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record ToggleExtendedModeCommand(
+    int Year,
+    int WeekNumber,
+    bool Enable) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412060256_AddExtendedMealPlanMode.cs
@@ -23,7 +23,7 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migration
                 type: "character varying(10)",
                 maxLength: 10,
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "Dinner");
         }
 
         /// <inheritdoc />

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/AssignRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/AssignRecipeCommandHandlerTests.cs
@@ -68,4 +68,25 @@ public class AssignRecipeCommandHandlerTests
 
         result.Value.Week.Should().Be("2026-W15");
     }
+
+    [Fact]
+    public async Task HandleAsync_WithBreakfastMealType_AssignsToBreakfastSlot()
+    {
+        var owner = OwnerIdentifier.From("user-123");
+        var week = WeekIdentifier.From(2026, 15);
+        var existing = WeeklyPlan.Create(owner, week);
+        existing.EnableExtendedMode();
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        var command = new AssignRecipeCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Pancakes", MealType.Breakfast);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.Should().Contain(s => s.RecipeTitle == "Pancakes" && s.MealType == "Breakfast");
+    }
 }

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/ToggleExtendedModeCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/ToggleExtendedModeCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class ToggleExtendedModeCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ToggleExtendedModeCommandHandler handler;
+
+    public ToggleExtendedModeCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new ToggleExtendedModeCommandHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_EnableNoPlan_CreatesExtended()
+    {
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((WeeklyPlan?)null);
+
+        var result = await handler.HandleAsync(new ToggleExtendedModeCommand(2026, 15, true));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsExtendedMode.Should().BeTrue();
+        result.Value.Slots.Should().HaveCount(21);
+        await plans.Received(1).AddAsync(Arg.Any<WeeklyPlan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_DisableExisting_Returns7Slots()
+    {
+        var owner = OwnerIdentifier.From("user-123");
+        var week = WeekIdentifier.From(2026, 15);
+        var existing = WeeklyPlan.Create(owner, week);
+        existing.EnableExtendedMode();
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        var result = await handler.HandleAsync(new ToggleExtendedModeCommand(2026, 15, false));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsExtendedMode.Should().BeFalse();
+        result.Value.Slots.Should().HaveCount(7);
+    }
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -273,4 +273,48 @@ public class WeeklyPlanTests
 
         plan.GetVisibleSlots().Should().HaveCount(7);
     }
+
+    [Fact]
+    public void AssignRecipe_BreakfastInDefaultMode_ThrowsEntityNotFoundException()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Cereal", MealType.Breakfast);
+
+        act.Should().Throw<EntityNotFoundException>();
+    }
+
+    [Fact]
+    public void ClearSlot_BreakfastInDefaultMode_ThrowsEntityNotFoundException()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.ClearSlot(DayOfWeek.Monday, MealType.Breakfast);
+
+        act.Should().Throw<EntityNotFoundException>();
+    }
+
+    [Fact]
+    public void SwapSlots_BreakfastInExtendedMode_Works()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.EnableExtendedMode();
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pancakes", MealType.Breakfast);
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Tuesday, MealType.Breakfast);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday && s.MealType == MealType.Breakfast).IsEmpty.Should().BeTrue();
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday && s.MealType == MealType.Breakfast).RecipeTitle.Should().Be("Pancakes");
+    }
+
+    [Fact]
+    public void DisableExtendedMode_NotExtended_NoOp()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.DisableExtendedMode();
+
+        plan.IsExtendedMode.Should().BeFalse();
+        plan.Slots.Should().HaveCount(7);
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up to #216 — addresses 4 gaps.

1. **ToggleExtendedMode endpoint** — `PUT .../extended-mode` with `{ enable: true/false }`
2. **Migration fix** — MealType default changed from "" to "Dinner" for existing rows
3. **4 new domain tests** — Breakfast in default mode throws, clear Breakfast throws, swap Breakfast extended, disable not-extended no-op
4. **3 new handler tests** — Breakfast assignment, toggle enable creates 21 slots, toggle disable returns 7

## Test plan
- [x] All 28 MealPlan domain tests pass (4 new)
- [x] All 8 MealPlan application tests pass (3 new)
- [x] All 64 architecture tests pass