### PR TITLE
fix(api): add JsonStringEnumConverter and fix shopping list paging (US-000)

### DIFF
--- a/client/libs/shared/api-client/src/lib/shopping-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.spec.ts
@@ -71,14 +71,14 @@ describe('ShoppingApiService', () => {
   });
 
   describe('getShoppingLists', () => {
-    it('should GET /api/v1/shopping-lists', () => {
+    it('should GET /api/v1/shopping-lists and extract items from paged response', () => {
       service.getShoppingLists().subscribe((result) => {
         expect(result).toEqual(mockSummaries);
       });
 
       const req = httpTesting.expectOne('/api/v1/shopping-lists');
       expect(req.request.method).toBe('GET');
-      req.flush(mockSummaries);
+      req.flush({ items: mockSummaries, totalCount: 2, page: 1, pageSize: 20 });
     });
   });
 

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { API_ENDPOINTS } from './api-endpoints';
 import type { CreateShoppingListRequest } from './create-shopping-list-request';
 import type { ShoppingListDetail } from './shopping-list-detail';
 import type { ShoppingListSummary } from './shopping-list-summary';
+import type { PagedResponse } from '@yumney/shared/models';
 import type {
   MergedShoppingList,
   AddItemRequest,
@@ -21,7 +22,9 @@ export class ShoppingApiService {
   }
 
   getShoppingLists(): Observable<ShoppingListSummary[]> {
-    return this.http.get<ShoppingListSummary[]>(API_ENDPOINTS.shoppingLists.base);
+    return this.http
+      .get<PagedResponse<ShoppingListSummary>>(API_ENDPOINTS.shoppingLists.base)
+      .pipe(map((response) => response.items));
   }
 
   getShoppingListById(identifier: string): Observable<ShoppingListDetail> {

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -31,6 +31,11 @@ public static class HostBuilderExtensions
         builder.AddRedisDistributedCache("redis");
         builder.AddRedisClient("redis");
 
+        builder.Services.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+        });
+
         builder.Services.Configure<HostOptions>(options =>
         {
             options.ShutdownTimeout = TimeSpan.FromSeconds(30);

--- a/tests/Yumney.Shared.Tests/Web/JsonStringEnumConverterTests.cs
+++ b/tests/Yumney.Shared.Tests/Web/JsonStringEnumConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Web;
+
+public class JsonStringEnumConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private sealed record DayRecord(DayOfWeek Day);
+
+    [Fact]
+    public void Deserialize_StringEnumValue_DeserializesCorrectly()
+    {
+        var json = """{"Day":"Monday"}""";
+
+        var result = JsonSerializer.Deserialize<DayRecord>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Day.Should().Be(DayOfWeek.Monday);
+    }
+
+    [Fact]
+    public void Deserialize_CaseInsensitiveString_DeserializesCorrectly()
+    {
+        var json = """{"Day":"monday"}""";
+
+        var result = JsonSerializer.Deserialize<DayRecord>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Day.Should().Be(DayOfWeek.Monday);
+    }
+
+    [Fact]
+    public void Serialize_EnumValue_SerializesAsString()
+    {
+        var record = new DayRecord(DayOfWeek.Monday);
+
+        var json = JsonSerializer.Serialize(record, Options);
+
+        json.Should().Contain("\"Monday\"");
+        json.Should().NotContain("1");
+    }
+
+    [Fact]
+    public void Deserialize_IntegerValue_DeserializesCorrectly()
+    {
+        var json = """{"Day":1}""";
+
+        var result = JsonSerializer.Deserialize<DayRecord>(json, Options);
+
+        result.Should().NotBeNull();
+        result!.Day.Should().Be(DayOfWeek.Monday);
+    }
+}


### PR DESCRIPTION
## Summary

### Fixes
- **JsonStringEnumConverter added globally** — APIs now accept string enum values (`"Monday"`, `"Dinner"`, `"Descending"`) from the frontend. Previously DayOfWeek/MealType/SortDirection required integer values, causing meal plan assignment to silently fail.
- **Shopping list paging fix** — `getShoppingLists()` now extracts `items` from `PagedResponse` wrapper. Previously returned the raw paged object, so the shopping list view showed nothing.

### Tests
- Backend: 4 tests verifying string enum serialization/deserialization (case-insensitive, integer fallback)
- Frontend: Updated shopping API test to verify `items` extraction from paged response

## Test plan
- [x] Backend: 208 shared tests pass (4 new)
- [x] Frontend: 34 API client tests pass
- [x] Meal plan assignment works in running app
- [x] Shopping list view shows lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)