### PR TITLE
feat(mealplan): add cooked confirmation with meal state tracking (US-327)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -53,6 +53,12 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapPut("/{year:int}/w/{weekNumber:int}/slots/confirm", ConfirmMealAsync)
+            .WithName("ConfirmMeal")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -151,6 +157,18 @@ public static class MealPlanEndpoints
         CancellationToken cancellationToken)
     {
         var command = new SwapMealSlotsCommand(year, weekNumber, request.SourceDay, request.TargetDay, request.MealType);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ConfirmMealAsync(
+        int year,
+        int weekNumber,
+        ConfirmMealRequest request,
+        ICommandHandler<ConfirmMealCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ConfirmMealCommand(year, weekNumber, request.Day, request.MealType, request.State);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Api/Requests/ConfirmMealRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ConfirmMealRequest.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record ConfirmMealRequest(DayOfWeek Day, MealType MealType, MealState State);

--- a/src/Yumney.MealPlan.Application/Commands/ConfirmMealCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/ConfirmMealCommand.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+/// <summary>
+/// Confirm whether a meal was cooked or skipped.
+/// </summary>
+public sealed record ConfirmMealCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek Day,
+    MealType MealType,
+    MealState NewState) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -1,0 +1,37 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class ConfirmMealCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<ConfirmMealCommand, Result<WeeklyPlanDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(ConfirmMealCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+
+        switch (command.NewState)
+        {
+            case MealState.Cooked:
+                plan.MarkAsCooked(command.Day, command.MealType);
+                break;
+            case MealState.Skipped:
+                plan.MarkAsSkipped(command.Day, command.MealType);
+                break;
+            case MealState.Planned:
+                plan.ResetToPlanned(command.Day, command.MealType);
+                break;
+        }
+
+        await plans.SaveChangesAsync(cancellationToken);
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+    }
+}

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotDto.cs
@@ -4,6 +4,7 @@ public sealed record MealSlotDto(
     string Day,
     string MealType,
     string ContentType,
+    string State,
     Guid? RecipeIdentifier,
     string? RecipeTitle,
     int Servings,

--- a/src/Yumney.MealPlan.Application/DTOs/MealSlotMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealSlotMappingExtensions.cs
@@ -10,6 +10,7 @@ public static class MealSlotMappingExtensions
             slot.Day.ToString(),
             slot.MealType.ToString(),
             slot.ContentType.ToString(),
+            slot.State.ToString(),
             slot.RecipeIdentifier,
             slot.RecipeTitle,
             slot.Servings,

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealSlot.cs
@@ -26,6 +26,8 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
 
     public MealType? LeftoverSourceMealType { get; private set; }
 
+    public MealState State { get; private set; }
+
     public bool IsEmpty => ContentType == SlotContentType.Empty;
 
     private MealSlot()
@@ -93,9 +95,24 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
         Servings = servings;
     }
 
+    internal void MarkAsCooked()
+    {
+        State = MealState.Cooked;
+    }
+
+    internal void MarkAsSkipped()
+    {
+        State = MealState.Skipped;
+    }
+
+    internal void ResetToPlanned()
+    {
+        State = MealState.Planned;
+    }
+
     internal SlotSnapshot TakeSnapshot()
     {
-        return new SlotSnapshot(ContentType, RecipeIdentifier, RecipeTitle, Servings, FreetextLabel, LeftoverSourceDay, LeftoverSourceMealType);
+        return new SlotSnapshot(ContentType, RecipeIdentifier, RecipeTitle, Servings, FreetextLabel, LeftoverSourceDay, LeftoverSourceMealType, State);
     }
 
     internal void RestoreFromSnapshot(SlotSnapshot snapshot)
@@ -107,6 +124,7 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
         FreetextLabel = snapshot.FreetextLabel;
         LeftoverSourceDay = snapshot.LeftoverSourceDay;
         LeftoverSourceMealType = snapshot.LeftoverSourceMealType;
+        State = snapshot.State;
     }
 
     internal sealed record SlotSnapshot(
@@ -116,5 +134,6 @@ public sealed class MealSlot : Entity<MealSlotIdentifier>
         int Servings,
         string? FreetextLabel,
         DayOfWeek? LeftoverSourceDay,
-        MealType? LeftoverSourceMealType);
+        MealType? LeftoverSourceMealType,
+        MealState State);
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/MealState.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/MealState.cs
@@ -1,0 +1,16 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+/// <summary>
+/// The preparation state of a meal slot.
+/// </summary>
+public enum MealState
+{
+    /// <summary>Meal is planned but not yet prepared.</summary>
+    Planned,
+
+    /// <summary>Meal was cooked/prepared.</summary>
+    Cooked,
+
+    /// <summary>Meal was skipped — ingredients stay at home.</summary>
+    Skipped,
+}

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -158,6 +158,51 @@ public sealed class WeeklyPlan : AggregateRoot<WeeklyPlanIdentifier>
     }
 
     /// <summary>
