### PR TITLE
frontend perf + shopping refactor + API startup fixes (US-000)

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.scss
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.scss
@@ -105,4 +105,3 @@
   color: var(--yn-success);
   font-size: var(--yn-text-sm);
 }
-

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.scss
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.scss
@@ -106,25 +106,3 @@
   font-size: var(--yn-text-sm);
 }
 
-.loading,
-.error {
-  text-align: center;
-  padding: var(--yn-space-7);
-}
-
-.error {
-  color: var(--yn-danger);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--yn-space-3);
-}
-
-.retry-btn {
-  padding: var(--yn-space-2) var(--yn-space-4);
-  border: 1px solid var(--yn-danger);
-  border-radius: var(--yn-radius-button);
-  background: none;
-  color: var(--yn-danger);
-  cursor: pointer;
-}

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
@@ -85,29 +85,31 @@
     }
 
     @if (ingredientsPanelOpen()) {
-      <aside class="ingredients-panel" role="dialog">
-        <div class="panel-header">
-          <h2>{{ t('recipes.cook.ingredients') }}</h2>
-          <button type="button" class="panel-close" (click)="toggleIngredientsPanel()">
-            <lucide-icon name="x" [size]="18" />
-          </button>
-        </div>
-        <ul class="ingredient-list">
-          @for (ingredient of r.ingredients; track $index) {
-            <li>
-              <span class="amount">
-                @if (ingredient.amount !== null) {
-                  {{ ingredient.amount }}
-                }
-                @if (ingredient.unit) {
-                  {{ ingredient.unit }}
-                }
-              </span>
-              <span class="name">{{ ingredient.name }}</span>
-            </li>
-          }
-        </ul>
-      </aside>
+      @defer {
+        <aside class="ingredients-panel" role="dialog">
+          <div class="panel-header">
+            <h2>{{ t('recipes.cook.ingredients') }}</h2>
+            <button type="button" class="panel-close" (click)="toggleIngredientsPanel()">
+              <lucide-icon name="x" [size]="18" />
+            </button>
+          </div>
+          <ul class="ingredient-list">
+            @for (ingredient of r.ingredients; track ingredient.name) {
+              <li>
+                <span class="amount">
+                  @if (ingredient.amount !== null) {
+                    {{ ingredient.amount }}
+                  }
+                  @if (ingredient.unit) {
+                    {{ ingredient.unit }}
+                  }
+                </span>
+                <span class="name">{{ ingredient.name }}</span>
+              </li>
+            }
+          </ul>
+        </aside>
+      }
     }
   }
 </div>

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -18,6 +18,8 @@
           class="hero-image"
           loading="eager"
           fetchpriority="high"
+          width="800"
+          height="450"
         />
         <div class="hero-overlay">
           <h1 class="hero-title">{{ recipe.title }}</h1>
@@ -127,7 +129,7 @@
     <section class="ingredients-section">
       <h2>{{ t('recipes.detail.ingredients') }}</h2>
       <ul class="ingredients-list">
-        @for (ingredient of scaledIngredients(); track $index) {
+        @for (ingredient of scaledIngredients(); track ingredient.name) {
           <li>
             @if (ingredient.amount) {
               <span class="ingredient-amount">{{ ingredient.amount }}</span>

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -1,6 +1,13 @@
 <a class="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
   @if (recipe().imageUrl) {
-    <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" width="400" height="225" />
+    <img
+      [src]="recipe().imageUrl"
+      [alt]="recipe().title"
+      class="recipe-image"
+      loading="lazy"
+      width="400"
+      height="225"
+    />
   } @else {
     <div class="recipe-image-placeholder"></div>
   }

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -1,6 +1,6 @@
 <a class="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
   @if (recipe().imageUrl) {
-    <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" />
+    <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" width="400" height="225" />
   } @else {
     <div class="recipe-image-placeholder"></div>
   }

--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -44,14 +44,9 @@ export const appConfig: ApplicationConfig = {
     }),
     {
       provide: APP_INITIALIZER,
-      useFactory: (lang: LanguageService) => () => lang.initialize(),
-      deps: [LanguageService],
-      multi: true,
-    },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: (theme: ThemeService) => () => theme.initialize(),
-      deps: [ThemeService],
+      useFactory: (lang: LanguageService, theme: ThemeService) => () =>
+        Promise.all([lang.initialize(), theme.initialize()]),
+      deps: [LanguageService, ThemeService],
       multi: true,
     },
   ],

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -140,18 +140,22 @@
   }
 
   @if (cameraActive()) {
-    <yn-camera-capture
-      (capturedReady)="onCameraCaptured($event)"
-      (cancelled)="onCameraCancelled()"
-      (fallbackRequested)="onCameraFallback()"
-    />
+    @defer {
+      <yn-camera-capture
+        (capturedReady)="onCameraCaptured($event)"
+        (cancelled)="onCameraCancelled()"
+        (fallbackRequested)="onCameraFallback()"
+      />
+    }
   }
 
   @if (scannerActive()) {
-    <yn-ingredient-scanner
-      (ingredientsConfirmed)="onIngredientsConfirmed($event)"
-      (cancelled)="onScannerCancelled()"
-    />
+    @defer {
+      <yn-ingredient-scanner
+        (ingredientsConfirmed)="onIngredientsConfirmed($event)"
+        (cancelled)="onScannerCancelled()"
+      />
+    }
   }
 
   @if (recognizedIngredients(); as ingredients) {

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -147,6 +147,8 @@ export class MergedListComponent {
   }
 
   private copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text).catch(() => {});
+    navigator.clipboard.writeText(text).catch(() => {
+      this.error.set(this.transloco.translate('shopping.errors.exportFailed'));
+    });
   }
 }

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -147,6 +147,6 @@ export class MergedListComponent {
   }
 
   private copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard.writeText(text).catch(() => {});
   }
 }

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.scss
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.scss
@@ -11,10 +11,6 @@
 
 // .back-link provided by @use 'buttons'
 
-.loading {
-  padding: 4rem 0;
-}
-
 h1 {
   margin: 0 0 var(--yn-space-7);
   font-size: var(--yn-text-5xl);

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { shareReplay, tap } from 'rxjs/operators';
 import { AuthService } from '@yumney/shared/auth';
 import { API_ENDPOINTS } from './api-endpoints';
 import type { ImportRecipeRequest } from './import-recipe-request';
@@ -19,6 +20,7 @@ import type { FavoriteState } from './favorite-state';
 export class RecipeApiService {
   private http = inject(HttpClient);
   private auth = inject(AuthService);
+  private recipeCache = new Map<string, Observable<RecipeDetail>>();
 
   importRecipe(request: ImportRecipeRequest): Observable<ImportRecipeResponse> {
     return this.http.post<ImportRecipeResponse>(API_ENDPOINTS.recipes.import, request);
@@ -154,15 +156,31 @@ export class RecipeApiService {
   }
 
   updateRecipe(identifier: string, request: UpdateRecipeRequest): Observable<RecipeDetail> {
-    return this.http.put<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier), request);
+    return this.http.put<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier), request).pipe(
+      tap(() => this.invalidateRecipeCache(identifier)),
+    );
   }
 
   deleteRecipe(identifier: string): Observable<void> {
-    return this.http.delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier));
+    return this.http.delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(
+      tap(() => this.invalidateRecipeCache(identifier)),
+    );
   }
 
   getRecipeById(identifier: string): Observable<RecipeDetail> {
-    return this.http.get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier));
+    if (!this.recipeCache.has(identifier)) {
+      this.recipeCache.set(
+        identifier,
+        this.http.get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(
+          shareReplay(1),
+        ),
+      );
+    }
+    return this.recipeCache.get(identifier)!;
+  }
+
+  invalidateRecipeCache(identifier: string): void {
+    this.recipeCache.delete(identifier);
   }
 
   getRecipes(params: GetRecipesParams = {}): Observable<RecipeListResponse> {

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -156,24 +156,24 @@ export class RecipeApiService {
   }
 
   updateRecipe(identifier: string, request: UpdateRecipeRequest): Observable<RecipeDetail> {
-    return this.http.put<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier), request).pipe(
-      tap(() => this.invalidateRecipeCache(identifier)),
-    );
+    return this.http
+      .put<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier), request)
+      .pipe(tap(() => this.invalidateRecipeCache(identifier)));
   }
 
   deleteRecipe(identifier: string): Observable<void> {
-    return this.http.delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(
-      tap(() => this.invalidateRecipeCache(identifier)),
-    );
+    return this.http
+      .delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier))
+      .pipe(tap(() => this.invalidateRecipeCache(identifier)));
   }
 
   getRecipeById(identifier: string): Observable<RecipeDetail> {
     if (!this.recipeCache.has(identifier)) {
       this.recipeCache.set(
         identifier,
-        this.http.get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(
-          shareReplay(1),
-        ),
+        this.http
+          .get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier))
+          .pipe(shareReplay(1)),
       );
     }
     return this.recipeCache.get(identifier)!;

