### PR TITLE
test(shopping): edge-case coverage for event store and writer

### DIFF
--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
@@ -180,6 +180,188 @@ public class EfCoreShoppingEventStoreTests(AspireFixture fixture) : IAsyncLifeti
 	}
 
 	[Fact]
+	public async Task SaveAsync_SecondLedgerForSameOwner_ViolatesUniqueOwnerIdConstraint()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var first = ShoppingLedger.Create(owner)
+				.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+			await CreateStore(ctx).SaveAsync(first);
+		}
+
+		await using var ctx2 = await fixture.CreateShoppingDbContextAsync();
+		var second = ShoppingLedger.Create(owner)
+			.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+		var act = () => CreateStore(ctx2).SaveAsync(second);
+
+		await act.Should().ThrowAsync<DbUpdateException>();
+	}
+
+	[Fact]
+	public async Task SaveAsync_DuplicateAggregateVersion_ViolatesUniqueVersionConstraint()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		ShoppingLedger ledger;
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			ledger = ShoppingLedger.Create(owner)
+				.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		verifyContext.Set<StoredEvent>().Add(new StoredEvent
+		{
+			Id = Guid.CreateVersion7(),
+			AggregateId = ledger.Identifier,
+			EventType = nameof(ShoppingItemAdded),
+			EventData = "{}",
+			Version = 1,
+			OccurredAt = DateTime.UtcNow,
+		});
+		var act = () => verifyContext.SaveChangesAsync();
+
+		await act.Should().ThrowAsync<DbUpdateException>();
+	}
+
+	[Fact]
+	public async Task LoadAsync_OtherOwnerHasEvents_ReturnsNullForThisOwner()
+	{
+		var otherOwner = OwnerIdentifier.From($"evtstore-other-{Guid.NewGuid():N}");
+		try
+		{
+			await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+			{
+				var ledger = ShoppingLedger.Create(otherOwner)
+					.AddItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), Source);
+				await CreateStore(ctx).SaveAsync(ledger);
+			}
+
+			await using var freshContext = await fixture.CreateShoppingDbContextAsync();
+			var loaded = await CreateStore(freshContext).LoadAsync(owner);
+
+			loaded.Should().BeNull();
+		}
+		finally
+		{
+			await fixture.ResetShoppingEventStoreAsync(otherOwner);
+		}
+	}
+
+	[Fact]
+	public async Task LoadAsync_UnknownEventTypeInStream_IsSkippedGracefully()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		ShoppingLedger ledger;
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			ledger = ShoppingLedger.Create(owner)
+				.AddItem(milk, Quantity.Of(Amount.From(2), litre), Source);
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			ctx.Set<StoredEvent>().Add(new StoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = ledger.Identifier,
+				EventType = "SomeFutureEventType",
+				EventData = "{}",
+				Version = 2,
+				OccurredAt = DateTime.UtcNow,
+			});
+			await ctx.SaveChangesAsync();
+		}
+
+		await using var freshContext = await fixture.CreateShoppingDbContextAsync();
+		var loaded = await CreateStore(freshContext).LoadAsync(owner);
+
+		loaded.Should().NotBeNull();
+		loaded!.Items.Values.Single().OnList.Value.Should().Be(2m);
+	}
+
+	[Fact]
+	public async Task SaveAsync_MultipleEventTypes_PublishesIntegrationEventForEach()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		var oneLitre = Quantity.Of(Amount.From(1), litre);
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var bus = Substitute.For<IEventBus>();
+		var store = CreateStore(context, bus);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(milk, oneLitre, Source)
+			.MarkBought(milk, oneLitre)
+			.MarkConsumed(milk, oneLitre, Source)
+			.AdjustQuantity(milk, Quantity.Of(Amount.From(3), litre))
+			.RemoveItem(milk, oneLitre);
+
+		await store.SaveAsync(ledger);
+
+		await bus.Received(1).PublishAsync(Arg.Any<ShoppingItemAddedIntegrationEvent>(), Arg.Any<CancellationToken>());
+		await bus.Received(1).PublishAsync(Arg.Any<ShoppingItemBoughtIntegrationEvent>(), Arg.Any<CancellationToken>());
+		await bus.Received(1).PublishAsync(Arg.Any<ShoppingItemConsumedIntegrationEvent>(), Arg.Any<CancellationToken>());
+		await bus.Received(1).PublishAsync(Arg.Any<ShoppingItemQuantityAdjustedIntegrationEvent>(), Arg.Any<CancellationToken>());
+		await bus.Received(1).PublishAsync(Arg.Any<ShoppingItemRemovedIntegrationEvent>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SaveAsync_CrossesSnapshotIntervalTwice_OverwritesSnapshotRow()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		var ledger = ShoppingLedger.Create(owner);
+		for (var i = 0; i < 50; i++)
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		for (var i = 0; i < 50; i++)
+		{
+			ledger.AddItem(milk, Quantity.Of(Amount.From(1), litre), Source);
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await CreateStore(ctx).SaveAsync(ledger);
+		}
+
+		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
+		var snapshots = await verifyContext.Set<StoredSnapshot>()
+			.Where(s => s.AggregateId == ledger.Identifier).ToListAsync();
+		snapshots.Should().ContainSingle();
+		snapshots[0].Version.Should().Be(100);
+	}
+
+	[Fact]
+	public async Task SaveAsync_CancelledToken_ThrowsOperationCanceled()
+	{
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), Source);
+
+		var act = () => store.SaveAsync(ledger, cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
 	public async Task LoadAsync_WithSnapshot_UsesSnapshotAsBaseline()
 	{
 		var milk = ItemName.From("Milk");

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
@@ -78,5 +79,63 @@ public class ShoppingListWriterTests
 		await writer.AddItemsAsync(OwnerId, Array.Empty<ShoppingItemRequest>());
 
 		await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_SameNameDifferentUnits_CreatesSeparateLedgerEntries()
+	{
+		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
+
+		await writer.AddItemsAsync(OwnerId, new[]
+		{
+			new ShoppingItemRequest("Milk", 1m, "l", "manual"),
+			new ShoppingItemRequest("Milk", 500m, "ml", "manual"),
+		});
+
+		existing.Items.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_LargeBatch_AssignsOneEventPerItem()
+	{
+		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
+		var items = Enumerable.Range(0, 50)
+			.Select(i => new ShoppingItemRequest($"Item{i}", 1m, "pc", "manual"))
+			.ToArray();
+
+		await writer.AddItemsAsync(OwnerId, items);
+
+		existing.UncommittedEvents.Should().HaveCount(50);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_CancelledToken_PropagatesToEventStore()
+	{
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns(Task.FromCanceled<ShoppingLedger?>(cts.Token));
+
+		var act = () => writer.AddItemsAsync(
+			OwnerId,
+			new[] { new ShoppingItemRequest("Milk", 1m, "l", "manual") },
+			cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_EmptySourceString_ThrowsGuardException()
+	{
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns(ShoppingLedger.Create(OwnerIdentifier.From(OwnerId)));
+
+		var act = () => writer.AddItemsAsync(
+			OwnerId,
+			new[] { new ShoppingItemRequest("Milk", 1m, "l", string.Empty) });
+
+		await act.Should().ThrowAsync<GuardException>();
 	}
 }


### PR DESCRIPTION
Follow-up to #278. Adds 11 edge-case tests the initial suite missed — response to reviewing the original tests against a deeper boundary-testing bar.

## Summary
**EfCoreShoppingEventStoreTests (+7 → 16 total)**
- Unique OwnerId constraint (one ledger per owner)
- Unique (AggregateId, Version) on events
- Owner isolation in LoadAsync
- Unknown event type skipped on load (forward compat)
- All 5 integration event types publish on multi-event save
- Snapshot row overwrites (not duplicates)
- Cancellation token propagation

**ShoppingListWriterTests (+4 → 8 total)**
- Same name, different units → separate ledger entries
- Large batch (50 items) — one event per item
- Cancellation propagation
- Empty source string fires ItemSource guard

## Test plan
- [x] 16 event-store tests pass locally against real PG via Aspire
- [x] 8 writer unit tests pass locally
- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean