### PR TITLE
ci(e2e): add E2E workflow with Aspire-managed test environment (US-000)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,11 +79,16 @@ jobs:
 
       - name: Start Aspire AppHost
         run: |
-          # Start Aspire in background, redirect output to log file for debugging
-          aspire run --project src/Yumney.AppHost/Yumney.AppHost.csproj > /tmp/aspire.log 2>&1 &
-          ASPIRE_PID=$!
-          echo "ASPIRE_PID=$ASPIRE_PID" >> "$GITHUB_ENV"
-          echo "Aspire started with PID $ASPIRE_PID"
+          # Start Aspire detached (--no-build since we already built, --detach returns after startup)
+          aspire run \
+            --project src/Yumney.AppHost/Yumney.AppHost.csproj \
+            --no-build \
+            --detach \
+            --non-interactive \
+            --log-level Information \
+            > /tmp/aspire.log 2>&1 || true
+          echo "Aspire detach completed"
+          cat /tmp/aspire.log
 
       - name: Wait for services to be ready
         run: |
@@ -140,11 +145,10 @@ jobs:
       - name: Stop Aspire
         if: always()
         run: |
-          if [ -n "$ASPIRE_PID" ]; then
-            kill $ASPIRE_PID 2>/dev/null || true
-          fi
+          aspire stop 2>/dev/null || true
           pkill -f "Yumney.AppHost" 2>/dev/null || true
           pkill -f "aspire" 2>/dev/null || true
