### PR TITLE
refactor(infra): per-API Scalar links and inherit AppHost environment (US-000)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.2.2" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.2.2-preview.1.26207.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,6 @@
     <!-- API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.20" />
-    <PackageVersion Include="Scalar.Aspire" Version="0.9.22" />
     <!-- DI, Configuration & Logging Abstractions -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />

--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -21,7 +21,8 @@ internal static class AppHostExtensions
             .WaitFor(keycloak)
             .WaitFor(migrationRunner)
             .WaitFor(redis)
-            .WaitFor(messaging);
+            .WaitFor(messaging)
+            .WithUrl("/scalar/v1", "Scalar");
     }
 
     public static IResourceBuilder<ProjectResource> WithLlmProvider(

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -95,18 +95,24 @@ if (!options.DatabaseOnly)
             .WithEndpoint("http", e => e.IsExternal = true);
     }
 
+    var apiEnvironment = builder.Environment.EnvironmentName;
+
     var recipesApi = builder
         .AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
+        .WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
         .AsYumneyApi(recipesDb, keycloak, redis, messaging, migrationRunner)
         .WithLlmProvider(builder, options);
     var shoppingApi = builder
         .AddProject<Projects.Yumney_Shopping_Api>("shopping-api")
+        .WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
         .AsYumneyApi(shoppingDb, keycloak, redis, messaging, migrationRunner);
     var usersApi = builder
         .AddProject<Projects.Yumney_Users_Api>("users-api")
+        .WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
         .AsYumneyApi(usersDb, keycloak, redis, messaging, migrationRunner);
     var mealplanApi = builder
         .AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
+        .WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
         .AsYumneyApi(mealplanDb, keycloak, redis, messaging, migrationRunner);
 
     // ── Container Registry (GHCR for CI/CD) ──

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.AppContainers;
-using Scalar.Aspire;
 using SmartSolutionsLab.Yumney.AppHost;
 using SmartSolutionsLab.Yumney.AppHost.Options;
 
@@ -174,21 +173,6 @@ if (!options.DatabaseOnly)
 
     if (isRunMode)
     {
-        if (!options.E2ETests)
-        {
-            var keycloakRealmUrl = "http://localhost:8080/realms/yumney";
-            builder.AddScalarApiReference("scalar", scalarOptions => scalarOptions
-                    .WithTheme(ScalarTheme.Mars)
-                    .AddAuthorizationCodeFlow("keycloak", flow => flow
-                        .WithClientId("yumney-web")
-                        .WithAuthorizationUrl($"{keycloakRealmUrl}/protocol/openid-connect/auth")
-                        .WithTokenUrl($"{keycloakRealmUrl}/protocol/openid-connect/token")
-                        .WithSelectedScopes(["openid", "profile"])))
-                .WithApiReference(recipesApi)
-                .WithApiReference(shoppingApi)
-                .WithApiReference(usersApi);
-        }
-
         var addMfe = (string name, string script, int port) =>
             builder.AddJavaScriptApp(name, "../../client", script)
                 .WithYarn()

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -113,7 +113,10 @@ if (!options.DatabaseOnly)
     var mealplanApi = builder
         .AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
         .WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-        .AsYumneyApi(mealplanDb, keycloak, redis, messaging, migrationRunner);
+        .AsYumneyApi(mealplanDb, keycloak, redis, messaging, migrationRunner)
+        .WithReference(recipesApi)
+        .WithReference(shoppingApi)
+        .WithReference(usersApi);
 
     // ── Container Registry (GHCR for CI/CD) ──
 #pragma warning disable ASPIRECOMPUTE003

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.Yarp" />
     <PackageReference Include="Aspire.Hosting.JavaScript" />
-    <PackageReference Include="Scalar.Aspire" />
   </ItemGroup>
 
 </Project>

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Services;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
@@ -25,6 +27,12 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
         });
 
         services.AddScoped<IWeeklyPlanRepository, WeeklyPlanRepository>();
+        services.AddScoped<IRecipeIngredientProvider, HttpRecipeIngredientProvider>();
+        services.AddScoped<IShoppingListWriter, HttpShoppingListWriter>();
+        services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
+        services.AddHttpClient("recipes-api", client => client.BaseAddress = new Uri("http://recipes-api"));
+        services.AddHttpClient("shopping-api", client => client.BaseAddress = new Uri("http://shopping-api"));
+        services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"));
         services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb");
 
         return services;

--- a/src/Yumney.MealPlan.Infrastructure/Services/HttpRecipeIngredientProvider.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Services/HttpRecipeIngredientProvider.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Services;
+
+public sealed class HttpRecipeIngredientProvider(IHttpClientFactory httpClientFactory) : IRecipeIngredientProvider
+{
+    public async Task<IReadOnlyList<RecipeIngredientInfo>> GetIngredientsAsync(
+        Guid recipeIdentifier,
+        CancellationToken cancellationToken = default)
+    {
+        var client = httpClientFactory.CreateClient("recipes-api");
+        var response = await client.GetFromJsonAsync<RecipeResponse>(
+            $"/api/v1/recipes/{recipeIdentifier}",
+            cancellationToken);
+
+        if (response is null)
+            return [];
+
+        return response.Ingredients
+            .Select(i => new RecipeIngredientInfo(i.Name, i.Amount, i.Unit, response.Servings))
+            .ToList();
+    }
+
+    private sealed record RecipeResponse(
+        int? Servings,
+        IReadOnlyList<IngredientResponse> Ingredients);
+
+    private sealed record IngredientResponse(string Name, decimal? Amount, string? Unit);
+}

