### PR TITLE
feat(events): cross-module integration events (closes #280)

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -2,10 +2,16 @@ using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
 
-public sealed class ConfirmMealCommandHandler(IMealPlanUnitOfWork unitOfWork, ICurrentUser currentUser)
+public sealed class ConfirmMealCommandHandler(
+	IMealPlanUnitOfWork unitOfWork,
+	ICurrentUser currentUser,
+	IRecipeIngredientProvider ingredientProvider,
+	IEventBus eventBus)
 	: ICommandHandler<ConfirmMealCommand, Result<WeeklyPlanDto>>
 {
 	public async Task<Result<WeeklyPlanDto>> HandleAsync(ConfirmMealCommand command, CancellationToken cancellationToken = default)
@@ -15,9 +21,19 @@ public sealed class ConfirmMealCommandHandler(IMealPlanUnitOfWork unitOfWork, IC
 
 		var plan = await unitOfWork.Plans.GetByOwnerAndWeekAsync(owner, week, cancellationToken);
 
+		SlotRecipeReference? confirmedRecipe = null;
+		SlotServings? confirmedServings = null;
+
 		switch (newState)
 		{
 			case MealState.Cooked:
+				var slot = plan.GetVisibleSlots().FirstOrDefault(s => s.Day == day && s.MealType == mealType);
+				if (slot is not null)
+				{
+					confirmedRecipe = slot.Recipe;
+					confirmedServings = slot.Servings;
+				}
+
 				plan.MarkAsCooked(day, mealType);
 				break;
 			case MealState.Skipped:
@@ -29,6 +45,26 @@ public sealed class ConfirmMealCommandHandler(IMealPlanUnitOfWork unitOfWork, IC
 		}
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
+
+		if (newState == MealState.Cooked && confirmedRecipe is not null && confirmedServings is not null)
+		{
+			var ingredients = await ingredientProvider.GetIngredientsAsync(
+				confirmedRecipe.RecipeIdentifier.Value,
+				cancellationToken);
+
+			var payload = ingredients
+				.Where(i => i.Amount.HasValue && i.Amount.Value > 0m)
+				.Select(i => new MealConfirmedIngredient(i.Name, i.Amount!.Value, i.Unit))
+				.ToList();
+
+			await eventBus.PublishAsync(
+				new MealConfirmedIntegrationEvent(
+					owner.Value,
+					confirmedRecipe.RecipeIdentifier.Value,
+					confirmedServings.Value,
+					payload),
+				cancellationToken);
+		}
 
 		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
 	}

--- a/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
+++ b/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 
 public sealed class DeleteRecipeCommandHandler(
 	IRecipesUnitOfWork unitOfWork,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IEventBus eventBus)
 	: ICommandHandler<DeleteRecipeCommand, Result>
 {
 	public async Task<Result> HandleAsync(DeleteRecipeCommand command, CancellationToken cancellationToken = default)
@@ -25,6 +28,10 @@ public sealed class DeleteRecipeCommandHandler(
 
 		unitOfWork.Recipes.Remove(recipe);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
+
+		await eventBus.PublishAsync(
+			new RecipeDeletedIntegrationEvent(owner.Value, identifier.Value),
+			cancellationToken);
 
 		return Result.Success();
 	}

--- a/src/Yumney.Recipes.Application/Yumney.Recipes.Application.csproj
+++ b/src/Yumney.Recipes.Application/Yumney.Recipes.Application.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Shared.Events/CrossModule/MealConfirmedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/MealConfirmedIntegrationEvent.cs
@@ -1,0 +1,15 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the MealPlan module when a planned meal transitions to the
+/// <c>Cooked</c> state. Carries the ingredient list at the time of confirmation
+/// so downstream subscribers (Shopping) can apply per-ingredient side effects
+/// without a sync call back into Recipes.
+/// </summary>
+public sealed record MealConfirmedIntegrationEvent(
+	string OwnerId,
+	Guid RecipeIdentifier,
+	int Servings,
+	IReadOnlyList<MealConfirmedIngredient> Ingredients) : IntegrationEvent;
+
+public sealed record MealConfirmedIngredient(string Name, decimal Quantity, string? Unit);

--- a/src/Yumney.Shared.Events/CrossModule/RecipeDeletedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/RecipeDeletedIntegrationEvent.cs
@@ -1,0 +1,10 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Recipes module after a recipe has been deleted.
+/// Subscribers (e.g. Shopping) use this to clean up any cross-module
+/// references to the deleted recipe.
+/// </summary>
+public sealed record RecipeDeletedIntegrationEvent(
+	string OwnerId,
+	Guid RecipeIdentifier) : IntegrationEvent;

--- a/src/Yumney.Shopping.Api/Program.cs
+++ b/src/Yumney.Shopping.Api/Program.cs
@@ -2,11 +2,14 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
 using SmartSolutionsLab.Yumney.Shopping.Api;
 using SmartSolutionsLab.Yumney.Shopping.Application;
+using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddYumneyDefaults(typeof(ShoppingInfrastructureServiceCollectionExtensions).Assembly);
+builder.AddYumneyDefaults(
+	typeof(ShoppingInfrastructureServiceCollectionExtensions).Assembly,
+	typeof(RecipeDeletedHandler).Assembly);
 
 builder.Services
 	.AddShoppingApi()

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/MealConfirmedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/MealConfirmedHandler.cs
@@ -1,0 +1,36 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Cross-module reaction to <see cref="MealConfirmedIntegrationEvent"/>.
+/// For each ingredient carried in the event, marks the corresponding quantity
+/// as consumed on the owner's shopping ledger. Items that are not on the
+/// ledger are tolerated (the ledger clamps negative values).
+/// </summary>
+public sealed class MealConfirmedHandler(IShoppingEventStore eventStore)
+	: IIntegrationEventHandler<MealConfirmedIntegrationEvent>
+{
+	/// <inheritdoc />
+	public async Task HandleAsync(MealConfirmedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		if (@event.Ingredients.Count == 0) return;
+
+		var owner = OwnerIdentifier.From(@event.OwnerId);
+		var ledger = await eventStore.LoadAsync(owner, cancellationToken);
+		if (ledger is null) return;
+
+		var source = ItemSource.From("meal-plan");
+		foreach (var ingredient in @event.Ingredients)
+		{
+			var itemName = ItemName.From(ingredient.Name);
+			var quantity = Quantity.Of(Amount.From(ingredient.Quantity), Unit.FromNullable(ingredient.Unit));
+			ledger.MarkConsumed(itemName, quantity, source);
+		}
+
+		await eventStore.SaveAsync(ledger, cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
@@ -1,0 +1,32 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Cross-module reaction to <see cref="RecipeDeletedIntegrationEvent"/>.
+/// Nulls out the <c>RecipeReference</c> on every shopping list owned by the
+/// publishing user that still references the deleted recipe. The user's list
+/// and items are preserved — only the broken link is severed.
+/// </summary>
+public sealed class RecipeDeletedHandler(IShoppingUnitOfWork unitOfWork)
+	: IIntegrationEventHandler<RecipeDeletedIntegrationEvent>
+{
+	/// <inheritdoc />
+	public async Task HandleAsync(RecipeDeletedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var owner = OwnerIdentifier.From(@event.OwnerId);
+		var reference = RecipeReference.From(@event.RecipeIdentifier);
+
+		var lists = await unitOfWork.ShoppingLists.FindByRecipeReferenceAsync(owner, reference, cancellationToken);
+		if (lists.Count == 0) return;
+
+		foreach (var list in lists)
+		{
+			list.ClearRecipeReference();
+		}
+
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj
+++ b/src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListRepository.cs
@@ -17,4 +17,9 @@ public interface IShoppingListRepository
 		PagingOptions paging,
 		SortingOptions<ShoppingListSortField> sorting,
 		CancellationToken cancellationToken = default);
+
+	Task<IReadOnlyList<ShoppingList>> FindByRecipeReferenceAsync(
+		OwnerIdentifier owner,
+		RecipeReference recipeReference,
+		CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -80,6 +80,12 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 		return this;
 	}
 
+	public ShoppingList ClearRecipeReference()
+	{
+		RecipeReference = null;
+		return this;
+	}
+
 	private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)
 	{
 		var item = items.FirstOrDefault(i => i.Id == itemId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260421160828_AddInboxMessages.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260421160828_AddInboxMessages.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421160828_AddInboxMessages")]
+    partial class AddInboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260421160828_AddInboxMessages.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260421160828_AddInboxMessages.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxMessages",
+                columns: table => new
+                {
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsumerName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ProcessedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxMessages", x => new { x.MessageId, x.ConsumerName });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InboxMessages");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
@@ -14,8 +16,11 @@ public sealed class ShoppingDbContext(DbContextOptions<ShoppingDbContext> option
 
 	public DbSet<AggregateMetadata> ShoppingAggregates => Set<AggregateMetadata>();
 
+	public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
+
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
 		modelBuilder.ApplyConfigurationsFromAssembly(typeof(ShoppingDbContext).Assembly);
+		modelBuilder.ApplyConfiguration(new InboxMessageConfiguration());
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
@@ -53,6 +53,16 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 		return (items, ItemCount.From(totalCount));
 	}
 
+	public async Task<IReadOnlyList<ShoppingList>> FindByRecipeReferenceAsync(
+		OwnerIdentifier owner,
+		RecipeReference recipeReference,
+		CancellationToken cancellationToken = default)
+	{
+		return await shoppingLists
+			.Where(l => l.Owner == owner && l.RecipeReference == recipeReference)
+			.ToListAsync(cancellationToken);
+	}
+
 	private static IQueryable<ShoppingList> ApplySorting(
 		IQueryable<ShoppingList> query,
 		SortingOptions<ShoppingListSortField> sorting)

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -47,6 +49,9 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingListProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
+		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
+		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
 		return services;

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.CrossModule;
+
+/// <summary>
+/// End-to-end: DELETE /api/v1/recipes/{id} publishes RecipeDeletedIntegrationEvent,
+/// Shopping subscribes and nulls the RecipeReference on any of the owner's lists
+/// that pointed at the deleted recipe.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => CleanupAsync();
+
+	public Task DisposeAsync() => CleanupAsync();
+
+	[Fact]
+	public async Task DeleteRecipe_WithLinkedShoppingList_NullsRecipeReference()
+	{
+		using var recipesClient = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		using var shoppingClient = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var recipeId = await CreateRecipeAsync(recipesClient);
+		var listId = await CreateShoppingListAsync(shoppingClient, recipeId);
+
+		var delete = await recipesClient.DeleteAsync($"/api/v1/recipes/{recipeId}");
+		delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+		await WaitForAsync(async () =>
+		{
+			var userId = await fixture.GetTestUserIdAsync();
+			var owner = OwnerIdentifier.From(userId);
+			await using var ctx = await fixture.CreateShoppingDbContextAsync();
+			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(listId) && l.Owner == owner);
+			return list.RecipeReference is null;
+		});
+	}
+
+	[Fact]
+	public async Task DeleteRecipe_WithUnrelatedShoppingList_LeavesReferenceIntact()
+	{
+		using var recipesClient = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		using var shoppingClient = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var recipeA = await CreateRecipeAsync(recipesClient);
+		var recipeB = await CreateRecipeAsync(recipesClient);
+		var linkedToB = await CreateShoppingListAsync(shoppingClient, recipeB);
+
+		var delete = await recipesClient.DeleteAsync($"/api/v1/recipes/{recipeA}");
+		delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+		await Task.Delay(2000);
+
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(linkedToB));
+		list.RecipeReference.Should().NotBeNull();
+	}
+
+	private static async Task<Guid> CreateRecipeAsync(HttpClient client)
+	{
+		var response = await client.PostAsJsonAsync("/api/v1/recipes", new
+		{
+			title = $"Recipe-{Guid.NewGuid():N}",
+			ingredients = new object[] { new { name = "Water", amount = 1m, unit = "l" } },
+			steps = new object[] { new { number = 1, description = "Boil." } },
+		});
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		return body.GetProperty("identifier").GetGuid();
+	}
+
+	private static async Task<Guid> CreateShoppingListAsync(HttpClient client, Guid recipeId)
+	{
+		var response = await client.PostAsJsonAsync("/api/v1/shopping-lists/", new
+		{
+			title = $"List-{Guid.NewGuid():N}",
+			items = new[] { new { name = "Water", amount = 1m, unit = "l" } },
+			recipeIdentifier = recipeId,
+		});
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		return body.GetProperty("identifier").GetGuid();
+	}
+
+	private static async Task WaitForAsync(Func<Task<bool>> predicate, int timeoutSeconds = 15)
+	{
+		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+		while (DateTime.UtcNow < deadline)
+		{
+			if (await predicate()) return;
+			await Task.Delay(250);
+		}
+
+		throw new TimeoutException($"Condition not met within {timeoutSeconds}s");
+	}
+
+	private async Task CleanupAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		var owner = OwnerIdentifier.From(userId);
+		await AspireFixture.CleanupAsync(
+			fixture.CreateShoppingDbContextAsync,
+			ctx => ctx.ShoppingLists.Where(l => l.Owner == owner));
+		await AspireFixture.CleanupAsync(
+			fixture.CreateRecipesDbContextAsync,
+			ctx => ctx.Recipes.Where(r => r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+	}
+}

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/ConfirmMealCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/ConfirmMealCommandHandlerTests.cs
@@ -3,6 +3,8 @@ using NSubstitute;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using Xunit;
 using static SmartSolutionsLab.Yumney.MealPlan.Application.Tests.MealPlanTestFixture;
 
@@ -12,12 +14,16 @@ public class ConfirmMealCommandHandlerTests
 {
 	private readonly IWeeklyPlanRepository plans = Substitute.For<IWeeklyPlanRepository>();
 	private readonly IMealPlanUnitOfWork unitOfWork = Substitute.For<IMealPlanUnitOfWork>();
+	private readonly IRecipeIngredientProvider ingredientProvider = Substitute.For<IRecipeIngredientProvider>();
+	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
 	private readonly ConfirmMealCommandHandler handler;
 
 	public ConfirmMealCommandHandlerTests()
 	{
 		unitOfWork.Plans.Returns(plans);
-		handler = new ConfirmMealCommandHandler(unitOfWork, CreateCurrentUser());
+		ingredientProvider.GetIngredientsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+			.Returns(Array.Empty<RecipeIngredientInfo>());
+		handler = new ConfirmMealCommandHandler(unitOfWork, CreateCurrentUser(), ingredientProvider, eventBus);
 	}
 
 	[Fact]

--- a/tests/Yumney.Recipes.Application.Tests/Commands/DeleteRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/DeleteRecipeCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
@@ -14,13 +15,14 @@ public class DeleteRecipeCommandHandlerTests
 	private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
 	private readonly IRecipesUnitOfWork unitOfWork = Substitute.For<IRecipesUnitOfWork>();
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
 	private readonly DeleteRecipeCommandHandler handler;
 
 	public DeleteRecipeCommandHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
 		unitOfWork.Recipes.Returns(recipes);
-		handler = new DeleteRecipeCommandHandler(unitOfWork, currentUser);
+		handler = new DeleteRecipeCommandHandler(unitOfWork, currentUser, eventBus);
 	}
 
 	[Fact]


### PR DESCRIPTION
Closes #280. Implements two cross-module event flows plus the supporting inbox infrastructure.

## Flows shipped

**Flow 1 — RecipeDeleted → Shopping cleanup**
Recipes publishes \`RecipeDeletedIntegrationEvent(OwnerId, RecipeIdentifier)\` after a successful delete. Shopping nulls the \`RecipeReference\` on every list the owner has pointing at that recipe. User data is preserved — only the broken link is severed.

**Flow 2 — MealConfirmed → Shopping deduction**
MealPlan fetches recipe ingredients via the existing \`IRecipeIngredientProvider\` when a slot transitions to \`Cooked\`, then publishes \`MealConfirmedIntegrationEvent\` with a denormalized ingredient list. Shopping raises \`MarkConsumed\` per ingredient on the ledger.

## Infrastructure
- New event contracts in \`Yumney.Shared.Events.CrossModule/\`
- \`EfCoreInboxStore<ShoppingDbContext>\` activated; \`InboxMessages\` table added via migration \`20260421160828_AddInboxMessages\`
- Shopping.Api now scans \`Shopping.Application\` for handler registrations alongside \`Shopping.Infrastructure\`
- New domain method \`ShoppingList.ClearRecipeReference()\`
- New repository query \`IShoppingListRepository.FindByRecipeReferenceAsync\`

## Tests
2 new integration tests in \`CrossModule/\` that run end-to-end through real RabbitMQ via the Aspire fixture:
- \`DeleteRecipe_WithLinkedShoppingList_NullsRecipeReference\` — propagation
- \`DeleteRecipe_WithUnrelatedShoppingList_LeavesReferenceIntact\` — isolation

Flow 2 has been fully implemented (code + wiring) but end-to-end tests for it would follow the same pattern; they were held back to keep this PR reviewable. Follow-up issue recommended for the confirmed-meal propagation tests + inbox dedup assertion.

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] 1715 existing unit tests pass (no regressions)
- [x] 2 new cross-module tests pass locally against the Aspire stack (PostgreSQL + Keycloak + RabbitMQ)