### PR TITLE
feat(mealplan): add swap/move meal slots endpoint (US-326)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -47,6 +47,12 @@ public static class MealPlanEndpoints
             .WithTags("MealPlan")
             .Produces<WeeklyPlannedRecipesDto>();
 
+        group.MapPut("/{year:int}/w/{weekNumber:int}/slots/swap", SwapSlotsAsync)
+            .WithName("SwapMealSlots")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -134,6 +140,18 @@ public static class MealPlanEndpoints
     {
         var query = new GetPlannedRecipesQuery(year, weekNumber);
         var result = await handler.HandleAsync(query, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> SwapSlotsAsync(
+        int year,
+        int weekNumber,
+        SwapSlotsRequest request,
+        ICommandHandler<SwapMealSlotsCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new SwapMealSlotsCommand(year, weekNumber, request.SourceDay, request.TargetDay, request.MealType);
+        var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }
 }

--- a/src/Yumney.MealPlan.Api/Requests/SwapSlotsRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/SwapSlotsRequest.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record SwapSlotsRequest(
+    DayOfWeek SourceDay,
+    DayOfWeek TargetDay,
+    MealType MealType = MealType.Dinner);

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/SwapMealSlotsCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/SwapMealSlotsCommandHandler.cs
@@ -1,0 +1,26 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class SwapMealSlotsCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<SwapMealSlotsCommand, Result<WeeklyPlanDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(SwapMealSlotsCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+
+        plan.SwapSlots(command.SourceDay, command.TargetDay, command.MealType);
+
+        await plans.SaveChangesAsync(cancellationToken);
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+    }
+}

--- a/src/Yumney.MealPlan.Application/Commands/SwapMealSlotsCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/SwapMealSlotsCommand.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record SwapMealSlotsCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek SourceDay,
+    DayOfWeek TargetDay,
+    MealType MealType = MealType.Dinner) : ICommand<Result<WeeklyPlanDto>>;

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/SwapMealSlotsCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/SwapMealSlotsCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class SwapMealSlotsCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly SwapMealSlotsCommandHandler handler;
+
+    public SwapMealSlotsCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new SwapMealSlotsCommandHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SwapsAndSaves()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var command = new SwapMealSlotsCommand(2026, 15, DayOfWeek.Monday, DayOfWeek.Wednesday);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.First(s => s.Day == "Monday").IsEmpty.Should().BeTrue();
+        result.Value.Slots.First(s => s.Day == "Wednesday").RecipeTitle.Should().Be("Pasta");
+        await plans.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoPlan_ThrowsEntityNotFoundException()
+    {
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns<WeeklyPlan>(_ => throw new EntityNotFoundException(nameof(WeeklyPlan), "2026-W15"));
+
+        var command = new SwapMealSlotsCommand(2026, 15, DayOfWeek.Monday, DayOfWeek.Tuesday);
+
+        var act = () => handler.HandleAsync(command);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}


### PR DESCRIPTION
## Summary
- \`SwapMealSlotsCommand\` + handler — delegates to aggregate SwapSlots
- Handles move-to-empty and swap-occupied via snapshot-based swap
- Endpoint: \`PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/swap\`
- Frontend drag & drop UI is a separate frontend story

Closes #174

## Test plan
- [x] Swap moves recipe and saves
- [x] Non-existent plan throws EntityNotFoundException
- [x] All 20 application tests pass (2 new)
- [x] All 64 architecture tests pass