### PR TITLE
test(shopping): add Shopping.Infrastructure test coverage (#278)

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -63,6 +63,7 @@
   <Folder Name="/tests/Shopping/">
     <Project Path="tests/Yumney.Shopping.Domain.Tests/Yumney.Shopping.Domain.Tests.csproj" />
     <Project Path="tests/Yumney.Shopping.Application.Tests/Yumney.Shopping.Application.Tests.csproj" />
+    <Project Path="tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj" />
     <Project Path="tests/Yumney.Shopping.Api.Tests/Yumney.Shopping.Api.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Users/">

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -10,6 +10,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 using Xunit;
@@ -165,6 +166,29 @@ public sealed class AspireFixture : IAsyncLifetime
 		var optionsBuilder = new DbContextOptionsBuilder<ShoppingReadDbContext>();
 		optionsBuilder.UseNpgsql(connectionString, x => x.EnableRetryOnFailure());
 		return new ShoppingReadDbContext(optionsBuilder.Options);
+	}
+
+	public async Task ResetShoppingEventStoreAsync(global::SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.OwnerIdentifier owner)
+	{
+		await using var context = await CreateShoppingDbContextAsync();
+		var aggregateIds = await context.Set<AggregateMetadata>()
+			.Where(m => m.OwnerId == owner.Value)
+			.Select(m => m.AggregateId)
+			.ToListAsync();
+
+		if (aggregateIds.Count == 0) return;
+
+		var events = await context.Set<StoredEvent>()
+			.Where(e => aggregateIds.Contains(e.AggregateId)).ToListAsync();
+		var snapshots = await context.Set<StoredSnapshot>()
+			.Where(s => aggregateIds.Contains(s.AggregateId)).ToListAsync();
+		var metadata = await context.Set<AggregateMetadata>()
+			.Where(m => aggregateIds.Contains(m.AggregateId)).ToListAsync();
+
+		context.RemoveRange(events);
+		context.RemoveRange(snapshots);
+		context.RemoveRange(metadata);
+		await context.SaveChangesAsync();
 	}
 
 	public async Task SeedShoppingListsAsync(params ShoppingList[] shoppingLists)

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
@@ -1,0 +1,219 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.EventStore;
+
+[Collection(AspireCollection.Name)]
+public class EfCoreShoppingEventStoreTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly ItemSource Source = ItemSource.From("manual");
+
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"evtstore-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingEventStoreAsync(owner);
+
+	[Fact]
+	public async Task LoadAsync_NoEventsForOwner_ReturnsNull()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+
+		var ledger = await store.LoadAsync(owner);
+
+		ledger.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task SaveAsync_NewLedgerWithItems_PersistsEventsAndMetadata()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l")), Source);
+
+		await store.SaveAsync(ledger);
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verifyContext.Set<StoredEvent>()
+			.Where(e => e.AggregateId == ledger.Identifier).ToListAsync();
+		var metadata = await verifyContext.Set<AggregateMetadata>()
+			.SingleAsync(m => m.AggregateId == ledger.Identifier);
+		stored.Should().HaveCount(1);
+		stored[0].EventType.Should().Be(nameof(ShoppingItemAdded));
+		stored[0].Version.Should().Be(1);
+		metadata.OwnerId.Should().Be(owner.Value);
+	}
+
+	[Fact]
+	public async Task SaveAsync_ExistingLedger_AssignsContiguousVersions()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+
+		ShoppingLedger ledger;
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(ctx);
+			ledger = ShoppingLedger.Create(owner)
+				.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+			await store.SaveAsync(ledger);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		var versions = await verifyContext.Set<StoredEvent>()
+			.Where(e => e.AggregateId == ledger.Identifier)
+			.OrderBy(e => e.Version).Select(e => e.Version).ToListAsync();
+		versions.Should().Equal(1, 2);
+	}
+
+	[Fact]
+	public async Task SaveAsync_NoUncommittedEvents_WritesNothing()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var ledger = ShoppingLedger.Create(owner);
+
+		await store.SaveAsync(ledger);
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		var hasEvents = await verifyContext.Set<StoredEvent>()
+			.AnyAsync(e => e.AggregateId == ledger.Identifier);
+		var hasMetadata = await verifyContext.Set<AggregateMetadata>()
+			.AnyAsync(m => m.OwnerId == owner.Value);
+		hasEvents.Should().BeFalse();
+		hasMetadata.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task SaveAsync_PublishesIntegrationEventsForKnownEvents()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var bus = Substitute.For<IEventBus>();
+		var store = CreateStore(context, bus);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), Source);
+
+		await store.SaveAsync(ledger);
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingItemAddedIntegrationEvent>(e => e.OwnerId == owner.Value),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SaveAsync_ClearsUncommittedEventsAfterWrite()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), Source);
+
+		await store.SaveAsync(ledger);
+
+		ledger.UncommittedEvents.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task LoadAsync_AfterSaveRoundtrip_RehydratesLedgerState()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var ledger = ShoppingLedger.Create(owner)
+				.AddItem(milk, Quantity.Of(Amount.From(2), litre), Source)
+				.MarkBought(milk, Quantity.Of(Amount.From(1), litre));
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var freshContext = await fixture.CreateShoppingDbContextAsync();
+		var loaded = await CreateStore(freshContext).LoadAsync(owner);
+
+		loaded.Should().NotBeNull();
+		loaded!.OwnerId.Should().Be(owner);
+		loaded.Version.Value.Should().Be(2);
+		var state = loaded.Items.Values.Single();
+		state.OnList.Value.Should().Be(2m);
+		state.Bought.Value.Should().Be(1m);
+	}
+
+	[Fact]
+	public async Task SaveAsync_WritesSnapshotWhenVersionReachesInterval()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		var ledger = ShoppingLedger.Create(owner);
+		for (var i = 0; i < 50; i++)
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		var snapshot = await verifyContext.Set<StoredSnapshot>()
+			.SingleAsync(s => s.AggregateId == ledger.Identifier);
+		snapshot.Version.Should().Be(50);
+		ledger.Version.Value.Should().Be(50);
+	}
+
+	[Fact]
+	public async Task LoadAsync_WithSnapshot_UsesSnapshotAsBaseline()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		var ledger = ShoppingLedger.Create(owner);
+		for (var i = 0; i < 50; i++)
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(3), litre), Source);
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var freshContext = await fixture.CreateShoppingDbContextAsync();
+		var loaded = await CreateStore(freshContext).LoadAsync(owner);
+
+		loaded.Should().NotBeNull();
+		loaded!.Version.Value.Should().Be(51);
+		loaded.Items.Values.Single().OnList.Value.Should().Be(53m);
+	}
+
+	private static EfCoreShoppingEventStore CreateStore(ShoppingDbContext context, IEventBus? bus = null)
+	{
+		return new EfCoreShoppingEventStore(
+			context,
+			bus ?? Substitute.For<IEventBus>(),
+			NullLogger<EfCoreShoppingEventStore>.Instance);
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Services;
+
+public class ShoppingListWriterTests
+{
+	private const string OwnerId = "user-1";
+
+	private readonly IShoppingEventStore eventStore = Substitute.For<IShoppingEventStore>();
+	private readonly ShoppingListWriter writer;
+
+	public ShoppingListWriterTests()
+	{
+		writer = new ShoppingListWriter(eventStore);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_NoExistingLedger_CreatesNewLedgerWithRaisedEvent()
+	{
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns((ShoppingLedger?)null);
+		ShoppingLedger? saved = null;
+		await eventStore.SaveAsync(Arg.Do<ShoppingLedger>(l => saved = l), Arg.Any<CancellationToken>());
+
+		await writer.AddItemsAsync(OwnerId, new[]
+		{
+			new ShoppingItemRequest("Milk", 1m, "l", "manual"),
+		});
+
+		saved.Should().NotBeNull();
+		saved!.OwnerId.Value.Should().Be(OwnerId);
+		saved.UncommittedEvents.Should().HaveCount(1);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_ExistingLedger_AppendsToLoadedLedger()
+	{
+		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
+
+		await writer.AddItemsAsync(OwnerId, new[]
+		{
+			new ShoppingItemRequest("Bread", 2m, null, "recipe"),
+			new ShoppingItemRequest("Butter", 250m, "g", "recipe"),
+		});
+
+		await eventStore.Received(1).SaveAsync(existing, Arg.Any<CancellationToken>());
+		existing.UncommittedEvents.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_WithNullUnit_PassesNullThroughToLedger()
+	{
+		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
+
+		await writer.AddItemsAsync(OwnerId, new[]
+		{
+			new ShoppingItemRequest("Eggs", 6m, null, "manual"),
+		});
+
+		var state = existing.Items.Values.Single();
+		state.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_EmptyInput_StillCallsSaveAsync()
+	{
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns((ShoppingLedger?)null);
+
+		await writer.AddItemsAsync(OwnerId, Array.Empty<ShoppingItemRequest>());
+
+		await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
@@ -6,22 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Yumney.AppHost\Yumney.AppHost.csproj" />
-    <ProjectReference Include="..\..\src\Yumney.Recipes.Infrastructure\Yumney.Recipes.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shopping.Infrastructure\Yumney.Shopping.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\src\Yumney.Users.Infrastructure\Yumney.Users.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #278.

## Summary
- New `Yumney.Shopping.Infrastructure.Tests` project with 4 unit tests for `ShoppingListWriter` (mocks `IShoppingEventStore`).
- 9 new real-PostgreSQL event-store tests in `Yumney.Integration.Tests/Shopping/EventStore/` covering `EfCoreShoppingEventStore` end-to-end via the existing `AspireFixture`.
- `AspireFixture.ResetShoppingEventStoreAsync(owner)` helper for per-owner test isolation.

## Design notes
Following discussion on #279, the integration-test substrate stays on .NET Aspire (no Testcontainers). Tests split by what they actually need:
- Pure unit (4 tests) → `Shopping.Infrastructure.Tests`, fast, no infra.
- EF/Npgsql behavior (9 tests) → `Integration.Tests`, real Postgres via Aspire — catches bugs InMemory would hide (unique indexes on `AggregateId+Version` and `OwnerId`, snapshot JSON, etc.).

## Test plan
- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] Unit tests pass locally (`Shopping.Infrastructure.Tests`: 4/4)
- [ ] Integration tests pass in CI (Docker available there; local box has Docker down)