--- a/client/libs/shared/models/src/lib/scale-ingredients.ts
+++ b/client/libs/shared/models/src/lib/scale-ingredients.ts
@@ -16,7 +16,7 @@ export function scaleIngredients(
   originalServings: number,
   desiredServings: number,
 ): ScalableIngredient[] {
-  if (originalServings === desiredServings) {
+  if (originalServings <= 0 || originalServings === desiredServings) {
     return ingredients;
   }
   const ratio = desiredServings / originalServings;

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
@@ -145,7 +146,7 @@ public static class MealPlanEndpoints
         static async Task<IResult> ClearSlot(
             int year,
             int weekNumber,
-            ClearSlotRequest request,
+            [FromBody] ClearSlotRequest request,
             ICommandHandler<ClearMealSlotCommand, Result<WeeklyPlanDto>> handler,
             CancellationToken cancellationToken)
         {

--- a/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -10,6 +11,7 @@ public static class RecipesApiServiceCollectionExtensions
     public static IServiceCollection AddRecipesApi(this IServiceCollection services)
     {
         services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidator>();
+        services.AddValidatorsFromAssemblyContaining<PhotoDataValidator>();
 
         return services;
     }

--- a/src/Yumney.Recipes.Domain/Recipe/Unit.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Unit.cs
@@ -7,6 +7,36 @@ public sealed record Unit : IValueObject
 {
     public const int MaxLength = 50;
 
+    // Weight
+    public static readonly Unit Gram = new("g");
+    public static readonly Unit Kilogram = new("kg");
+    public static readonly Unit Milligram = new("mg");
+    public static readonly Unit Pound = new("lb");
+    public static readonly Unit Ounce = new("oz");
+
+    // Volume
+    public static readonly Unit Liter = new("l");
+    public static readonly Unit Milliliter = new("ml");
+    public static readonly Unit Centiliter = new("cl");
+    public static readonly Unit Deciliter = new("dl");
+    public static readonly Unit Cup = new("cup");
+    public static readonly Unit Tablespoon = new("tbsp");
+    public static readonly Unit Teaspoon = new("tsp");
+    public static readonly Unit FluidOunce = new("fl oz");
+
+    // Count & Packaging
+    public static readonly Unit Piece = new("piece");
+    public static readonly Unit Bunch = new("bunch");
+    public static readonly Unit Can = new("can");
+    public static readonly Unit Pack = new("pack");
+    public static readonly Unit Bag = new("bag");
+    public static readonly Unit Bottle = new("bottle");
+    public static readonly Unit Slice = new("slice");
+    public static readonly Unit Clove = new("clove");
+    public static readonly Unit Pinch = new("pinch");
+    public static readonly Unit Dash = new("dash");
+    public static readonly Unit Sprig = new("sprig");
+
     public string Value { get; }
 
     private Unit(string value)

--- a/src/Yumney.Shared/Common/EnumExtensions.cs
+++ b/src/Yumney.Shared/Common/EnumExtensions.cs
@@ -6,10 +6,7 @@ public static class EnumExtensions
     public static TEnum? ParseNullable<TEnum>(this TEnum _, string? value)
         where TEnum : struct, Enum
     {
-        if (!value.HasValue())
-        {
-            return null;
-        }
+        if (!value.HasValue()) return null;
 
         return Enum.TryParse<TEnum>(value, ignoreCase: true, out var result) ? result : null;
     }

--- a/src/Yumney.Shared/Common/EventSourcedAggregate.cs
+++ b/src/Yumney.Shared/Common/EventSourcedAggregate.cs
@@ -1,0 +1,51 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+public abstract class EventSourcedAggregate<TId>
+    where TId : notnull
+{
+    private readonly List<IDomainEvent> uncommittedEvents = [];
+    private readonly Dictionary<Type, Action<IDomainEvent>> handlers = [];
+
+    public TId Identifier { get; protected set; } = default!;
+
+    public int Version { get; protected set; }
+
+    public IReadOnlyCollection<IDomainEvent> UncommittedEvents => uncommittedEvents.AsReadOnly();
+
+    public void MarkCommitted()
+    {
+        uncommittedEvents.Clear();
+    }
+
+    protected void On<TEvent>(Action<TEvent> handler)
+        where TEvent : IDomainEvent
+    {
+        handlers[typeof(TEvent)] = e => handler((TEvent)e);
+    }
+
+    protected void RaiseEvent(IDomainEvent @event)
+    {
+        Apply(@event);
+        uncommittedEvents.Add(@event);
+        Version++;
+    }
+
+    // Replays events without buffering them as uncommitted — use from rehydration factories.
+    protected void LoadFromHistory(IEnumerable<IDomainEvent> events, int startVersion = 0)
+    {
+        Version = startVersion;
+        foreach (var @event in events)
+        {
+            Apply(@event);
+            Version++;
+        }
+    }
+
+    private void Apply(IDomainEvent @event)
+    {
+        if (handlers.TryGetValue(@event.GetType(), out var handler))
+        {
+            handler(@event);
+        }
+    }
+}

--- a/src/Yumney.Shared/Common/ResolvedQuantity.cs
+++ b/src/Yumney.Shared/Common/ResolvedQuantity.cs
@@ -1,8 +1,0 @@
-namespace SmartSolutionsLab.Yumney.Shared.Common;
-
-public sealed record ResolvedQuantity(decimal Amount, string Unit)
-{
-    public static readonly ResolvedQuantity OnePiece = new(1, "pc");
-
-    public override string ToString() => $"{Amount} {Unit}";
-}

--- a/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
@@ -4,6 +4,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
 public sealed record AddManualItemRequest(string Name, decimal? Quantity = null, string? Unit = null)
 {
-    public (ItemName ItemName, decimal? Quantity, string? Unit) ToValueObjects() =>
-        (ItemName.From(Name.Trim()), Quantity, Unit);
+    public void Deconstruct(out ItemName itemName, out Quantity? quantity)
+    {
+        itemName = ItemName.From(Name.Trim());
+        quantity = Shopping.Domain.ShoppingList.Quantity.FromNullable(
+            Amount.FromNullable(Quantity),
+            Shopping.Domain.ShoppingList.Unit.FromNullable(Unit));
+    }
 }

--- a/src/Yumney.Shopping.Api/Requests/RemoveItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/RemoveItemRequest.cs
@@ -4,6 +4,12 @@ namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
 public sealed record RemoveItemRequest(string Name, decimal? Quantity = null, string? Unit = null, string? Reason = null)
 {
-    public (ItemName ItemName, decimal? Quantity, string? Unit, string? Reason) ToValueObjects() =>
-        (ItemName.From(Name.Trim()), Quantity, Unit, Reason);
+    public void Deconstruct(out ItemName itemName, out Quantity? quantity, out RemovalReason? reason)
+    {
+        itemName = ItemName.From(Name);
+        quantity = Shopping.Domain.ShoppingList.Quantity.FromNullable(
+            Amount.FromNullable(Quantity),
+            Shopping.Domain.ShoppingList.Unit.FromNullable(Unit));
+        reason = RemovalReason.FromNullable(Reason);
+    }
 }

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -55,6 +55,7 @@ public static class ShoppingEndpoints
                 PagingOptions.From(page, pageSize),
                 SortingOptions<ShoppingListSortField>.Parse(sortBy, sortDirection, ShoppingListSortField.Date));
             var result = await handler.HandleAsync(query, cancellationToken);
+
             return result.ToOk();
         }
 
@@ -71,6 +72,7 @@ public static class ShoppingEndpoints
         {
             var query = new GetShoppingListByIdQuery(ShoppingListIdentifier.From(identifier));
             var result = await handler.HandleAsync(query, cancellationToken);
+
             return result.ToOk();
         }
 
@@ -131,8 +133,8 @@ public static class ShoppingEndpoints
             var validation = await validator.ValidateAsync(request, cancellationToken);
             if (validation.HasFailed()) return validation.ToValidationProblem();
 
-            var (itemName, quantity, unit) = request.ToValueObjects();
-            var command = new AddManualItemCommand(itemName, Quantity.FromNullable(Amount.FromNullable(quantity), Unit.FromNullable(unit)));
+            var (itemName, quantity) = request;
+            var command = new AddManualItemCommand(itemName, quantity);
 
             var result = await handler.HandleAsync(command, cancellationToken);
             return result.IsSuccess
@@ -155,8 +157,8 @@ public static class ShoppingEndpoints
             var validation = await validator.ValidateAsync(request, cancellationToken);
             if (validation.HasFailed()) return validation.ToValidationProblem();
 
-            var (itemName, quantity, unit, reason) = request.ToValueObjects();
-            var command = new RemoveShoppingItemCommand(itemName, Quantity.FromNullable(Amount.FromNullable(quantity), Unit.FromNullable(unit)), RemovalReason.FromNullable(reason));
+            var (itemName, quantity, reason) = request;
+            var command = new RemoveShoppingItemCommand(itemName, quantity, reason);
 
             var result = await handler.HandleAsync(command, cancellationToken);
             return result.ToNoContent();
@@ -199,6 +201,7 @@ public static class ShoppingEndpoints
             CancellationToken cancellationToken)
         {
             var result = await handler.HandleAsync(new EndShoppingModeCommand(request.AcceptPendingChanges), cancellationToken);
+
             return result.ToNoContent();
         }
 
@@ -212,8 +215,8 @@ public static class ShoppingEndpoints
             CancellationToken cancellationToken)
         {
             var result = await handler.HandleAsync(new ExportShoppingListQuery(), cancellationToken);
-            if (result.IsFailure) return result.ToOk();
 
+            if (result.IsFailure) return result.ToOk();
             return Results.Text(result.Value, MediaTypes.TextPlain);
         }
 

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
@@ -149,7 +150,7 @@ public static class ShoppingEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         static async Task<IResult> RemoveItem(
-            RemoveItemRequest request,
+            [FromBody] RemoveItemRequest request,
             IValidator<RemoveItemRequest> validator,
             ICommandHandler<RemoveShoppingItemCommand, Result> handler,
             CancellationToken cancellationToken)

