### PR TITLE
feat(mealplan): add clear slot command for chat integration (US-329)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -59,6 +59,12 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapDelete("/{year:int}/w/{weekNumber:int}/slots", ClearSlotAsync)
+            .WithName("ClearMealSlot")
+            .WithTags("MealPlan")
+            .Produces<WeeklyPlanDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
     }
 
@@ -169,6 +175,18 @@ public static class MealPlanEndpoints
         CancellationToken cancellationToken)
     {
         var command = new ConfirmMealCommand(year, weekNumber, request.Day, request.MealType, request.State);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> ClearSlotAsync(
+        int year,
+        int weekNumber,
+        ClearSlotRequest request,
+        ICommandHandler<ClearMealSlotCommand, Result<WeeklyPlanDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new ClearMealSlotCommand(year, weekNumber, request.Day, request.MealType);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Api/Requests/ClearSlotRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ClearSlotRequest.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record ClearSlotRequest(DayOfWeek Day, MealType MealType = MealType.Dinner);

--- a/src/Yumney.MealPlan.Application/Commands/ClearMealSlotCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/ClearMealSlotCommand.cs
@@ -1,0 +1,12 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record ClearMealSlotCommand(
+    int Year,
+    int WeekNumber,
+    DayOfWeek Day,
+    MealType MealType = MealType.Dinner) : ICommand<Result<WeeklyPlanDto>>;

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ClearMealSlotCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ClearMealSlotCommandHandler.cs
@@ -1,0 +1,26 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class ClearMealSlotCommandHandler(
+    IWeeklyPlanRepository plans,
+    ICurrentUser currentUser) : ICommandHandler<ClearMealSlotCommand, Result<WeeklyPlanDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<WeeklyPlanDto>> HandleAsync(ClearMealSlotCommand command, CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
+
+        plan.ClearSlot(command.Day, command.MealType);
+
+        await plans.SaveChangesAsync(cancellationToken);
+
+        return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+    }
+}

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/ClearMealSlotCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/ClearMealSlotCommandHandlerTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class ClearMealSlotCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly ClearMealSlotCommandHandler handler;
+
+    public ClearMealSlotCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        handler = new ClearMealSlotCommandHandler(plans, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ClearsSlotAndSaves()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plan.AssignRecipe(DayOfWeek.Wednesday, Guid.NewGuid(), "Pasta");
+        plans.GetByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var command = new ClearMealSlotCommand(2026, 15, DayOfWeek.Wednesday);
+
+        var result = await handler.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Slots.First(s => s.Day == "Wednesday").IsEmpty.Should().BeTrue();
+        await plans.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- \`ClearMealSlotCommand\` + handler — clears a slot back to Empty
- Endpoint: \`DELETE /api/v1/meal-plans/{year}/w/{weekNumber}/slots\`
- MealPlan API now covers all chat intents: query_plan, plan_meal, swap_meals, cancel

Closes #177

## Test plan
- [x] Clear slot saves and returns empty slot
- [x] All 21 application tests pass (1 new)
- [x] All 64 architecture tests pass