### PR TITLE
feat(mealplan): add per-slot serving override (US-323)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -30,6 +30,12 @@ public static class MealPlanEndpoints
             .WithTags("MealPlan")
             .Produces<WeeklyPlanDto>();
 
+        group.MapPut("/{year:int}/w/{weekNumber:int}/slots/servings", AdjustServingsAsync)
+            .WithName("AdjustSlotServings")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -72,6 +78,18 @@ public static class MealPlanEndpoints
         CancellationToken cancellationToken)
     {
         var command = new ToggleExtendedModeCommand(year, weekNumber, request.Enable);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> AdjustServingsAsync(
+        int year,
+        int weekNumber,
+        AdjustServingsRequest request,
+        ICommandHandler<AdjustSlotServingsCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new AdjustSlotServingsCommand(year, weekNumber, request.Day, request.MealType, request.Servings);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Api/Requests/AdjustServingsRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AdjustServingsRequest.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record AdjustServingsRequest(DayOfWeek Day, MealType MealType, int Servings);

--- a/src/Yumney.MealPlan.Application/Commands/AdjustSlotServingsCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/AdjustSlotServingsCommand.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record AdjustSlotServingsCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek Day,
+    MealType MealType,
+    int Servings) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AdjustSlotServingsCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AdjustSlotServingsCommandHandler.cs
@@ -1,0 +1,24 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class AdjustSlotServingsCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<AdjustSlotServingsCommand, Result<WeeklyPlanDto>>
+{
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(AdjustSlotServingsCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+
+        plan.AdjustServings(command.Day, command.Servings, command.MealType);
+        await plans.SaveChangesAsync(cancellationToken);
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+    }
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -145,6 +145,18 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
     }
 
     /// <summary>
+    /// Adjust servings for a specific slot.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="servings">The new serving count.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void AdjustServings(DayOfWeek day, int servings, MealType mealType = MealType.Dinner)
+    {
+        var slot = FindSlot(day, mealType);
+        slot.AdjustServingsTo(servings);
+    }
+
+    /// <summary>
     /// Swap the meals between two slots.
     /// </summary>
     /// <param name="day1">First day.</param>

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -464,4 +464,37 @@ public class WeeklyPlanTests
         plan.Slots.First(s => s.Day == DayOfWeek.Monday).IsEmpty.Should().BeTrue();
         plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).FreetextLabel.Should().Be("Pizza order");
     }
+
+    [Fact]
+    public void AdjustServings_ChangesSlotServings()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15), 4);
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        plan.AdjustServings(DayOfWeek.Monday, 8);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).Servings.Should().Be(8);
+    }
+
+    [Fact]
+    public void AdjustServings_DefaultServingsPreservedOnOtherSlots()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15), 4);
+
+        plan.AdjustServings(DayOfWeek.Monday, 6);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).Servings.Should().Be(4);
+    }
+
+    [Fact]
+    public void SwapSlots_PreservesServings()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15), 4);
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", servings: 8);
+
+        plan.SwapSlots(DayOfWeek.Monday, DayOfWeek.Tuesday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).Servings.Should().Be(8);
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).Servings.Should().Be(4);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `AdjustServings(day, servings, mealType)` on aggregate
- `AdjustSlotServingsCommand` + handler
- Endpoint: `PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/servings`
- Servings are per-slot, independent of household default

Closes #171

## Test plan
- [x] AdjustServings changes slot servings
- [x] Other slots retain default servings
- [x] SwapSlots preserves servings
- [x] All 42 MealPlan domain tests pass (3 new)
- [x] All 64 architecture tests pass