### PR TITLE
feat(mealplan): add cook-with-leftovers for volume planning (US-324)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -36,6 +36,12 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapPost("/{year:int}/w/{weekNumber:int}/cook-with-leftovers", CookWithLeftoversAsync)
+            .WithName("CookWithLeftovers")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         return app;
     }
 
@@ -90,6 +96,27 @@ public static class MealPlanEndpoints
         CancellationToken cancellationToken)
     {
         var command = new AdjustSlotServingsCommand(year, weekNumber, request.Day, request.MealType, request.Servings);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> CookWithLeftoversAsync(
+        int year,
+        int weekNumber,
+        CookWithLeftoversRequest request,
+        ICommandHandler<CookWithLeftoversCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new CookWithLeftoversCommand(
+            year,
+            weekNumber,
+            request.CookDay,
+            request.RecipeIdentifier,
+            request.RecipeTitle,
+            request.TotalServings,
+            request.EatServings,
+            request.LeftoverDay,
+            request.MealType);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Api/Requests/CookWithLeftoversRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/CookWithLeftoversRequest.cs
@@ -1,0 +1,12 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record CookWithLeftoversRequest(
+    DayOfWeek CookDay,
+    Guid RecipeIdentifier,
+    string RecipeTitle,
+    int TotalServings,
+    int EatServings,
+    DayOfWeek LeftoverDay,
+    MealType MealType = MealType.Dinner);

--- a/src/Yumney.MealPlan.Application/Commands/CookWithLeftoversCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/CookWithLeftoversCommand.cs
@@ -1,0 +1,21 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+/// <summary>
+/// Assign a recipe with extra servings and create a linked leftover slot on another day.
+/// Shopping list calculates for total servings, leftover slot generates no shopping items.
+/// </summary>
+public sealed record CookWithLeftoversCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek CookDay,
+    Guid RecipeIdentifier,
+    string RecipeTitle,
+    int TotalServings,
+    int EatServings,
+    DayOfWeek LeftoverDay,
+    MealType MealType = MealType.Dinner) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
@@ -1,0 +1,43 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class CookWithLeftoversCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<CookWithLeftoversCommand, Result<WeeklyPlanDto>>
+{
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(CookWithLeftoversCommand command, CancellationToken cancellationToken = default)
+    {
+        Ensure.That(command.TotalServings).IsPositive();
+        Ensure.That(command.EatServings).IsPositive();
+        Ensure.That(command.RecipeTitle).IsNotNullOrWhiteSpace();
+
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+        var leftoverServings = command.TotalServings - command.EatServings;
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+        if (plan is null)
+        {
+            plan = WeeklyPlan.Create(owner, week);
+            plan.AssignRecipe(command.CookDay, command.RecipeIdentifier, command.RecipeTitle, command.MealType, command.TotalServings);
+            if (leftoverServings > 0)
+                plan.SetLeftover(command.LeftoverDay, command.CookDay, command.MealType, command.RecipeTitle, command.MealType, leftoverServings);
+            await plans.AddAsync(plan, cancellationToken);
+        }
+        else
+        {
+            plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+            plan.AssignRecipe(command.CookDay, command.RecipeIdentifier, command.RecipeTitle, command.MealType, command.TotalServings);
+            if (leftoverServings > 0)
+                plan.SetLeftover(command.LeftoverDay, command.CookDay, command.MealType, command.RecipeTitle, command.MealType, leftoverServings);
+            await plans.SaveChangesAsync(cancellationToken);
+        }
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+    }
+}

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/CookWithLeftoversCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/CookWithLeftoversCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class CookWithLeftoversCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly CookWithLeftoversCommandHandler handler;
+
+    public CookWithLeftoversCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new CookWithLeftoversCommandHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_Cook8Eat4_CreatesRecipeAndLeftover()
+    {
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((WeeklyPlan?)null);
+
+        var command = new CookWithLeftoversCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Bolognese", 8, 4, DayOfWeek.Wednesday);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var monday = result.Value.Slots.First(s => s.Day == "Monday");
+        monday.ContentType.Should().Be("Recipe");
+        monday.Servings.Should().Be(8);
+
+        var wednesday = result.Value.Slots.First(s => s.Day == "Wednesday");
+        wednesday.ContentType.Should().Be("Leftover");
+        wednesday.LeftoverSourceDay.Should().Be("Monday");
+        wednesday.Servings.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoLeftoverWhenEqual_OnlyRecipe()
+    {
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((WeeklyPlan?)null);
+
+        var command = new CookWithLeftoversCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Pasta", 4, 4, DayOfWeek.Tuesday);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.First(s => s.Day == "Monday").ContentType.Should().Be("Recipe");
+        result.Value.Slots.First(s => s.Day == "Tuesday").ContentType.Should().Be("Empty");
+    }
+
+    [Fact]
+    public async Task HandleAsync_InvalidServings_ThrowsGuardException()
+    {
+        var command = new CookWithLeftoversCommand(2026, 15, DayOfWeek.Monday, Guid.NewGuid(), "Pasta", 0, 0, DayOfWeek.Tuesday);
+
+        var act = () => handler.HandleAsync(command);
+
+        await act.Should().ThrowAsync<GuardException>();
+    }
+}


### PR DESCRIPTION
## Summary
- `CookWithLeftoversCommand` — assign recipe with total servings + create linked leftover
- Source meal gets total servings (for shopping calculation)
- Leftover slot gets remaining servings, linked to source day
- No leftover created if total == eat servings
- Endpoint: `POST .../cook-with-leftovers`

Closes #172

## Test plan
- [x] Cook 8 eat 4: Monday=Recipe(8), Wednesday=Leftover(4)
- [x] Cook 4 eat 4: Monday=Recipe(4), Tuesday stays Empty
- [x] Invalid servings (0) throws GuardException
- [x] All 13 application tests pass (3 new)
- [x] All 64 architecture tests pass