### PR TITLE
fix: shopping detail routing and create-from-recipe flow (US-000)

### DIFF
--- a/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
@@ -22,6 +22,6 @@ export class ShoppingDetailPage {
   }
 
   async goto(identifier: string): Promise<void> {
-    await this.page.goto(`/shopping/${identifier}`);
+    await this.page.goto(`/shopping/lists/${identifier}`);
   }
 }

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.spec.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.spec.ts
@@ -187,12 +187,12 @@ describe('ShoppingCreateComponent', () => {
     tick();
 
     const router = TestBed.inject(Router);
-    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
     component.onCreateShoppingList();
     tick();
 
-    expect(navigateSpy).toHaveBeenCalledWith(['/shopping', 'list-123']);
+    expect(navigateSpy).toHaveBeenCalledWith('/shopping/lists/list-123');
     navigateSpy.mockRestore();
   }));
 

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -101,7 +101,7 @@ export class ShoppingCreateComponent implements OnInit {
         recipeIdentifier: recipe.identifier,
       }),
       ERROR_MAPS.shopping.create,
-      (result) => this.router.navigate([ROUTES.shopping.list, result.identifier]),
+      (result) => this.router.navigateByUrl(ROUTES.shopping.detail(result.identifier)),
       (error) => this.serverError.set(error),
     );
   }

--- a/client/libs/shared/models/src/lib/route-paths.ts
+++ b/client/libs/shared/models/src/lib/route-paths.ts
@@ -14,7 +14,7 @@ export const ROUTES = {
   mealPlanner: '/meal-planner',
   shopping: {
     list: '/shopping',
-    detail: (identifier: string) => `/shopping/${identifier}`,
+    detail: (identifier: string) => `/shopping/lists/${identifier}`,
     create: (recipeId: string) => `/shopping/create/${recipeId}`,
   },
 } as const;

--- a/src/Yumney.Shopping.Api/Requests/CreateShoppingListRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/CreateShoppingListRequest.cs
@@ -6,7 +6,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 public sealed record CreateShoppingListRequest(
     string Title,
     List<ShoppingListItem> Items,
-    Guid? RecipeReference = null)
+    Guid? RecipeIdentifier = null)
 {
     public (ShoppingListTitle Title, IReadOnlyList<CommandItem> Items, RecipeReference? RecipeReference) ToValueObjects() =>
     (
@@ -17,5 +17,5 @@ public sealed record CreateShoppingListRequest(
                 Amount.FromNullable(i.Amount),
                 Unit.FromNullable(i.Unit))))
             .ToList(),
-        Domain.ShoppingList.RecipeReference.FromNullable(RecipeReference));
+        Domain.ShoppingList.RecipeReference.FromNullable(RecipeIdentifier));
 }


### PR DESCRIPTION
## Summary

Two related runtime fixes for the shopping flow.

### 1. Shopping detail route path mismatch
\`ROUTES.shopping.detail\` returned \`/shopping/<id>\`, but the actual route in \`shopping.routes.ts\` is \`lists/:identifier\`. Following any generated detail link triggered \`NG04002\` from the Angular Router. Fixed the path generator and the matching e2e page object.

### 2. Create-shopping-list-from-recipe flow
Two related bugs broke the create flow end-to-end:

- After successful creation, \`ShoppingCreateComponent\` navigated to \`[ROUTES.shopping.list, identifier]\` which builds \`/shopping/<id>\` — the same broken URL as #1. Switched to \`ROUTES.shopping.detail(id)\`.
- Frontend posts \`recipeIdentifier\` but backend \`CreateShoppingListRequest\` declared the property as \`RecipeReference\`. System.Text.Json is case-insensitive but doesn't translate field names, so the recipe linkage was silently dropped on every create. Renamed the backend property to match the wire format.

## Test plan
- [x] All 642 frontend tests pass
- [x] Backend builds clean
- [ ] Manual: navigate from a recipe detail page to "Create Shopping List", complete the flow, verify the resulting shopping list opens correctly and has the recipe linked