### PR TITLE
test(shopping): contract tests for Shopping module (#279)

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -11,6 +11,7 @@ using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 using Xunit;
@@ -188,6 +189,16 @@ public sealed class AspireFixture : IAsyncLifetime
 		context.RemoveRange(events);
 		context.RemoveRange(snapshots);
 		context.RemoveRange(metadata);
+		await context.SaveChangesAsync();
+	}
+
+	public async Task ResetShoppingReadModelAsync(string ownerId)
+	{
+		await using var context = await CreateShoppingDbContextAsync();
+		var items = await context.Set<ShoppingListReadItem>()
+			.Where(r => r.OwnerId == ownerId).ToListAsync();
+		if (items.Count == 0) return;
+		context.RemoveRange(items);
 		await context.SaveChangesAsync();
 	}
 

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -215,6 +215,24 @@ public sealed class AspireFixture : IAsyncLifetime
 
 	public async Task<HttpClient> CreateAuthenticatedClientAsync(string resourceName)
 	{
+		var accessToken = await GetTestUserAccessTokenAsync();
+		var client = App.CreateHttpClient(resourceName);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+		return client;
+	}
+
+	public async Task<string> GetTestUserIdAsync()
+	{
+		var accessToken = await GetTestUserAccessTokenAsync();
+		var payload = accessToken.Split('.')[1];
+		var padded = payload.PadRight(payload.Length + ((4 - (payload.Length % 4)) % 4), '=');
+		var decoded = Convert.FromBase64String(padded.Replace('-', '+').Replace('_', '/'));
+		var claims = JsonSerializer.Deserialize<JsonElement>(decoded);
+		return claims.GetProperty("sub").GetString()!;
+	}
+
+	private async Task<string> GetTestUserAccessTokenAsync()
+	{
 		var keycloakClient = App.CreateHttpClient("keycloak");
 		var tokenResponse = await keycloakClient.PostAsync(
 			"/realms/yumney/protocol/openid-connect/token",
@@ -228,13 +246,10 @@ public sealed class AspireFixture : IAsyncLifetime
 
 		tokenResponse.EnsureSuccessStatusCode();
 		var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
-		var accessToken = tokenJson.GetProperty("access_token").GetString()!;
-
-		var client = App.CreateHttpClient(resourceName);
-		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-		return client;
+		return tokenJson.GetProperty("access_token").GetString()!;
 	}
 
+#pragma warning disable SA1204
 	private static async Task CleanupStaleContainersAsync()
 	{
 		try

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/AddManualItemContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/AddManualItemContractTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for POST /api/v1/shopping-lists/items.
+/// Reference template for issue #279 — this is the depth/style we will scale to
+/// all remaining endpoints. Every endpoint test file should probe: happy paths,
+/// validator failures (422), guard failures (400 via global exception handler),
+/// auth (401), and stateful/idempotent behavior where applicable.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class AddManualItemContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/shopping-lists/items";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		await fixture.ResetShoppingEventStoreAsync(OwnerIdentifier.From(userId));
+	}
+
+	[Fact]
+	public async Task AddManualItem_NameOnly_Returns201WithResolvedDefaults()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "Apples" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Created);
+		response.Headers.Location!.ToString().Should().StartWith("/shopping-lists/items/");
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("itemName").GetString().Should().Be("Apples");
+		body.GetProperty("quantity").GetDecimal().Should().BeGreaterThan(0m);
+		body.GetProperty("source").GetString().Should().Be("manual");
+		body.GetProperty("ledgerIdentifier").GetGuid().Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public async Task AddManualItem_WithQuantityAndUnit_Returns201WithEchoedValues()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "Milk", quantity = 2m, unit = "l" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Created);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("quantity").GetDecimal().Should().Be(2m);
+		body.GetProperty("unit").GetString().Should().Be("l");
+	}
+
+	[Fact]
+	public async Task AddManualItem_LeadingTrailingWhitespace_IsTrimmedBeforePersist()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "  Bread  " });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Created);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("itemName").GetString().Should().Be("Bread");
+	}
+
+	[Fact]
+	public async Task AddManualItem_CalledTwice_AppendsToSameLedger()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var first = await client.PostAsJsonAsync(Endpoint, new { name = "Tomatoes", quantity = 3m });
+		var second = await client.PostAsJsonAsync(Endpoint, new { name = "Onions", quantity = 2m });
+
+		first.StatusCode.Should().Be(HttpStatusCode.Created);
+		second.StatusCode.Should().Be(HttpStatusCode.Created);
+		var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		secondBody.GetProperty("ledgerIdentifier").GetGuid()
+			.Should().Be(firstBody.GetProperty("ledgerIdentifier").GetGuid());
+	}
+
+	[Fact]
+	public async Task AddManualItem_EmptyName_Returns422ValidationProblem()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = string.Empty });
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task AddManualItem_WhitespaceOnlyName_Returns422ValidationProblem()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "   " });
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task AddManualItem_NameOverMaxLength_Returns400GuardFailure()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		var overMax = new string('x', ItemName.MaxLength + 1);
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = overMax });
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task AddManualItem_NegativeQuantity_Returns400GuardFailure()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "Apples", quantity = -1m });
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task AddManualItem_MissingNameField_Returns422ValidationProblem()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { quantity = 5m, unit = "kg" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task AddManualItem_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { name = "Apples" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for PUT /api/v1/shopping-lists/{id}/check-all.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class CheckOffAllItemsContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		var owner = OwnerIdentifier.From(userId);
+		await AspireFixture.CleanupAsync(
+			fixture.CreateShoppingDbContextAsync,
+			ctx => ctx.ShoppingLists.Where(l => l.Owner == owner));
+	}
+
+	[Fact]
+	public async Task CheckOffAll_IsCheckedTrue_Returns204AndMarksAllItemsChecked()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		var listId = await CreateListAsync(client);
+
+		var response = await client.PutAsJsonAsync(
+			$"/api/v1/shopping-lists/{listId}/check-all",
+			new { isChecked = true });
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		var detail = await GetListAsync(client, listId);
+		detail.GetProperty("items").EnumerateArray()
+			.Select(i => i.GetProperty("isChecked").GetBoolean())
+			.Should().AllBeEquivalentTo(true);
+	}
+
+	[Fact]
+	public async Task CheckOffAll_IsCheckedFalse_Returns204AndUnchecksAllItems()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		var listId = await CreateListAsync(client);
+		await client.PutAsJsonAsync($"/api/v1/shopping-lists/{listId}/check-all", new { isChecked = true });
+
+		var response = await client.PutAsJsonAsync(
+			$"/api/v1/shopping-lists/{listId}/check-all",
+			new { isChecked = false });
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		var detail = await GetListAsync(client, listId);
+		detail.GetProperty("items").EnumerateArray()
+			.Select(i => i.GetProperty("isChecked").GetBoolean())
+			.Should().AllBeEquivalentTo(false);
+	}
+
+	[Fact]
+	public async Task CheckOffAll_ListDoesNotExist_Returns404()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PutAsJsonAsync(
+			$"/api/v1/shopping-lists/{Guid.NewGuid()}/check-all",
+			new { isChecked = true });
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+
+	[Fact]
+	public async Task CheckOffAll_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.PutAsJsonAsync(
+			$"/api/v1/shopping-lists/{Guid.NewGuid()}/check-all",
+			new { isChecked = true });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	private static async Task<Guid> CreateListAsync(HttpClient client)
+	{
+		var response = await client.PostAsJsonAsync("/api/v1/shopping-lists/", new
+		{
+			title = "Check-All Test",
+			items = new object[]
+			{
+				new { name = "Milk", amount = 1m, unit = "l" },
+				new { name = "Bread", amount = 1m },
+			},
+		});
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		return body.GetProperty("identifier").GetGuid();
+	}
+
+	private static async Task<JsonElement> GetListAsync(HttpClient client, Guid listId)
+	{
+		var response = await client.GetAsync($"/api/v1/shopping-lists/{listId}");
+		response.EnsureSuccessStatusCode();
+		return await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for GET /api/v1/shopping-lists/export.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class ExportShoppingListContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/shopping-lists/export";
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		await fixture.ResetShoppingEventStoreAsync(OwnerIdentifier.From(userId));
+		await fixture.ResetShoppingReadModelAsync(userId);
+	}
+
+	[Fact]
+	public async Task Export_NoItems_ReturnsOkWithTextPlainContentType()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		response.Content.Headers.ContentType!.MediaType.Should().Be("text/plain");
+	}
+
+	[Fact]
+	public async Task Export_AfterAddManualItem_IncludesItemNameInPayload()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await client.PostAsJsonAsync(
+			"/api/v1/shopping-lists/items",
+			new { name = "Strawberries", quantity = 500m, unit = "g" });
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadAsStringAsync();
+		body.Should().Contain("Strawberries");
+	}
+
+	[Fact]
+	public async Task Export_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for GET /api/v1/shopping-lists/merged.
+/// Read-model projection is populated synchronously by in-process integration
+/// event handlers, so items added via POST /items are visible immediately.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class GetMergedShoppingListContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/shopping-lists/merged";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		await fixture.ResetShoppingEventStoreAsync(OwnerIdentifier.From(userId));
+		await fixture.ResetShoppingReadModelAsync(userId);
+	}
+
+	[Fact]
+	public async Task GetMerged_NoItems_ReturnsEmptyDto()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("items").GetArrayLength().Should().Be(0);
+	}
+
+	[Fact]
+	public async Task GetMerged_AfterAddManualItem_ItemAppearsInMergedList()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await client.PostAsJsonAsync("/api/v1/shopping-lists/items", new { name = "Oranges", quantity = 4m });
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		var items = body.GetProperty("items");
+		items.GetArrayLength().Should().Be(1);
+		items[0].GetProperty("itemName").GetString().Should().Be("Oranges");
+	}
+
+	[Fact]
+	public async Task GetMerged_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for GET /api/v1/shopping-lists — paginated, owner-scoped.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class GetShoppingListsContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/shopping-lists";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => CleanupOwnersListsAsync();
+
+	public Task DisposeAsync() => CleanupOwnersListsAsync();
+
+	[Fact]
+	public async Task GetShoppingLists_NoListsForOwner_ReturnsEmptyPagedResult()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("items").GetArrayLength().Should().Be(0);
+		body.GetProperty("totalCount").GetInt32().Should().Be(0);
+	}
+
+	[Fact]
+	public async Task GetShoppingLists_AfterCreate_ReturnsCreatedList()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await CreateListAsync(client, "List A");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("totalCount").GetInt32().Should().Be(1);
+		body.GetProperty("items")[0].GetProperty("title").GetString().Should().Be("List A");
+	}
+
+	[Fact]
+	public async Task GetShoppingLists_Pagination_LimitsItemsAndReportsTotalCount()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await CreateListAsync(client, "One");
+		await CreateListAsync(client, "Two");
+		await CreateListAsync(client, "Three");
+
+		var response = await client.GetAsync($"{Endpoint}?page=1&pageSize=2");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("items").GetArrayLength().Should().Be(2);
+		body.GetProperty("totalCount").GetInt32().Should().Be(3);
+	}
+
+	[Fact]
+	public async Task GetShoppingLists_SortByTitleAscending_ReturnsSorted()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await CreateListAsync(client, "Charlie");
+		await CreateListAsync(client, "Alpha");
+		await CreateListAsync(client, "Bravo");
+
+		var response = await client.GetAsync($"{Endpoint}?sortBy=Title&sortDirection=Ascending");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		var titles = body.GetProperty("items").EnumerateArray()
+			.Select(i => i.GetProperty("title").GetString()).ToList();
+		titles.Should().Equal("Alpha", "Bravo", "Charlie");
+	}
+
+	[Fact]
+	public async Task GetShoppingLists_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	private static Task<HttpResponseMessage> CreateListAsync(HttpClient client, string title) =>
+		client.PostAsJsonAsync(Endpoint + "/", new
+		{
+			title,
+			items = new[] { new { name = "Milk", amount = 1m, unit = "l" } },
+		});
+
+	private async Task CleanupOwnersListsAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		var owner = OwnerIdentifier.From(userId);
+		await AspireFixture.CleanupAsync(
+			fixture.CreateShoppingDbContextAsync,
+			ctx => ctx.ShoppingLists.Where(l => l.Owner == owner));
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/RemoveItemContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/RemoveItemContractTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for DELETE /api/v1/shopping-lists/items.
+/// Removal is idempotent at the domain layer — absent item / absent ledger returns 204.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class RemoveItemContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/shopping-lists/items";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		await fixture.ResetShoppingEventStoreAsync(OwnerIdentifier.From(userId));
+	}
+
+	[Fact]
+	public async Task RemoveItem_ExistingItemOnLedger_Returns204()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await client.PostAsJsonAsync("/api/v1/shopping-lists/items", new { name = "Bananas", quantity = 3m });
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = "Bananas", quantity = 1m }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task RemoveItem_NoLedgerForOwner_Returns204Idempotently()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = "Nothing", quantity = 1m }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task RemoveItem_EmptyName_Returns422ValidationProblem()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = string.Empty }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task RemoveItem_NameOverMaxLength_Returns400GuardFailure()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		var overMax = new string('x', ItemName.MaxLength + 1);
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = overMax }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task RemoveItem_NegativeQuantity_Returns400GuardFailure()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = "Bananas", quantity = -1m }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task RemoveItem_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var request = new HttpRequestMessage(HttpMethod.Delete, Endpoint)
+		{
+			Content = JsonContent.Create(new { name = "Bananas" }, options: JsonOptions),
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ShoppingModeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ShoppingModeContractTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Contract;
+
+/// <summary>
+/// Contract tests for the shopping-mode session endpoints
+/// (POST /shopping-lists/shopping-mode/start and /end). Both are idempotent
+/// at the domain layer: start while already in mode is a no-op; end while
+/// not in mode is a no-op.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class ShoppingModeContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string StartEndpoint = "/api/v1/shopping-lists/shopping-mode/start";
+	private const string EndEndpoint = "/api/v1/shopping-lists/shopping-mode/end";
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		await fixture.ResetShoppingEventStoreAsync(OwnerIdentifier.From(userId));
+	}
+
+	[Fact]
+	public async Task StartShoppingMode_FreshOwner_Returns204()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsync(StartEndpoint, content: null);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task StartShoppingMode_CalledTwice_IsIdempotentReturns204()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var first = await client.PostAsync(StartEndpoint, content: null);
+		var second = await client.PostAsync(StartEndpoint, content: null);
+
+		first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+		second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task EndShoppingMode_WithoutStart_Returns204Idempotently()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.PostAsJsonAsync(EndEndpoint, new { acceptPendingChanges = false });
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task StartThenEnd_AcceptPendingChanges_Returns204()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		await client.PostAsync(StartEndpoint, content: null);
+
+		var response = await client.PostAsJsonAsync(EndEndpoint, new { acceptPendingChanges = true });
+
+		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task StartShoppingMode_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.PostAsync(StartEndpoint, content: null);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task EndShoppingMode_WithoutAuth_Returns401()
+	{
+		var client = fixture.ShoppingApi;
+
+		var response = await client.PostAsJsonAsync(EndEndpoint, new { acceptPendingChanges = false });
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}


