### PR TITLE
fix(mealplan): add servings validation and handler tests (US-323)

### DIFF
--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -152,6 +152,7 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
     /// <param name="mealType">The meal type (defaults to Dinner).</param>
     public void AdjustServings(DayOfWeek day, int servings, MealType mealType = MealType.Dinner)
     {
+        Ensure.That(servings).IsPositive();
         var slot = FindSlot(day, mealType);
         slot.AdjustServingsTo(servings);
     }

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/AdjustSlotServingsCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/AdjustSlotServingsCommandHandlerTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class AdjustSlotServingsCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly AdjustSlotServingsCommandHandler handler;
+
+    public AdjustSlotServingsCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new AdjustSlotServingsCommandHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_AdjustsServingsAndSaves()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var command = new AdjustSlotServingsCommand(2026, 15, DayOfWeek.Monday, MealType.Dinner, 8);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.First(s => s.Day == "Monday").Servings.Should().Be(8);
+        await plans.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentPlan_ThrowsEntityNotFoundException()
+    {
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns<WeeklyPlan>(_ => throw new EntityNotFoundException(nameof(WeeklyPlan), "2026-W15"));
+
+        var command = new AdjustSlotServingsCommand(2026, 15, DayOfWeek.Monday, MealType.Dinner, 6);
+
+        var act = () => handler.HandleAsync(command);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -497,4 +497,16 @@ public class WeeklyPlanTests
         plan.Slots.First(s => s.Day == DayOfWeek.Tuesday).Servings.Should().Be(8);
         plan.Slots.First(s => s.Day == DayOfWeek.Monday).Servings.Should().Be(4);
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void AdjustServings_ZeroOrNegative_ThrowsGuardException(int servings)
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        var act = () => plan.AdjustServings(DayOfWeek.Monday, servings);
+
+        act.Should().Throw<GuardException>();
+    }
 }


### PR DESCRIPTION
## Summary
- Validate servings > 0 with `Ensure.That(servings).IsPositive()`
- 2 handler tests: adjusts and saves, non-existent plan throws
- 2 domain tests: 0 and negative servings throw GuardException

## Test plan
- [x] All 44 domain tests pass (2 new)
- [x] All 10 application tests pass (2 new)