### PR TITLE
feat(mealplan): add slot content types — Recipe, Leftover, Freetext, Empty (US-322)

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
@@ -28,12 +28,6 @@ public sealed class AssignRecipeCommandHandler(
             await plans.SaveChangesAsync(cancellationToken);
         }
 
-        var visibleSlots = plan.GetVisibleSlots()
-            .OrderBy(s => s.Day)
-            .ThenBy(s => s.MealType)
-            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
-            .ToList();
-
-        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
     }
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
@@ -32,12 +32,6 @@ public sealed class ToggleExtendedModeCommandHandler(
             await plans.SaveChangesAsync(cancellationToken);
         }
 
-        var visibleSlots = plan.GetVisibleSlots()
-            .OrderBy(s => s.Day)
-            .ThenBy(s => s.MealType)
-            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
-            .ToList();
-
-        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
     }
 }

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
@@ -1,5 +1,15 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public sealed record MealSlotDto(string Day, string MealType, Guid? RecipeIdentifier, string? RecipeTitle, int Servings, bool IsEmpty);
+public sealed record MealSlotDto(
+    string Day,
+    string MealType,
+    string ContentType,
+    Guid? RecipeIdentifier,
+    string? RecipeTitle,
+    int Servings,
+    string? FreetextLabel,
+    string? LeftoverSourceDay,
+    string? LeftoverSourceMealType,
+    bool IsEmpty);
 
 public sealed record WeeklyPlanDto(string Week, bool IsExtendedMode, IReadOnlyList<MealSlotDto> Slots);

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotMappingExtensions.cs
@@ -1,0 +1,30 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+public static class MealSlotMappingExtensions
+{
+    public static MealSlotDto ToDto(this MealSlot slot)
+    {
+        return new MealSlotDto(
+            slot.Day.ToString(),
+            slot.MealType.ToString(),
+            slot.ContentType.ToString(),
+            slot.RecipeIdentifier,
+            slot.RecipeTitle,
+            slot.Servings,
+            slot.FreetextLabel,
+            slot.LeftoverSourceDay?.ToString(),
+            slot.LeftoverSourceMealType?.ToString(),
+            slot.IsEmpty);
+    }
+
+    public static List<MealSlotDto> ToOrderedDtos(this IEnumerable<MealSlot> slots)
+    {
+        return slots
+            .OrderBy(s => s.Day)
+            .ThenBy(s => s.MealType)
+            .Select(s => s.ToDto())
+            .ToList();
+    }
+}

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetWeeklyPlanQueryHandler.cs
@@ -18,24 +18,10 @@ public sealed class GetWeeklyPlanQueryHandler(
 
         if (plan is null)
         {
-            var emptySlots = Enumerable.Range(0, 7)
-                .Select(i => new MealSlotDto(
-                    ((DayOfWeek)((i + 1) % 7)).ToString(),
-                    MealType.Dinner.ToString(),
-                    null,
-                    null,
-                    4,
-                    true))
-                .ToList();
-            return new WeeklyPlanDto(week.Value, false, emptySlots);
+            var empty = WeeklyPlan.Create(owner, week);
+            return new WeeklyPlanDto(week.Value, false, empty.GetVisibleSlots().ToOrderedDtos());
         }
 
-        var visibleSlots = plan.GetVisibleSlots()
-            .OrderBy(s => s.Day)
-            .ThenBy(s => s.MealType)
-            .Select(s => new MealSlotDto(s.Day.ToString(), s.MealType.ToString(), s.RecipeIdentifier, s.RecipeTitle, s.Servings, s.IsEmpty))
-            .ToList();
-
-        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, visibleSlots);
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
     }
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
@@ -4,7 +4,7 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 /// <summary>
 /// A single meal slot within a weekly plan.
-/// Default mode: one Dinner slot per day. Extended mode: Breakfast + Lunch + Dinner.
+/// Supports four content types: Empty, Recipe, Leftover, Freetext.
 /// </summary>
 public sealed class MealSlot : Entity<MealSlotIdentifier>
 {
@@ -12,13 +12,21 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
 
     public MealType MealType { get; private set; }
 
+    public SlotContentType ContentType { get; private set; }
+
     public Guid? RecipeIdentifier { get; private set; }
 
     public string? RecipeTitle { get; private set; }
 
     public int Servings { get; private set; }
 
-    public bool IsEmpty => RecipeIdentifier is null;
+    public string? FreetextLabel { get; private set; }
+
+    public DayOfWeek? LeftoverSourceDay { get; private set; }
+
+    public MealType? LeftoverSourceMealType { get; private set; }
+
+    public bool IsEmpty => ContentType == SlotContentType.Empty;
 
     private MealSlot()
     {
@@ -31,22 +39,53 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
             Id = MealSlotIdentifier.New(),
             Day = day,
             MealType = mealType,
+            ContentType = SlotContentType.Empty,
             Servings = defaultServings,
         };
     }
 
     internal void AssignRecipe(Guid recipeIdentifier, string recipeTitle, int? servings = null)
     {
+        ContentType = SlotContentType.Recipe;
         RecipeIdentifier = recipeIdentifier;
         RecipeTitle = recipeTitle;
+        FreetextLabel = null;
+        LeftoverSourceDay = null;
+        LeftoverSourceMealType = null;
         if (servings.HasValue)
             Servings = servings.Value;
     }
 