### PR DESCRIPTION
Partial progress on #279 — complete Shopping module HTTP contract coverage.

**37 tests across 7 endpoints**, following the template established in the original commit.

## Endpoints covered
| Endpoint | Tests |
|---|---|
| POST /shopping-lists/items (AddManualItem) | 10 |
| DELETE /shopping-lists/items (RemoveItem) | 6 |
| GET /shopping-lists (GetAll) | 5 |
| GET /shopping-lists/merged (GetMerged) | 3 |
| PUT /shopping-lists/{id}/check-all (CheckOffAll) | 4 |
| POST /shopping-lists/shopping-mode/start + /end | 6 |
| GET /shopping-lists/export (Export) | 3 |

Each endpoint probes happy paths, validator failures (422), domain-guard failures (400 via global handler) where the validator does not cover them, 401 without auth, and 404/idempotency where the behavior is interesting.

## Fixture additions
- \`GetTestUserIdAsync()\` — decodes sub claim from the JWT
- \`ResetShoppingEventStoreAsync(owner)\` — per-owner event-store cleanup
- \`ResetShoppingReadModelAsync(ownerId)\` — per-owner projection cleanup

## Next PRs
- #279-b Users module (Register, Profile, Staples, Activity, Suggestions)
- #279-c Recipes (GetAll, ToggleFavorite) + MealPlan remaining endpoints
- LLM endpoints deferred (need mocked Semantic Kernel)

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] 37/37 pass locally against real stack via Aspire