+    /// Mark a meal as cooked — ingredients consumed from balance sheet.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void MarkAsCooked(DayOfWeek day, MealType mealType = MealType.Dinner)
+    {
+        var slot = FindSlot(day, mealType);
+        slot.MarkAsCooked();
+    }
+
+    /// <summary>
+    /// Mark a meal as skipped — ingredients stay at home.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void MarkAsSkipped(DayOfWeek day, MealType mealType = MealType.Dinner)
+    {
+        var slot = FindSlot(day, mealType);
+        slot.MarkAsSkipped();
+    }
+
+    /// <summary>
+    /// Reset a cooked/skipped meal back to planned.
+    /// </summary>
+    /// <param name="day">The day of the week.</param>
+    /// <param name="mealType">The meal type (defaults to Dinner).</param>
+    public void ResetToPlanned(DayOfWeek day, MealType mealType = MealType.Dinner)
+    {
+        var slot = FindSlot(day, mealType);
+        slot.ResetToPlanned();
+    }
+
+    /// <summary>
+    /// Get meals that need cooked confirmation (planned recipes from past days).
+    /// </summary>
+    /// <param name="today">Today's day of week.</param>
+    /// <returns>Slots that are Recipe type, still in Planned state, and before today.</returns>
+    public IReadOnlyList<MealSlot> GetUnconfirmedPastMeals(DayOfWeek today)
+    {
+        return slots
+            .Where(s => s.ContentType == SlotContentType.Recipe && s.State == MealState.Planned && s.Day < today)
+            .ToList();
+    }
+
+    /// <summary>
     /// Swap the meals between two slots.
     /// </summary>
     /// <param name="day1">First day.</param>

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/WeeklyPlanConfiguration.cs
@@ -33,6 +33,7 @@ internal sealed class WeeklyPlanConfiguration : IEntityTypeConfiguration<WeeklyP
             slot.Property(s => s.Day).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.MealType).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.ContentType).HasConversion<string>().HasMaxLength(10).IsRequired();
+            slot.Property(s => s.State).HasConversion<string>().HasMaxLength(10).IsRequired();
             slot.Property(s => s.RecipeIdentifier);
             slot.Property(s => s.RecipeTitle).HasMaxLength(200);
             slot.Property(s => s.Servings).IsRequired();

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412150919_AddMealState.Designer.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412150919_AddMealState.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MealPlanDbContext))]
-    partial class MealPlanDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412150919_AddMealState")]
+    partial class AddMealState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412150919_AddMealState.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Migrations/20260412150919_AddMealState.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMealState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "State",
+                table: "MealSlots",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "State",
+                table: "MealSlots");
+        }
+    }
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -509,4 +509,73 @@ public class WeeklyPlanTests
 
         act.Should().Throw<GuardException>();
     }
+
+    [Fact]
+    public void MarkAsCooked_SetsState()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        plan.MarkAsCooked(DayOfWeek.Monday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).State.Should().Be(MealState.Cooked);
+    }
+
+    [Fact]
+    public void MarkAsSkipped_SetsState()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+
+        plan.MarkAsSkipped(DayOfWeek.Monday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).State.Should().Be(MealState.Skipped);
+    }
+
+    [Fact]
+    public void ResetToPlanned_ResetsState()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+        plan.MarkAsCooked(DayOfWeek.Monday);
+
+        plan.ResetToPlanned(DayOfWeek.Monday);
+
+        plan.Slots.First(s => s.Day == DayOfWeek.Monday).State.Should().Be(MealState.Planned);
+    }
+
+    [Fact]
+    public void Create_AllSlotsStartAsPlanned()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+
+        plan.Slots.Should().OnlyContain(s => s.State == MealState.Planned);
+    }
+
+    [Fact]
+    public void GetUnconfirmedPastMeals_ReturnsOnlyPlannedRecipesBeforeToday()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Monday, Guid.NewGuid(), "Pasta");
+        plan.AssignRecipe(DayOfWeek.Tuesday, Guid.NewGuid(), "Steak");
+        plan.MarkAsCooked(DayOfWeek.Monday);
+
+        var unconfirmed = plan.GetUnconfirmedPastMeals(DayOfWeek.Wednesday);
+
+        unconfirmed.Should().HaveCount(1);
+        unconfirmed[0].Day.Should().Be(DayOfWeek.Tuesday);
+    }
+
+    [Fact]
+    public void GetUnconfirmedPastMeals_ExcludesFreetextAndLeftover()
+    {
+        var plan = Domain.WeeklyPlan.WeeklyPlan.Create(TestOwner, WeekIdentifier.From(2026, 15));
+        plan.SetFreetext(DayOfWeek.Monday, "Eating out");
+        plan.AssignRecipe(DayOfWeek.Tuesday, Guid.NewGuid(), "Steak");
+
+        var unconfirmed = plan.GetUnconfirmedPastMeals(DayOfWeek.Wednesday);
+
+        unconfirmed.Should().HaveCount(1);
+        unconfirmed[0].RecipeTitle.Should().Be("Steak");
+    }
 }


### PR DESCRIPTION
## Summary
- Add \`MealState\` enum: Planned, Cooked, Skipped
- \`MarkAsCooked()\`, \`MarkAsSkipped()\`, \`ResetToPlanned()\` on aggregate
- \`GetUnconfirmedPastMeals(today)\` returns Recipe slots still Planned before today
- State included in DTO, snapshot-based swap, and EF persistence
- Endpoint: \`PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/confirm\`

Closes #175

## Test plan
- [x] MarkAsCooked sets state
- [x] MarkAsSkipped sets state
- [x] ResetToPlanned resets state
- [x] All new slots start as Planned
- [x] GetUnconfirmedPastMeals returns only Planned Recipes before today
- [x] GetUnconfirmedPastMeals excludes Freetext
- [x] All 50 domain tests pass (6 new)
- [x] All 20 application + 64 architecture tests pass