### PR TITLE
fix(mealplan): fix SwapSlots to swap all content types (US-322)

### DIFF
--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
@@ -92,4 +92,29 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
     {
         Servings = servings;
     }
+
+    internal SlotSnapshot TakeSnapshot()
+    {
+        return new SlotSnapshot(ContentType, RecipeIdentifier, RecipeTitle, Servings, FreetextLabel, LeftoverSourceDay, LeftoverSourceMealType);
+    }
+
+    internal void RestoreFromSnapshot(SlotSnapshot snapshot)
+    {
+        ContentType = snapshot.ContentType;
+        RecipeIdentifier = snapshot.RecipeIdentifier;
+        RecipeTitle = snapshot.RecipeTitle;
+        Servings = snapshot.Servings;
+        FreetextLabel = snapshot.FreetextLabel;
+        LeftoverSourceDay = snapshot.LeftoverSourceDay;
+        LeftoverSourceMealType = snapshot.LeftoverSourceMealType;
+    }
+
+    internal sealed record SlotSnapshot(
+        SlotContentType ContentType,
+        Guid? RecipeIdentifier,
+        string? RecipeTitle,
+        int Servings,
+        string? FreetextLabel,
+        DayOfWeek? LeftoverSourceDay,
+        MealType? LeftoverSourceMealType);
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -155,19 +155,9 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
         var slot1 = FindSlot(day1, mealType);
         var slot2 = FindSlot(day2, mealType);
 
-        var tempRecipe = slot1.RecipeIdentifier;
-        var tempTitle = slot1.RecipeTitle;
-        var tempServings = slot1.Servings;
-
-        if (slot2.RecipeIdentifier.HasValue)
-            slot1.AssignRecipe(slot2.RecipeIdentifier.Value, slot2.RecipeTitle!, slot2.Servings);
-        else
-            slot1.ClearSlot();
-
-        if (tempRecipe.HasValue)
-            slot2.AssignRecipe(tempRecipe.Value, tempTitle!, tempServings);
-        else
-            slot2.ClearSlot();
+        var snapshot1 = slot1.TakeSnapshot();
+        slot1.RestoreFromSnapshot(slot2.TakeSnapshot());
+        slot2.RestoreFromSnapshot(snapshot1);
     }
 
     private MealSlot FindSlot(DayOfWeek day, MealType mealType)

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -413,4 +413,55 @@ public class WeeklyPlanTests
 
         plan.Slots.Should().OnlyContain(s => s.ContentType == SlotContentType.Empty);
     }
+
+    [Fact]
+    public void SwapSlots_RecipeWithFreetext_SwapsAllContent()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        var recipeId = Guid.NewGuid();
+        plan.AssignRecipe(DayOfWeek.Monday, recipeId, "Pasta");
+        plan.SetFreetext(DayOfWeek.Tuesday, "Eating out");
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Tuesday);
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.ContentType.Should().Be(SlotContentType.Freetext);
+        monday.FreetextLabel.Should().Be("Eating out");
+        monday.RecipeIdentifier.Should().BeNull();
+
+        var tuesday = plan.Slots.First(s => s.Day == DayOfWeek.Tuesday);
+        tuesday.ContentType.Should().Be(SlotContentType.Recipe);
+        tuesday.RecipeIdentifier.Should().Be(recipeId);
+        tuesday.FreetextLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public void SwapSlots_RecipeWithLeftover_SwapsAllContent()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Bolognese");
+        plan.SetLeftover(DayOfWeek.Wednesday, DayOfWeek.Monday, MealType.Dinner, "Bolognese");
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Wednesday);
+
+        var monday = plan.Slots.First(s => s.Day == DayOfWeek.Monday);
+        monday.ContentType.Should().Be(SlotContentType.Leftover);
+        monday.LeftoverSourceDay.Should().Be(DayOfWeek.Monday);
+
+        var wednesday = plan.Slots.First(s => s.Day == DayOfWeek.Wednesday);
+        wednesday.ContentType.Should().Be(SlotContentType.Recipe);
+        wednesday.RecipeTitle.Should().Be("Bolognese");
+    }
+
+    [Fact]
+    public void SwapSlots_FreetextWithEmpty_MovesContent()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.SetFreetext(DayOfWeek.Monday, "Pizza order");
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Tuesday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).IsEmpty.Should().BeTrue();
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).FreetextLabel.Should().Be("Pizza order");
+    }
 }


### PR DESCRIPTION
## Summary
**Bug:** SwapSlots only swapped Recipe fields, losing Freetext/Leftover content.

**Fix:** Introduce `TakeSnapshot()`/`RestoreFromSnapshot()` on MealSlot — captures all 7 content fields atomically. SwapSlots now uses snapshot-based swap.

## Test plan
- [x] Swap Recipe ↔ Freetext: both content types preserved
- [x] Swap Recipe ↔ Leftover: source reference preserved
- [x] Swap Freetext ↔ Empty: freetext moves correctly
- [x] All 39 MealPlan domain tests pass (3 new regression tests)