### PR TITLE
test(e2e): add recipe, meal plan, and shopping generation E2E tests (US-000)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -209,7 +209,7 @@ if (!options.DatabaseOnly)
             .WithReference(keycloak)
             .WaitFor(keycloak);
     }
-    else
+    else if (!isRunMode)
     {
         var frontend = builder
             .AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")

--- a/tests/Yumney.Integration.Tests/MealPlan/GenerateShoppingListFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/GenerateShoppingListFlowTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.MealPlan;
+
+[Collection(AspireCollection.Name)]
+public class GenerateShoppingListFlowTests(AspireFixture fixture)
+{
+    private const int TestWeek = 52;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private static int Year => DateTime.UtcNow.Year;
+
+    private static string WeekPath => $"/api/v1/meal-plans/{Year}/w/{TestWeek}";
+
+    [Fact(Skip = "Requires auth propagation in HTTP adapters (service-to-service calls don't forward JWT)")]
+    public async Task GenerateShoppingList_WithRecipes_ReturnsItemCount()
+    {
+        // 1. Create a recipe with ingredients via recipes-api
+        using var recipesClient = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var recipeRequest = new
+        {
+            title = "Shopping Gen Recipe",
+            ingredients = new object[]
+            {
+                new { name = "Flour", amount = 500m, unit = "g" },
+                new { name = "Sugar", amount = 200m, unit = "g" },
+                new { name = "Butter", amount = 100m, unit = "g" },
+            },
+            steps = new object[] { new { number = 1, description = "Mix all" } },
+            servings = 4,
+        };
+
+        var recipeResponse = await recipesClient.PostAsJsonAsync("/api/v1/recipes", recipeRequest);
+        recipeResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var recipe = await recipeResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var recipeId = recipe.GetProperty("identifier").GetGuid();
+
+        // 2. Assign recipe to meal plan via mealplan-api
+        using var mealplanClient = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        var assignRequest = new
+        {
+            day = DayOfWeek.Monday,
+            recipeIdentifier = recipeId,
+            recipeTitle = "Shopping Gen Recipe",
+            mealType = 0,
+            servings = 4,
+        };
+
+        var assignResponse = await mealplanClient.PostAsJsonAsync($"{WeekPath}/slots", assignRequest);
+        assignResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // 3. Generate shopping list
+        var generateResponse = await mealplanClient.PostAsync($"{WeekPath}/generate-shopping-list", null);
+
+        generateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await generateResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        result.GetProperty("itemsAdded").GetInt32().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GenerateShoppingList_EmptyPlan_ReturnsError()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        // Use a week with no assignments
+        var response = await client.PostAsync(
+            $"/api/v1/meal-plans/{Year}/w/1/generate-shopping-list", null);
+
+        // Should fail — no recipes assigned
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.BadRequest,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task GenerateShoppingList_WithoutAuth_Returns401()
+    {
+        var client = fixture.MealPlanApi;
+
+        var response = await client.PostAsync($"{WeekPath}/generate-shopping-list", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.MealPlan;
+
+[Collection(AspireCollection.Name)]
+public class MealPlanFlowTests(AspireFixture fixture)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private static int Year => DateTime.UtcNow.Year;
+
+    private static int Week => System.Globalization.ISOWeek.GetWeekOfYear(DateTime.UtcNow);
+
+    private static string WeekPath => $"/api/v1/meal-plans/{Year}/w/{Week}";
+
+    [Fact]
+    public async Task GetWeeklyPlan_EmptyWeek_ReturnsEmptySlots()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        var response = await client.GetAsync(WeekPath);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var plan = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        plan.GetProperty("week").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task AssignRecipe_ValidSlot_ReturnsOk()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        var recipeId = Guid.NewGuid();
+        var request = new
+        {
+            day = DayOfWeek.Monday,
+            recipeIdentifier = recipeId,
+            recipeTitle = "Test Recipe",
+            mealType = 0,
+            servings = 4,
+        };
+
+        var response = await client.PostAsJsonAsync($"{WeekPath}/slots", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var plan = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var slots = plan.GetProperty("slots");
+        slots.GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task AssignAndClearSlot_RemovesAssignment()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        // Assign
+        var assignRequest = new
+        {
+            day = DayOfWeek.Tuesday,
+            recipeIdentifier = Guid.NewGuid(),
+            recipeTitle = "Temp Recipe",
+            mealType = 0,
+        };
+        await client.PostAsJsonAsync($"{WeekPath}/slots", assignRequest);
+
+        // Clear
+        var clearRequest = new { day = DayOfWeek.Tuesday, mealType = 0 };
+        var clearResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, $"{WeekPath}/slots")
+        {
+            Content = JsonContent.Create(clearRequest),
+        });
+
+        clearResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task AssignRecipe_ThenGetPlan_SlotIsPopulated()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+        var recipeId = Guid.NewGuid();
+        var request = new
+        {
+            day = DayOfWeek.Wednesday,
+            recipeIdentifier = recipeId,
+            recipeTitle = "Wednesday Dinner",
+            mealType = 0,
+            servings = 2,
+        };
+
+        await client.PostAsJsonAsync($"{WeekPath}/slots", request);
+
+        var response = await client.GetAsync(WeekPath);
+        var plan = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var slots = plan.GetProperty("slots");
+
+        var wednesdayDinner = slots.EnumerateArray()
+            .FirstOrDefault(s =>
+                s.GetProperty("day").GetString() == "Wednesday" &&
+                s.GetProperty("mealType").GetString() == "Dinner" &&
+                !s.GetProperty("isEmpty").GetBoolean());
+
+        wednesdayDinner.GetProperty("recipeTitle").GetString().Should().Be("Wednesday Dinner");
+        wednesdayDinner.GetProperty("servings").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetWeeklyPlan_WithoutAuth_Returns401()
+    {
+        var client = fixture.MealPlanApi;
+
+        var response = await client.GetAsync(WeekPath);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeSaveFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeSaveFlowTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes;
+
+[Collection(AspireCollection.Name)]
+public class RecipeSaveFlowTests(AspireFixture fixture)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public async Task Save_ValidRecipe_ReturnsCreated()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var request = BuildRecipeRequest("Save Test Pasta");
+
+        var response = await client.PostAsJsonAsync("/api/v1/recipes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Save_ValidRecipe_ReturnsIdentifierAndTitle()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var request = BuildRecipeRequest("Identifier Test Recipe");
+
+        var response = await client.PostAsJsonAsync("/api/v1/recipes", request);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        body.GetProperty("identifier").GetGuid().Should().NotBeEmpty();
+        body.GetProperty("title").GetString().Should().Be("Identifier Test Recipe");
+    }
+
+    [Fact]
+    public async Task SaveAndRetrieve_PersistsAllFields()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var request = new
+        {
+            title = "Full Recipe Test",
+            description = "A complete test recipe",
+            ingredients = new object[]
+            {
+                new { name = "Spaghetti", amount = 500m, unit = "g" },
+                new { name = "Eggs", amount = 4m },
+            },
+            steps = new object[]
+            {
+                new { number = 1, description = "Boil pasta" },
+                new { number = 2, description = "Mix eggs" },
+            },
+            servings = 4,
+            prepTimeMinutes = 10,
+            cookTimeMinutes = 20,
+            difficulty = "medium",
+            tags = new[] { "italian", "quick" },
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/recipes", request);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var id = created.GetProperty("identifier").GetGuid();
+
+        var getResponse = await client.GetAsync($"/api/v1/recipes/{id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        detail.GetProperty("title").GetString().Should().Be("Full Recipe Test");
+        detail.GetProperty("description").GetString().Should().Be("A complete test recipe");
+        detail.GetProperty("servings").GetInt32().Should().Be(4);
+        detail.GetProperty("prepTimeMinutes").GetInt32().Should().Be(10);
+        detail.GetProperty("cookTimeMinutes").GetInt32().Should().Be(20);
+        detail.GetProperty("difficulty").GetString().Should().Be("medium");
+        detail.GetProperty("ingredients").GetArrayLength().Should().Be(2);
+        detail.GetProperty("steps").GetArrayLength().Should().Be(2);
+        detail.GetProperty("tags").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SaveAndUpdate_PersistsChanges()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var createRequest = BuildRecipeRequest("Before Update");
+        var createResponse = await client.PostAsJsonAsync("/api/v1/recipes", createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var id = created.GetProperty("identifier").GetGuid();
+
+        var updateRequest = new
+        {
+            title = "After Update",
+            ingredients = new object[] { new { name = "Updated Ingredient", amount = 1m, unit = "pc" } },
+            steps = new object[] { new { number = 1, description = "Updated step" } },
+            servings = 2,
+        };
+
+        var updateResponse = await client.PutAsJsonAsync($"/api/v1/recipes/{id}", updateRequest);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getResponse = await client.GetAsync($"/api/v1/recipes/{id}");
+        var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+
+        detail.GetProperty("title").GetString().Should().Be("After Update");
+        detail.GetProperty("servings").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SaveAndDelete_RemovesRecipe()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/recipes", BuildRecipeRequest("Delete Me"));
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var id = created.GetProperty("identifier").GetGuid();
+
+        var deleteResponse = await client.DeleteAsync($"/api/v1/recipes/{id}");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var getResponse = await client.GetAsync($"/api/v1/recipes/{id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Save_EmptyTitle_ReturnsValidationError()
+    {
+        using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+        var request = new
+        {
+            title = string.Empty,
+            ingredients = new object[] { new { name = "Milk" } },
+            steps = new object[] { new { number = 1, description = "Pour" } },
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/recipes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Save_WithoutAuth_Returns401()
+    {
+        var client = fixture.RecipesApi;
+
+        var response = await client.PostAsJsonAsync("/api/v1/recipes", BuildRecipeRequest("Unauthorized"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static object BuildRecipeRequest(string title) => new
+    {
+        title,
+        ingredients = new object[] { new { name = "Test Ingredient", amount = 1m, unit = "pc" } },
+        steps = new object[] { new { number = 1, description = "Test step" } },
+    };
+}


### PR DESCRIPTION
## Summary

Add 15 new integration tests covering three previously untested flows:

### RecipeSaveFlowTests (7 tests)
- Save recipe via API, verify created response
- Save and retrieve with all fields (ingredients, steps, tags, timing)
- Save and update, verify changes persist
- Save and delete, verify 404 on re-fetch
- Validation error on empty title (422)
- Auth guard (401 without token)

### MealPlanFlowTests (5 tests)
- Get empty weekly plan
- Assign recipe to slot
- Assign and clear slot
- Assign and verify slot populated on re-fetch
- Auth guard (401 without token)

### GenerateShoppingListFlowTests (3 tests)
- Generate shopping list from meal plan with recipes (skipped — needs auth propagation in HTTP adapters)
- Empty plan returns error
- Auth guard (401 without token)

### Fixes
- Fix AppHost to skip Docker frontend build in E2E mode
- Use integer enum values for DayOfWeek/MealType (no JsonStringEnumConverter)

**Integration tests: 77 passed, 1 skipped (was 63)**

## Test plan
- [x] All 77 integration tests pass locally, 1 skipped
- [x] All backend unit tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)