### PR TITLE
feat(account): add profile settings page with backend API (US-302)

### DIFF
--- a/client/apps/account/public/assets/i18n/de.json
+++ b/client/apps/account/public/assets/i18n/de.json
@@ -16,6 +16,24 @@
     "placeholder": {
       "title": "Kontoeinstellungen",
       "message": "Kontoverwaltungsfunktionen folgen in Kürze."
+    },
+    "settings": {
+      "title": "Profileinstellungen",
+      "loading": "Profil wird geladen…",
+      "retry": "Erneut versuchen",
+      "household": "Haushalt",
+      "defaultServings": "Standard-Portionen",
+      "dietary": "Ernährungspräferenzen",
+      "dietaryType": "Ernährungstyp",
+      "none": "Keine",
+      "restrictions": "Einschränkungen & Allergien",
+      "cookingEffort": "Kochaufwand",
+      "weeklyGoals": "Wochenziele",
+      "minVeggie": "Min. vegetarische Gerichte",
+      "maxMeat": "Max. Rotfleisch-Gerichte",
+      "save": "Speichern",
+      "saving": "Speichert…",
+      "saved": "Gespeichert!"
     }
   }
 }

--- a/client/apps/account/public/assets/i18n/en.json
+++ b/client/apps/account/public/assets/i18n/en.json
@@ -16,6 +16,24 @@
     "placeholder": {
       "title": "Account Settings",
       "message": "Account management features are coming soon."
+    },
+    "settings": {
+      "title": "Profile Settings",
+      "loading": "Loading profile…",
+      "retry": "Retry",
+      "household": "Household",
+      "defaultServings": "Default servings",
+      "dietary": "Dietary Preferences",
+      "dietaryType": "Dietary type",
+      "none": "None",
+      "restrictions": "Restrictions & allergies",
+      "cookingEffort": "Cooking effort",
+      "weeklyGoals": "Weekly Goals",
+      "minVeggie": "Min. veggie meals",
+      "maxMeat": "Max. red-meat meals",
+      "save": "Save",
+      "saving": "Saving…",
+      "saved": "Saved!"
     }
   }
 }