--- a/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
@@ -1,5 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.Common;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -16,7 +17,7 @@ public sealed class AddManualItemCommandHandler(
         var name = itemName.Value;
         var ownerId = OwnerIdentifier.From(currentUser.UserId);
 
-        var quantity = explicitQuantity ?? ResolveDefaultQuantity(name);
+        var quantity = explicitQuantity ?? DefaultQuantityResolver.Resolve(name);
         var category = IngredientCategoryResolver.Resolve(name) ?? IngredientCategory.Other;
 
         var ledger = await eventStore.LoadAsync(ownerId, cancellationToken)
@@ -33,11 +34,5 @@ public sealed class AddManualItemCommandHandler(
             category.Value,
             ItemSource.Manual.Value,
             ledger.Identifier);
-    }
-
-    private static Quantity ResolveDefaultQuantity(string itemName)
-    {
-        var defaultQty = DefaultQuantityResolver.Resolve(itemName);
-        return Quantity.Of(Amount.From(defaultQty.Amount), Unit.FromNullable(defaultQty.Unit));
     }
 }

--- a/src/Yumney.Shopping.Application/Commands/Handlers/RemoveShoppingItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/RemoveShoppingItemCommandHandler.cs
@@ -1,5 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.Common;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
@@ -17,17 +18,11 @@ public sealed class RemoveShoppingItemCommandHandler(
         var ledger = await eventStore.LoadAsync(ownerId, cancellationToken);
         if (ledger is null) return Result.Success();
 
-        var quantity = explicitQuantity ?? ResolveDefaultQuantity(itemName.Value);
+        var quantity = explicitQuantity ?? DefaultQuantityResolver.Resolve(itemName.Value);
         ledger.RemoveItem(itemName, quantity, reason);
 
         await eventStore.SaveAsync(ledger, cancellationToken);
 
         return Result.Success();
-    }
-
-    private static Quantity ResolveDefaultQuantity(string itemName)
-    {
-        var defaultQty = DefaultQuantityResolver.Resolve(itemName);
-        return Quantity.Of(Amount.From(defaultQty.Amount), Unit.FromNullable(defaultQty.Unit));
     }
 }

--- a/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
@@ -1,40 +1,31 @@
-namespace SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-/// <summary>
-/// Resolves default quantities for items added without explicit amounts.
-/// Supports EN and DE item names with basic plural normalization.
-/// Category-based lookup with a fallback of 1 piece for unknown items.
-/// </summary>
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Common;
+
 #pragma warning disable SA1311
 public static class DefaultQuantityResolver
 {
-    private static readonly Dictionary<string, ResolvedQuantity> itemDefaults =
-        BuilditemDefaults();
+    public static readonly Quantity OnePiece = Q(1, "pc");
 
-    private static readonly Dictionary<string, ResolvedQuantity> categoryDefaults =
+    private static readonly Dictionary<string, Quantity> itemDefaults = BuildItemDefaults();
+
+    private static readonly Dictionary<string, Quantity> categoryDefaults =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["liquid"] = new(1, "L"),
-            ["dairy"] = new(250, "g"),
-            ["meat"] = new(500, "g"),
-            ["fish"] = new(500, "g"),
-            ["vegetable"] = new(1, "pc"),
-            ["fruit"] = new(1, "pc"),
-            ["baking"] = new(1, "pc"),
-            ["household"] = new(1, "pc"),
+            ["liquid"] = Q(1, "L"),
+            ["dairy"] = Q(250, "g"),
+            ["meat"] = Q(500, "g"),
+            ["fish"] = Q(500, "g"),
+            ["vegetable"] = Q(1, "pc"),
+            ["fruit"] = Q(1, "pc"),
+            ["baking"] = Q(1, "pc"),
+            ["household"] = Q(1, "pc"),
         };
 
-    /// <summary>
-    /// Resolve the default quantity for an item. Returns the standard default
-    /// for known items, or falls back to 1 piece for unknown items.
-    /// </summary>
-    /// <param name="itemName">The item name (EN or DE).</param>
-    /// <param name="category">Optional category hint for unknown items.</param>
-    /// <returns>The resolved default quantity.</returns>
-    public static ResolvedQuantity Resolve(string itemName, string? category = null)
+    public static Quantity Resolve(string itemName, string? category = null)
     {
         if (string.IsNullOrWhiteSpace(itemName))
-            return ResolvedQuantity.OnePiece;
+            return OnePiece;
 
         var normalized = Normalize(itemName);
 
@@ -44,8 +35,12 @@ public static class DefaultQuantityResolver
         if (category is not null && categoryDefaults.TryGetValue(category, out var categoryDefault))
             return categoryDefault;
 
-        return ResolvedQuantity.OnePiece;
+        return OnePiece;
     }
+
+#pragma warning disable SA1204
+    private static Quantity Q(decimal amount, string unit) =>
+        Quantity.Of(Amount.From(amount), Unit.FromNullable(unit));
 
     private static string Normalize(string input)
     {
@@ -63,38 +58,38 @@ public static class DefaultQuantityResolver
     }
 
 #pragma warning disable SA1117 // Parameters should be on same line or each on its own line
