### PR TITLE
feat(shopping): toast + empty-state UX for list export (US-316)

### DIFF
--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -58,7 +58,12 @@
     "loading": "Wird geladen...",
     "empty": "Deine Einkaufsliste ist leer. Füge Artikel hinzu oder plane Mahlzeiten.",
     "addPlaceholder": "Artikel hinzufügen...",
-    "export": "Liste exportieren",
+    "export": {
+      "button": "Liste exportieren",
+      "copied": "In Zwischenablage kopiert",
+      "shared": "Geteilt",
+      "nothing": "Nichts zu teilen — alle Artikel sind abgehakt."
+    },
     "remove": "Artikel entfernen",
     "checked": "erledigt",
     "retry": "Erneut versuchen",

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -58,7 +58,12 @@
     "loading": "Loading...",
     "empty": "Your shopping list is empty. Add items or plan meals.",
     "addPlaceholder": "Add an item...",
-    "export": "Export list",
+    "export": {
+      "button": "Export list",
+      "copied": "Copied to clipboard",
+      "shared": "Shared",
+      "nothing": "Nothing to export — all items are checked off."
+    },
     "remove": "Remove item",
     "checked": "checked",
     "retry": "Retry",

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -2,7 +2,11 @@
   <div class="list-header">
     <h1>{{ t('shopping.title') }}</h1>
     <div class="list-actions">
