### PR TITLE
feat(frontend): add merged shopping list page with ES endpoints

### DIFF
--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -53,6 +53,14 @@
       },
       "allDone": "Alles erledigt!",
       "allDoneMessage": "Alles auf deiner Liste ist abgehakt."
-    }
+    },
+    "title": "Einkaufsliste",
+    "loading": "Wird geladen...",
+    "empty": "Deine Einkaufsliste ist leer. Füge Artikel hinzu oder plane Mahlzeiten.",
+    "addPlaceholder": "Artikel hinzufügen...",
+    "export": "Liste exportieren",
+    "remove": "Artikel entfernen",
+    "checked": "erledigt",
+    "retry": "Erneut versuchen"
   }
 }

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -53,6 +53,14 @@
       },
       "allDone": "All done!",
       "allDoneMessage": "Everything on your list is checked off."
-    }
+    },
+    "title": "Shopping List",
+    "loading": "Loading...",
+    "empty": "Your shopping list is empty. Add items or plan meals.",
+    "addPlaceholder": "Add an item...",
+    "export": "Export list",
+    "remove": "Remove item",
+    "checked": "checked",
+    "retry": "Retry"
   }
 }

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -1,0 +1,71 @@
+<div class="merged-list" *transloco="let t">
+  <div class="list-header">
+    <h1>{{ t('shopping.title') }}</h1>
+    <div class="list-actions">
+      <button class="export-btn" (click)="onExport()" [attr.aria-label]="t('shopping.export')">
+        <lucide-icon name="share" [size]="18" />
+      </button>
+    </div>
+  </div>
+
+  @if (totalItems() > 0) {
+    <div class="progress-bar">
+      {{ boughtItems() }} / {{ totalItems() }} {{ t('shopping.checked') }}
+    </div>
+  }
+
+  <div class="add-item">
+    <input
+      type="text"
+      [ngModel]="newItemName()"
+      (ngModelChange)="newItemName.set($event)"
+      (keydown)="onKeydown($event)"
+      [placeholder]="t('shopping.addPlaceholder')"
+      class="add-input"
+    />
+    <button class="add-btn" (click)="onAddItem()" [disabled]="!newItemName().trim()">
+      <lucide-icon name="plus" [size]="18" />
+    </button>
+  </div>
+
+  @if (loading()) {
+    <div class="loading">{{ t('shopping.loading') }}</div>
+  }
+
+  @if (error(); as err) {
+    <div class="error" role="alert">
+      {{ err }}
+      <button class="retry-btn" (click)="onRetry()">{{ t('shopping.retry') }}</button>
+    </div>
+  }
+
+  @for (group of categoryGroups(); track group.category) {
+    <div class="category-group">
+      <h2 class="category-header">{{ getCategoryLabel(group.category) }}</h2>
+
+      @for (item of group.items; track item.itemName) {
+        <div class="item-row" [class.bought]="item.isBought">
+          <div class="item-info">
+            <span class="item-quantity"
+              >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
+            >
+            <span class="item-name">{{ item.itemName }}</span>
+          </div>
+          <button
+            class="remove-btn"
+            (click)="onRemoveItem(item.itemName)"
+            [attr.aria-label]="t('shopping.remove')"
+          >
+            <lucide-icon name="x" [size]="14" />
+          </button>
+        </div>
+      }
+    </div>
+  }
+
+  @if (!loading() && totalItems() === 0) {
+    <div class="empty-state">
+      <p>{{ t('shopping.empty') }}</p>
+    </div>
+  }
+</div>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.scss
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.scss
@@ -1,0 +1,171 @@
+@use 'glass';
+
+.merged-list {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--yn-space-5);
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--yn-space-5);
+
+  h1 {
+    margin: 0;
+    font-size: var(--yn-text-2xl);
+    font-weight: var(--yn-font-bold);
+    color: var(--yn-text);
+  }
+}
+
+.export-btn {
+  @include glass.glass-surface(1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--yn-radius-circle);
+  border: 1px solid var(--yn-glass-border);
+  cursor: pointer;
+  color: var(--yn-text);
+}
+
+.progress-bar {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  margin-bottom: var(--yn-space-5);
+}
+
+.add-item {
+  display: flex;
+  gap: var(--yn-space-3);
+  margin-bottom: var(--yn-space-7);
+}
+
+.add-input {
+  flex: 1;
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-input);
+  background: var(--yn-glass-bg);
+  font-size: var(--yn-text-base);
+  color: var(--yn-text);
+
+  &:focus {
+    outline: none;
+    border-color: var(--yn-primary);
+  }
+
+  &::placeholder {
+    color: var(--yn-text-placeholder);
+  }
+}
+
+.add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--yn-radius-circle);
+  background: var(--yn-primary);
+  color: var(--yn-text-inverse);
+  border: none;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.category-group {
+  margin-bottom: var(--yn-space-5);
+}
+
+.category-header {
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+  margin: 0 0 var(--yn-space-3);
+  padding-bottom: var(--yn-space-2);
+  border-bottom: 1px solid var(--yn-glass-border-subtle);
+}
+
+.item-row {
+  @include glass.glass-surface(0);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-radius: var(--yn-radius-card);
+  margin-bottom: var(--yn-space-2);
+
+  &.bought {
+    opacity: 0.5;
+    text-decoration: line-through;
+  }
+}
+
+.item-info {
+  display: flex;
+  gap: var(--yn-space-3);
+}
+
+.item-quantity {
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-primary);
+  min-width: 50px;
+}
+
+.item-name {
+  color: var(--yn-text);
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  color: var(--yn-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--yn-duration-fast);
+
+  .item-row:hover & {
+    opacity: 1;
+  }
+}
+
+.loading,
+.empty-state {
+  text-align: center;
+  color: var(--yn-text-muted);
+  padding: var(--yn-space-7);
+}
+
+.error {
+  text-align: center;
+  color: var(--yn-danger);
+  padding: var(--yn-space-5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.retry-btn {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 1px solid var(--yn-danger);
+  border-radius: var(--yn-radius-button);
+  background: none;
+  color: var(--yn-danger);
+  cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .remove-btn {
+    transition: none;
+  }
+}

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { MergedListComponent } from './merged-list.component';
+import { ShoppingApiService, type MergedShoppingList } from '@yumney/shared/api-client';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { provideYumneyIcons } from '@yumney/ui';
+
+const en = {
+  shopping: {
+    title: 'Shopping List',
+    loading: 'Loading...',
+    empty: 'Empty list',
+    addPlaceholder: 'Add item...',
+    export: 'Export',
+    remove: 'Remove',
+    checked: 'checked',
+    retry: 'Retry',
+  },
+};
+
+const mockList: MergedShoppingList = {
+  items: [
+    {
+      itemName: 'Milk',
+      totalQuantity: 2,
+      displayQuantity: 2,
+      unit: 'L',
+      category: 'dairy',
+      isBought: false,
+      sources: [],
+    },
+    {
+      itemName: 'Chicken',
+      totalQuantity: 500,
+      displayQuantity: 500,
+      unit: 'g',
+      category: 'meat-fish',
+      isBought: false,
+      sources: [],
+    },
+  ],
+};
+
+describe('MergedListComponent', () => {
+  let fixture: ComponentFixture<MergedListComponent>;
+  let apiMock: {
+    getMergedList: ReturnType<typeof vi.fn>;
+    addItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+    exportList: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    apiMock = {
+      getMergedList: vi.fn().mockReturnValue(of(mockList)),
+      addItem: vi.fn().mockReturnValue(of({ itemName: 'Eggs' })),
+      removeItem: vi.fn().mockReturnValue(of(undefined)),
+      exportList: vi.fn().mockReturnValue(of('Shopping list text')),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [MergedListComponent, setupTranslocoTesting(en)],
+      providers: [
+        provideYumneyIcons(),
+        provideRouter([]),
+        { provide: ShoppingApiService, useValue: apiMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MergedListComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should load list on init', () => {
+    expect(apiMock.getMergedList).toHaveBeenCalled();
+  });
+
+  it('should display items grouped by category', () => {
+    const groups = fixture.nativeElement.querySelectorAll('.category-group');
+    expect(groups.length).toBe(2);
+  });
+
+  it('should show item names', () => {
+    expect(fixture.nativeElement.textContent).toContain('Milk');
+    expect(fixture.nativeElement.textContent).toContain('Chicken');
+  });
+
+  it('should show add item input', () => {
+    const input = fixture.nativeElement.querySelector('.add-input');
+    expect(input).toBeTruthy();
+  });
+
+  it('should call addItem when submitting', () => {
+    fixture.componentInstance['newItemName'].set('Eggs');
+    fixture.componentInstance['onAddItem']();
+
+    expect(apiMock.addItem).toHaveBeenCalledWith({ name: 'Eggs' });
+  });
+
+  it('should call removeItem', () => {
+    fixture.componentInstance['onRemoveItem']('Milk');
+
+    expect(apiMock.removeItem).toHaveBeenCalledWith({ name: 'Milk' });
+  });
+
+  it('should show error with retry on failure', () => {
+    apiMock.getMergedList.mockReturnValue(throwError(() => new Error('fail')));
+    fixture.componentInstance['loadList']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.retry-btn')).toBeTruthy();
+  });
+
+  it('should show empty state when no items', () => {
+    apiMock.getMergedList.mockReturnValue(of({ items: [] }));
+    fixture.componentInstance['loadList']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.empty-state')).toBeTruthy();
+  });
+
+  it('should show progress when items exist', () => {
+    expect(fixture.nativeElement.querySelector('.progress-bar')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('0 / 2');
+  });
+});

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -1,0 +1,153 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  DestroyRef,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+import {
+  ShoppingApiService,
+  type MergedShoppingList,
+  type MergedShoppingItem,
+} from '@yumney/shared/api-client';
+
+interface CategoryGroup {
+  category: string;
+  items: MergedShoppingItem[];
+  isExpanded: boolean;
+}
+
+@Component({
+  selector: 'yn-merged-list',
+  standalone: true,
+  imports: [FormsModule, TranslocoModule, LucideAngularModule],
+  templateUrl: './merged-list.component.html',
+  styleUrl: './merged-list.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MergedListComponent {
+  private api = inject(ShoppingApiService);
+  private destroyRef = inject(DestroyRef);
+
+  protected list = signal<MergedShoppingList | null>(null);
+  protected loading = signal(false);
+  protected error = signal<string | null>(null);
+  protected newItemName = signal('');
+
+  protected categoryGroups = computed<CategoryGroup[]>(() => {
+    const l = this.list();
+    if (!l) return [];
+
+    const grouped = new Map<string, MergedShoppingItem[]>();
+    for (const item of l.items) {
+      const existing = grouped.get(item.category) ?? [];
+      existing.push(item);
+      grouped.set(item.category, existing);
+    }
+
+    return Array.from(grouped.entries()).map(([category, items]) => ({
+      category,
+      items,
+      isExpanded: true,
+    }));
+  });
+
+  protected totalItems = computed(() => this.list()?.items.length ?? 0);
+  protected boughtItems = computed(() => this.list()?.items.filter((i) => i.isBought).length ?? 0);
+
+  constructor() {
+    this.loadList();
+  }
+
+  protected onAddItem(): void {
+    const name = this.newItemName().trim();
+    if (!name) return;
+
+    this.newItemName.set('');
+    this.api
+      .addItem({ name })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.loadList(),
+        error: () => this.error.set('Failed to add item'),
+      });
+  }
+
+  protected onRemoveItem(itemName: string): void {
+    this.api
+      .removeItem({ name: itemName })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.loadList(),
+        error: () => this.error.set('Failed to remove item'),
+      });
+  }
+
+  protected onExport(): void {
+    this.api
+      .exportList()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (text) => {
+          if (navigator.share) {
+            navigator.share({ text }).catch(() => this.copyToClipboard(text));
+          } else {
+            this.copyToClipboard(text);
+          }
+        },
+        error: () => this.error.set('Failed to export'),
+      });
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.onAddItem();
+    }
+  }
+
+  protected onRetry(): void {
+    this.loadList();
+  }
+
+  protected getCategoryLabel(category: string): string {
+    const labels: Record<string, string> = {
+      produce: '🥦 Produce',
+      dairy: '🥛 Dairy',
+      'meat-fish': '🥩 Meat & Fish',
+      bakery: '🍞 Bakery',
+      frozen: '❄️ Frozen',
+      beverages: '🥤 Beverages',
+      pantry: '🏠 Pantry',
+      household: '🧹 Household',
+      other: '📦 Other',
+    };
+    return labels[category] ?? category;
+  }
+
+  private loadList(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.api
+      .getMergedList()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (list) => {
+          this.list.set(list);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.error.set('Failed to load shopping list');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  private copyToClipboard(text: string): void {
+    navigator.clipboard.writeText(text);
+  }
+}

--- a/client/apps/shopping/src/app/shopping.routes.ts
+++ b/client/apps/shopping/src/app/shopping.routes.ts
@@ -8,15 +8,21 @@ export const shoppingRoutes: Route[] = [
       import('./shopping-create/shopping-create.component').then((m) => m.ShoppingCreateComponent),
   },
   {
-    path: ':identifier',
+    path: 'lists/:identifier',
     title: 'Shopping List — Yumney',
     loadComponent: () =>
       import('./shopping-detail/shopping-detail.component').then((m) => m.ShoppingDetailComponent),
   },
   {
-    path: '',
+    path: 'lists',
     title: 'Shopping Lists — Yumney',
     loadComponent: () =>
       import('./shopping-list/shopping-list.component').then((m) => m.ShoppingListComponent),
+  },
+  {
+    path: '',
+    title: 'Shopping — Yumney',
+    loadComponent: () =>
+      import('./merged-list/merged-list.component').then((m) => m.MergedListComponent),
   },
 ];

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -24,6 +24,14 @@ export type { CreateShoppingListItem } from './lib/create-shopping-list-item';
 export type { CreateShoppingListRequest } from './lib/create-shopping-list-request';
 export type { ShoppingListItemResponse } from './lib/shopping-list-item-response';
 export type { ShoppingListDetail } from './lib/shopping-list-detail';
