### PR TITLE
ci(infra): add 6 missing test projects to Stryker mutation matrix (US-000)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -30,6 +30,10 @@ jobs:
         include:
           - project: Yumney.Shared.Tests
             display: Shared
+          - project: Yumney.Shared.Guards.Tests
+            display: Shared.Guards
+          - project: Yumney.Shared.Events.Tests
+            display: Shared.Events
           - project: Yumney.Recipes.Api.Tests
             display: Recipes.Api
           - project: Yumney.Recipes.Domain.Tests
@@ -40,14 +44,22 @@ jobs:
             display: Recipes.Infrastructure
           - project: Yumney.Shopping.Api.Tests
             display: Shopping.Api
+          - project: Yumney.Shopping.Domain.Tests
+            display: Shopping.Domain
           - project: Yumney.Shopping.Application.Tests
             display: Shopping.Application
+          - project: Yumney.MealPlan.Domain.Tests
+            display: MealPlan.Domain
+          - project: Yumney.MealPlan.Application.Tests
+            display: MealPlan.Application
           - project: Yumney.Users.Api.Tests
             display: Users.Api
           - project: Yumney.Users.Domain.Tests
             display: Users.Domain
           - project: Yumney.Users.Application.Tests
             display: Users.Application
+          - project: Yumney.Users.Infrastructure.Tests
+            display: Users.Infrastructure
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Add 6 test projects that were missing from the Stryker mutation testing matrix:

| Added | Tests |
|-------|-------|
| `Yumney.Shared.Guards.Tests` | 51 |
| `Yumney.Shared.Events.Tests` | 7 |
| `Yumney.Shopping.Domain.Tests` | 118 |
| `Yumney.MealPlan.Domain.Tests` | 77 |
| `Yumney.MealPlan.Application.Tests` | 31 |
| `Yumney.Users.Infrastructure.Tests` | 19 |

Matrix grows from 10 to 16 projects. Architecture and Integration tests remain excluded (not applicable for mutation testing).

## Test plan
- [ ] CI pipeline green
- [ ] New Stryker jobs appear in PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)