-    private static Dictionary<string, ResolvedQuantity> BuilditemDefaults()
+    private static Dictionary<string, Quantity> BuildItemDefaults()
     {
-        var defaults = new Dictionary<string, ResolvedQuantity>(StringComparer.OrdinalIgnoreCase);
+        var defaults = new Dictionary<string, Quantity>(StringComparer.OrdinalIgnoreCase);
 
         // Liquids → 1L
-        AddWithAliases(defaults, new(1, "L"),
+        AddWithAliases(defaults, Q(1, "L"),
             "milk", "milch",
             "cream", "sahne", "schlagsahne",
             "juice", "saft",
             "water", "wasser",
             "broth", "bruehe", "brühe",
             "stock", "fond");
-        AddWithAliases(defaults, new(0.5m, "L"),
+        AddWithAliases(defaults, Q(0.5m, "L"),
             "oil", "oel", "öl",
             "olive oil", "olivenoel", "olivenöl",
             "vegetable oil", "pflanzenoel", "pflanzenöl");
 
         // Eggs → 6
-        AddWithAliases(defaults, new(6, "pc"),
+        AddWithAliases(defaults, Q(6, "pc"),
             "egg", "eggs", "ei", "eier");
 
         // Dairy → 250g
-        AddWithAliases(defaults, new(250, "g"),
+        AddWithAliases(defaults, Q(250, "g"),
             "butter",
             "cheese", "kaese", "käse");
-        AddWithAliases(defaults, new(500, "g"),
+        AddWithAliases(defaults, Q(500, "g"),
             "yogurt", "joghurt");
-        AddWithAliases(defaults, new(200, "g"),
+        AddWithAliases(defaults, Q(200, "g"),
             "sour cream", "schmand", "saure sahne");
 
         // Meat / Fish → 500g
-        AddWithAliases(defaults, new(500, "g"),
+        AddWithAliases(defaults, Q(500, "g"),
             "chicken", "haehnchen", "hähnchen", "huhn",
             "beef", "rindfleisch", "rind",
             "pork", "schweinefleisch", "schwein",
@@ -104,25 +99,25 @@ public static class DefaultQuantityResolver
             "shrimp", "garnelen", "garnele");
 
         // Baking
-        AddWithAliases(defaults, new(1, "kg"),
+        AddWithAliases(defaults, Q(1, "kg"),
             "flour", "mehl",
             "sugar", "zucker");
-        AddWithAliases(defaults, new(1, "pc"),
+        AddWithAliases(defaults, Q(1, "pc"),
             "baking powder", "backpulver",
             "yeast", "hefe");
 
         // Staples
-        AddWithAliases(defaults, new(1, "pc"),
+        AddWithAliases(defaults, Q(1, "pc"),
             "salt", "salz",
             "pepper", "pfeffer",
             "bread", "brot");
-        AddWithAliases(defaults, new(1, "kg"),
+        AddWithAliases(defaults, Q(1, "kg"),
             "rice", "reis");
-        AddWithAliases(defaults, new(500, "g"),
+        AddWithAliases(defaults, Q(500, "g"),
             "pasta", "nudeln");
 
         // Common vegetables
-        AddWithAliases(defaults, new(1, "pc"),
+        AddWithAliases(defaults, Q(1, "pc"),
             "onion", "zwiebel",
             "garlic", "knoblauch",
             "potato", "kartoffel",
@@ -136,7 +131,7 @@ public static class DefaultQuantityResolver
     }
 #pragma warning restore SA1117
 
-    private static void AddWithAliases(Dictionary<string, ResolvedQuantity> dict, ResolvedQuantity quantity, params string[] names)
+    private static void AddWithAliases(Dictionary<string, Quantity> dict, Quantity quantity, params string[] names)
     {
         foreach (var name in names)
             dict.TryAdd(name, quantity);

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAdded.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAdded.cs
@@ -5,6 +5,5 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 public sealed record ShoppingItemAdded(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit,
+    Quantity Quantity,
     ItemSource Source) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAddedAsAtHome.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemAddedAsAtHome.cs
@@ -8,5 +8,4 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 /// </summary>
 public sealed record ShoppingItemAddedAsAtHome(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit) : DomainEvent;
+    Quantity Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemBought.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemBought.cs
@@ -5,5 +5,4 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 public sealed record ShoppingItemBought(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit) : DomainEvent;
+    Quantity Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemConsumed.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemConsumed.cs
@@ -5,6 +5,5 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 public sealed record ShoppingItemConsumed(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit,
+    Quantity Quantity,
     ItemSource Source) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemQuantityAdjusted.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemQuantityAdjusted.cs
@@ -5,5 +5,4 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 public sealed record ShoppingItemQuantityAdjusted(
     ItemName ItemName,
-    Amount NewQuantity,
-    Unit? Unit) : DomainEvent;
+    Quantity NewQuantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemRemoved.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemRemoved.cs
@@ -5,6 +5,5 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 
 public sealed record ShoppingItemRemoved(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit,
+    Quantity Quantity,
     RemovalReason? Reason) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemUndoBought.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/Events/ShoppingItemUndoBought.cs
@@ -8,5 +8,4 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 /// </summary>
 public sealed record ShoppingItemUndoBought(
     ItemName ItemName,
-    Amount Quantity,
-    Unit? Unit) : DomainEvent;
+    Quantity Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingItemState.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingItemState.cs
@@ -2,24 +2,20 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 
-/// <summary>
-/// Internal mutable state for a single item in the shopping list.
-/// Rebuilt from events during aggregate hydration.
-/// </summary>
 #pragma warning disable SA1600
-public sealed class ShoppingItemState
+public sealed record ShoppingItemState
 {
     public ItemName ItemName { get; init; } = default!;
 
     public Unit? Unit { get; init; }
 
-    public Amount OnList { get; set; } = Amount.From(0);
+    public Amount OnList { get; init; } = Amount.From(0);
 
-    public Amount Bought { get; set; } = Amount.From(0);
+    public Amount Bought { get; init; } = Amount.From(0);
 
-    public Amount Consumed { get; set; } = Amount.From(0);
+    public Amount Consumed { get; init; } = Amount.From(0);
 
-    public Amount Removed { get; set; } = Amount.From(0);
+    public Amount Removed { get; init; } = Amount.From(0);
 
     public Amount AtHome => Amount.From(Math.Max(0, Bought.Value - Consumed.Value - Removed.Value));
 
@@ -27,8 +23,5 @@ public sealed class ShoppingItemState
 
     public bool IsBought => Bought.Value > 0;
 
-    /// <summary>
-    /// Gets the grouping key: item name + unit (case-insensitive).
-    /// </summary>
     public string GroupKey => $"{ItemName.Value.ToLowerInvariant()}|{Unit?.Value ?? string.Empty}";
 }

--- a/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingLedger/ShoppingLedger.cs
@@ -1,22 +1,14 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 
-public sealed class ShoppingLedger
+public sealed class ShoppingLedger : EventSourcedAggregate<ShoppingLedgerIdentifier>
 {
-    private readonly List<IDomainEvent> uncommittedEvents = [];
     private readonly Dictionary<string, ShoppingItemState> items = new(StringComparer.OrdinalIgnoreCase);
 
-    public ShoppingLedgerIdentifier Identifier { get; private set; } = default!;
-
     public OwnerIdentifier OwnerId { get; private set; } = default!;
-
-    public int Version { get; private set; }
-
-    public IReadOnlyCollection<IDomainEvent> UncommittedEvents => uncommittedEvents.AsReadOnly();
 
     public IReadOnlyDictionary<string, ShoppingItemState> Items => items;
 
@@ -28,6 +20,15 @@ public sealed class ShoppingLedger
 
     private ShoppingLedger()
     {
+        On<ShoppingItemAdded>(OnItemAdded);
+        On<ShoppingItemBought>(OnItemBought);
+        On<ShoppingItemConsumed>(OnItemConsumed);
+        On<ShoppingItemRemoved>(OnItemRemoved);
+        On<ShoppingItemQuantityAdjusted>(OnQuantityAdjusted);
+        On<ShoppingItemUndoBought>(OnUndoBought);
+        On<ShoppingItemAddedAsAtHome>(OnAddedAsAtHome);
+        On<ShoppingModeStarted>(OnShoppingModeStarted);
+        On<ShoppingModeEnded>(_ => OnShoppingModeEnded());
     }
 
     public static ShoppingLedger Create(OwnerIdentifier ownerId)
@@ -45,12 +46,8 @@ public sealed class ShoppingLedger
         IEnumerable<IDomainEvent> events,
         int startVersion = 0)
     {
-        var ledger = new ShoppingLedger { Identifier = identifier, OwnerId = ownerId, Version = startVersion };
-        foreach (var @event in events)
-        {
-            ledger.Apply(@event);
-            ledger.Version++;
-        }
+        var ledger = new ShoppingLedger { Identifier = identifier, OwnerId = ownerId };
+        ledger.LoadFromHistory(events, startVersion);
 
         return ledger;
     }
@@ -62,52 +59,50 @@ public sealed class ShoppingLedger
         int snapshotVersion,
         IEnumerable<IDomainEvent> eventsSinceSnapshot)
     {
-        var ledger = new ShoppingLedger { Identifier = identifier, OwnerId = ownerId, Version = snapshotVersion };
+        var ledger = new ShoppingLedger { Identifier = identifier, OwnerId = ownerId };
         foreach (var item in snapshotItems)
-            ledger.items[item.Key] = item.Value;
-
-        foreach (var @event in eventsSinceSnapshot)
         {
-            ledger.Apply(@event);
-            ledger.Version++;
+            ledger.items[item.Key] = item.Value;
         }
+
+        ledger.LoadFromHistory(eventsSinceSnapshot, snapshotVersion);
 
         return ledger;
     }
 
     public void AddItem(ItemName itemName, Quantity quantity, ItemSource source)
     {
-        RaiseEvent(new ShoppingItemAdded(itemName, quantity.Amount, quantity.Unit, source));
+        RaiseEvent(new ShoppingItemAdded(itemName, quantity, source));
     }
 
     public void MarkBought(ItemName itemName, Quantity quantity)
     {
-        RaiseEvent(new ShoppingItemBought(itemName, quantity.Amount, quantity.Unit));
+        RaiseEvent(new ShoppingItemBought(itemName, quantity));
     }
 
     public void MarkConsumed(ItemName itemName, Quantity quantity, ItemSource source)
     {
-        RaiseEvent(new ShoppingItemConsumed(itemName, quantity.Amount, quantity.Unit, source));
+        RaiseEvent(new ShoppingItemConsumed(itemName, quantity, source));
     }
 
     public void RemoveItem(ItemName itemName, Quantity quantity, RemovalReason? reason = null)
     {
-        RaiseEvent(new ShoppingItemRemoved(itemName, quantity.Amount, quantity.Unit, reason));
+        RaiseEvent(new ShoppingItemRemoved(itemName, quantity, reason));
     }
 
     public void AdjustQuantity(ItemName itemName, Quantity newQuantity)
     {
-        RaiseEvent(new ShoppingItemQuantityAdjusted(itemName, newQuantity.Amount, newQuantity.Unit));
+        RaiseEvent(new ShoppingItemQuantityAdjusted(itemName, newQuantity));
     }
 
     public void UndoBought(ItemName itemName, Quantity quantity)
     {
-        RaiseEvent(new ShoppingItemUndoBought(itemName, quantity.Amount, quantity.Unit));
+        RaiseEvent(new ShoppingItemUndoBought(itemName, quantity));
     }
 
     public void AddAsAtHome(ItemName itemName, Quantity quantity)
     {
-        RaiseEvent(new ShoppingItemAddedAsAtHome(itemName, quantity.Amount, quantity.Unit));
+        RaiseEvent(new ShoppingItemAddedAsAtHome(itemName, quantity));
     }
 
     public void StartShoppingMode()
@@ -122,74 +117,62 @@ public sealed class ShoppingLedger
         RaiseEvent(new ShoppingModeEnded(acceptPendingChanges));
     }
 
-    public void MarkCommitted()
+    private void OnItemAdded(ShoppingItemAdded e)
     {
-        uncommittedEvents.Clear();
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { OnList = Amount.From(s.OnList + e.Quantity.Amount) });
+        if (IsInShoppingMode) PendingChangesCount++;
     }
 
-    private void RaiseEvent(IDomainEvent @event)
+    private void OnItemBought(ShoppingItemBought e) =>
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { Bought = Amount.From(s.Bought + e.Quantity.Amount) });
+
+    private void OnItemConsumed(ShoppingItemConsumed e) =>
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { Consumed = Amount.From(s.Consumed + e.Quantity.Amount) });
+
+    private void OnItemRemoved(ShoppingItemRemoved e)
     {
-        Apply(@event);
-        uncommittedEvents.Add(@event);
-        Version++;
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { Removed = Amount.From(s.Removed + e.Quantity.Amount) });
+        if (IsInShoppingMode) PendingChangesCount++;
     }
 
-    private void Apply(IDomainEvent @event)
+    private void OnQuantityAdjusted(ShoppingItemQuantityAdjusted e)
     {
-        switch (@event)
+        UpdateItem(e.ItemName, e.NewQuantity.Unit, s => s with { OnList = e.NewQuantity.Amount });
+        if (IsInShoppingMode) PendingChangesCount++;
+    }
+
+    private void OnUndoBought(ShoppingItemUndoBought e) =>
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { Bought = Amount.From(Math.Max(0, s.Bought - e.Quantity.Amount)) });
+
+    private void OnAddedAsAtHome(ShoppingItemAddedAsAtHome e) =>
+        UpdateItem(e.ItemName, e.Quantity.Unit, s => s with { Bought = Amount.From(s.Bought + e.Quantity.Amount) });
+
+    private void OnShoppingModeStarted(ShoppingModeStarted e)
+    {
+        IsInShoppingMode = true;
+        ShoppingModeStartedAt = e.SnapshotTakenAt;
+        PendingChangesCount = 0;
+    }
+
+    private void OnShoppingModeEnded()
+    {
+        IsInShoppingMode = false;
+        ShoppingModeStartedAt = null;
+        PendingChangesCount = 0;
+    }
+
+#pragma warning disable SA1204
+    private static string KeyFor(ItemName itemName, Unit? unit) =>
+        $"{itemName.Value.ToLowerInvariant()}|{unit?.Value ?? string.Empty}";
+
+    private void UpdateItem(ItemName itemName, Unit? unit, Func<ShoppingItemState, ShoppingItemState> update)
+    {
+        var key = KeyFor(itemName, unit);
+        if (!items.TryGetValue(key, out var current))
         {
-            case ShoppingItemAdded e:
-                var addedItem = GetOrCreateItem(e.ItemName, e.Unit);
-                addedItem.OnList = Amount.From(addedItem.OnList + e.Quantity);
-                if (IsInShoppingMode) PendingChangesCount++;
-                break;
-            case ShoppingItemBought e:
-                var boughtItem = GetOrCreateItem(e.ItemName, e.Unit);
-                boughtItem.Bought = Amount.From(boughtItem.Bought + e.Quantity);
-                break;
-            case ShoppingItemConsumed e:
-                var consumedItem = GetOrCreateItem(e.ItemName, e.Unit);
-                consumedItem.Consumed = Amount.From(consumedItem.Consumed + e.Quantity);
-                break;
-            case ShoppingItemRemoved e:
-                var removedItem = GetOrCreateItem(e.ItemName, e.Unit);
-                removedItem.Removed = Amount.From(removedItem.Removed + e.Quantity);
-                if (IsInShoppingMode) PendingChangesCount++;
-                break;
-            case ShoppingItemQuantityAdjusted e:
-                GetOrCreateItem(e.ItemName, e.Unit).OnList = e.NewQuantity;
-                if (IsInShoppingMode) PendingChangesCount++;
-                break;
-            case ShoppingItemUndoBought e:
-                var undoItem = GetOrCreateItem(e.ItemName, e.Unit);
-                undoItem.Bought = Amount.From(Math.Max(0, undoItem.Bought - e.Quantity));
-                break;
-            case ShoppingItemAddedAsAtHome e:
-                var atHomeItem = GetOrCreateItem(e.ItemName, e.Unit);
-                atHomeItem.Bought = Amount.From(atHomeItem.Bought + e.Quantity);
-                break;
-            case ShoppingModeStarted e:
-                IsInShoppingMode = true;
-                ShoppingModeStartedAt = e.SnapshotTakenAt;
-                PendingChangesCount = 0;
-                break;
-            case ShoppingModeEnded:
-                IsInShoppingMode = false;
-                ShoppingModeStartedAt = null;
-                PendingChangesCount = 0;
-                break;
-        }
-    }
-
-    private ShoppingItemState GetOrCreateItem(ItemName itemName, Unit? unit)
-    {
-        var key = $"{itemName.Value.ToLowerInvariant()}|{unit?.Value ?? string.Empty}";
-        if (!items.TryGetValue(key, out var item))
-        {
-            item = new ShoppingItemState { ItemName = itemName, Unit = unit };
-            items[key] = item;
+            current = new ShoppingItemState { ItemName = itemName, Unit = unit };
         }
 
-        return item;
+        items[key] = update(current);
     }
 }

--- a/src/Yumney.Shopping.Domain/ShoppingList/Unit.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Unit.cs
@@ -7,6 +7,36 @@ public sealed record Unit : IValueObject
 {
     public const int MaxLength = 50;
 
+    // Weight
+    public static readonly Unit Gram = new("g");
+    public static readonly Unit Kilogram = new("kg");
+    public static readonly Unit Milligram = new("mg");
+    public static readonly Unit Pound = new("lb");
+    public static readonly Unit Ounce = new("oz");
+
+    // Volume
+    public static readonly Unit Liter = new("l");
+    public static readonly Unit Milliliter = new("ml");
+    public static readonly Unit Centiliter = new("cl");
+    public static readonly Unit Deciliter = new("dl");
+    public static readonly Unit Cup = new("cup");
+    public static readonly Unit Tablespoon = new("tbsp");
+    public static readonly Unit Teaspoon = new("tsp");
+    public static readonly Unit FluidOunce = new("fl oz");
+
+    // Count & Packaging
+    public static readonly Unit Piece = new("piece");
+    public static readonly Unit Bunch = new("bunch");
+    public static readonly Unit Can = new("can");
+    public static readonly Unit Pack = new("pack");
+    public static readonly Unit Bag = new("bag");
+    public static readonly Unit Bottle = new("bottle");
+    public static readonly Unit Slice = new("slice");
+    public static readonly Unit Clove = new("clove");
+    public static readonly Unit Pinch = new("pinch");
+    public static readonly Unit Dash = new("dash");
+    public static readonly Unit Sprig = new("sprig");
+
     public string Value { get; }
 
     private Unit(string value)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionHandler.cs
@@ -21,11 +21,11 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     public async Task HandleAsync(ShoppingItemAddedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var readItem = await FindOrCreateAsync(@event.OwnerId, inner.ItemName, inner.Unit?.Value, cancellationToken);
-        readItem.TotalQuantity += inner.Quantity;
+        var readItem = await FindOrCreateAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, cancellationToken);
+        readItem.TotalQuantity += inner.Quantity.Amount;
         readItem.LastUpdated = DateTime.UtcNow;
 
-        AppendSource(readItem, inner.Quantity, inner.Source);
+        AppendSource(readItem, inner.Quantity.Amount, inner.Source);
 
         await context.SaveChangesAsync(cancellationToken);
     }
@@ -34,7 +34,7 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     public async Task HandleAsync(ShoppingItemBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit?.Value, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, cancellationToken);
         if (readItem is null) return;
 
         readItem.IsBought = true;
@@ -48,7 +48,7 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     public async Task HandleAsync(ShoppingItemConsumedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit?.Value, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, cancellationToken);
         if (readItem is null) return;
 
         readItem.LastUpdated = DateTime.UtcNow;
@@ -59,10 +59,10 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     public async Task HandleAsync(ShoppingItemRemovedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit?.Value, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, cancellationToken);
         if (readItem is null) return;
 
-        readItem.TotalQuantity = Math.Max(0, readItem.TotalQuantity - inner.Quantity);
+        readItem.TotalQuantity = Math.Max(0, readItem.TotalQuantity - inner.Quantity.Amount);
         readItem.LastUpdated = DateTime.UtcNow;
 
         if (readItem.TotalQuantity <= 0)
@@ -75,10 +75,10 @@ public sealed class ShoppingListProjectionHandler(ShoppingDbContext context)
     public async Task HandleAsync(ShoppingItemQuantityAdjustedIntegrationEvent @event, CancellationToken cancellationToken = default)
     {
         var inner = @event.Inner;
-        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.Unit?.Value, cancellationToken);
+        var readItem = await FindAsync(@event.OwnerId, inner.ItemName, inner.NewQuantity.Unit?.Value, cancellationToken);
         if (readItem is null) return;
 
-        readItem.TotalQuantity = inner.NewQuantity;
+        readItem.TotalQuantity = inner.NewQuantity.Amount;
         readItem.LastUpdated = DateTime.UtcNow;
 
         await context.SaveChangesAsync(cancellationToken);

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -15,6 +15,7 @@ public sealed partial class UpdateUserProfileCommandHandler(
     {
         var (defaultServings, dietaryTypeValue, restrictionValues, minVeggieMeals, maxRedMeatMeals, cookingEffortValue) = command;
 
+
         var keycloakId = KeycloakUserId.From(currentUser.UserId);
         var profile = await profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
 

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -15,7 +15,6 @@ public sealed partial class UpdateUserProfileCommandHandler(
     {
         var (defaultServings, dietaryTypeValue, restrictionValues, minVeggieMeals, maxRedMeatMeals, cookingEffortValue) = command;
 
-
         var keycloakId = KeycloakUserId.From(currentUser.UserId);
         var profile = await profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
 

--- a/tests/Yumney.Integration.Tests/Fixtures/ShoppingListFactory.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/ShoppingListFactory.cs
@@ -8,27 +8,27 @@ public static class ShoppingListFactory
         ShoppingListTitle.From("Weekly Groceries"),
         OwnerIdentifier.From(owner ?? "integration-test-user"),
         [
-            ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l"))),
+            ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.Liter)),
             ShoppingListItem.Create(ItemName.From("Bread"), Quantity.Of(Amount.From(1), null)),
             ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(12), null)),
-            ShoppingListItem.Create(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.Gram)),
         ]);
 
     public static ShoppingList PartySupplies(string? owner = null) => ShoppingList.Create(
         ShoppingListTitle.From("Party Supplies"),
         OwnerIdentifier.From(owner ?? "integration-test-user"),
         [
-            ShoppingListItem.Create(ItemName.From("Chips"), Quantity.Of(Amount.From(3), Unit.From("bags"))),
-            ShoppingListItem.Create(ItemName.From("Soda"), Quantity.Of(Amount.From(6), Unit.From("bottles"))),
-            ShoppingListItem.Create(ItemName.From("Napkins"), Quantity.Of(Amount.From(1), Unit.From("pack"))),
+            ShoppingListItem.Create(ItemName.From("Chips"), Quantity.Of(Amount.From(3), Unit.Bag)),
+            ShoppingListItem.Create(ItemName.From("Soda"), Quantity.Of(Amount.From(6), Unit.Bottle)),
+            ShoppingListItem.Create(ItemName.From("Napkins"), Quantity.Of(Amount.From(1), Unit.Pack)),
         ]);
 
     public static ShoppingList BakingIngredients(string? owner = null) => ShoppingList.Create(
         ShoppingListTitle.From("Baking Ingredients"),
         OwnerIdentifier.From(owner ?? "integration-test-user"),
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(1000), Unit.From("g"))),
-            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(1000), Unit.Gram)),
+            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(500), Unit.Gram)),
         ],
         RecipeReference.From(Guid.NewGuid()));
 }

