### PR TITLE
style(frontend): fix all lint warnings across frontend libs and apps (US-000)

### DIFF
--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { provideRouter, ActivatedRoute } from '@angular/router';
-import { of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import { signal } from '@angular/core';
 import { CookModeComponent } from './cook-mode.component';
 import { RecipeApiService, type RecipeDetail } from '@yumney/shared/api-client';
@@ -10,7 +10,6 @@ import {
   CookingTimerService,
   setupTranslocoTesting,
 } from '@yumney/shared/models';
-import { TranslocoService } from '@jsverse/transloco';
 import { provideYumneyIcons } from '@yumney/ui';
 
 const mockRecipe: RecipeDetail = {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -7,7 +7,6 @@ import {
   signal,
   computed,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '@yumney/shared/api-client';

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
-import { workspaceRoot } from '@nx/devkit';
 
 /**
  * E2E tests run against the full system.

--- a/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
@@ -25,6 +25,7 @@ test.describe('Dashboard — Recipe Import (US-010, US-011, US-012, US-013)', ()
     await expect(dashboard.fieldError(/valid.*URL|invalid/i)).toBeVisible();
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   test('should show error for unreachable URL', async ({ authenticatedPage }) => {
     await dashboard.urlInput.fill('https://this-domain-does-not-exist-e2e.invalid/recipe');
     await dashboard.importButton.click();

--- a/client/apps/shell-e2e/src/dashboard/share-intent.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/share-intent.spec.ts
@@ -18,7 +18,6 @@ test.describe('Dashboard — Share Intent (US-124)', () => {
       }),
     );
 
-    const dashboard = new DashboardPage(authenticatedPage);
     await authenticatedPage.goto('/dashboard?url=https://example.com/recipe');
 
     await expect(authenticatedPage.getByText(/fetching|extracting|loading/i)).toBeVisible({


### PR DESCRIPTION
## Summary
- Remove **5 unused imports** across recipe-detail, cook-mode spec, playwright config, and e2e specs
- All **6 Nx projects now lint with zero warnings** (shell, recipes, shopping, account, ui, shell-e2e)

## Changes
| File | Fix |
|------|-----|
| `recipe-detail.component.ts` | Remove unused `takeUntilDestroyed` (after favorite toggle extraction) |
| `cook-mode.component.spec.ts` | Remove unused `Subject`, `TranslocoService` |
| `playwright.config.ts` | Remove unused `workspaceRoot` import |
| `share-intent.spec.ts` | Remove unused `dashboard` variable |
| `import-recipe.spec.ts` | Suppress unavoidable Playwright fixture param warning |

## Test plan
- [x] All 5 test projects pass
- [x] All 4 apps build
- [x] All 6 projects lint clean (0 warnings)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)