--- a/src/Yumney.MealPlan.Infrastructure/Services/HttpShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Services/HttpShoppingListWriter.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Services;
+
+public sealed class HttpShoppingListWriter(IHttpClientFactory httpClientFactory) : IShoppingListWriter
+{
+    public async Task AddItemsAsync(
+        string ownerId,
+        IReadOnlyList<ShoppingItemRequest> items,
+        CancellationToken cancellationToken = default)
+    {
+        var client = httpClientFactory.CreateClient("shopping-api");
+
+        foreach (var item in items)
+        {
+            var request = new AddItemRequest(item.ItemName, item.Quantity, item.Unit);
+            await client.PostAsJsonAsync("/api/v1/shopping-lists/items", request, cancellationToken);
+        }
+    }
+
+    private sealed record AddItemRequest(string Name, decimal Quantity, string? Unit);
+}

--- a/src/Yumney.MealPlan.Infrastructure/Services/HttpStaplesProvider.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Services/HttpStaplesProvider.cs
@@ -1,0 +1,19 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Services;
+
+public sealed class HttpStaplesProvider(IHttpClientFactory httpClientFactory) : IStaplesProvider
+{
+    public async Task<IReadOnlySet<string>> GetStapleNamesAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var client = httpClientFactory.CreateClient("users-api");
+        var staples = await client.GetFromJsonAsync<List<string>>(
+            "/api/v1/users/staples",
+            cancellationToken);
+
+        return (staples ?? []).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
+++ b/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -163,21 +163,20 @@ public static class HostBuilderExtensions
 
         app.MapOpenApi();
 
-        if (!app.Environment.IsProduction())
+        // Scalar is safe to expose in all environments — the YARP gateway
+        // only routes /api/v1/*, so /scalar/v1 is unreachable from outside.
+        app.MapScalarApiReference(options =>
         {
-            app.MapScalarApiReference(options =>
-            {
-                options
-                    .WithTitle("Yumney API")
-                    .WithTheme(ScalarTheme.Saturn)
-                    .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-                    .AddAuthorizationCodeFlow("keycloak", flow => flow
-                        .WithClientId(KeycloakDefaults.WebClientId)
-                        .WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
-                        .WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
-                        .WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile]));
-            });
-        }
+            options
+                .WithTitle("Yumney API")
+                .WithTheme(ScalarTheme.Saturn)
+                .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
+                .AddAuthorizationCodeFlow("keycloak", flow => flow
+                    .WithClientId(KeycloakDefaults.WebClientId)
+                    .WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
+                    .WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
+                    .WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile]));
+        });
 
         app.MapDefaultEndpoints();
 

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -163,20 +163,21 @@ public static class HostBuilderExtensions
 
         app.MapOpenApi();
 
-        // Scalar is safe to expose in all environments — the YARP gateway
-        // only routes /api/v1/*, so /scalar/v1 is unreachable from outside.
-        app.MapScalarApiReference(options =>
+        if (!app.Environment.IsProduction())
         {
-            options
-                .WithTitle("Yumney API")
-                .WithTheme(ScalarTheme.Saturn)
-                .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-                .AddAuthorizationCodeFlow("keycloak", flow => flow
-                    .WithClientId(KeycloakDefaults.WebClientId)
-                    .WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
-                    .WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
-                    .WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile]));
-        });
+            app.MapScalarApiReference(options =>
+            {
+                options
+                    .WithTitle("Yumney API")
+                    .WithTheme(ScalarTheme.Saturn)
+                    .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
+                    .AddAuthorizationCodeFlow("keycloak", flow => flow
+                        .WithClientId(KeycloakDefaults.WebClientId)
+                        .WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
+                        .WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
+                        .WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile]));
+            });
+        }
 
         app.MapDefaultEndpoints();
 

--- a/src/Yumney.Users.Api/StaplesEndpoints.cs
+++ b/src/Yumney.Users.Api/StaplesEndpoints.cs
@@ -1,0 +1,27 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Api;
+
+public static class StaplesEndpoints
+{
+    public static IEndpointRouteBuilder MapStaplesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/users/staples");
+
+        group.MapGet("/", GetStaples)
+            .WithName("GetUserStaples")
+            .WithTags("Users")
+            .Produces<IReadOnlyList<string>>();
+
+        return app;
+
+        static async Task<IResult> GetStaples(
+            IStaplesProvider staplesProvider,
+            ICurrentUser currentUser,
+            CancellationToken cancellationToken)
+        {
+            var staples = await staplesProvider.GetStapleNamesAsync(currentUser.UserId, cancellationToken);
+            return Results.Ok(staples.ToList());
+        }
+    }
+}

