### PR TITLE
test(frontend): add missing meal planner tests

### DIFF
--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.spec.ts
@@ -196,4 +196,21 @@ describe('MealPlannerComponent', () => {
     expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
     expect(fixture.nativeElement.querySelector('.retry-btn')).toBeTruthy();
   });
+
+  it('should navigate to previous week', () => {
+    const initialCalls = apiMock.getWeeklyPlan.mock.calls.length;
+
+    fixture.componentInstance['onPreviousWeek']();
+    fixture.detectChanges();
+
+    expect(apiMock.getWeeklyPlan.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it('should call clearSlot API when clearing a slot', () => {
+    fixture.componentInstance['onClearSlot']('Monday');
+
+    expect(apiMock.clearSlot).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), {
+      day: 'Monday',
+    });
+  });
 });

--- a/client/libs/ui/src/lib/header/header.component.spec.ts
+++ b/client/libs/ui/src/lib/header/header.component.spec.ts
@@ -17,6 +17,7 @@ const en = {
       navigation: 'Main navigation',
       recipes: 'My Recipes',
       shoppingLists: 'Shopping Lists',
+      mealPlanner: 'Meal Planner',
       logout: 'Logout',
       login: 'Login',
       openChat: 'Open chat',
@@ -151,6 +152,18 @@ describe('HeaderComponent', () => {
       (el as HTMLElement).textContent?.includes('Shopping Lists'),
     );
     expect(shoppingLink).toBeTruthy();
+  });
+
+  it('should render the meal planner nav link when user is authenticated', () => {
+    isAuthenticated.set(true);
+
+    fixture.detectChanges();
+
+    const navLinks = fixture.nativeElement.querySelectorAll('.nav-link');
+    const mealPlannerLink = Array.from(navLinks).find((el) =>
+      (el as HTMLElement).textContent?.includes('Meal Planner'),
+    );
+    expect(mealPlannerLink).toBeTruthy();
   });
 
   // ── Chat toggle ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Header spec: add meal planner nav link test + i18n mock key
- MealPlanner spec: add previous week navigation test + clear slot API test

## Test plan
- [x] All 208 shell tests pass (2 new)
- [x] All 161 UI tests pass (1 new)