--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -3,10 +3,10 @@ import { Route } from '@angular/router';
 export const accountRoutes: Route[] = [
   {
     path: '',
-    title: 'Account — Yumney',
+    title: 'Profile Settings — Yumney',
     loadComponent: () =>
-      import('./account-placeholder/account-placeholder.component').then(
-        (m) => m.AccountPlaceholderComponent,
+      import('./profile-settings/profile-settings.component').then(
+        (m) => m.ProfileSettingsComponent,
       ),
   },
 ];

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -1,0 +1,122 @@
+<div class="profile-settings" *transloco="let t">
+  <h1>{{ t('account.settings.title') }}</h1>
+
+  @if (loading()) {
+    <div class="loading">{{ t('account.settings.loading') }}</div>
+  }
+
+  @if (error(); as err) {
+    <div class="error" role="alert">
+      {{ err }}
+      <button class="retry-btn" (click)="onRetry()">{{ t('account.settings.retry') }}</button>
+    </div>
+  }
+
+  @if (profile(); as p) {
+    <form (submit)="$event.preventDefault(); onSave()">
+      <section class="settings-section">
+        <h2>{{ t('account.settings.household') }}</h2>
+        <div class="form-field">
+          <label for="servings">{{ t('account.settings.defaultServings') }}</label>
+          <input
+            id="servings"
+            type="number"
+            min="1"
+            max="12"
+            [ngModel]="defaultServings()"
+            (ngModelChange)="defaultServings.set($event)"
+            name="servings"
+          />
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <h2>{{ t('account.settings.dietary') }}</h2>
+        <div class="form-field">
+          <label for="dietaryType">{{ t('account.settings.dietaryType') }}</label>
+          <select
+            id="dietaryType"
+            [ngModel]="dietaryType()"
+            (ngModelChange)="dietaryType.set($event)"
+            name="dietaryType"
+          >
+            <option value="">{{ t('account.settings.none') }}</option>
+            @for (type of dietaryTypes; track type) {
+              <option [value]="type">{{ type }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="form-field">
+          <label>{{ t('account.settings.restrictions') }}</label>
+          <div class="checkbox-group">
+            @for (r of availableRestrictions; track r) {
+              <label class="checkbox-label">
+                <input
+                  type="checkbox"
+                  [checked]="restrictions().includes(r)"
+                  (change)="onToggleRestriction(r)"
+                />
+                {{ r }}
+              </label>
+            }
+          </div>
+        </div>
+
+        <div class="form-field">
+          <label for="cookingEffort">{{ t('account.settings.cookingEffort') }}</label>
+          <select
+            id="cookingEffort"
+            [ngModel]="cookingEffort()"
+            (ngModelChange)="cookingEffort.set($event)"
+            name="cookingEffort"
+          >
+            <option value="">{{ t('account.settings.none') }}</option>
+            @for (effort of cookingEfforts; track effort) {
+              <option [value]="effort">{{ effort }}</option>
+            }
+          </select>
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <h2>{{ t('account.settings.weeklyGoals') }}</h2>
+        <div class="form-row">
+          <div class="form-field">
+            <label for="minVeggie">{{ t('account.settings.minVeggie') }}</label>
+            <input
+              id="minVeggie"
+              type="number"
+              min="0"
+              max="7"
+              [ngModel]="minVeggieMeals()"
+              (ngModelChange)="minVeggieMeals.set($event)"
+              name="minVeggie"
+            />
+          </div>
+          <div class="form-field">
+            <label for="maxMeat">{{ t('account.settings.maxMeat') }}</label>
+            <input
+              id="maxMeat"
+              type="number"
+              min="0"
+              max="7"
+              [ngModel]="maxRedMeatMeals()"
+              (ngModelChange)="maxRedMeatMeals.set($event)"
+              name="maxMeat"
+            />
+          </div>
+        </div>
+      </section>
+
+      <div class="form-actions">
+        <button type="submit" class="save-btn" [disabled]="saving()">
+          {{ saving() ? t('account.settings.saving') : t('account.settings.save') }}
+        </button>
+        @if (saved()) {
+          <span class="saved-indicator">{{ t('account.settings.saved') }}</span>
+        }
+      </div>
+    </form>
+  }
+</div>

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.scss
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.scss
@@ -1,0 +1,130 @@
+@use 'glass';
+
+.profile-settings {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: var(--yn-space-5);
+
+  h1 {
+    font-size: var(--yn-text-2xl);
+    font-weight: var(--yn-font-bold);
+    margin: 0 0 var(--yn-space-7);
+  }
+}
+
+.settings-section {
+  @include glass.glass-surface(1);
+  border-radius: var(--yn-radius-card);
+  padding: var(--yn-space-5);
+  margin-bottom: var(--yn-space-5);
+
+  h2 {
+    font-size: var(--yn-text-lg);
+    font-weight: var(--yn-font-semibold);
+    margin: 0 0 var(--yn-space-4);
+    color: var(--yn-text);
+  }
+}
+
+.form-field {
+  margin-bottom: var(--yn-space-4);
+
+  label {
+    display: block;
+    font-size: var(--yn-text-sm);
+    font-weight: var(--yn-font-medium);
+    color: var(--yn-text-muted);
+    margin-bottom: var(--yn-space-2);
+  }
+
+  input[type='number'],
+  select {
+    width: 100%;
+    padding: var(--yn-space-3) var(--yn-space-4);
+    border: 1px solid var(--yn-glass-border);
+    border-radius: var(--yn-radius-input);
+    background: var(--yn-glass-bg);
+    font-size: var(--yn-text-base);
+    color: var(--yn-text);
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: var(--yn-primary);
+    }
+  }
+}
+
+.form-row {
+  display: flex;
+  gap: var(--yn-space-4);
+
+  .form-field {
+    flex: 1;
+  }
+}
+
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-3);
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text);
+  cursor: pointer;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-4);
+}
+
+.save-btn {
+  padding: var(--yn-space-3) var(--yn-space-6);
+  border: none;
+  border-radius: var(--yn-radius-button);
+  background: var(--yn-primary);
+  color: var(--yn-text-inverse);
+  font-size: var(--yn-text-base);
+  font-weight: var(--yn-font-semibold);
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.saved-indicator {
+  color: var(--yn-success);
+  font-size: var(--yn-text-sm);
+}
+
+.loading,
+.error {
+  text-align: center;
+  padding: var(--yn-space-7);
+}
+
+.error {
+  color: var(--yn-danger);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.retry-btn {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 1px solid var(--yn-danger);
+  border-radius: var(--yn-radius-button);
+  background: none;
+  color: var(--yn-danger);
+  cursor: pointer;
+}

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.spec.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ProfileSettingsComponent } from './profile-settings.component';
+import { UserProfileApiService, type UserProfile } from '@yumney/shared/api-client';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+
+const en = {
+  account: {
+    settings: {
+      title: 'Profile Settings',
+      loading: 'Loading profile…',
+      retry: 'Retry',
+      household: 'Household',
+      defaultServings: 'Default servings',
+      dietary: 'Dietary Preferences',
+      dietaryType: 'Dietary type',
+      none: 'None',
+      restrictions: 'Restrictions & allergies',
+      cookingEffort: 'Cooking effort',
+      weeklyGoals: 'Weekly Goals',
+      minVeggie: 'Min. veggie meals',
+      maxMeat: 'Max. red-meat meals',
+      save: 'Save',
+      saving: 'Saving…',
+      saved: 'Saved!',
+    },
+  },
+};
+
+const mockProfile: UserProfile = {
+  displayName: 'Test User',
+  preferredLanguage: 'en',
+  preferredUnitSystem: 'metric',
+  defaultServings: 4,
+  dietaryProfile: {
+    dietaryType: 'vegetarian',
+    restrictions: ['gluten-free'],
+    minVeggieMeals: 3,
+    maxRedMeatMeals: 2,
+    cookingEffort: 'balanced',
+  },
+};
+
+describe('ProfileSettingsComponent', () => {
+  let fixture: ComponentFixture<ProfileSettingsComponent>;
+  let apiMock: {
+    getProfile: ReturnType<typeof vi.fn>;
+    updateProfile: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    apiMock = {
+      getProfile: vi.fn().mockReturnValue(of(mockProfile)),
+      updateProfile: vi.fn().mockReturnValue(of(mockProfile)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProfileSettingsComponent, setupTranslocoTesting(en)],
+      providers: [{ provide: UserProfileApiService, useValue: apiMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileSettingsComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should load profile on init', () => {
+    expect(apiMock.getProfile).toHaveBeenCalled();
+  });
+
+  it('should render form after profile loads', () => {
+    const form = fixture.nativeElement.querySelector('form');
+    expect(form).toBeTruthy();
+  });
+
+  it('should display title', () => {
+    expect(fixture.nativeElement.textContent).toContain('Profile Settings');
+  });
+
+  it('should populate servings from profile', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('#servings');
+    expect(input.value).toBe('4');
+  });
+
+  it('should populate dietary type from profile', () => {
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector('#dietaryType');
+    expect(select.value).toBe('vegetarian');
+  });
+
+  it('should check active restrictions', () => {
+    const checkboxes: NodeListOf<HTMLInputElement> = fixture.nativeElement.querySelectorAll(
+      '.checkbox-label input[type="checkbox"]',
+    );
+    const checked = Array.from(checkboxes).filter((cb) => cb.checked);
+    expect(checked.length).toBe(1);
+  });
+
+  it('should toggle restriction on click', () => {
+    fixture.componentInstance['onToggleRestriction']('nut-allergy');
+    expect(fixture.componentInstance['restrictions']()).toContain('nut-allergy');
+
+    fixture.componentInstance['onToggleRestriction']('nut-allergy');
+    expect(fixture.componentInstance['restrictions']()).not.toContain('nut-allergy');
+  });
+
+  it('should call updateProfile on save', () => {
+    fixture.componentInstance['onSave']();
+
+    expect(apiMock.updateProfile).toHaveBeenCalledWith({
+      defaultServings: 4,
+      dietaryType: 'vegetarian',
+      restrictions: ['gluten-free'],
+      minVeggieMeals: 3,
+      maxRedMeatMeals: 2,
+      cookingEffort: 'balanced',
+    });
+  });
+
+  it('should show saved indicator after save', () => {
+    fixture.componentInstance['onSave']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.saved-indicator')).toBeTruthy();
+  });
+
+  it('should show error with retry on load failure', () => {
+    apiMock.getProfile.mockReturnValue(throwError(() => new Error('fail')));
+    fixture.componentInstance['loadProfile']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.retry-btn')).toBeTruthy();
+  });
+
+  it('should show error on save failure', () => {
+    apiMock.updateProfile.mockReturnValue(throwError(() => new Error('fail')));
+    fixture.componentInstance['onSave']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+  });
+});

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,0 +1,126 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  UserProfileApiService,
+  type UserProfile,
+  type UpdateProfileRequest,
+} from '@yumney/shared/api-client';
+
+@Component({
+  selector: 'yn-profile-settings',
+  standalone: true,
+  imports: [FormsModule, TranslocoModule],
+  templateUrl: './profile-settings.component.html',
+  styleUrl: './profile-settings.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileSettingsComponent {
+  private api = inject(UserProfileApiService);
+  private destroyRef = inject(DestroyRef);
+
+  protected profile = signal<UserProfile | null>(null);
+  protected loading = signal(false);
+  protected saving = signal(false);
+  protected error = signal<string | null>(null);
+  protected saved = signal(false);
+
+  protected defaultServings = signal(4);
+  protected dietaryType = signal<string>('');
+  protected restrictions = signal<string[]>([]);
+  protected minVeggieMeals = signal<number | null>(null);
+  protected maxRedMeatMeals = signal<number | null>(null);
+  protected cookingEffort = signal<string>('');
+
+  protected dietaryTypes = ['omnivore', 'vegetarian', 'vegan', 'pescatarian', 'flexitarian'];
+  protected availableRestrictions = [
+    'gluten-free',
+    'lactose-free',
+    'nut-allergy',
+    'egg-free',
+    'soy-free',
+    'shellfish-allergy',
+    'halal',
+    'kosher',
+  ];
+  protected cookingEfforts = ['quick-weekdays', 'balanced', 'elaborate-weekends'];
+
+  constructor() {
+    this.loadProfile();
+  }
+
+  protected onSave(): void {
+    this.saving.set(true);
+    this.saved.set(false);
+    this.error.set(null);
+
+    const request: UpdateProfileRequest = {
+      defaultServings: this.defaultServings(),
+      dietaryType: this.dietaryType() || null,
+      restrictions: this.restrictions(),
+      minVeggieMeals: this.minVeggieMeals(),
+      maxRedMeatMeals: this.maxRedMeatMeals(),
+      cookingEffort: this.cookingEffort() || null,
+    };
+
+    this.api
+      .updateProfile(request)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.profile.set(updated);
+          this.saving.set(false);
+          this.saved.set(true);
+          setTimeout(() => this.saved.set(false), 3000);
+        },
+        error: () => {
+          this.error.set('Failed to save profile');
+          this.saving.set(false);
+        },
+      });
+  }
+
+  protected onToggleRestriction(restriction: string): void {
+    const current = this.restrictions();
+    if (current.includes(restriction)) {
+      this.restrictions.set(current.filter((r) => r !== restriction));
+    } else {
+      this.restrictions.set([...current, restriction]);
+    }
+  }
+
+  protected onRetry(): void {
+    this.loadProfile();
+  }
+
+  private loadProfile(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.api
+      .getProfile()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (profile) => {
+          this.profile.set(profile);
+          this.defaultServings.set(profile.defaultServings);
+          this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
+          this.restrictions.set([...profile.dietaryProfile.restrictions]);
+          this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
+          this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
+          this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
+          this.loading.set(false);
+        },
+        error: () => {
+          this.error.set('Failed to load profile');
+          this.loading.set(false);
+        },
+      });
+  }
+}

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  DestroyRef,
-  inject,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -60,3 +60,5 @@ export type {
   ConfirmMealRequest,
   CookWithLeftoversRequest,
 } from './lib/meal-plan';
