### PR TITLE
feat(mealplan): generate shopping list from weekly meal plan (US-325)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -457,6 +457,10 @@
     "loading": "Essensplan wird geladen...",
     "servings": "Portionen",
     "clearSlot": "Slot leeren",
-    "retry": "Erneut versuchen"
+    "retry": "Erneut versuchen",
+    "generateShoppingList": "Einkaufsliste erstellen",
+    "generatingList": "Wird erstellt...",
+    "itemsAdded": "{{count}} Artikel hinzugefügt",
+    "staplesSkipped": "{{count}} Grundzutaten übersprungen"
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -457,6 +457,10 @@
     "loading": "Loading meal plan...",
     "servings": "servings",
     "clearSlot": "Clear this slot",
-    "retry": "Retry"
+    "retry": "Retry",
+    "generateShoppingList": "Generate Shopping List",
+    "generatingList": "Generating...",
+    "itemsAdded": "{{count}} items added",
+    "staplesSkipped": "{{count}} staples skipped"
   }
 }

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -24,6 +24,25 @@
     </div>
   }
 
+  @if (hasRecipeSlots()) {
+    <div class="planner-actions">
+      <button class="generate-btn" [disabled]="generatingList()" (click)="onGenerateShoppingList()">
+        <lucide-icon name="shopping-cart" [size]="16" />
+        {{
+          generatingList() ? t('mealPlanner.generatingList') : t('mealPlanner.generateShoppingList')
+        }}
+      </button>
+      @if (shoppingResult(); as result) {
+        <span class="shopping-result">
+          {{ t('mealPlanner.itemsAdded', { count: result.itemsAdded }) }}
+          @if (result.staplesSkipped > 0) {
+            ({{ t('mealPlanner.staplesSkipped', { count: result.staplesSkipped }) }})
+          }
+        </span>
+      }
+    </div>
+  }
+
   <div class="week-grid">
     @for (entry of dinnerSlots(); track entry.day) {
       <div

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.scss
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.scss
@@ -40,6 +40,37 @@
   }
 }
 
+.planner-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-4);
+  margin-bottom: var(--yn-space-5);
+}
+
+.generate-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border: none;
+  border-radius: var(--yn-radius-button);
+  background: var(--yn-primary);
+  color: var(--yn-text-inverse);
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-semibold);
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.shopping-result {
+  color: var(--yn-success);
+  font-size: var(--yn-text-sm);
+}
+
 .week-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -9,7 +9,12 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { MealPlanApiService, type WeeklyPlan, type MealSlot } from '@yumney/shared/api-client';
