### PR TITLE
fix(shared): MassTransit consumers, code quality, and infrastructure fixes (US-000)

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -52,6 +52,7 @@ public static partial class RecipesEndpoints
 		string url,
 		IWebScraper scraper,
 		IRecipeExtractionService extraction,
+		ILogger<Program> logger,
 		CancellationToken cancellationToken)
 	{
 		httpContext.Response.ContentType = MediaTypes.TextEventStream;
@@ -106,8 +107,9 @@ public static partial class RecipesEndpoints
 		{
 			return;
 		}
-		catch (Exception)
+		catch (Exception ex)
 		{
+			logger.LogError(ex, "Recipe extraction failed while streaming from {Url}", url);
 			await WriteSseEventAsync(SseEvent.Fail, ImportStreaming.ExtractionFailedMessage);
 			return;
 		}

--- a/src/Yumney.Shared.Web/Services/CurrentUserProvider.cs
+++ b/src/Yumney.Shared.Web/Services/CurrentUserProvider.cs
@@ -20,9 +20,8 @@ public sealed class CurrentUserProvider(IHttpContextAccessor httpContextAccessor
 
 	public IReadOnlyCollection<string> Roles => User?.FindAll(ClaimTypes.Role)
 		.Select(c => c.Value)
-		.ToList()
-		.AsReadOnly()
-		?? (IReadOnlyCollection<string>)Array.Empty<string>();
+		.ToArray()
+		?? Array.Empty<string>();
 
 	public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
 

--- a/src/Yumney.Users.Api/StaplesEndpoints.cs
+++ b/src/Yumney.Users.Api/StaplesEndpoints.cs
@@ -21,7 +21,7 @@ public static class StaplesEndpoints
 			CancellationToken cancellationToken)
 		{
 			var staples = await staplesProvider.GetStapleNamesAsync(currentUser.UserId, cancellationToken);
-			return Results.Ok(staples.ToList());
+			return Results.Ok(staples);
 		}
 	}
 }

--- a/tests/Yumney.Recipes.Api.Tests/ImportStreamSseTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/ImportStreamSseTests.cs
@@ -2,6 +2,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
@@ -222,7 +224,7 @@ public class ImportStreamSseTests
 		var httpContext = new DefaultHttpContext();
 		httpContext.Response.Body = body;
 
-		await RecipesEndpoints.ImportStreamAsync(httpContext, url, scraper, extraction, CancellationToken.None);
+		await RecipesEndpoints.ImportStreamAsync(httpContext, url, scraper, extraction, NullLogger<Program>.Instance, CancellationToken.None);
 
 		body.Position = 0;
 	}


### PR DESCRIPTION
## Summary
- Register MassTransit consumers for integration event handlers in Shopping module
- Fix AddHttpMessageHandler registration in MealPlan module
- Propagate auth tokens in service-to-service HTTP calls
- Log swallowed exceptions in SSE streaming endpoint
- Remove unnecessary `.ToList()` allocations in CurrentUserProvider and StaplesEndpoints
- Upgrade PostgreSQL container image from 16 to 17
- Optimize container base images for smaller footprint
- Enforce brace rules and explicit collection types across the solution
- Refactor domain methods to return self for fluent chaining
- Replace primitives with value objects on MealSlot (SlotRecipeReference, LeftoverLabel, WeekIdentifier)
- Add architecture test to verify MassTransit consumer registration
- Add AuthTokenDelegatingHandler unit tests

## Test plan
- [x] All three affected projects build with `TreatWarningsAsErrors=true` (0 warnings, 0 errors)
- [ ] Run full test suite (`dotnet test`)
- [ ] Verify SSE streaming endpoint logs extraction failures
- [ ] Verify MassTransit consumers are correctly resolved at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)