--- a/src/Yumney.Users.Api/UsersEndpoints.cs
+++ b/src/Yumney.Users.Api/UsersEndpoints.cs
@@ -9,6 +9,7 @@ public static class UsersEndpoints
         app.MapAuthEndpoints();
         app.MapUserActivityEndpoints();
         app.MapProfileEndpoints();
+        app.MapStaplesEndpoints();
 
         return app;
     }

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
@@ -138,5 +141,27 @@ public sealed class AspireFixture : IAsyncLifetime
         await using var context = await CreateUsersDbContextAsync();
         context.AppUserProfiles.AddRange(profiles);
         await context.SaveChangesAsync();
+    }
+
+    public async Task<HttpClient> CreateAuthenticatedClientAsync(string resourceName)
+    {
+        var keycloakClient = App.CreateHttpClient("keycloak");
+        var tokenResponse = await keycloakClient.PostAsync(
+            "/realms/yumney/protocol/openid-connect/token",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "password",
+                ["client_id"] = "yumney-web",
+                ["username"] = "testuser",
+                ["password"] = "Test1234",
+            }));
+
+        tokenResponse.EnsureSuccessStatusCode();
+        var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var accessToken = tokenJson.GetProperty("access_token").GetString()!;
+
+        var client = App.CreateHttpClient(resourceName);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return client;
     }
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListCreateFlowTests(AspireFixture fixture)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public async Task CreateAndRetrieve_PersistsShoppingList()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+        // Create
+        var createRequest = new
+        {
+            title = "Integration Test List",
+            items = new object[]
+            {
+                new { name = "Pasta", amount = 500m, unit = "g" },
+                new { name = "Tomatoes", amount = 4m },
+                new { name = "Olive Oil", amount = 100m, unit = "ml" },
+            },
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var identifier = created.GetProperty("identifier").GetGuid();
+        identifier.Should().NotBeEmpty();
+
+        // Retrieve
+        var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{identifier}");
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        detail.GetProperty("title").GetString().Should().Be("Integration Test List");
+        detail.GetProperty("items").GetArrayLength().Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreateWithRecipeReference_PersistsLink()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+        var recipeId = Guid.NewGuid();
+        var createRequest = new
+        {
+            title = "Recipe Link Test",
+            items = new[] { new { name = "Flour", amount = 1000m, unit = "g" } },
+            recipeIdentifier = recipeId,
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        created.GetProperty("recipeReference").GetGuid().Should().Be(recipeId);
+    }
+
+    [Fact]
+    public async Task CreateAndCheckOff_PersistsCheckedState()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+        // Create
+        var createRequest = new
+        {
+            title = "Check-Off Test",
+            items = new[] { new { name = "Milk", amount = 1m, unit = "L" } },
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var listId = created.GetProperty("identifier").GetGuid();
+        var itemId = created.GetProperty("items")[0].GetProperty("identifier").GetGuid();
+
+        // Check off item
+        var checkResponse = await client.PutAsJsonAsync(
+            $"/api/v1/shopping-lists/{listId}/items/{itemId}/check",
+            new { isChecked = true });
+
+        checkResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Retrieve and verify
+        var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{listId}");
+        var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        detail.GetProperty("items")[0].GetProperty("isChecked").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Create_WithoutAuth_Returns401()
+    {
+        var client = fixture.ShoppingApi;
+
+        var createRequest = new
+        {
+            title = "Unauthorized",
+            items = new[] { new { name = "Water", amount = 1m, unit = "L" } },
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_EmptyTitle_ReturnsValidationError()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+        var createRequest = new
+        {
+            title = string.Empty,
+            items = new[] { new { name = "Milk", amount = 1m, unit = "L" } },
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Create_NoItems_ReturnsValidationError()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+        var createRequest = new
+        {
+            title = "Empty List",
+            items = Array.Empty<object>(),
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/shopping-lists", createRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+}


### PR DESCRIPTION
## Summary

- Remove centralized `AddScalarApiReference` from AppHost and the `Scalar.Aspire` package dependency
- Add `WithUrl("/scalar/v1", "Scalar")` per API so the Aspire dashboard links directly to each backend's Scalar UI
- Propagate the AppHost's `ASPNETCORE_ENVIRONMENT` (Development via launchSettings) to all API projects — Aspire defaults child projects to Production, which skipped Scalar registration and other dev-only middleware
- Restore the `!IsProduction()` guard on `MapScalarApiReference` (now works correctly since APIs inherit Development)

## Test plan
- [ ] Restart Aspire, verify each API shows "Scalar" link on dashboard
- [ ] Click Scalar link — verify it opens and shows the API docs
- [ ] Verify APIs log `Hosting environment: Development`
- [ ] Verify Scalar is NOT exposed through the gateway (GET localhost:5100/scalar/v1 should 404)