-      <button class="export-btn" (click)="onExport()" [attr.aria-label]="t('shopping.export')">
+      <button
+        class="export-btn"
+        (click)="onExport()"
+        [attr.aria-label]="t('shopping.export.button')"
+      >
         <lucide-icon name="share" [size]="18" />
       </button>
     </div>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -12,7 +12,12 @@ const en = {
     loading: 'Loading...',
     empty: 'Empty list',
     addPlaceholder: 'Add item...',
-    export: 'Export',
+    export: {
+      button: 'Export list',
+      copied: 'Copied to clipboard',
+      shared: 'Shared',
+      nothing: 'Nothing to export',
+    },
     remove: 'Remove',
     checked: 'checked',
     retry: 'Retry',

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -3,7 +3,7 @@ import { provideRouter } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { MergedListComponent } from './merged-list.component';
 import { ShoppingApiService, type MergedShoppingList } from '../api';
-import { setupTranslocoTesting } from '@yumney/shared/models';
+import { setupTranslocoTesting, ToastService } from '@yumney/shared/models';
 import { provideYumneyIcons } from '@yumney/ui';
 
 const en = {
@@ -128,5 +128,96 @@ describe('MergedListComponent', () => {
   it('should show progress when items exist', () => {
     expect(fixture.nativeElement.querySelector('.progress-bar')).toBeTruthy();
     expect(fixture.nativeElement.textContent).toContain('0 / 2');
+  });
+
+  describe('export', () => {
+    let toasts: ToastService;
+    let shareSpy: ReturnType<typeof vi.fn>;
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      toasts = TestBed.inject(ToastService);
+      toasts.clear();
+
+      shareSpy = vi.fn().mockResolvedValue(undefined);
+      writeTextSpy = vi.fn().mockResolvedValue(undefined);
+
+      vi.stubGlobal('navigator', {
+        share: shareSpy,
+        clipboard: { writeText: writeTextSpy },
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('shows info toast when server returns no items', async () => {
+      apiMock.exportList.mockReturnValue(of(''));
+
+      fixture.componentInstance['onExport']();
+      await Promise.resolve();
+
+      expect(shareSpy).not.toHaveBeenCalled();
+      expect(writeTextSpy).not.toHaveBeenCalled();
+      expect(toasts.toasts()).toHaveLength(1);
+      expect(toasts.toasts()[0]).toMatchObject({
+        kind: 'info',
+        messageKey: 'shopping.export.nothing',
+      });
+    });
+
+    it('uses Web Share API when available and toasts shared on success', async () => {
+      fixture.componentInstance['onExport']();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(shareSpy).toHaveBeenCalledWith({ text: 'Shopping list text' });
+      expect(toasts.toasts()[0]).toMatchObject({
+        kind: 'success',
+        messageKey: 'shopping.export.shared',
+      });
+    });
+
+    it('falls back to clipboard when Web Share API is unavailable', async () => {
+      vi.stubGlobal('navigator', { clipboard: { writeText: writeTextSpy } });
+
+      fixture.componentInstance['onExport']();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(writeTextSpy).toHaveBeenCalledWith('Shopping list text');
+      expect(toasts.toasts()[0]).toMatchObject({
+        kind: 'success',
+        messageKey: 'shopping.export.copied',
+      });
+    });
+
+    it('does not fall back to clipboard when user aborts the share sheet', async () => {
+      const abort = new DOMException('Share canceled', 'AbortError');
+      shareSpy.mockRejectedValue(abort);
+
+      fixture.componentInstance['onExport']();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(writeTextSpy).not.toHaveBeenCalled();
+      expect(toasts.toasts()).toHaveLength(0);
+    });
+
+    it('falls back to clipboard when share fails for a non-abort reason', async () => {
+      shareSpy.mockRejectedValue(new Error('denied'));
+
+      fixture.componentInstance['onExport']();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(writeTextSpy).toHaveBeenCalledWith('Shopping list text');
+      expect(toasts.toasts()[0]).toMatchObject({
+        kind: 'success',
+        messageKey: 'shopping.export.copied',
+      });
+    });
   });
 });

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -12,6 +12,7 @@ import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem } from '../api';
 import { TranslocoService } from '@jsverse/transloco';
+import { ToastService } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
 interface CategoryGroup {
@@ -32,6 +33,7 @@ export class MergedListComponent {
   private api = inject(ShoppingApiService);
   private destroyRef = inject(DestroyRef);
   private transloco = inject(TranslocoService);
+  private toasts = inject(ToastService);
 
   protected list = signal<MergedShoppingList | null>(null);
   protected loading = signal(false);
@@ -104,8 +106,20 @@ export class MergedListComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (text) => {
+          if (text.trim().length === 0) {
+            this.toasts.info('shopping.export.nothing');
+            return;
+          }
+
           if (navigator.share) {
-            navigator.share({ text }).catch(() => this.copyToClipboard(text));
+            navigator
+              .share({ text })
+              .then(() => this.toasts.success('shopping.export.shared'))
+              .catch((err: unknown) => {
+                // AbortError = user dismissed share sheet; do not fall back.
+                if (err instanceof DOMException && err.name === 'AbortError') return;
+                this.copyToClipboard(text);
+              });
           } else {
             this.copyToClipboard(text);
           }
@@ -143,8 +157,11 @@ export class MergedListComponent {
   }
 
   private copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text).catch(() => {
-      this.error.set(this.transloco.translate('shopping.errors.exportFailed'));
-    });
+    navigator.clipboard
+      .writeText(text)
+      .then(() => this.toasts.success('shopping.export.copied'))
+      .catch(() => {
+        this.error.set(this.transloco.translate('shopping.errors.exportFailed'));
+      });
   }
 }


### PR DESCRIPTION
Closes #165 (US-316 *Shopping List Export*).

## Summary

Backend handler and Web Share + clipboard flow were already in place. This PR closes the remaining acceptance criteria:

- ✅ Success toast after share (`shopping.export.shared`) or clipboard copy (`shopping.export.copied`) via `ToastService`.
- ✅ Info toast when the list is empty (`shopping.export.nothing`) instead of silently doing nothing.
- ✅ Abort-aware share: dismissing the share sheet no longer falls back to clipboard.
- ✅ en/de translations for the three new keys under `shopping.export.*`.
- ✅ 5 new unit tests covering empty / share-success / clipboard-fallback / share-abort / share-failure paths.

## Breaking i18n shape

`shopping.export` was a string (`"Export list"`); it's now an object `{ button, copied, shared, nothing }`. The button aria-label in `merged-list.component.html` updated to `shopping.export.button`. No other consumer.

## Test plan

- [x] `yarn nx test shopping` — 39 passed.
- [x] `yarn nx lint shopping,shared-models` — clean.
- [x] `yarn nx build shopping` — clean.
- [ ] Manual browser check: share button on a list with items triggers native share (desktop: copies to clipboard); on empty list shows info toast.