### PR TITLE
feat(mealplan): add planned recipes query for shopping integration (US-325)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -42,6 +42,11 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
+        group.MapGet("/{year:int}/w/{weekNumber:int}/planned-recipes", GetPlannedRecipesAsync)
+            .WithName("GetPlannedRecipes")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlannedRecipesDto>();
+
         return app;
     }
 
@@ -118,6 +123,17 @@ public static class MealPlanEndpoints
             request.LeftoverDay,
             request.MealType);
         var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> GetPlannedRecipesAsync(
+        int year,
+        int weekNumber,
+        IQueryHandler<GetPlannedRecipesQuery, Result<WeeklyPlannedRecipesDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetPlannedRecipesQuery(year, weekNumber);
+        var result = await handler.HandleAsync(query, cancellationToken);
         return result.ToOk();
     }
 }

--- a/src/Yumney.MealPlan.Application/DTOs/PlannedIngredientDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/PlannedIngredientDto.cs
@@ -1,0 +1,18 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+/// <summary>
+/// An ingredient needed from the meal plan — ready to be added to the shopping list.
+/// </summary>
+public sealed record PlannedIngredientDto(
+    string ItemName,
+    decimal Quantity,
+    string? Unit,
+    string Source,
+    int Servings);
+
+/// <summary>
+/// All ingredients needed for a weekly meal plan.
+/// </summary>
+public sealed record PlannedShoppingListDto(
+    string Week,
+    IReadOnlyList<PlannedIngredientDto> Ingredients);

--- a/src/Yumney.MealPlan.Application/DTOs/PlannedRecipeDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/PlannedRecipeDto.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+/// <summary>
+/// A recipe planned for the week with its serving count.
+/// Used to generate shopping lists — only Recipe slots contribute, not Leftover/Freetext.
+/// </summary>
+public sealed record PlannedRecipeDto(
+    Guid RecipeIdentifier,
+    string RecipeTitle,
+    int Servings,
+    string Day,
+    string MealType);
+
+/// <summary>
+/// All recipes planned for a week — input for shopping list generation.
+/// </summary>
+public sealed record WeeklyPlannedRecipesDto(
+    string Week,
+    IReadOnlyList<PlannedRecipeDto> Recipes);

--- a/src/Yumney.MealPlan.Application/Queries/GetPlannedRecipesQuery.cs
+++ b/src/Yumney.MealPlan.Application/Queries/GetPlannedRecipesQuery.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+
+/// <summary>
+/// Get all recipes planned for a week — only Recipe slots, not Leftover/Freetext.
+/// </summary>
+public sealed record GetPlannedRecipesQuery(int Year, int WeekNumber) : IQuery<Result<WeeklyPlannedRecipesDto>>;

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetPlannedRecipesQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetPlannedRecipesQueryHandler.cs
@@ -1,0 +1,38 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
+
+/// <summary>
+/// Returns all recipes planned for a week (Recipe slots only).
+/// Leftover and Freetext slots are excluded — they don't contribute to shopping.
+/// </summary>
+public sealed class GetPlannedRecipesQueryHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : IQueryHandler<GetPlannedRecipesQuery, Result<WeeklyPlannedRecipesDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<WeeklyPlannedRecipesDto>> HandleAsync(GetPlannedRecipesQuery query, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(query.Year, query.WeekNumber);
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+        if (plan is null)
+            return new WeeklyPlannedRecipesDto(week.Value, []);
+
+        var recipes = plan.Slots
+            .Where(s => s.ContentType == SlotContentType.Recipe && s.RecipeIdentifier.HasValue)
+            .Select(s => new PlannedRecipeDto(
+                s.RecipeIdentifier!.Value,
+                s.RecipeTitle!,
+                s.Servings,
+                s.Day.ToString(),
+                s.MealType.ToString()))
+            .ToList();
+
+        return new WeeklyPlannedRecipesDto(week.Value, recipes);
+    }
+}

--- a/tests/Yumney.MealPlan.Application.Tests/Queries/GetPlannedRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Queries/GetPlannedRecipesQueryHandlerTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Queries;
+
+public class GetPlannedRecipesQueryHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly GetPlannedRecipesQueryHandler handler;
+
+    public GetPlannedRecipesQueryHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new GetPlannedRecipesQueryHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoPlan_ReturnsEmptyRecipes()
+    {
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((WeeklyPlan?)null);
+
+        var result = await handler.HandleAsync(new GetPlannedRecipesQuery(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Recipes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OnlyRecipeSlots_Returned()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+        plan.SetFreetext(DayOfWeek.Tuesday, "Eating out");
+        plan.SetLeftover(DayOfWeek.Wednesday, DayOfWeek.Monday, MealType.Dinner, "Pasta");
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var result = await handler.HandleAsync(new GetPlannedRecipesQuery(2026, 15));
+
+        result.Value.Recipes.Should().HaveCount(1);
+        result.Value.Recipes[0].RecipeTitle.Should().Be("Pasta");
+    }
+
+    [Fact]
+    public async Task HandleAsync_MultipleRecipes_AllReturned()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", servings: 4);
+        plan.AssignRecipe(DayOfWeek.Wednesday, Guid.NewGuid(), "Steak", servings: 6);
+        plan.AssignRecipe(DayOfWeek.Friday, Guid.NewGuid(), "Fish", servings: 2);
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var result = await handler.HandleAsync(new GetPlannedRecipesQuery(2026, 15));
+
+        result.Value.Recipes.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task HandleAsync_IncludesServingsPerSlot()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta", servings: 8);
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var result = await handler.HandleAsync(new GetPlannedRecipesQuery(2026, 15));
+
+        result.Value.Recipes[0].Servings.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task HandleAsync_EmptySlots_Excluded()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var result = await handler.HandleAsync(new GetPlannedRecipesQuery(2026, 15));
+
+        result.Value.Recipes.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- `GetPlannedRecipesQuery` — returns Recipe slots only, with serving counts
- Leftover/Freetext/Empty slots excluded (no shopping contribution)
- Endpoint: \`GET /api/v1/meal-plans/{year}/w/{weekNumber}/planned-recipes\`
- Designed as input for shopping list generation — the frontend or an orchestrating service fetches recipe ingredients, scales by servings, excludes staples, and adds to the shopping ledger

Closes #173

## Test plan
- [x] No plan → empty recipes list
- [x] Only Recipe slots returned (Freetext/Leftover excluded)
- [x] Multiple recipes all returned
- [x] Servings per slot included
- [x] Empty slots excluded
- [x] All 18 application tests pass (5 new)
- [x] All 64 architecture tests pass