+export type {
+  MergedShoppingList,
+  MergedShoppingItem,
+  ItemSource,
+  AddItemRequest,
+  AddedItem,
+  RemoveItemRequest,
+} from './lib/merged-shopping-list';
 export type { ShoppingListSummary } from './lib/shopping-list-summary';
 export { DashboardApiService } from './lib/dashboard-api.service';
 export type { UserActivityItem } from './lib/user-activity';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -20,6 +20,11 @@ export const API_ENDPOINTS = {
     checkItem: (listIdentifier: string, itemIdentifier: string) =>
       `${API_BASE}/shopping-lists/${listIdentifier}/items/${itemIdentifier}/check`,
     checkAll: (listIdentifier: string) => `${API_BASE}/shopping-lists/${listIdentifier}/check-all`,
+    merged: `${API_BASE}/shopping-lists/merged`,
+    items: `${API_BASE}/shopping-lists/items`,
+    export: `${API_BASE}/shopping-lists/export`,
+    shoppingModeStart: `${API_BASE}/shopping-lists/shopping-mode/start`,
+    shoppingModeEnd: `${API_BASE}/shopping-lists/shopping-mode/end`,
   },
   mealPlans: {
     byWeek: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}`,

--- a/client/libs/shared/api-client/src/lib/merged-shopping-list.ts
+++ b/client/libs/shared/api-client/src/lib/merged-shopping-list.ts
@@ -1,0 +1,41 @@
+export interface ItemSource {
+  quantity: number;
+  source: string;
+  occurredAt: string;
+}
+
+export interface MergedShoppingItem {
+  itemName: string;
+  totalQuantity: number;
+  displayQuantity: number;
+  unit: string | null;
+  category: string;
+  isBought: boolean;
+  sources: ItemSource[];
+}
+
+export interface MergedShoppingList {
+  items: MergedShoppingItem[];
+}
+
+export interface AddItemRequest {
+  name: string;
+  quantity?: number;
+  unit?: string;
+}
+
+export interface AddedItem {
+  itemName: string;
+  quantity: number;
+  unit: string | null;
+  category: string;
+  source: string;
+  ledgerIdentifier: string;
+}
+
+export interface RemoveItemRequest {
+  name: string;
+  quantity?: number;
+  unit?: string;
+  reason?: string;
+}

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -5,6 +5,12 @@ import { API_ENDPOINTS } from './api-endpoints';
 import type { CreateShoppingListRequest } from './create-shopping-list-request';
 import type { ShoppingListDetail } from './shopping-list-detail';
 import type { ShoppingListSummary } from './shopping-list-summary';
+import type {
+  MergedShoppingList,
+  AddItemRequest,
+  AddedItem,
+  RemoveItemRequest,
+} from './merged-shopping-list';
 
 @Injectable({ providedIn: 'root' })
 export class ShoppingApiService {
@@ -36,6 +42,32 @@ export class ShoppingApiService {
   checkOffAllItems(listIdentifier: string, isChecked: boolean): Observable<void> {
     return this.http.put<void>(API_ENDPOINTS.shoppingLists.checkAll(listIdentifier), {
       isChecked,
+    });
+  }
+
+  getMergedList(): Observable<MergedShoppingList> {
+    return this.http.get<MergedShoppingList>(API_ENDPOINTS.shoppingLists.merged);
+  }
+
+  addItem(request: AddItemRequest): Observable<AddedItem> {
+    return this.http.post<AddedItem>(API_ENDPOINTS.shoppingLists.items, request);
+  }
+
+  removeItem(request: RemoveItemRequest): Observable<void> {
+    return this.http.delete<void>(API_ENDPOINTS.shoppingLists.items, { body: request });
+  }
+
+  exportList(): Observable<string> {
+    return this.http.get(API_ENDPOINTS.shoppingLists.export, { responseType: 'text' });
+  }
+
+  startShoppingMode(): Observable<void> {
+    return this.http.post<void>(API_ENDPOINTS.shoppingLists.shoppingModeStart, {});
+  }
+
+  endShoppingMode(acceptPendingChanges: boolean): Observable<void> {
+    return this.http.post<void>(API_ENDPOINTS.shoppingLists.shoppingModeEnd, {
+      acceptPendingChanges,
     });
   }
 }


### PR DESCRIPTION
## Summary
New default landing page for /shopping showing the event-sourced merged shopping list.

### Features
- Category-grouped items (Produce, Dairy, Meat & Fish, etc.)
- Display quantities with unit
- Add item input (Enter to submit)
- Remove item button (hover reveal)
- Export button (Web Share API with clipboard fallback)
- Progress counter (bought / total)
- Empty state
- Error with retry
- Glassmorphism styling

### API Service
- 6 new methods on ShoppingApiService: getMergedList, addItem, removeItem, exportList, startShoppingMode, endShoppingMode
- TypeScript interfaces for MergedShoppingList, AddItemRequest, etc.

### Routes
- \`/shopping\` → new MergedListComponent (default)
- \`/shopping/lists\` → old list overview
- \`/shopping/lists/:id\` → old detail

### Tests
- 10 component tests (renders, API calls, add/remove, error, empty, progress)
- All 34 shopping tests pass

Closes #161 #162 #163 #164 #165 #166 #167