### PR TITLE
feat(shopping): add remove item command for chat integration (US-328)

### DIFF
--- a/src/Yumney.Shopping.Api/Requests/RemoveItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/RemoveItemRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record RemoveItemRequest(string Name, decimal? Quantity = null, string? Unit = null, string? Reason = null);

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -52,6 +52,12 @@ public static class ShoppingEndpoints
             .Produces<AddedItemDto>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
+        group.MapDelete("/items", RemoveItemAsync)
+            .WithName("RemoveShoppingItem")
+            .WithTags("Shopping")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         group.MapGet("/merged", GetMergedAsync)
             .WithName("GetMergedShoppingList")
             .WithTags("Shopping")
@@ -207,5 +213,18 @@ public static class ShoppingEndpoints
             return result.ToOk();
 
         return Results.Text(result.Value, "text/plain");
+    }
+
+    private static async Task<IResult> RemoveItemAsync(
+        RemoveItemRequest request,
+        ICommandHandler<RemoveShoppingItemCommand, Result> handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return Results.Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Item name is required.");
+
+        var command = new RemoveShoppingItemCommand(ItemName.From(request.Name.Trim()), request.Quantity, request.Unit, request.Reason);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToNoContent();
     }
 }

--- a/src/Yumney.Shopping.Application/Commands/Handlers/RemoveShoppingItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/RemoveShoppingItemCommandHandler.cs
@@ -1,0 +1,28 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+public sealed class RemoveShoppingItemCommandHandler(
+    IShoppingEventStore eventStore,
+    ICurrentUser currentUser) : ICommandHandler<RemoveShoppingItemCommand, Result>
+{
+    /// <inheritdoc />
+    public async Task<Result> HandleAsync(RemoveShoppingItemCommand command, CancellationToken cancellationToken = default)
+    {
+        var ownerId = currentUser.UserId;
+
+        var ledger = await eventStore.LoadAsync(ownerId, cancellationToken);
+        if (ledger is null)
+            return Result.Success();
+
+        var name = command.ItemName.Value;
+        var quantity = command.Quantity ?? DefaultQuantityResolver.Resolve(name).Amount;
+        ledger.RemoveItem(name, quantity, command.Unit, command.Reason);
+
+        await eventStore.SaveAsync(ledger, cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Yumney.Shopping.Application/Commands/RemoveShoppingItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/RemoveShoppingItemCommand.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+/// <summary>
+/// Remove an item from the shopping list (via chat command or UI).
+/// </summary>
+public sealed record RemoveShoppingItemCommand(
+    ItemName ItemName,
+    decimal? Quantity,
+    string? Unit,
+    string? Reason) : ICommand<Result>;

--- a/tests/Yumney.Shopping.Application.Tests/Commands/RemoveShoppingItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/RemoveShoppingItemCommandHandlerTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Commands;
+
+public class RemoveShoppingItemCommandHandlerTests
+{
+    private readonly IShoppingEventStore eventStore = Substitute.For<IShoppingEventStore>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly RemoveShoppingItemCommandHandler handler;
+
+    public RemoveShoppingItemCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new RemoveShoppingItemCommandHandler(eventStore, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExistingLedger_RemovesAndSaves()
+    {
+        var ledger = ShoppingLedger.Create("user-123");
+        ledger.AddItem("Eggs", 6, "pc", "manual");
+        ledger.MarkCommitted();
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns(ledger);
+
+        var command = new RemoveShoppingItemCommand(ItemName.From("Eggs"), 6, "pc", "not needed");
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoLedger_ReturnsSuccess()
+    {
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns((ShoppingLedger?)null);
+
+        var command = new RemoveShoppingItemCommand(ItemName.From("Eggs"), null, null, null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.DidNotReceive().SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutQuantity_UsesDefaultQuantity()
+    {
+        var ledger = ShoppingLedger.Create("user-123");
+        ledger.AddItem("Milk", 2, "L", "manual");
+        ledger.MarkCommitted();
+        eventStore.LoadAsync("user-123", Arg.Any<CancellationToken>()).Returns(ledger);
+
+        var command = new RemoveShoppingItemCommand(ItemName.From("Milk"), null, null, null);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- \`RemoveShoppingItemCommand\` + handler — removes items via event store
- Resolves default quantity when not specified
- Endpoint: \`DELETE /api/v1/shopping-lists/items\`
- Shopping API now supports all chat intents: add_to_list, remove_from_list, query_list

Closes #176

## Test plan
- [x] Remove with existing ledger saves
- [x] Remove with no ledger returns success (no-op)
- [x] Remove without quantity uses default
- [x] All 56 Shopping application tests pass (3 new)
- [x] All 64 architecture tests pass