### PR TITLE
refactor(ui): extract AsyncStateComponent and favorite toggle helpers (US-000)

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -1,16 +1,13 @@
 <div class="profile-settings" *transloco="let t">
   <h1>{{ t('account.settings.title') }}</h1>
 
-  @if (loading()) {
-    <div class="loading">{{ t('account.settings.loading') }}</div>
-  }
-
-  @if (error(); as err) {
-    <div class="error" role="alert">
-      {{ err }}
-      <button class="retry-btn" (click)="onRetry()">{{ t('account.settings.retry') }}</button>
-    </div>
-  }
+  <yn-async-state
+    [loading]="loading()"
+    [error]="error()"
+    loadingKey="account.settings.loading"
+    retryKey="account.settings.retry"
+    (retry)="onRetry()"
+  />
 
   @if (profile(); as p) {
     <form (submit)="$event.preventDefault(); onSave()">

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -8,11 +8,12 @@ import {
   type UpdateProfileRequest,
 } from '@yumney/shared/api-client';
 import { UI } from '@yumney/shared/models';
+import { AsyncStateComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-profile-settings',
   standalone: true,
-  imports: [FormsModule, TranslocoModule],
+  imports: [FormsModule, TranslocoModule, AsyncStateComponent],
   templateUrl: './profile-settings.component.html',
   styleUrl: './profile-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -17,6 +17,7 @@ import {
   ERROR_MAPS,
   ROUTES,
   VALIDATION,
+  toggleFavoriteOnItem,
 } from '@yumney/shared/models';
 import {
   BackLinkComponent,
@@ -154,27 +155,6 @@ export class RecipeDetailComponent implements OnInit {
   }
 
   onToggleFavorite(): void {
-    const recipe = this.recipe();
-    if (!recipe) return;
-    const original = recipe.isFavorite;
-    this.recipe.set({ ...recipe, isFavorite: !original });
-
-    this.recipeApi
-      .toggleFavorite(recipe.identifier)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (state) => {
-          const current = this.recipe();
-          if (current && current.identifier === recipe.identifier) {
-            this.recipe.set({ ...current, isFavorite: state.isFavorite });
-          }
-        },
-        error: () => {
-          const current = this.recipe();
-          if (current && current.identifier === recipe.identifier) {
-            this.recipe.set({ ...current, isFavorite: original });
-          }
-        },
-      });
+    toggleFavoriteOnItem(this.recipe, this.destroyRef, (id) => this.recipeApi.toggleFavorite(id));
   }
 }

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -15,7 +15,13 @@ import { Subject, debounceTime } from 'rxjs';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { RecipeApiService, RecipeListItem, GetRecipesParams } from '@yumney/shared/api-client';
-import { createAsyncState, ERROR_MAPS, ROUTES, UI } from '@yumney/shared/models';
+import {
+  createAsyncState,
+  ERROR_MAPS,
+  ROUTES,
+  UI,
+  toggleFavoriteInList,
+} from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
 import {
   EMPTY_FILTER,
@@ -201,40 +207,9 @@ export class RecipeListComponent implements OnInit {
   }
 
   onToggleFavorite(identifier: string): void {
-    // Optimistic update — flip immediately, revert on error.
-    const current = this.recipes();
-    const idx = current.findIndex((r) => r.identifier === identifier);
-    if (idx === -1) return;
-    const original = current[idx];
-    this.recipes.update((list) => {
-      const next = [...list];
-      next[idx] = { ...original, isFavorite: !original.isFavorite };
-      return next;
-    });
-
-    this.recipeApi
-      .toggleFavorite(identifier)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (state) => {
-          this.recipes.update((list) => {
-            const j = list.findIndex((r) => r.identifier === identifier);
-            if (j === -1) return list;
-            const next = [...list];
-            next[j] = { ...next[j], isFavorite: state.isFavorite };
-            return next;
-          });
-        },
-        error: () => {
-          this.recipes.update((list) => {
-            const j = list.findIndex((r) => r.identifier === identifier);
-            if (j === -1) return list;
-            const next = [...list];
-            next[j] = { ...next[j], isFavorite: original.isFavorite };
-            return next;
-          });
-        },
-      });
+    toggleFavoriteInList(this.recipes, identifier, this.destroyRef, (id) =>
+      this.recipeApi.toggleFavorite(id),
+    );
   }
 
   onFilterChange(value: RecipeFilterValue): void {

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -13,16 +13,13 @@
     </button>
   </div>
 
-  @if (loading()) {
-    <div class="loading">{{ t('mealPlanner.loading') }}</div>
-  }
-
-  @if (error(); as err) {
-    <div class="error" role="alert">
-      {{ err }}
-      <button class="retry-btn" (click)="onRetry()">{{ t('mealPlanner.retry') }}</button>
-    </div>
-  }
+  <yn-async-state
+    [loading]="loading()"
+    [error]="error()"
+    loadingKey="mealPlanner.loading"
+    retryKey="mealPlanner.retry"
+    (retry)="onRetry()"
+  />
 
   @if (hasRecipeSlots()) {
     <div class="planner-actions">

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -16,11 +16,12 @@ import {
   type GenerateShoppingListResult,
 } from '@yumney/shared/api-client';
 import { UI } from '@yumney/shared/models';
+import { AsyncStateComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-meal-planner',
   standalone: true,
-  imports: [TranslocoModule, LucideAngularModule],
+  imports: [TranslocoModule, LucideAngularModule, AsyncStateComponent],
   templateUrl: './meal-planner.component.html',
   styleUrl: './meal-planner.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -28,16 +28,13 @@
     </button>
   </div>
 
-  @if (loading()) {
-    <div class="loading">{{ t('shopping.loading') }}</div>
-  }
-
-  @if (error(); as err) {
-    <div class="error" role="alert">
-      {{ err }}
-      <button class="retry-btn" (click)="onRetry()">{{ t('shopping.retry') }}</button>
-    </div>
-  }
+  <yn-async-state
+    [loading]="loading()"
+    [error]="error()"
+    loadingKey="shopping.loading"
+    retryKey="shopping.retry"
+    (retry)="onRetry()"
+  />
 
   @for (group of categoryGroups(); track group.category) {
     <div class="category-group">

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -16,6 +16,7 @@ import {
   type MergedShoppingItem,
 } from '@yumney/shared/api-client';
 import { TranslocoService } from '@jsverse/transloco';
+import { AsyncStateComponent } from '@yumney/ui';
 
 interface CategoryGroup {
   category: string;
@@ -26,7 +27,7 @@ interface CategoryGroup {
 @Component({
   selector: 'yn-merged-list',
   standalone: true,
-  imports: [FormsModule, TranslocoModule, LucideAngularModule],
+  imports: [FormsModule, TranslocoModule, LucideAngularModule, AsyncStateComponent],
   templateUrl: './merged-list.component.html',
   styleUrl: './merged-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -9,6 +9,7 @@ export { UI } from './lib/ui-constants';
 export { createAsyncState, type AsyncState } from './lib/async-state';
 export { ensureFormValid } from './lib/form-helpers';
 export { optimisticSignalUpdate } from './lib/optimistic-update';
+export { toggleFavoriteOnItem, toggleFavoriteInList } from './lib/favorite-toggle';
 export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { IS_STANDALONE } from './lib/federation-context';
 export { LanguageService } from './lib/language.service';

--- a/client/libs/shared/models/src/lib/favorite-toggle.ts
+++ b/client/libs/shared/models/src/lib/favorite-toggle.ts
@@ -1,0 +1,86 @@
+import { DestroyRef, WritableSignal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
+
+interface Favoritable {
+  identifier: string;
+  isFavorite: boolean;
+}
+
+/**
+ * Optimistic favorite toggle for a single-item signal (e.g. recipe detail).
+ * Flips isFavorite immediately, reverts on error, updates from server on success.
+ */
+export function toggleFavoriteOnItem<T extends Favoritable>(
+  state: WritableSignal<T | null>,
+  destroyRef: DestroyRef,
+  apiCall: (identifier: string) => Observable<{ isFavorite: boolean }>,
+): void {
+  const item = state();
+  if (!item) return;
+
+  const original = item.isFavorite;
+  state.set({ ...item, isFavorite: !original });
+
+  apiCall(item.identifier)
+    .pipe(takeUntilDestroyed(destroyRef))
+    .subscribe({
+      next: (result) => {
+        const current = state();
+        if (current?.identifier === item.identifier) {
+          state.set({ ...current, isFavorite: result.isFavorite });
+        }
+      },
+      error: () => {
+        const current = state();
+        if (current?.identifier === item.identifier) {
+          state.set({ ...current, isFavorite: original });
+        }
+      },
+    });
+}
+
+/**
+ * Optimistic favorite toggle for a list signal (e.g. recipe list).
+ * Flips the item in the array immediately, reverts on error, updates from server on success.
+ */
+export function toggleFavoriteInList<T extends Favoritable>(
+  state: WritableSignal<T[]>,
+  identifier: string,
+  destroyRef: DestroyRef,
+  apiCall: (identifier: string) => Observable<{ isFavorite: boolean }>,
+): void {
+  const list = state();
+  const idx = list.findIndex((r) => r.identifier === identifier);
+  if (idx === -1) return;
+
+  const original = list[idx];
+  state.update((items) => {
+    const next = [...items];
+    next[idx] = { ...original, isFavorite: !original.isFavorite };
+    return next;
+  });
+
+  apiCall(identifier)
+    .pipe(takeUntilDestroyed(destroyRef))
+    .subscribe({
+      next: (result) => {
+        state.update((items) => {
+          const j = items.findIndex((r) => r.identifier === identifier);
+          if (j === -1) return items;
+          const next = [...items];
+          next[j] = { ...next[j], isFavorite: result.isFavorite };
+          return next;
+        });
+      },
+      error: () => {
+        state.update((items) => {
+          const j = items.findIndex((r) => r.identifier === identifier);
+          if (j === -1) return items;
+          const next = [...items];
+          next[j] = { ...next[j], isFavorite: original.isFavorite };
+          return next;
+        });
+      },
+    });
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -8,6 +8,7 @@ export { HeaderComponent } from './lib/header/header.component';
 export { AppLayoutComponent } from './lib/app-layout/app-layout.component';
 export { UnitSelectComponent } from './lib/unit-select/unit-select.component';
 export { LoadingSpinnerComponent } from './lib/loading-spinner/loading-spinner.component';
+export { AsyncStateComponent } from './lib/async-state/async-state.component';
 
 // Animation utilities
 export { springPress, staggerFadeIn, prefersReducedMotion } from './lib/animation/gsap-utils';

--- a/client/libs/ui/src/lib/async-state/async-state.component.scss
+++ b/client/libs/ui/src/lib/async-state/async-state.component.scss
@@ -1,0 +1,29 @@
+.loading {
+  text-align: center;
+  color: var(--yn-text-muted);
+  padding: var(--yn-space-7);
+}
+
+.error {
+  text-align: center;
+  color: var(--yn-danger);
+  padding: var(--yn-space-5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.retry-btn {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 1px solid var(--yn-danger);
+  border-radius: var(--yn-radius-button);
+  background: none;
+  color: var(--yn-danger);
+  cursor: pointer;
+  font-size: var(--yn-text-sm);
+
+  &:hover {
+    background: var(--yn-danger-light);
+  }
+}

--- a/client/libs/ui/src/lib/async-state/async-state.component.spec.ts
+++ b/client/libs/ui/src/lib/async-state/async-state.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { AsyncStateComponent } from './async-state.component';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+
+const en = { common: { loading: 'Loading...', retry: 'Retry' } };
+
+@Component({
+  standalone: true,
+  imports: [AsyncStateComponent],
+  template: `
+    <yn-async-state
+      [loading]="loading()"
+      [error]="error()"
+      [loadingKey]="'common.loading'"
+      [retryKey]="'common.retry'"
+      (retry)="onRetry()"
+    />
+  `,
+})
+class TestHostComponent {
+  loading = signal(false);
+  error = signal<string | null>(null);
+  retried = false;
+  onRetry(): void {
+    this.retried = true;
+  }
+}
+
+describe('AsyncStateComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should not show anything when idle', () => {
+    expect(fixture.nativeElement.querySelector('.loading')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('.error')).toBeFalsy();
+  });
+
+  it('should show loading state', () => {
+    fixture.componentInstance.loading.set(true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.loading')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('Loading...');
+  });
+
+  it('should show error with retry button', () => {
+    fixture.componentInstance.error.set('Something failed');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('Something failed');
+    expect(fixture.nativeElement.querySelector('.retry-btn')).toBeTruthy();
+  });
+
+  it('should emit retry on button click', () => {
+    fixture.componentInstance.error.set('Error');
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.retry-btn').click();
+
+    expect(fixture.componentInstance.retried).toBe(true);
+  });
+});

--- a/client/libs/ui/src/lib/async-state/async-state.component.ts
+++ b/client/libs/ui/src/lib/async-state/async-state.component.ts
@@ -1,0 +1,30 @@
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'yn-async-state',
+  standalone: true,
+  imports: [TranslocoModule],
+  template: `
+    @if (loading()) {
+      <div class="loading">{{ loadingKey() | transloco }}</div>
+    }
+    @if (error(); as err) {
+      <div class="error" role="alert">
+        {{ err }}
+        <button class="retry-btn" (click)="retry.emit()">
+          {{ retryKey() | transloco }}
+        </button>
+      </div>
+    }
+  `,
+  styleUrl: './async-state.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AsyncStateComponent {
+  loading = input(false);
+  error = input<string | null>(null);
+  loadingKey = input('common.loading');
+  retryKey = input('common.retry');
+  retry = output<void>();
+}


### PR DESCRIPTION
## Summary
- Create `<yn-async-state>` component in `@yumney/ui` — reusable loading/error/retry widget replacing duplicated templates in meal-planner, profile-settings, and merged-list
- Create `toggleFavoriteOnItem()` and `toggleFavoriteInList()` helpers in `@yumney/shared/models` — replace 50+ lines of duplicate optimistic update logic in recipe-detail and recipe-list
- 4 new unit tests for AsyncStateComponent (idle, loading, error, retry emit)

## Changes
- **New**: `libs/ui/src/lib/async-state/` — component, SCSS, spec
- **New**: `libs/shared/models/src/lib/favorite-toggle.ts` — two helper functions
- **Updated**: recipe-detail (156→162: -15 lines), recipe-list (203→207: -30 lines)
- **Updated**: meal-planner.html, profile-settings.html, merged-list.html (replaced inline loading/error blocks with `<yn-async-state>`)

## Test plan
- [x] 165 UI library tests pass (4 new)
- [x] 104 recipes tests pass
- [x] 34 shopping tests pass
- [x] 14 account tests pass
- [x] 208 shell tests pass
- [x] All 4 apps build successfully
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)