--- a/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
@@ -117,7 +117,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
     {
         var recipe = RecipeFactory.Lasagne(owner.Value);
         await fixture.SeedRecipesAsync(recipe);
-        var paging = PagingOptions.Of(Page.From(1), PageSize.From(20));
+        var paging = PagingOptions.From(1, 20);
         var sorting = new SortingOptions<RecipeSortField>(RecipeSortField.Date, SortDirection.Descending);
 
         await using var readContext = await fixture.CreateRecipesDbContextAsync();
@@ -139,7 +139,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
             var loaded = await recipes.GetByIdForUpdateAsync(recipe.Id);
             loaded.Update(
                 RecipeTitle.From("Updated Tomato Soup"),
-                [Ingredient.Create(IngredientName.From("Cherry tomatoes"), Quantity.Of(Amount.From(800), Unit.From("g")))],
+                [Ingredient.Create(IngredientName.From("Cherry tomatoes"), Quantity.Of(Amount.From(800), Unit.Gram))],
                 [Step.Create(StepNumber.From(1), StepDescription.From("Roast cherry tomatoes"))],
                 RecipeDescription.From("Updated description"),
                 Servings.From(2));

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -112,7 +112,7 @@ public class SaveRecipeCommandHandlerTests
         var command = new SaveRecipeCommand(
             RecipeTitle.From("Test"),
             [
-                new SaveRecipeIngredientItem(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+                new SaveRecipeIngredientItem(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
                 new SaveRecipeIngredientItem(IngredientName.From("Sugar"), Quantity.Of(Amount.From(100), null)),
             ],
             [new SaveRecipeStepItem(StepNumber.From(1), StepDescription.From("Mix"))],
@@ -285,7 +285,7 @@ public class SaveRecipeCommandHandlerTests
     {
         return new SaveRecipeCommand(
             RecipeTitle.From("Pasta Carbonara"),
-            [new SaveRecipeIngredientItem(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.From("g")))],
+            [new SaveRecipeIngredientItem(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.Gram))],
             [new SaveRecipeStepItem(StepNumber.From(1), StepDescription.From("Cook pasta"))],
             SourceUrl: RecipeUrl.From("https://example.com/recipe"));
     }

--- a/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
@@ -318,7 +318,7 @@ public class UpdateRecipeCommandHandlerTests
         return new UpdateRecipeCommand(
             identifier,
             RecipeTitle.From("Updated Pasta"),
-            [new SaveRecipeIngredientItem(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.From("g")))],
+            [new SaveRecipeIngredientItem(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.Gram))],
             [new SaveRecipeStepItem(StepNumber.From(1), StepDescription.From("Cook pasta"))]);
     }
 