+import {
+  MealPlanApiService,
+  type WeeklyPlan,
+  type MealSlot,
+  type GenerateShoppingListResult,
+} from '@yumney/shared/api-client';
 
 @Component({
   selector: 'yn-meal-planner',
@@ -28,6 +33,8 @@ export class MealPlannerComponent {
   protected plan = signal<WeeklyPlan | null>(null);
   protected loading = signal(false);
   protected error = signal<string | null>(null);
+  protected generatingList = signal(false);
+  protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
   protected weekLabel = computed(
     () => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`,
@@ -66,6 +73,31 @@ export class MealPlannerComponent {
       this.weekNumber.update((w) => w + 1);
     }
     this.loadPlan();
+  }
+
+  protected hasRecipeSlots = computed(
+    () => this.plan()?.slots.some((s) => s.contentType === 'Recipe') ?? false,
+  );
+
+  protected onGenerateShoppingList(): void {
+    this.generatingList.set(true);
+    this.shoppingResult.set(null);
+    this.error.set(null);
+
+    this.api
+      .generateShoppingList(this.year(), this.weekNumber())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.shoppingResult.set(result);
+          this.generatingList.set(false);
+          setTimeout(() => this.shoppingResult.set(null), 5000);
+        },
+        error: () => {
+          this.error.set('Failed to generate shopping list');
+          this.generatingList.set(false);
+        },
+      });
   }
 
   protected onClearSlot(day: string): void {

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -59,6 +59,7 @@ export type {
   AdjustServingsRequest,
   ConfirmMealRequest,
   CookWithLeftoversRequest,
+  GenerateShoppingListResult,
 } from './lib/meal-plan';
 export { UserProfileApiService } from './lib/user-profile-api.service';
 export type { UserProfile, DietaryProfileDto, UpdateProfileRequest } from './lib/user-profile';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -41,6 +41,8 @@ export const API_ENDPOINTS = {
       `${API_BASE}/meal-plans/${year}/w/${week}/cook-with-leftovers`,
     plannedRecipes: (year: number, week: number) =>
       `${API_BASE}/meal-plans/${year}/w/${week}/planned-recipes`,
+    generateShoppingList: (year: number, week: number) =>
+      `${API_BASE}/meal-plans/${year}/w/${week}/generate-shopping-list`,
   },
   auth: {
     register: `${API_BASE}/auth/register`,

--- a/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
@@ -11,6 +11,7 @@ import type {
   AdjustServingsRequest,
   ConfirmMealRequest,
   CookWithLeftoversRequest,
+  GenerateShoppingListResult,
 } from './meal-plan';
 
 @Injectable({ providedIn: 'root' })
@@ -66,5 +67,12 @@ export class MealPlanApiService {
 
   getPlannedRecipes(year: number, week: number): Observable<WeeklyPlannedRecipes> {
     return this.http.get<WeeklyPlannedRecipes>(API_ENDPOINTS.mealPlans.plannedRecipes(year, week));
+  }
+
+  generateShoppingList(year: number, week: number): Observable<GenerateShoppingListResult> {
+    return this.http.post<GenerateShoppingListResult>(
+      API_ENDPOINTS.mealPlans.generateShoppingList(year, week),
+      {},
+    );
   }
 }

--- a/client/libs/shared/api-client/src/lib/meal-plan.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan.ts
@@ -71,3 +71,8 @@ export interface CookWithLeftoversRequest {
   leftoverDay: string;
   mealType?: string;
 }
+
+export interface GenerateShoppingListResult {
+  itemsAdded: number;
+  staplesSkipped: number;
+}

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -65,6 +65,12 @@ public static class MealPlanEndpoints
             .Produces<WeeklyPlanDto>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        group.MapPost("/{year:int}/w/{weekNumber:int}/generate-shopping-list", GenerateShoppingListAsync)
+            .WithName("GenerateShoppingList")
+            .WithTags("MealPlan")
+            .Produces<GenerateShoppingListResult>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         return app;
     }
 
@@ -187,6 +193,17 @@ public static class MealPlanEndpoints
         CancellationToken cancellationToken)
     {
         var command = new ClearMealSlotCommand(year, weekNumber, request.Day, request.MealType);
+        var result = await handler.HandleAsync(command, cancellationToken);
+        return result.ToOk();
+    }
+
+    private static async Task<IResult> GenerateShoppingListAsync(
+        int year,
+        int weekNumber,
+        ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResult>> handler,
+        CancellationToken cancellationToken)
+    {
+        var command = new GenerateShoppingListCommand(year, weekNumber);
         var result = await handler.HandleAsync(command, cancellationToken);
         return result.ToOk();
     }

--- a/src/Yumney.MealPlan.Application/Commands/GenerateShoppingListCommand.cs
+++ b/src/Yumney.MealPlan.Application/Commands/GenerateShoppingListCommand.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public sealed record GenerateShoppingListCommand(int Year, int WeekNumber) : ICommand<Result<GenerateShoppingListResult>>;
+
+public sealed record GenerateShoppingListResult(int ItemsAdded, int StaplesSkipped);

--- a/src/Yumney.MealPlan.Application/Commands/GenerateShoppingListErrors.cs
+++ b/src/Yumney.MealPlan.Application/Commands/GenerateShoppingListErrors.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+
+public static class GenerateShoppingListErrors
+{
+    public static readonly ApiError NoPlanFound = new("MEALPLAN_NOT_FOUND", "No meal plan found for this week.", 404);
+    public static readonly ApiError NoRecipes = new("MEALPLAN_NO_RECIPES", "No recipes assigned to this week's plan.", 400);
+}

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -1,0 +1,89 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+
+public sealed class GenerateShoppingListCommandHandler(
+    IWeeklyPlanRepository plans,
+    IRecipeIngredientProvider ingredientProvider,
+    IStaplesProvider staplesProvider,
+    IShoppingListWriter shoppingListWriter,
+    ICurrentUser currentUser) : ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResult>>
+{
+    public async Task<Result<GenerateShoppingListResult>> HandleAsync(
+        GenerateShoppingListCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var owner = currentUser.AsOwner();
+        var week = WeekIdentifier.From(command.Year, command.WeekNumber);
+
+        var plan = await plans.FindByOwnerAndWeekAsync(owner, week, cancellationToken);
+        if (plan is null)
+            return GenerateShoppingListErrors.NoPlanFound;
+
+        var recipeSlots = plan.Slots
+            .Where(s => s.ContentType == SlotContentType.Recipe && s.RecipeIdentifier.HasValue)
+            .ToList();
+
+        if (recipeSlots.Count == 0)
+            return GenerateShoppingListErrors.NoRecipes;
+
+        // Fetch ingredients for all recipes
+        var merged = new Dictionary<string, MergedItem>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var slot in recipeSlots)
+        {
+            var ingredients = await ingredientProvider.GetIngredientsAsync(slot.RecipeIdentifier!.Value, cancellationToken);
+            var recipeServings = (ingredients.Count > 0 ? ingredients[0].RecipeServings : null) ?? slot.Servings;
+            var scaleFactor = recipeServings > 0 ? (decimal)slot.Servings / recipeServings : 1m;
+
+            foreach (var ingredient in ingredients)
+            {
+                var scaledAmount = ingredient.Amount.HasValue
+                    ? Math.Round(ingredient.Amount.Value * scaleFactor, 2)
+                    : 0m;
+
+                var key = $"{ingredient.Name.ToLowerInvariant()}|{ingredient.Unit ?? string.Empty}";
+                if (merged.TryGetValue(key, out var existing))
+                {
+                    existing.Quantity += scaledAmount;
+                }
+                else
+                {
+                    merged[key] = new MergedItem(ingredient.Name, scaledAmount, ingredient.Unit);
+                }
+            }
+        }
+
+        // Filter out staples
+        var staples = await staplesProvider.GetStapleNamesAsync(currentUser.UserId, cancellationToken);
+        var staplesSkipped = 0;
+        var itemsToAdd = new List<ShoppingItemRequest>();
+
+        foreach (var item in merged.Values)
+        {
+            if (staples.Contains(item.Name.ToLowerInvariant()))
+            {
+                staplesSkipped++;
+                continue;
+            }
+
+            itemsToAdd.Add(new ShoppingItemRequest(item.Name, item.Quantity, item.Unit, "meal-plan"));
+        }
+
+        if (itemsToAdd.Count > 0)
+            await shoppingListWriter.AddItemsAsync(currentUser.UserId, itemsToAdd, cancellationToken);
+
+        return new GenerateShoppingListResult(itemsToAdd.Count, staplesSkipped);
+    }
+
+    private sealed class MergedItem(string name, decimal quantity, string? unit)
+    {
+        public string Name { get; } = name;
+
+        public decimal Quantity { get; set; } = quantity;
+
+        public string? Unit { get; } = unit;
+    }
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure;
@@ -21,6 +23,7 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 
         services.AddScoped<IRecipeRepository, RecipeRepository>();
         services.AddScoped<IRecipeFavoriteRepository, RecipeFavoriteRepository>();
+        services.AddScoped<IRecipeIngredientProvider, RecipeIngredientProvider>();
         services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
         return services;

--- a/src/Yumney.Recipes.Infrastructure/Services/RecipeIngredientProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/RecipeIngredientProvider.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+
+public sealed class RecipeIngredientProvider(IRecipeRepository recipes) : IRecipeIngredientProvider
+{
+    public async Task<IReadOnlyList<RecipeIngredientInfo>> GetIngredientsAsync(
+        Guid recipeIdentifier,
+        CancellationToken cancellationToken = default)
+    {
+        var recipe = await recipes.GetByIdAsync(RecipeIdentifier.From(recipeIdentifier), cancellationToken);
+
+        return recipe.Ingredients
+            .Select(i => new RecipeIngredientInfo(
+                i.Name.Value,
+                i.Quantity?.Amount.Value,
+                i.Quantity?.Unit?.Value,
+                recipe.Servings?.Value))
+            .ToList();
+    }
+}

--- a/src/Yumney.Shared/Common/IRecipeIngredientProvider.cs
+++ b/src/Yumney.Shared/Common/IRecipeIngredientProvider.cs
@@ -1,0 +1,17 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Cross-module interface for fetching recipe ingredients.
+/// Implemented by Recipes.Infrastructure, consumed by MealPlan.Application.
+/// </summary>
+public interface IRecipeIngredientProvider
+{
+    Task<IReadOnlyList<RecipeIngredientInfo>> GetIngredientsAsync(
+        Guid recipeIdentifier,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Lightweight ingredient info for cross-module use.
+/// </summary>
+public sealed record RecipeIngredientInfo(string Name, decimal? Amount, string? Unit, int? RecipeServings);

--- a/src/Yumney.Shared/Common/IShoppingListWriter.cs
+++ b/src/Yumney.Shared/Common/IShoppingListWriter.cs
@@ -1,0 +1,18 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Cross-module interface for writing items to the shopping ledger.
+/// Implemented by Shopping.Infrastructure, consumed by MealPlan.Application.
+/// </summary>
+public interface IShoppingListWriter
+{
+    Task AddItemsAsync(
+        string ownerId,
+        IReadOnlyList<ShoppingItemRequest> items,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A single item to add to the shopping list.
+/// </summary>
+public sealed record ShoppingItemRequest(string ItemName, decimal Quantity, string? Unit, string Source);

--- a/src/Yumney.Shared/Common/IStaplesProvider.cs
+++ b/src/Yumney.Shared/Common/IStaplesProvider.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Cross-module interface for checking user staples.
+/// Implemented by Users.Infrastructure, consumed by MealPlan.Application.
+/// </summary>
+public interface IStaplesProvider
+{
+    Task<IReadOnlySet<string>> GetStapleNamesAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ItemSources.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ItemSources.cs
@@ -7,4 +7,7 @@ public static class ItemSources
 {
     /// <summary>Gets the source value for manually added items.</summary>
     public const string Manual = "manual";
+
+    /// <summary>Gets the source value for items generated from a meal plan.</summary>
+    public const string MealPlan = "meal-plan";
 }

--- a/src/Yumney.Shopping.Infrastructure/Services/ShoppingListWriter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Services/ShoppingListWriter.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+
+public sealed class ShoppingListWriter(IShoppingEventStore eventStore) : IShoppingListWriter
+{
+    public async Task AddItemsAsync(
+        string ownerId,
+        IReadOnlyList<ShoppingItemRequest> items,
+        CancellationToken cancellationToken = default)
+    {
+        var ledger = await eventStore.LoadAsync(ownerId, cancellationToken)
+                     ?? ShoppingLedger.Create(ownerId);
+
+        foreach (var item in items)
+        {
+            ledger.AddItem(item.ItemName, item.Quantity, item.Unit, item.Source);
+        }
+
+        await eventStore.SaveAsync(ledger, cancellationToken);
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
@@ -10,6 +11,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure;
 
@@ -31,6 +33,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 
         services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
         services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
+        services.AddScoped<IShoppingListWriter, ShoppingListWriter>();
         services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
         services.AddScoped<ShoppingListProjectionHandler>();
         services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/src/Yumney.Users.Infrastructure/Services/StaplesProvider.cs
+++ b/src/Yumney.Users.Infrastructure/Services/StaplesProvider.cs
@@ -1,0 +1,26 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+public sealed class StaplesProvider(IStaplesListRepository staplesLists) : IStaplesProvider
+{
+    public async Task<IReadOnlySet<string>> GetStapleNamesAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var owner = OwnerIdentifier.From(ownerId);
+        var staples = await staplesLists.FindByOwnerAsync(owner, cancellationToken);
+
+        if (staples is null)
+        {
+            return StaplesList.DefaultItems
+                .Select(i => i.Value.ToLowerInvariant())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return staples.Items
+            .Select(i => i.Value.ToLowerInvariant())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
@@ -32,6 +33,7 @@ public static class UsersInfrastructureServiceCollectionExtensions
         services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
         services.AddScoped<IUserActivityRepository, UserActivityRepository>();
         services.AddScoped<IStaplesListRepository, StaplesListRepository>();
+        services.AddScoped<IStaplesProvider, StaplesProvider>();
 
         services.AddHttpClient<IKeycloakAdminService, KeycloakAdminService>(client =>
         {

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/GenerateShoppingListCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/GenerateShoppingListCommandHandlerTests.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Commands;
+
+public class GenerateShoppingListCommandHandlerTests
+{
+    private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
+    private readonly IRecipeIngredientProvider ingredientProvider = Substitute.For<IRecipeIngredientProvider>();
+    private readonly IStaplesProvider staplesProvider = Substitute.For<IStaplesProvider>();
+    private readonly IShoppingListWriter shoppingListWriter = Substitute.For<IShoppingListWriter>();
+    private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+    private readonly GenerateShoppingListCommandHandler handler;
+
+    public GenerateShoppingListCommandHandlerTests()
+    {
+        currentUser.UserId.Returns("user-123");
+        staplesProvider.GetStapleNamesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "salt", "pepper", "flour" });
+        handler = new GenerateShoppingListCommandHandler(plans, ingredientProvider, staplesProvider, shoppingListWriter, currentUser);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoPlanFound_ReturnsFailure()
+    {
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns((WeeklyPlan?)null);
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be("MEALPLAN_NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoRecipeSlots_ReturnsFailure()
+    {
+        var plan = WeeklyPlan.Create(OwnerIdentifier.From("user-123"), WeekIdentifier.From(2026, 15));
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be("MEALPLAN_NO_RECIPES");
+    }
+
+    [Fact]
+    public async Task HandleAsync_SingleRecipe_AddsIngredientsToShoppingList()
+    {
+        var recipeId = Guid.NewGuid();
+        var plan = CreatePlanWithRecipe(recipeId, "Pasta", 4);
+
+        ingredientProvider.GetIngredientsAsync(recipeId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("Spaghetti", 500m, "g", 4),
+                new("Tomatoes", 400m, "g", 4),
+            });
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ItemsAdded.Should().Be(2);
+        await shoppingListWriter.Received(1).AddItemsAsync(
+            "user-123",
+            Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items => items.Count == 2),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ScalesQuantitiesByServings()
+    {
+        var recipeId = Guid.NewGuid();
+        var plan = CreatePlanWithRecipe(recipeId, "Pasta", 8);
+
+        ingredientProvider.GetIngredientsAsync(recipeId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("Spaghetti", 500m, "g", 4),
+            });
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        await shoppingListWriter.Received(1).AddItemsAsync(
+            "user-123",
+            Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items =>
+                items.Count == 1 && items[0].Quantity == 1000m),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_MergesSameIngredientAcrossRecipes()
+    {
+        var recipeA = Guid.NewGuid();
+        var recipeB = Guid.NewGuid();
+        var plan = CreatePlanWithTwoRecipes(recipeA, "Pasta", 4, recipeB, "Risotto", 4);
+
+        ingredientProvider.GetIngredientsAsync(recipeA, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("Olive Oil", 2m, "tbsp", 4),
+            });
+        ingredientProvider.GetIngredientsAsync(recipeB, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("olive oil", 3m, "tbsp", 4),
+            });
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ItemsAdded.Should().Be(1);
+        await shoppingListWriter.Received(1).AddItemsAsync(
+            "user-123",
+            Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items =>
+                items.Count == 1 && items[0].Quantity == 5m),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_FilterStaples_SkipsStapleItems()
+    {
+        var recipeId = Guid.NewGuid();
+        var plan = CreatePlanWithRecipe(recipeId, "Steak", 2);
+
+        ingredientProvider.GetIngredientsAsync(recipeId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("Steak", 500m, "g", 2),
+                new("Salt", 1m, "tsp", 2),
+                new("Pepper", 0.5m, "tsp", 2),
+            });
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ItemsAdded.Should().Be(1);
+        result.Value.StaplesSkipped.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoItemsAfterFiltering_DoesNotCallWriter()
+    {
+        var recipeId = Guid.NewGuid();
+        var plan = CreatePlanWithRecipe(recipeId, "Salt Toast", 2);
+
+        ingredientProvider.GetIngredientsAsync(recipeId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecipeIngredientInfo>
+            {
+                new("Salt", 1m, "tsp", 2),
+                new("Flour", 100m, "g", 2),
+            });
+
+        var result = await handler.HandleAsync(new GenerateShoppingListCommand(2026, 15));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ItemsAdded.Should().Be(0);
+        await shoppingListWriter.DidNotReceive().AddItemsAsync(
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<ShoppingItemRequest>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private WeeklyPlan CreatePlanWithRecipe(Guid recipeId, string title, int servings)
+    {
+        var owner = OwnerIdentifier.From("user-123");
+        var week = WeekIdentifier.From(2026, 15);
+        var plan = WeeklyPlan.Create(owner, week);
+        plan.AssignRecipe(DayOfWeek.Monday, recipeId, title, servings: servings);
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        return plan;
+    }
+
+    private WeeklyPlan CreatePlanWithTwoRecipes(Guid recipeA, string titleA, int servingsA, Guid recipeB, string titleB, int servingsB)
+    {
+        var owner = OwnerIdentifier.From("user-123");
+        var week = WeekIdentifier.From(2026, 15);
+        var plan = WeeklyPlan.Create(owner, week);
+        plan.AssignRecipe(DayOfWeek.Monday, recipeA, titleA, servings: servingsA);
+        plan.AssignRecipe(DayOfWeek.Tuesday, recipeB, titleB, servings: servingsB);
+
+        plans.FindByOwnerAndWeekAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<WeekIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(plan);
+
+        return plan;
+    }
+}


### PR DESCRIPTION
## Summary
- Add cross-module interfaces (`IRecipeIngredientProvider`, `IShoppingListWriter`, `IStaplesProvider`) in Shared with Infrastructure implementations
- New `GenerateShoppingListCommand` handler: fetches recipe ingredients for all meal slots, scales by per-slot servings, merges duplicates (case-insensitive), filters user staples, writes to event-sourced shopping ledger
- `POST /meal-plans/{year}/w/{week}/generate-shopping-list` API endpoint
- "Generate Shopping List" button on meal planner page with result feedback (items added + staples skipped)
- i18n keys (EN + DE) for new UI elements

## Test plan
- [x] 7 new handler unit tests (no plan, no recipes, single recipe, scaling, merging, staples filtering, empty after filter)
- [x] 28 total MealPlan.Application tests pass
- [x] 208 shell frontend tests pass
- [x] Full solution builds with TreatWarningsAsErrors
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)