-    internal void ClearRecipe()
+    internal void SetAsFreetext(string label)
     {
+        ContentType = SlotContentType.Freetext;
+        FreetextLabel = label;
         RecipeIdentifier = null;
         RecipeTitle = null;
+        LeftoverSourceDay = null;
+        LeftoverSourceMealType = null;
+    }
+
+    internal void SetAsLeftover(DayOfWeek sourceDay, MealType sourceMealType, string sourceRecipeTitle, int? servings = null)
+    {
+        ContentType = SlotContentType.Leftover;
+        LeftoverSourceDay = sourceDay;
+        LeftoverSourceMealType = sourceMealType;
+        RecipeTitle = $"Leftovers: {sourceRecipeTitle}";
+        RecipeIdentifier = null;
+        FreetextLabel = null;
+        if (servings.HasValue)
+            Servings = servings.Value;
+    }
+
+    internal void ClearSlot()
+    {
+        ContentType = SlotContentType.Empty;
+        RecipeIdentifier = null;
+        RecipeTitle = null;
+        FreetextLabel = null;
+        LeftoverSourceDay = null;
+        LeftoverSourceMealType = null;
     }
 
     internal void AdjustServingsTo(int servings)

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotContentType.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotContentType.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// The type of content in a meal slot.
+/// </summary>
+public enum SlotContentType
+{
+    /// <summary>No plan for this slot.</summary>
+    Empty,
+
+    /// <summary>Linked to a saved recipe with full ingredient/shopping integration.</summary>
+    Recipe,
+
+    /// <summary>Leftovers from another meal — no new shopping items.</summary>
+    Leftover,
+
+    /// <summary>Freetext label only — eating out, pizza order, etc.</summary>
+    Freetext,
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -105,14 +105,43 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
     }
 
     /// <summary>
-    /// Remove the recipe from a specific slot.
+    /// Set a slot as freetext (eating out, pizza order, etc.). No shopping integration.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="label">The freetext label.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void SetFreetext(DayOfWeek day, string label, MealType mealType = MealType.Dinner)
+    {
+        Ensure.That(label).IsNotNullOrWhiteSpace();
+        var slot = FindSlot(day, mealType);
+        slot.SetAsFreetext(label);
+    }
+
+    /// <summary>
+    /// Set a slot as leftovers from another meal. No new shopping items.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="sourceDay">The day of the source meal.</param>
+    /// <param name="sourceMealType">The meal type of the source meal.</param>
+    /// <param name="sourceRecipeTitle">The source recipe title for display.</param>
+    /// <param name="mealType">The meal type of this slot (defaults to Dinner).</param>
+    /// <param name="servings">Optional serving count.</param>
+    public void SetLeftover(DayOfWeek day, DayOfWeek sourceDay, MealType sourceMealType, string sourceRecipeTitle, MealType mealType = MealType.Dinner, int? servings = null)
+    {
+        Ensure.That(sourceRecipeTitle).IsNotNullOrWhiteSpace();
+        var slot = FindSlot(day, mealType);
+        slot.SetAsLeftover(sourceDay, sourceMealType, sourceRecipeTitle, servings);
+    }
+
+    /// <summary>
+    /// Clear a slot back to empty.
     /// </summary>
     /// <param name="day">The day of the week.</param>
     /// <param name="mealType">The meal type (defaults to Dinner).</param>
     public void ClearSlot(DayOfWeek day, MealType mealType = MealType.Dinner)
     {
         var slot = FindSlot(day, mealType);
-        slot.ClearRecipe();
+        slot.ClearSlot();
     }
 
     /// <summary>
@@ -133,12 +162,12 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
         if (slot2.RecipeIdentifier.HasValue)
             slot1.AssignRecipe(slot2.RecipeIdentifier.Value, slot2.RecipeTitle!, slot2.Servings);
         else
-            slot1.ClearRecipe();
+            slot1.ClearSlot();
 
         if (tempRecipe.HasValue)
             slot2.AssignRecipe(tempRecipe.Value, tempTitle!, tempServings);
         else
-            slot2.ClearRecipe();
+            slot2.ClearSlot();
     }
 
     private MealSlot FindSlot(DayOfWeek day, MealType mealType)

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
@@ -32,9 +32,13 @@ internal sealed class WeeklyPlanConfiguration : IEntityTypeConfiguration<WeeklyP
                 .HasConversion<MealSlotIdentifierConverter>();
             slot.Property(s => s.Day).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.MealType).HasConversion<string>().HasMaxLength(10).IsRequired();
+            slot.Property(s => s.ContentType).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.RecipeIdentifier);
             slot.Property(s => s.RecipeTitle).HasMaxLength(200);
             slot.Property(s => s.Servings).IsRequired();
