### PR TITLE
perf(infra): speed up Aspire AppHost startup (US-000)

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -5,7 +5,7 @@ export default [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*'],
+    ignores: ['**/dist', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*', '**/federation.config.js'],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -14,14 +14,11 @@ internal static class AppHostExtensions
     {
         return api
             .WithHttpEndpoint()
-            .WithReference(keycloak)
             .WithReference(database)
+            .WaitFor(migrationRunner)
+            .WithReference(keycloak)
             .WithReference(redis)
             .WithReference(messaging)
-            .WaitFor(keycloak)
-            .WaitFor(migrationRunner)
-            .WaitFor(redis)
-            .WaitFor(messaging)
             .WithUrl("/scalar/v1", "Scalar");
     }
 

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -75,10 +75,10 @@ if (!options.DatabaseOnly)
 
     if (isRunMode && !options.E2ETests)
     {
-        var mailpit = builder.AddContainer("mailpit", "axllent/mailpit", "latest")
+        builder.AddContainer("mailpit", "axllent/mailpit", "latest")
             .WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
-            .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp");
-        keycloak.WaitFor(mailpit);
+            .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
+            .WithLifetime(ContainerLifetime.Persistent);
     }
     else
     {
@@ -202,14 +202,7 @@ if (!options.DatabaseOnly)
             .WithReference(mealplanApi)
             .WithReference(shell)
             .WithReference(keycloak)
-            .WaitFor(recipesApi)
-            .WaitFor(shoppingApi)
-            .WaitFor(usersApi)
-            .WaitFor(mealplanApi)
-            .WaitFor(shell)
-            .WaitFor(recipesMfe)
-            .WaitFor(shoppingMfe)
-            .WaitFor(accountMfe);
+            .WaitFor(keycloak);
     }
     else
     {


### PR DESCRIPTION
## Summary

Reduces the Aspire startup dependency chain so services start in parallel rather than sequentially.

- **Remove Keycloak → Mailpit WaitFor** — Keycloak no longer blocks on Mailpit. Mailpit made persistent.
- **APIs no longer WaitFor keycloak/redis/messaging** — only wait for migrations (hard dependency). MassTransit and Redis reconnect automatically.
- **Gateway only WaitFor keycloak** — previously waited for all 4 APIs + 4 MFEs. YARP handles upstream unavailability gracefully.

### Before
`postgres → dbs → migrations → keycloak healthy → all APIs → gateway` (sequential)

### After
`postgres → dbs → migrations → APIs` (parallel with keycloak/redis/messaging)
`keycloak → gateway` (parallel with APIs)

## Test plan
- [x] All services start and report Healthy in Aspire dashboard
- [x] mealplan-api connects to recipes/shopping/users APIs successfully
- [ ] Manual QA: login flow works (Keycloak auth)
- [ ] Manual QA: recipe import works (Redis cache + RabbitMQ events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)