@@ -327,7 +327,7 @@ public class UpdateRecipeCommandHandlerTests
         return new UpdateRecipeCommand(
             identifier,
             RecipeTitle.From("New Title"),
-            [new SaveRecipeIngredientItem(IngredientName.From("Butter"), Quantity.Of(Amount.From(200), Unit.From("g")))],
+            [new SaveRecipeIngredientItem(IngredientName.From("Butter"), Quantity.Of(Amount.From(200), Unit.Gram))],
             [new SaveRecipeStepItem(StepNumber.From(1), StepDescription.From("Melt butter"))],
             RecipeDescription.From("New description"),
             Servings.From(6),

--- a/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
+++ b/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
@@ -44,7 +44,7 @@ internal static class RecipeTestData
             RecipeTitle.From("Recipe With Ingredients"),
             OwnerIdentifier.From(ownerId),
             [
-                Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500m), Unit.From("g"))),
+                Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500m), Unit.Gram)),
                 Ingredient.Create(IngredientName.From("Eggs"), null),
             ],
             [Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/IngredientTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/IngredientTests.cs
@@ -11,7 +11,7 @@ public class IngredientTests
     {
         var name = IngredientName.From("Flour");
         var amount = Amount.From(500);
-        var unit = Unit.From("g");
+        var unit = Unit.Gram;
 
         var ingredient = Ingredient.Create(name, Quantity.Of(amount, unit));
 

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -70,8 +70,8 @@ public class RecipeTests
     {
         List<Ingredient> ingredients =
         [
-            Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.From("g"))),
-            Ingredient.Create(IngredientName.From("Pancetta"), Quantity.Of(Amount.From(200), Unit.From("g"))),
+            Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.Gram)),
+            Ingredient.Create(IngredientName.From("Pancetta"), Quantity.Of(Amount.From(200), Unit.Gram)),
         ];
 
         var recipe = CreateValidRecipe(ingredients: ingredients);
@@ -241,13 +241,13 @@ public class RecipeTests
     {
         var recipe = CreateValidRecipe(ingredients:
         [
-            Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
-            Ingredient.Create(IngredientName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.From("g"))),
+            Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+            Ingredient.Create(IngredientName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
         ]);
 
         List<Ingredient> newIngredients =
         [
-            Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.From("g"))),
+            Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.Gram)),
         ];
 
         recipe.Update(RecipeTitle.From("Updated"), newIngredients, [Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);
@@ -514,7 +514,7 @@ public class RecipeTests
 
         List<Ingredient> newIngredients =
         [
-            Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.From("g"))),
+            Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.Gram)),
         ];
         List<Step> newSteps =
         [
@@ -551,7 +551,7 @@ public class RecipeTests
         return Domain.Recipe.Recipe.Create(
             title ?? RecipeTitle.From("Test Recipe"),
             owner ?? OwnerIdentifier.From("user-123"),
-            ingredients ?? [Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")))],
+            ingredients ?? [Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
             steps ?? [Step.Create(StepNumber.From(1), StepDescription.From("Mix ingredients"))],
             description,
             servings,

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/UnitTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/UnitTests.cs
@@ -10,7 +10,7 @@ public class UnitTests
     [Fact]
     public void Constructor_ValidUnit_CreatesInstance()
     {
-        var unit = Unit.From("g");
+        var unit = Unit.Gram;
 
         unit.Value.Should().Be("g");
     }
@@ -57,8 +57,8 @@ public class UnitTests
     [Fact]
     public void Equality_SameValue_AreEqual()
     {
-        var unit1 = Unit.From("ml");
-        var unit2 = Unit.From("ml");
+        var unit1 = Unit.Milliliter;
+        var unit2 = Unit.Milliliter;
 
         unit1.Should().Be(unit2);
     }
@@ -66,8 +66,8 @@ public class UnitTests
     [Fact]
     public void Equality_DifferentValue_AreNotEqual()
     {
-        var unit1 = Unit.From("ml");
-        var unit2 = Unit.From("g");
+        var unit1 = Unit.Milliliter;
+        var unit2 = Unit.Gram;
 
         unit1.Should().NotBe(unit2);
     }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/RecipeIngredientProviderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/RecipeIngredientProviderTests.cs
@@ -23,8 +23,8 @@ public class RecipeIngredientProviderTests
         var recipeId = Guid.NewGuid();
         SetupRecipe(
             [
-                Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(500m), Unit.From("g"))),
-                Ingredient.Create(IngredientName.From("Tomato Sauce"), Quantity.Of(Amount.From(200m), Unit.From("ml"))),
+                Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(500m), Unit.Gram)),
+                Ingredient.Create(IngredientName.From("Tomato Sauce"), Quantity.Of(Amount.From(200m), Unit.Milliliter)),
             ],
             Servings.From(4));
 
@@ -58,7 +58,7 @@ public class RecipeIngredientProviderTests
     {
         var recipeId = Guid.NewGuid();
         SetupRecipe(
-            [Ingredient.Create(IngredientName.From("Water"), Quantity.Of(Amount.From(500m), Unit.From("ml")))]);
+            [Ingredient.Create(IngredientName.From("Water"), Quantity.Of(Amount.From(500m), Unit.Milliliter))]);
 
         var result = await provider.GetIngredientsAsync(recipeId);
 

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListCommandHandlerTests.cs
@@ -61,14 +61,14 @@ public class CreateShoppingListCommandHandlerTests
         var command = new CreateShoppingListCommand(
             ShoppingListTitle.From("Big List"),
             [
-                new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
-                new ShoppingListItem(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.From("g"))),
-                new ShoppingListItem(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g"))),
+                new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+                new ShoppingListItem(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
+                new ShoppingListItem(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.Gram)),
                 new ShoppingListItem(ItemName.From("Eggs"), Quantity.Of(Amount.From(6), null)),
-                new ShoppingListItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l"))),
+                new ShoppingListItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter)),
                 new ShoppingListItem(ItemName.From("Salt"), null),
                 new ShoppingListItem(ItemName.From("Pepper"), null),
