### PR TITLE
test(users): HTTP contract tests for Users module (#279)

### DIFF
--- a/tests/Yumney.Integration.Tests/Users/Contract/AuthEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/AuthEndpointsContractTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Users.Contract;
+
+/// <summary>
+/// Contract tests for /api/v1/auth endpoints (Register, ResendVerificationEmail).
+/// Both are anonymous. ResendVerificationEmail always returns 200 to prevent email enumeration.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class AuthEndpointsContractTests(AspireFixture fixture)
+{
+	private const string Register = "/api/v1/auth/register";
+	private const string ResendVerify = "/api/v1/auth/resend-verification-email";
+	private const string KnownTestEmail = "test@yumney.dev";
+
+	[Fact]
+	public async Task Register_ValidInput_Returns201()
+	{
+		var client = fixture.UsersApi;
+		var uniqueEmail = $"register-{Guid.NewGuid():N}@yumney.dev";
+
+		var response = await client.PostAsJsonAsync(Register, new
+		{
+			email = uniqueEmail,
+			password = "Valid1Pass",
+			displayName = "New User",
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.Created);
+	}
+
+	[Fact]
+	public async Task Register_InvalidEmailFormat_Returns422()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(Register, new
+		{
+			email = "not-an-email",
+			password = "Valid1Pass",
+			displayName = "New User",
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task Register_PasswordWithoutUppercase_Returns422()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(Register, new
+		{
+			email = $"noupper-{Guid.NewGuid():N}@yumney.dev",
+			password = "allowercase1",
+			displayName = "New User",
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task Register_EmptyDisplayName_Returns422()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(Register, new
+		{
+			email = $"nodn-{Guid.NewGuid():N}@yumney.dev",
+			password = "Valid1Pass",
+			displayName = string.Empty,
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task Register_ExistingEmail_Returns409()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(Register, new
+		{
+			email = KnownTestEmail,
+			password = "Valid1Pass",
+			displayName = "Duplicate",
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+	}
+
+	[Fact]
+	public async Task ResendVerification_UnknownEmail_ReturnsOkToPreventEnumeration()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(ResendVerify, new
+		{
+			email = $"nosuch-{Guid.NewGuid():N}@yumney.dev",
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task ResendVerification_InvalidEmailFormat_Returns422()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PostAsJsonAsync(ResendVerify, new { email = "not-an-email" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Users.Contract;
+
+/// <summary>
+/// Contract tests for /api/v1/users/me/profile (GET and PUT).
+/// Both require authentication. GET returns 404 if no profile row exists for
+/// the Keycloak user.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class ProfileEndpointsContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/users/me/profile";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	private KeycloakUserId? keycloakId;
+
+	public async Task InitializeAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		keycloakId = KeycloakUserId.From(userId);
+		await CleanupProfileAsync();
+	}
+
+	public Task DisposeAsync() => CleanupProfileAsync();
+
+	[Fact]
+	public async Task GetProfile_NoProfileRow_Returns404()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+
+	[Fact]
+	public async Task GetProfile_ExistingProfile_ReturnsDto()
+	{
+		await fixture.SeedUserProfilesAsync(AppUserProfile.Create(keycloakId!, DisplayName.From("Test User")));
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("displayName").GetString().Should().Be("Test User");
+		body.GetProperty("defaultServings").GetInt32().Should().BeGreaterThan(0);
+	}
+
+	[Fact]
+	public async Task GetProfile_WithoutAuth_Returns401()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task UpdateProfile_ValidInput_Returns200AndPersistsChanges()
+	{
+		await fixture.SeedUserProfilesAsync(AppUserProfile.Create(keycloakId!, DisplayName.From("Test User")));
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.PutAsJsonAsync(Endpoint, new
+		{
+			defaultServings = 6,
+			dietaryType = "vegetarian",
+			restrictions = Array.Empty<string>(),
+			minVeggieMeals = (int?)null,
+			maxRedMeatMeals = (int?)null,
+			cookingEffort = (string?)null,
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("defaultServings").GetInt32().Should().Be(6);
+	}
+
+	[Fact]
+	public async Task UpdateProfile_DefaultServingsOutOfRange_Returns400GuardFailure()
+	{
+		await fixture.SeedUserProfilesAsync(AppUserProfile.Create(keycloakId!, DisplayName.From("Test User")));
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.PutAsJsonAsync(Endpoint, new
+		{
+			defaultServings = 0,
+			dietaryType = (string?)null,
+			restrictions = Array.Empty<string>(),
+			minVeggieMeals = (int?)null,
+			maxRedMeatMeals = (int?)null,
+			cookingEffort = (string?)null,
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task UpdateProfile_WithoutAuth_Returns401()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.PutAsJsonAsync(Endpoint, new
+		{
+			defaultServings = 4,
+			restrictions = Array.Empty<string>(),
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	private Task CleanupProfileAsync()
+	{
+		var id = keycloakId;
+		if (id is null) return Task.CompletedTask;
+		return AspireFixture.CleanupAsync(
+			fixture.CreateUsersDbContextAsync,
+			ctx => ctx.AppUserProfiles.Where(p => p.KeycloakUserId == id));
+	}
+}

--- a/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Users.Contract;
+
+/// <summary>
+/// Contract tests for the remaining authenticated Users endpoints:
+/// GET /users/staples, GET /users/me/activity, GET /users/me/suggestions.
+/// All require auth; all return JSON payloads tied to the current user.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class StaplesAndActivityContractTests(AspireFixture fixture)
+{
+	private const string Staples = "/api/v1/users/staples";
+	private const string Activity = "/api/v1/users/me/activity";
+	private const string Suggestions = "/api/v1/users/me/suggestions";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task GetStaples_Authenticated_Returns200WithJsonArray()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync(Staples);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.ValueKind.Should().Be(JsonValueKind.Array);
+	}
+
+	[Fact]
+	public async Task GetStaples_WithoutAuth_Returns401()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.GetAsync(Staples);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetRecentActivity_Authenticated_Returns200WithJsonArray()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync(Activity);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.ValueKind.Should().Be(JsonValueKind.Array);
+	}
+
+	[Fact]
+	public async Task GetRecentActivity_WithLimitParameter_Returns200()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync($"{Activity}?limit=3");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task GetRecentActivity_InvalidLimitOutOfRange_Returns400GuardFailure()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync($"{Activity}?limit=0");
+
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task GetRecentActivity_WithoutAuth_Returns401()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.GetAsync(Activity);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetSuggestions_Authenticated_Returns200WithObject()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
+
+		var response = await client.GetAsync(Suggestions);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.ValueKind.Should().Be(JsonValueKind.Object);
+	}
+
+	[Fact]
+	public async Task GetSuggestions_WithoutAuth_Returns401()
+	{
+		var client = fixture.UsersApi;
+
+		var response = await client.GetAsync(Suggestions);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+}


### PR DESCRIPTION
Partial progress on #279 — Users module HTTP contract coverage.

**21 tests across 7 endpoints**, same depth/style as the Shopping PR (#286).

## Endpoints covered
| Endpoint | Auth | Tests |
|---|---|---|
| POST /auth/register | anon | 5 |
| POST /auth/resend-verification-email | anon | 2 |
| GET /users/me/profile | required | 3 |
| PUT /users/me/profile | required | 3 |
| GET /users/staples | required | 2 |
| GET /users/me/activity | required | 4 |
| GET /users/me/suggestions | required | 2 |

## Notes
- Register happy path uses unique per-run emails; Keycloak test users accumulate (admin cleanup out of scope)
- \`ResendVerification_KnownEmail_Returns200\` is omitted: the real SMTP send triggered by Keycloak is not configured in E2ETests mode, so a 5xx is unavoidable and not useful to assert. Unknown-email and invalid-format cover the rest of the contract surface.

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] 21/21 pass locally against real stack via Aspire