+          docker stop $(docker ps -q) 2>/dev/null || true
 
       - name: Upload Aspire logs
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,149 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  NODE_VERSION: '22'
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Aspire workload
+        run: dotnet workload install aspire
+
+      - name: Install Aspire CLI
+        run: |
+          curl -sSL https://aspire.dev/install.sh | bash
+          echo "$HOME/.aspire/bin" >> $GITHUB_PATH
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Install Yarn
+        run: corepack enable
+
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        working-directory: client
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('client/yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
+      - name: Install frontend dependencies
+        working-directory: client
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        working-directory: client
+        run: npx playwright install chromium --with-deps
+
+      - name: Restore .NET packages
+        run: dotnet restore Yumney.slnx
+
+      - name: Build backend
+        run: dotnet build Yumney.slnx --no-restore
+
+      - name: Start Aspire AppHost
+        run: |
+          aspire run --project src/Yumney.AppHost/Yumney.AppHost.csproj &
+          ASPIRE_PID=$!
+          echo "ASPIRE_PID=$ASPIRE_PID" >> "$GITHUB_ENV"
+
+      - name: Wait for services to be ready
+        run: |
+          echo "Waiting for Gateway (port 5100)..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5100/health > /dev/null 2>&1; then
+              echo "Gateway is ready!"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "::warning::Gateway did not become ready within 60s"
+              curl -v http://localhost:5100/health 2>&1 || true
+            fi
+            sleep 5
+          done
+
+          echo "Waiting for Frontend (port 4200)..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:4200 > /dev/null 2>&1; then
+              echo "Frontend is ready!"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "::warning::Frontend did not become ready within 60s"
+            fi
+            sleep 5
+          done
+
+      - name: Run backend integration tests
+        continue-on-error: true
+        run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj --no-build
+
+      - name: Run Playwright e2e tests
+        continue-on-error: true
+        working-directory: client
+        run: npx nx e2e shell-e2e --skip-nx-cache
+        env:
+          BASE_URL: http://localhost:4200
+          E2E_USER: testuser
+          E2E_PASSWORD: Test1234
+          CI: true
+
+      - name: Stop Aspire
+        if: always()
+        run: |
+          if [ -n "$ASPIRE_PID" ]; then
+            kill $ASPIRE_PID 2>/dev/null || true
+          fi
+          # Also clean up any remaining dotnet processes
+          pkill -f "Yumney.AppHost" 2>/dev/null || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: client/test-results/
+          retention-days: 14
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-html-report
+          path: client/apps/shell-e2e/playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6
@@ -73,38 +74,51 @@ jobs:
       - name: Restore .NET packages
         run: dotnet restore Yumney.slnx
 
-      - name: Build backend
+      - name: Build solution (including AppHost)
         run: dotnet build Yumney.slnx --no-restore
 
       - name: Start Aspire AppHost
         run: |
-          aspire run --project src/Yumney.AppHost/Yumney.AppHost.csproj &
+          # Start Aspire in background, redirect output to log file for debugging
+          aspire run --project src/Yumney.AppHost/Yumney.AppHost.csproj > /tmp/aspire.log 2>&1 &
           ASPIRE_PID=$!
           echo "ASPIRE_PID=$ASPIRE_PID" >> "$GITHUB_ENV"
+          echo "Aspire started with PID $ASPIRE_PID"
 
       - name: Wait for services to be ready
         run: |
+          # Wait up to 10 minutes for Gateway (Docker images may need to pull)
           echo "Waiting for Gateway (port 5100)..."
-          for i in $(seq 1 60); do
+          GATEWAY_READY=false
+          for i in $(seq 1 120); do
             if curl -sf http://localhost:5100/health > /dev/null 2>&1; then
-              echo "Gateway is ready!"
+              echo "Gateway is ready after $((i * 5))s!"
+              GATEWAY_READY=true
               break
             fi
-            if [ $i -eq 60 ]; then
-              echo "::warning::Gateway did not become ready within 60s"
-              curl -v http://localhost:5100/health 2>&1 || true
+            # Show Aspire log tail every 30s for debugging
+            if [ $((i % 6)) -eq 0 ]; then
+              echo "--- Aspire log (last 5 lines) at $((i * 5))s ---"
+              tail -5 /tmp/aspire.log 2>/dev/null || true
             fi
             sleep 5
           done
 
+          if [ "$GATEWAY_READY" = false ]; then
+            echo "::warning::Gateway did not become ready within 10 minutes"
+            echo "--- Full Aspire log ---"
+            cat /tmp/aspire.log 2>/dev/null || true
+          fi
+
+          # Wait up to 5 minutes for Frontend
           echo "Waiting for Frontend (port 4200)..."
           for i in $(seq 1 60); do
             if curl -sf http://localhost:4200 > /dev/null 2>&1; then
-              echo "Frontend is ready!"
+              echo "Frontend is ready after $((i * 5))s!"
               break
             fi
             if [ $i -eq 60 ]; then
-              echo "::warning::Frontend did not become ready within 60s"
+              echo "::warning::Frontend did not become ready within 5 minutes"
             fi
             sleep 5
           done
@@ -129,21 +143,23 @@ jobs:
           if [ -n "$ASPIRE_PID" ]; then
             kill $ASPIRE_PID 2>/dev/null || true
           fi
-          # Also clean up any remaining dotnet processes
           pkill -f "Yumney.AppHost" 2>/dev/null || true
+          pkill -f "aspire" 2>/dev/null || true
+
+      - name: Upload Aspire logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aspire-logs
+          path: /tmp/aspire.log
+          retention-days: 7
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: client/test-results/
-          retention-days: 14
-
-      - name: Upload Playwright HTML report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-html-report
-          path: client/apps/shell-e2e/playwright-report/
+          path: |
+            client/test-results/
+            client/apps/shell-e2e/playwright-report/
           retention-days: 14


### PR DESCRIPTION
## Summary
New GitHub Actions workflow that runs E2E tests against a full Aspire-managed environment:

1. **Starts Aspire AppHost** — Keycloak, PostgreSQL, Redis, all 4 API modules, Gateway (port 5100), Angular shell + MFEs (port 4200)
2. **Waits for readiness** — polls Gateway `/health` and Frontend until available (up to 5min)
3. **Runs backend integration tests** — `dotnet test Yumney.Integration.Tests`
4. **Runs Playwright e2e tests** — `nx e2e shell-e2e` against `http://localhost:4200`
5. **Uploads artifacts** — Playwright HTML report + test results (14-day retention)

### Non-blocking by design
- `continue-on-error: true` on the job and both test steps
- Will not block PR merges
- Gives visibility into e2e health without gating releases

### Triggers
- Push to `develop`
- PRs targeting `develop`
- Manual dispatch (`workflow_dispatch`)

## Test plan
- [ ] Workflow appears in Actions tab
- [ ] Aspire starts successfully in CI
- [ ] Playwright report uploaded as artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)