-                new ShoppingListItem(ItemName.From("Vanilla"), Quantity.Of(Amount.From(1), Unit.From("tsp"))),
+                new ShoppingListItem(ItemName.From("Vanilla"), Quantity.Of(Amount.From(1), Unit.Teaspoon)),
             ]);
 
         var result = await handler.HandleAsync(command);
@@ -112,7 +112,7 @@ public class CreateShoppingListCommandHandlerTests
         var recipeId = Guid.NewGuid();
         var command = new CreateShoppingListCommand(
             ShoppingListTitle.From("From Recipe"),
-            [new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")))],
+            [new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
             RecipeReference.From(recipeId));
 
         var result = await handler.HandleAsync(command);
@@ -126,7 +126,7 @@ public class CreateShoppingListCommandHandlerTests
         var command = new CreateShoppingListCommand(
             ShoppingListTitle.From("Test"),
             [
-                new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+                new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
                 new ShoppingListItem(ItemName.From("Salt"), null),
             ]);
 
@@ -144,6 +144,10 @@ public class CreateShoppingListCommandHandlerTests
     {
         return new CreateShoppingListCommand(
             ShoppingListTitle.From("Weekly Groceries"),
-            [new ShoppingListItem(ItemName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.From("g")))]);
+            [
+                new ShoppingListItem(
+                    ItemName.From("Spaghetti"),
+                    Quantity.Of(Amount.From(400), Unit.Gram))
+            ]);
     }
 }

--- a/tests/Yumney.Shopping.Application.Tests/Common/DefaultQuantityResolverTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Common/DefaultQuantityResolverTests.cs
@@ -1,8 +1,9 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using Xunit;
 
-namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Common;
 
 public class DefaultQuantityResolverTests
 {
@@ -15,8 +16,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -26,8 +27,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("pc");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("pc");
     }
 
     [Theory]
@@ -37,8 +38,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("g");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("g");
     }
 
     [Theory]
@@ -49,8 +50,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("g");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("g");
     }
 
     [Theory]
@@ -62,8 +63,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -76,8 +77,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -87,8 +88,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("pc");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("pc");
     }
 
     [Theory]
@@ -98,8 +99,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("g");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("g");
     }
 
     [Theory]
@@ -112,8 +113,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be("g");
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be("g");
     }
 
     [Theory]
@@ -126,8 +127,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -139,8 +140,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -153,8 +154,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Fact]
@@ -162,7 +163,7 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("toilet paper");
 
-        result.Should().Be(ResolvedQuantity.OnePiece);
+        result.Should().Be(DefaultQuantityResolver.OnePiece);
     }
 
     [Fact]
@@ -170,8 +171,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("coconut milk", "liquid");
 
-        result.Amount.Should().Be(1);
-        result.Unit.Should().Be("L");
+        result.Amount.Value.Should().Be(1);
+        result.Unit!.Value.Should().Be("L");
     }
 
     [Fact]
@@ -179,7 +180,7 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("mystery item", "unknown-category");
 
-        result.Should().Be(ResolvedQuantity.OnePiece);
+        result.Should().Be(DefaultQuantityResolver.OnePiece);
     }
 
     [Fact]
@@ -187,8 +188,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("MILK");
 
-        result.Amount.Should().Be(1);
-        result.Unit.Should().Be("L");
+        result.Amount.Value.Should().Be(1);
+        result.Unit!.Value.Should().Be("L");
     }
 
     [Theory]
@@ -198,8 +199,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item);
 
-        result.Amount.Should().Be(amount);
-        result.Unit.Should().Be(unit);
+        result.Amount.Value.Should().Be(amount);
+        result.Unit!.Value.Should().Be(unit);
     }
 
     [Theory]
@@ -210,7 +211,7 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve(item!);
 
-        result.Should().Be(ResolvedQuantity.OnePiece);
+        result.Should().Be(DefaultQuantityResolver.OnePiece);
     }
 
     [Fact]
@@ -218,8 +219,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("pasta");
 
-        result.Amount.Should().Be(500);
-        result.Unit.Should().Be("g");
+        result.Amount.Value.Should().Be(500);
+        result.Unit!.Value.Should().Be("g");
     }
 
     [Fact]
@@ -227,16 +228,8 @@ public class DefaultQuantityResolverTests
     {
         var result = DefaultQuantityResolver.Resolve("flour");
 
-        result.Amount.Should().Be(1);
-        result.Unit.Should().Be("kg");
-    }
-
-    [Fact]
-    public void ResolvedQuantity_ToString_FormatsCorrectly()
-    {
-        var qty = new ResolvedQuantity(1, "L");
-
-        qty.ToString().Should().Be("1 L");
+        result.Amount.Value.Should().Be(1);
+        result.Unit!.Value.Should().Be("kg");
     }
 
     [Fact]
@@ -245,6 +238,6 @@ public class DefaultQuantityResolverTests
         // "eggs" is a direct match, not a plural normalization
         var result = DefaultQuantityResolver.Resolve("eggs");
 
-        result.Amount.Should().Be(6);
+        result.Amount.Value.Should().Be(6);
     }
 }