+export { UserProfileApiService } from './lib/user-profile-api.service';
+export type { UserProfile, DietaryProfileDto, UpdateProfileRequest } from './lib/user-profile';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -49,5 +49,6 @@ export const API_ENDPOINTS = {
   users: {
     activity: `${API_BASE}/users/me/activity`,
     suggestions: `${API_BASE}/users/me/suggestions`,
+    profile: `${API_BASE}/users/me/profile`,
   },
 } as const;

--- a/client/libs/shared/api-client/src/lib/user-profile-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/user-profile-api.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
+import type { UserProfile, UpdateProfileRequest } from './user-profile';
+
+@Injectable({ providedIn: 'root' })
+export class UserProfileApiService {
+  private http = inject(HttpClient);
+
+  getProfile(): Observable<UserProfile> {
+    return this.http.get<UserProfile>(API_ENDPOINTS.users.profile);
+  }
+
+  updateProfile(request: UpdateProfileRequest): Observable<UserProfile> {
+    return this.http.put<UserProfile>(API_ENDPOINTS.users.profile, request);
+  }
+}

--- a/client/libs/shared/api-client/src/lib/user-profile.ts
+++ b/client/libs/shared/api-client/src/lib/user-profile.ts
@@ -1,0 +1,24 @@
+export interface DietaryProfileDto {
+  dietaryType: string | null;
+  restrictions: string[];
+  minVeggieMeals: number | null;
+  maxRedMeatMeals: number | null;
+  cookingEffort: string | null;
+}
+
+export interface UserProfile {
+  displayName: string;
+  preferredLanguage: string;
+  preferredUnitSystem: string;
+  defaultServings: number;
+  dietaryProfile: DietaryProfileDto;
+}
+
+export interface UpdateProfileRequest {
+  defaultServings: number;
+  dietaryType: string | null;
+  restrictions: string[];
+  minVeggieMeals: number | null;
+  maxRedMeatMeals: number | null;
+  cookingEffort: string | null;
+}