+            slot.Property(s => s.FreetextLabel).HasMaxLength(200);
+            slot.Property(s => s.LeftoverSourceDay).HasConversion<string>().HasMaxLength(10);
+            slot.Property(s => s.LeftoverSourceMealType).HasConversion<string>().HasMaxLength(10);
         });
 
         entity.Property(e => e.IsExtendedMode).IsRequired();

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412074506_AddSlotContentTypes.Designer.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412074506_AddSlotContentTypes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MealPlanDbContext))]
-    partial class MealPlanDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412074506_AddSlotContentTypes")]
+    partial class AddSlotContentTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412074506_AddSlotContentTypes.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412074506_AddSlotContentTypes.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSlotContentTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ContentType",
+                table: "MealSlots",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FreetextLabel",
+                table: "MealSlots",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LeftoverSourceDay",
+                table: "MealSlots",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LeftoverSourceMealType",
+                table: "MealSlots",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContentType",
+                table: "MealSlots");
+
+            migrationBuilder.DropColumn(
+                name: "FreetextLabel",
+                table: "MealSlots");
+
+            migrationBuilder.DropColumn(
+                name: "LeftoverSourceDay",
+                table: "MealSlots");
+
+            migrationBuilder.DropColumn(
+                name: "LeftoverSourceMealType",
+                table: "MealSlots");
+        }
+    }
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -317,4 +317,100 @@ public class WeeklyPlanTests
         plan.IsExtendedMode.Should().BeFalse();
         plan.Slots.Should().HaveCount(7);
     }
+
+    [Fact]
+    public void SetFreetext_SetsContentType()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.SetFreetext(DayOfWeek.Monday, "Eating out");
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.ContentType.Should().Be(SlotContentType.Freetext);
+        monday.FreetextLabel.Should().Be("Eating out");
+        monday.IsEmpty.Should().BeFalse();
+        monday.RecipeIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetFreetext_EmptyLabel_ThrowsGuardException()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.SetFreetext(DayOfWeek.Monday, string.Empty);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void SetLeftover_SetsContentTypeAndSource()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Bolognese");
+
+        plan.SetLeftover(DayOfWeek.Wednesday, DayOfWeek.Monday, MealType.Dinner, "Bolognese");
+
+        var wednesday = plan.Slots.First(s => s.Day == DayOfWeek.Wednesday);
+        wednesday.ContentType.Should().Be(SlotContentType.Leftover);
+        wednesday.LeftoverSourceDay.Should().Be(DayOfWeek.Monday);
+        wednesday.LeftoverSourceMealType.Should().Be(MealType.Dinner);
+        wednesday.RecipeTitle.Should().Contain("Bolognese");
+        wednesday.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetLeftover_EmptyTitle_ThrowsGuardException()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.SetLeftover(DayOfWeek.Wednesday, DayOfWeek.Monday, MealType.Dinner, string.Empty);
+
+        act.Should().Throw<GuardException>();
+    }
+
+    [Fact]
+    public void AssignRecipe_SetsContentTypeToRecipe()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.AssignRecipe(DayOfWeek.Tuesday, Guid.NewGuid(), "Steak");
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).ContentType.Should().Be(SlotContentType.Recipe);
+    }
+
+    [Fact]
+    public void ClearSlot_ResetsContentTypeToEmpty()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.SetFreetext(DayOfWeek.Monday, "Pizza night");
+
+        plan.ClearSlot(DayOfWeek.Monday);
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.ContentType.Should().Be(SlotContentType.Empty);
+        monday.FreetextLabel.Should().BeNull();
+        monday.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AssignRecipe_ClearsFreetextAndLeftoverFields()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.SetFreetext(DayOfWeek.Monday, "Eating out");
+
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.ContentType.Should().Be(SlotContentType.Recipe);
+        monday.FreetextLabel.Should().BeNull();
+        monday.LeftoverSourceDay.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_AllSlotsStartEmpty()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.Slots.Should().OnlyContain(s => s.ContentType == SlotContentType.Empty);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `SlotContentType` enum: Empty, Recipe, Leftover, Freetext
- `SetFreetext(day, label)` — label-only slot, no shopping integration
- `SetLeftover(day, sourceDay, sourceMealType, title)` — leftovers from another meal
- `ClearSlot()` resets to Empty, clears all fields
- `AssignRecipe()` sets Recipe type, clears freetext/leftover fields
- `MealSlotMappingExtensions.ToDto()` centralizes DTO mapping
- Migration adds 4 new columns to MealSlots table

Closes #170

## Test plan
- [x] SetFreetext sets ContentType and label
- [x] SetFreetext empty label throws GuardException
- [x] SetLeftover sets source day/type and title
- [x] SetLeftover empty title throws GuardException
- [x] AssignRecipe sets ContentType to Recipe
- [x] ClearSlot resets to Empty
- [x] AssignRecipe clears freetext/leftover fields
- [x] All new slots start as Empty
- [x] All 36 MealPlan domain tests pass (8 new)
- [x] All 8 application + 64 architecture tests pass