--- a/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
+++ b/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
@@ -9,7 +9,7 @@ internal static class ShoppingListTestData
         return ShoppingList.Create(
             ShoppingListTitle.From("Test List"),
             OwnerIdentifier.From(ownerId),
-            [ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")))]);
+            [ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
     }
 
     public static ShoppingList CreateListWithItems(string ownerId = "user-123")
@@ -18,15 +18,15 @@ internal static class ShoppingListTestData
             ShoppingListTitle.From("Test List"),
             OwnerIdentifier.From(ownerId),
             [
-                ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l"))),
-                ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+                ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter)),
+                ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
                 ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(6), null)),
             ]);
     }
 
     public static ShoppingList CreateListWithItem(string ownerId, out ShoppingListItemIdentifier itemId)
     {
-        var item = ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")));
+        var item = ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter));
         var list = ShoppingList.Create(
             ShoppingListTitle.From("Test List"),
             OwnerIdentifier.From(ownerId),

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/EventSerializationTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/EventSerializationTests.cs
@@ -26,59 +26,58 @@ public class EventSerializationTests
     [Fact]
     public void ShoppingItemAdded_RoundTrip_PreservesValues()
     {
-        var original = new ShoppingItemAdded(ItemName.From("Milk"), Amount.From(2.5m), Unit.From("L"), ItemSource.Manual);
+        var original = new ShoppingItemAdded(
+            ItemName.From("Milk"),
+            Quantity.Of(Amount.From(2.5m), Unit.From("L")),
+            ItemSource.Manual);
 
         var json = JsonSerializer.Serialize(original, JsonOptions);
         var deserialized = JsonSerializer.Deserialize<ShoppingItemAdded>(json, JsonOptions)!;
 
         deserialized.ItemName.Value.Should().Be("Milk");
-        deserialized.Quantity.Value.Should().Be(2.5m);
-        deserialized.Unit!.Value.Should().Be("L");
+        deserialized.Quantity.Amount.Value.Should().Be(2.5m);
+        deserialized.Quantity.Unit!.Value.Should().Be("L");
         deserialized.Source.Value.Should().Be("manual");
     }
 
     [Fact]
-    public void ShoppingItemAdded_SerializesAsFlatJson()
+    public void ShoppingItemAdded_SerializesAsNestedQuantity()
     {
-        var @event = new ShoppingItemAdded(ItemName.From("Eggs"), Amount.From(6), Unit.From("pc"), ItemSource.From("recipe:abc"));
+        var @event = new ShoppingItemAdded(
+            ItemName.From("Eggs"),
+            Quantity.Of(Amount.From(6), Unit.From("pc")),
+            ItemSource.From("recipe:abc"));
 
         var json = JsonSerializer.Serialize(@event, JsonOptions);
 
         json.Should().Contain("\"itemName\":\"Eggs\"");
-        json.Should().Contain("\"quantity\":6");
+        json.Should().Contain("\"amount\":6");
         json.Should().Contain("\"unit\":\"pc\"");
         json.Should().Contain("\"source\":\"recipe:abc\"");
     }
 
     [Fact]
-    public void ShoppingItemAdded_DeserializesFromLegacyJson()
-    {
-        var legacyJson = """{"itemName":"Butter","quantity":250,"unit":"g","source":"manual"}""";
-
-        var deserialized = JsonSerializer.Deserialize<ShoppingItemAdded>(legacyJson, JsonOptions)!;
-
-        deserialized.ItemName.Value.Should().Be("Butter");
-        deserialized.Quantity.Value.Should().Be(250);
-        deserialized.Unit!.Value.Should().Be("g");
-    }
-
-    [Fact]
     public void ShoppingItemBought_WithNullUnit_RoundTrips()
     {
-        var original = new ShoppingItemBought(ItemName.From("Banana"), Amount.From(3), null);
+        var original = new ShoppingItemBought(
+            ItemName.From("Banana"),
+            Quantity.Of(Amount.From(3), null));
 
         var json = JsonSerializer.Serialize(original, JsonOptions);
         var deserialized = JsonSerializer.Deserialize<ShoppingItemBought>(json, JsonOptions)!;
 
         deserialized.ItemName.Value.Should().Be("Banana");
-        deserialized.Quantity.Value.Should().Be(3);
-        deserialized.Unit.Should().BeNull();
+        deserialized.Quantity.Amount.Value.Should().Be(3);
+        deserialized.Quantity.Unit.Should().BeNull();
     }
 
     [Fact]
     public void ShoppingItemRemoved_RoundTrip_PreservesReason()
     {
-        var original = new ShoppingItemRemoved(ItemName.From("Milk"), Amount.From(1), Unit.From("L"), RemovalReason.From("spoiled"));
+        var original = new ShoppingItemRemoved(
+            ItemName.From("Milk"),
+            Quantity.Of(Amount.From(1), Unit.From("L")),
+            RemovalReason.From("spoiled"));
 
         var json = JsonSerializer.Serialize(original, JsonOptions);
         var deserialized = JsonSerializer.Deserialize<ShoppingItemRemoved>(json, JsonOptions)!;
@@ -89,12 +88,15 @@ public class EventSerializationTests
     [Fact]
     public void ShoppingItemQuantityAdjusted_RoundTrip()
     {
-        var original = new ShoppingItemQuantityAdjusted(ItemName.From("Rice"), Amount.From(1.5m), Unit.From("kg"));
+        var original = new ShoppingItemQuantityAdjusted(
+            ItemName.From("Rice"),
+            Quantity.Of(Amount.From(1.5m), Unit.From("kg")));
 
         var json = JsonSerializer.Serialize(original, JsonOptions);
         var deserialized = JsonSerializer.Deserialize<ShoppingItemQuantityAdjusted>(json, JsonOptions)!;
 
-        deserialized.NewQuantity.Value.Should().Be(1.5m);
+        deserialized.NewQuantity.Amount.Value.Should().Be(1.5m);
+        deserialized.NewQuantity.Unit!.Value.Should().Be("kg");
     }
 
     [Fact]

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingItemStateTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingItemStateTests.cs
@@ -10,10 +10,7 @@ public class ShoppingItemStateTests
     [Fact]
     public void AtHome_BoughtMinusConsumedAndRemoved()
     {
-        var state = CreateState();
-        state.Bought = A(10);
-        state.Consumed = A(3);
-        state.Removed = A(2);
+        var state = CreateState() with { Bought = A(10), Consumed = A(3), Removed = A(2) };
 
         state.AtHome.Value.Should().Be(5);
     }
@@ -21,10 +18,7 @@ public class ShoppingItemStateTests
     [Fact]
     public void AtHome_NeverNegative()
     {
-        var state = CreateState();
-        state.Bought = A(1);
-        state.Consumed = A(5);
-        state.Removed = A(3);
+        var state = CreateState() with { Bought = A(1), Consumed = A(5), Removed = A(3) };
 
         state.AtHome.Value.Should().Be(0);
     }
@@ -40,9 +34,7 @@ public class ShoppingItemStateTests
     [Fact]
     public void Remaining_OnListMinusBought()
     {
-        var state = CreateState();
-        state.OnList = A(5);
-        state.Bought = A(2);
+        var state = CreateState() with { OnList = A(5), Bought = A(2) };
 
         state.Remaining.Should().Be(3);
     }
@@ -50,9 +42,7 @@ public class ShoppingItemStateTests
     [Fact]
     public void Remaining_CanBeNegative_WhenOverbought()
     {
-        var state = CreateState();
-        state.OnList = A(2);
-        state.Bought = A(5);
+        var state = CreateState() with { OnList = A(2), Bought = A(5) };
 
         state.Remaining.Should().Be(-3);
     }
@@ -60,8 +50,7 @@ public class ShoppingItemStateTests
     [Fact]
     public void IsBought_True_WhenBoughtPositive()
     {
-        var state = CreateState();
-        state.Bought = A(1);
+        var state = CreateState() with { Bought = A(1) };
 
         state.IsBought.Should().BeTrue();
     }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -186,7 +186,7 @@ public class ShoppingLedgerTests
 
         var snapshotItems = original.Items.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        var newEvents = new[] { new ShoppingItemConsumed(N("Milk"), Amount.From(1), Unit.From("L"), ItemSource.From("recipe:abc")) };
+        var newEvents = new[] { new ShoppingItemConsumed(N("Milk"), Q(1, "L"), ItemSource.From("recipe:abc")) };
 
         var rebuilt = Domain.ShoppingLedger.ShoppingLedger.FromSnapshot(
             original.Identifier, Owner("user-123"), snapshotItems, 2, newEvents);

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
@@ -11,7 +11,7 @@ public class ShoppingListItemTests
     {
         var name = ItemName.From("Flour");
         var amount = Amount.From(500);
-        var unit = Unit.From("g");
+        var unit = Unit.Gram;
 
         var item = ShoppingListItem.Create(name, Quantity.Of(amount, unit));
 
@@ -43,7 +43,7 @@ public class ShoppingListItemTests
     [Fact]
     public void Create_SetsIsCheckedToFalse()
     {
-        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")));
+        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 
         item.IsChecked.Should().BeFalse();
     }
@@ -51,7 +51,7 @@ public class ShoppingListItemTests
     [Fact]
     public void Check_SetsIsCheckedToTrue()
     {
-        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")));
+        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 
         item.Check();
 
@@ -61,7 +61,7 @@ public class ShoppingListItemTests
     [Fact]
     public void Uncheck_SetsIsCheckedToFalse()
     {
-        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")));
+        var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
         item.Check();
 
         item.Uncheck();

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -52,8 +52,8 @@ public class ShoppingListTests
     {
         List<ShoppingListItem> items =
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
-            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
         ];
 
         var shoppingList = CreateValidShoppingList(items: items);
@@ -124,7 +124,7 @@ public class ShoppingListTests
     {
         List<ShoppingListItem> items =
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
         ];
         var shoppingList = CreateValidShoppingList(items: items);
 
@@ -138,7 +138,7 @@ public class ShoppingListTests
     {
         List<ShoppingListItem> items =
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
         ];
         var shoppingList = CreateValidShoppingList(items: items);
         shoppingList.CheckOffItem(items[0].Id);
@@ -153,8 +153,8 @@ public class ShoppingListTests
     {
         List<ShoppingListItem> items =
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
-            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
         ];
         var shoppingList = CreateValidShoppingList(items: items);
 
@@ -168,8 +168,8 @@ public class ShoppingListTests
     {
         List<ShoppingListItem> items =
         [
-            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g"))),
-            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.From("g"))),
+            ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+            ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
         ];
         var shoppingList = CreateValidShoppingList(items: items);
         shoppingList.CheckAllItems();
@@ -198,7 +198,7 @@ public class ShoppingListTests
         return Domain.ShoppingList.ShoppingList.Create(
             title ?? ShoppingListTitle.From("Test Shopping List"),
             owner ?? OwnerIdentifier.From("user-123"),
-            items ?? [ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.From("g")))],
+            items ?? [ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
             recipeReference);
     }
 }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/UnitTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/UnitTests.cs
@@ -10,7 +10,7 @@ public class UnitTests
     [Fact]
     public void Constructor_ValidUnit_CreatesInstance()
     {
-        var unit = Unit.From("kg");
+        var unit = Unit.Kilogram;
 
         unit.Value.Should().Be("kg");
     }


### PR DESCRIPTION
## Summary

Combines three threads of work that all landed on the same branch (supersedes #252):

### Frontend performance
- Parallelized \`APP_INITIALIZER\` (language + theme) for faster bootstrap
- \`track ingredient.name\` instead of \`track \$index\` on recipe lists
- \`width\`/\`height\` attributes on recipe images (CLS fix)
- \`@defer\` blocks on heavy components (camera, ingredient scanner, ingredients panel)
- In-memory \`shareReplay\` cache for \`getRecipeById\` with auto-invalidation on update/delete

### Shopping domain refactor (DDD)
- 7 ledger events use \`Quantity\` VO instead of \`Amount\` + \`Unit?\` pairs
- \`ShoppingItemState\` is now an immutable record
- New \`EventSourcedAggregate<TId>\` base in Yumney.Shared with typed event-handler registry — replaces the big switch in \`Apply\`
- \`DefaultQuantityResolver\` moved from Shared → Shopping.Application; returns \`Quantity\` VO directly (no more \`ResolvedQuantity\` primitive pair)
- Request DTOs use \`Deconstruct\` returning VOs

### Bug fixes
- \`scaleIngredients\` guards against \`originalServings <= 0\` (prevents NaN/Infinity)
- \`navigator.clipboard.writeText\` has an error handler
- Removed unused \`.loading\`, \`.error\`, \`.retry-btn\` CSS

### .NET 10 API startup fixes
- \`[FromBody]\` on DELETE endpoints with body (\`RemoveItem\`, \`ClearSlot\`)
- Register \`PhotoDataValidator\` from \`Recipes.Application\` so \`IValidator<PhotoData>\` resolves as a service
- Apply prettier formatting (3 files) so the \`yarn format:check\` step passes

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — clean
- [x] \`nx run-many -t test\` — all 642 frontend tests pass
- [x] All three previously-crashed APIs (shopping/mealplan/recipes) reach \`Application started\` in Aspire
- [ ] Manual QA: recipe scaling, camera/scanner deferral, recipe-detail cache invalidation