--- a/src/Yumney.Users.Api/ProfileEndpoints.cs
+++ b/src/Yumney.Users.Api/ProfileEndpoints.cs
@@ -1,0 +1,47 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+namespace SmartSolutionsLab.Yumney.Users.Api;
+
+public static class ProfileEndpoints
+{
+    public static IEndpointRouteBuilder MapProfileEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/users/me/profile");
+
+        group.MapGet("/", GetProfileAsync)
+            .WithName("GetUserProfile")
+            .WithTags("Users")
+            .Produces<UserProfileDto>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPut("/", UpdateProfileAsync)
+            .WithName("UpdateUserProfile")
+            .WithTags("Users")
+            .Produces<UserProfileDto>()
+            .ProducesValidationProblem();
+
+        return app;
+    }
+
+    private static async Task<IResult> GetProfileAsync(
+        IQueryHandler<GetUserProfileQuery, Result<UserProfileDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(new GetUserProfileQuery(), cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> UpdateProfileAsync(
+        UpdateUserProfileCommand command,
+        ICommandHandler<UpdateUserProfileCommand, Result<UserProfileDto>> handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+}

--- a/src/Yumney.Users.Api/UsersEndpoints.cs
+++ b/src/Yumney.Users.Api/UsersEndpoints.cs
@@ -8,6 +8,7 @@ public static class UsersEndpoints
     {
         app.MapAuthEndpoints();
         app.MapUserActivityEndpoints();
+        app.MapProfileEndpoints();
 
         return app;
     }

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -1,0 +1,43 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class UpdateUserProfileCommandHandler(
+    IAppUserProfileRepository profiles,
+    ICurrentUser currentUser) : ICommandHandler<UpdateUserProfileCommand, Result<UserProfileDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<UserProfileDto>> HandleAsync(UpdateUserProfileCommand command, CancellationToken cancellationToken = default)
+    {
+        var keycloakId = KeycloakUserId.From(currentUser.UserId);
+        var profile = await profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
+
+        profile.AdjustDefaultServingsTo(DefaultServings.From(command.DefaultServings));
+
+        var dietaryType = command.DietaryType is not null ? DietaryType.From(command.DietaryType) : null;
+        var restrictions = command.Restrictions.Select(DietaryRestriction.From).ToList();
+        var balanceGoals = WeeklyBalanceGoals.From(command.MinVeggieMeals, command.MaxRedMeatMeals);
+        var cookingEffort = command.CookingEffort is not null ? CookingEffortPreference.From(command.CookingEffort) : null;
+
+        profile.UpdateDietaryProfile(DietaryProfile.From(dietaryType, restrictions, balanceGoals, cookingEffort));
+
+        await profiles.SaveChangesAsync(cancellationToken);
+
+        var dietary = profile.DietaryProfile;
+        return new UserProfileDto(
+            profile.DisplayName.Value,
+            profile.PreferredLanguage.Value,
+            profile.PreferredUnitSystem.Value,
+            profile.DefaultServings.Value,
+            new DietaryProfileDto(
+                dietary.DietaryType?.Value,
+                dietary.Restrictions.Select(r => r.Value).ToList(),
+                dietary.BalanceGoals.MinVeggieMeals,
+                dietary.BalanceGoals.MaxRedMeatMeals,
+                dietary.CookingEffort?.Value));
+    }
+}

--- a/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
+++ b/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
+
+public sealed record UpdateUserProfileCommand(
+    int DefaultServings,
+    string? DietaryType,
+    IReadOnlyList<string> Restrictions,
+    int? MinVeggieMeals,
+    int? MaxRedMeatMeals,
+    string? CookingEffort) : ICommand<Result<UserProfileDto>>;

--- a/src/Yumney.Users.Application/DTOs/UserProfileDto.cs
+++ b/src/Yumney.Users.Application/DTOs/UserProfileDto.cs
@@ -1,0 +1,15 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record UserProfileDto(
+    string DisplayName,
+    string PreferredLanguage,
+    string PreferredUnitSystem,
+    int DefaultServings,
+    DietaryProfileDto DietaryProfile);
+
+public sealed record DietaryProfileDto(
+    string? DietaryType,
+    IReadOnlyList<string> Restrictions,
+    int? MinVeggieMeals,
+    int? MaxRedMeatMeals,
+    string? CookingEffort);

--- a/src/Yumney.Users.Application/Queries/GetUserProfileQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetUserProfileQuery.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+public sealed record GetUserProfileQuery : IQuery<Result<UserProfileDto>>;

--- a/src/Yumney.Users.Application/Queries/Handlers/GetUserProfileQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetUserProfileQueryHandler.cs
@@ -1,0 +1,36 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
+
+public sealed class GetUserProfileQueryHandler(
+    IAppUserProfileRepository profiles,
+    ICurrentUser currentUser) : IQueryHandler<GetUserProfileQuery, Result<UserProfileDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<UserProfileDto>> HandleAsync(GetUserProfileQuery query, CancellationToken cancellationToken = default)
+    {
+        var keycloakId = KeycloakUserId.From(currentUser.UserId);
+        var profile = await profiles.FindByKeycloakUserIdAsync(keycloakId, cancellationToken);
+
+        if (profile is null)
+            return new ApiError("PROFILE_NOT_FOUND", "User profile not found.", 404);
+
+        var dietary = profile.DietaryProfile;
+        var dietaryDto = new DietaryProfileDto(
+            dietary.DietaryType?.Value,
+            dietary.Restrictions.Select(r => r.Value).ToList(),
+            dietary.BalanceGoals.MinVeggieMeals,
+            dietary.BalanceGoals.MaxRedMeatMeals,
+            dietary.CookingEffort?.Value);
+
+        return new UserProfileDto(
+            profile.DisplayName.Value,
+            profile.PreferredLanguage.Value,
+            profile.PreferredUnitSystem.Value,
+            profile.DefaultServings.Value,
+            dietaryDto);
+    }
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
@@ -8,4 +8,11 @@ public interface IAppUserProfileRepository
     Task<AppUserProfile> GetByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 
     Task AddAsync(AppUserProfile profile, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Save changes to a tracked profile.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -24,4 +24,9 @@ public sealed class AppUserProfileRepository(UsersDbContext context) : IAppUserP
         await profiles.AddAsync(profile, cancellationToken);
         await context.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await context.SaveChangesAsync(cancellationToken);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `GET/PUT /users/me/profile` endpoints with CQRS handlers for reading and updating user profile (default servings, dietary preferences, weekly balance goals, cooking effort)
- Add `ProfileSettingsComponent` in the account MFE with glassmorphism form (household size, dietary type, restrictions checkboxes, cooking effort, weekly veggie/meat goals)
- Add `UserProfileApiService` and TypeScript interfaces in shared api-client
- Add i18n keys (EN + DE) and 12 component tests

## Test plan
- [x] 14 account MFE tests pass (12 new + 2 existing)
- [x] 180 Users domain tests pass
- [x] Account MFE builds successfully
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)