### PR TITLE
feat(recipes): implement meal plan recipe assignment flow (US-000)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -22,6 +22,8 @@
   "recipes": {
     "list": {
       "title": "Meine Rezepte",
+      "assignTitle": "Rezept auswählen",
+      "assign": "Zum Essensplan hinzufügen",
       "sortLabel": "Rezepte sortieren",
       "sort": {
         "dateDesc": "Neueste zuerst",

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -22,6 +22,8 @@
   "recipes": {
     "list": {
       "title": "My Recipes",
+      "assignTitle": "Select a recipe",
+      "assign": "Assign to meal plan",
       "sortLabel": "Sort recipes",
       "sort": {
         "dateDesc": "Newest first",

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -1,43 +1,78 @@
-<a class="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
-  @if (recipe().imageUrl) {
-    <img
-      [src]="recipe().imageUrl"
-      [alt]="recipe().title"
-      class="recipe-image"
-      loading="lazy"
-      width="400"
-      height="225"
-    />
-  } @else {
-    <div class="recipe-image-placeholder"></div>
-  }
-  <div class="favorite-overlay">
-    <yn-favorite-button [isFavorite]="recipe().isFavorite" (toggled)="onToggleFavorite()" />
-  </div>
-  <div class="recipe-info">
-    <h3 class="recipe-title">{{ recipe().title }}</h3>
-    @if (recipe().description) {
-      <p class="recipe-description">{{ recipe().description }}</p>
+@if (assignMode()) {
+  <div class="recipe-card assign-card" (click)="onAssign($event)" *transloco="let t">
+    @if (recipe().imageUrl) {
+      <img
+        [src]="recipe().imageUrl"
+        [alt]="recipe().title"
+        class="recipe-image"
+        loading="lazy"
+        width="400"
+        height="225"
+      />
+    } @else {
+      <div class="recipe-image-placeholder"></div>
     }
-    <div class="recipe-meta">
-      @if (recipe().servings) {
-        <span class="meta-item">{{
-          t('recipes.list.servings', { count: recipe().servings })
-        }}</span>
-      }
-      @if (recipe().prepTimeMinutes) {
-        <span class="meta-item">{{
-          t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
-        }}</span>
-      }
-      @if (recipe().cookTimeMinutes) {
-        <span class="meta-item">{{
-          t('recipes.list.cookTime', { minutes: recipe().cookTimeMinutes })
-        }}</span>
-      }
-      @if (recipe().difficulty) {
-        <span class="meta-item">{{ recipe().difficulty }}</span>
-      }
+    <div class="assign-overlay">
+      <span>{{ t('recipes.list.assign') }}</span>
+    </div>
+    <div class="recipe-info">
+      <h3 class="recipe-title">{{ recipe().title }}</h3>
+      <div class="recipe-meta">
+        @if (recipe().servings) {
+          <span class="meta-item">{{
+            t('recipes.list.servings', { count: recipe().servings })
+          }}</span>
+        }
+        @if (recipe().prepTimeMinutes) {
+          <span class="meta-item">{{
+            t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
+          }}</span>
+        }
+      </div>
     </div>
   </div>
-</a>
+} @else {
+  <a class="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
+    @if (recipe().imageUrl) {
+      <img
+        [src]="recipe().imageUrl"
+        [alt]="recipe().title"
+        class="recipe-image"
+        loading="lazy"
+        width="400"
+        height="225"
+      />
+    } @else {
+      <div class="recipe-image-placeholder"></div>
+    }
+    <div class="favorite-overlay">
+      <yn-favorite-button [isFavorite]="recipe().isFavorite" (toggled)="onToggleFavorite()" />
+    </div>
+    <div class="recipe-info">
+      <h3 class="recipe-title">{{ recipe().title }}</h3>
+      @if (recipe().description) {
+        <p class="recipe-description">{{ recipe().description }}</p>
+      }
+      <div class="recipe-meta">
+        @if (recipe().servings) {
+          <span class="meta-item">{{
+            t('recipes.list.servings', { count: recipe().servings })
+          }}</span>
+        }
+        @if (recipe().prepTimeMinutes) {
+          <span class="meta-item">{{
+            t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
+          }}</span>
+        }
+        @if (recipe().cookTimeMinutes) {
+          <span class="meta-item">{{
+            t('recipes.list.cookTime', { minutes: recipe().cookTimeMinutes })
+          }}</span>
+        }
+        @if (recipe().difficulty) {
+          <span class="meta-item">{{ recipe().difficulty }}</span>
+        }
+      </div>
+    </div>
+  </a>
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -32,7 +32,11 @@
     </div>
   </div>
 } @else {
-  <a class="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
+  <a
+    class="recipe-card"
+    [routerLink]="ROUTES.recipes.detail(recipe().identifier)"
+    *transloco="let t"
+  >
     @if (recipe().imageUrl) {
       <img
         [src]="recipe().imageUrl"

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.scss
@@ -83,3 +83,31 @@
   padding: var(--yn-space-1) var(--yn-space-3);
   border-radius: var(--yn-radius-badge);
 }
+
+.assign-card {
+  &:hover .assign-overlay {
+    opacity: 1;
+  }
+}
+
+.assign-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--yn-space-2);
+  background: rgb(0 0 0 / 50%);
+  color: white;
+  font-weight: var(--yn-font-semibold);
+  font-size: var(--yn-text-lg);
+  opacity: 0;
+  transition: opacity var(--yn-duration-fast) ease;
+  z-index: 3;
+  border-radius: var(--yn-radius-card);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.ts
@@ -16,9 +16,17 @@ export class RecipeCardComponent {
   protected readonly ROUTES = ROUTES;
 
   recipe = input.required<RecipeListItem>();
+  assignMode = input(false);
   toggleFavorite = output<string>();
+  assign = output<RecipeListItem>();
 
   protected onToggleFavorite(): void {
     this.toggleFavorite.emit(this.recipe().identifier);
+  }
+
+  protected onAssign(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.assign.emit(this.recipe());
   }
 }

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -1,6 +1,15 @@
 <div class="recipe-list-container" *transloco="let t">
   <div class="list-header">
-    <h1>{{ t('recipes.list.title') }}</h1>
+    @if (assignMode()) {
+      <div class="assign-header">
+        <button class="btn-back" (click)="onCancelAssign()">
+          <lucide-icon name="arrow-left" [size]="20" />
+        </button>
+        <h1>{{ t('recipes.list.assignTitle') }}</h1>
+      </div>
+    } @else {
+      <h1>{{ t('recipes.list.title') }}</h1>
+    }
     <div class="sort-dropdown" #sortDropdown>
       <button
         type="button"
@@ -98,7 +107,13 @@
   @if (recipes().length > 0) {
     <div class="recipe-grid">
       @for (recipe of recipes(); track recipe.identifier) {
-        <yn-recipe-card #recipeCard [recipe]="recipe" (toggleFavorite)="onToggleFavorite($event)" />
+        <yn-recipe-card
+          #recipeCard
+          [recipe]="recipe"
+          [assignMode]="assignMode()"
+          (toggleFavorite)="onToggleFavorite($event)"
+          (assign)="onAssignRecipe($event)"
+        />
       }
     </div>
   }

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -20,6 +20,26 @@
   }
 }
 
+.assign-header {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+
+  .btn-back {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border: 1px solid var(--yn-glass-border);
+    border-radius: var(--yn-radius-circle);
+    background: var(--yn-glass-bg);
+    color: var(--yn-text);
+    cursor: pointer;
+  }
+}
+
 .sort-dropdown {
   position: relative;
 }

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -16,7 +16,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, debounceTime } from 'rxjs';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { RecipeApiService, RecipeListItem, GetRecipesParams } from '@yumney/shared/api-client';
+import {
+  RecipeApiService,
+  MealPlanApiService,
+  RecipeListItem,
+  GetRecipesParams,
+} from '@yumney/shared/api-client';
 import {
   createAsyncState,
   ERROR_MAPS,
@@ -24,7 +29,7 @@ import {
   UI,
   toggleFavoriteInList,
 } from '@yumney/shared/models';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import {
   EMPTY_FILTER,
   FilterPanelComponent,
@@ -80,10 +85,17 @@ export class RecipeListComponent implements OnInit {
   ];
 
   private recipeApi = inject(RecipeApiService);
+  private mealPlanApi = inject(MealPlanApiService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
   private searchSubject = new Subject<string>();
   private loadRequestId = 0;
+
+  assignTo = signal<string | null>(null);
+  assignMode = computed(() => this.assignTo() !== null);
+  assigning = signal(false);
 
   private sortDropdown = viewChild<ElementRef>('sortDropdown');
   private recipeCards = viewChildren<ElementRef>('recipeCard');
@@ -156,6 +168,7 @@ export class RecipeListComponent implements OnInit {
   readonly sortOptions = RecipeListComponent.sortOptionList;
 
   ngOnInit(): void {
+    this.assignTo.set(this.route.snapshot.queryParamMap.get('assignTo'));
     this.loadRecipes(false);
 
     this.searchSubject
@@ -219,6 +232,33 @@ export class RecipeListComponent implements OnInit {
     toggleFavoriteInList(this.recipes, identifier, this.destroyRef, (id) =>
       this.recipeApi.toggleFavorite(id),
     );
+  }
+
+  onAssignRecipe(recipe: RecipeListItem): void {
+    const raw = this.assignTo();
+    if (!raw) return;
+
+    const match = raw.match(/^(\d{4})-W(\d{1,2})-(\w+)$/);
+    if (!match) return;
+
+    const [, yearStr, weekStr, day] = match;
+    this.assigning.set(true);
+
+    this.mealPlanApi
+      .assignRecipe(Number(yearStr), Number(weekStr), {
+        day,
+        recipeIdentifier: recipe.identifier,
+        recipeTitle: recipe.title,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.router.navigate([ROUTES.mealPlanner]),
+        error: () => this.assigning.set(false),
+      });
+  }
+
+  onCancelAssign(): void {
+    this.router.navigate([ROUTES.mealPlanner]);
   }
 
   onFilterChange(value: RecipeFilterValue): void {


### PR DESCRIPTION
## Summary

Implements the missing recipe assignment flow for the meal planner.

### Before
Clicking an empty meal plan slot navigated to `/recipes?assignTo=...` but the query parameter was never consumed. Users had no way to assign a recipe to a slot.

### After
1. Click empty slot → recipe list opens in **assign mode**
2. Header shows "Select a recipe" with back button
3. Recipe cards show hover overlay "Assign to meal plan"
4. Click a card → calls `MealPlanApiService.assignRecipe()` → navigates back to meal planner
5. Back button cancels and returns to meal planner

### Changes
- `RecipeCardComponent`: new `assignMode` input + `assign` output + overlay UI
- `RecipeListComponent`: parses `assignTo` query param, calls meal plan API on card click
- i18n keys added (EN + DE)

## Test plan
- [x] `nx build recipes` — builds successfully
- [x] `nx test recipes` — 104 tests pass
- [ ] Manual QA: click slot → select recipe → verify it appears in meal planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)