### PR TITLE
test(shared): backfill tests for inbox and query interceptor (closes #282)

### DIFF
--- a/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shared;
+
+/// <summary>
+/// Integration tests for <see cref="EfCoreInboxStore{TContext}"/> using the
+/// Shopping module's DbContext (the first module to activate the inbox
+/// per #280). Real PostgreSQL is required so the unique constraint on
+/// (MessageId, ConsumerName) fires for the duplicate-insert path.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class EfCoreInboxStoreTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly List<(Guid MessageId, string ConsumerName)> recorded = [];
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		if (recorded.Count == 0) return;
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		foreach (var (messageId, consumerName) in recorded)
+		{
+			var row = await context.InboxMessages
+				.FirstOrDefaultAsync(m => m.MessageId == messageId && m.ConsumerName == consumerName);
+			if (row is not null)
+			{
+				context.InboxMessages.Remove(row);
+			}
+		}
+
+		await context.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task TryMarkProcessedAsync_NewPair_ReturnsTrueAndPersists()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerName = $"consumer-{Guid.NewGuid():N}";
+		recorded.Add((messageId, consumerName));
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+
+		var result = await store.TryMarkProcessedAsync(messageId, consumerName);
+
+		result.Should().BeTrue();
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		(await verify.InboxMessages.AnyAsync(m => m.MessageId == messageId && m.ConsumerName == consumerName))
+			.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task TryMarkProcessedAsync_DuplicatePair_ReturnsFalse()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerName = $"consumer-{Guid.NewGuid():N}";
+		recorded.Add((messageId, consumerName));
+
+		await using (var firstContext = await fixture.CreateShoppingDbContextAsync())
+		{
+			var first = new EfCoreInboxStore<ShoppingDbContext>(firstContext);
+			(await first.TryMarkProcessedAsync(messageId, consumerName)).Should().BeTrue();
+		}
+
+		await using var secondContext = await fixture.CreateShoppingDbContextAsync();
+		var second = new EfCoreInboxStore<ShoppingDbContext>(secondContext);
+		var duplicateResult = await second.TryMarkProcessedAsync(messageId, consumerName);
+
+		duplicateResult.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task TryMarkProcessedAsync_DuplicatePair_DetachesFailedEntity()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerName = $"consumer-{Guid.NewGuid():N}";
+		recorded.Add((messageId, consumerName));
+
+		await using (var first = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new EfCoreInboxStore<ShoppingDbContext>(first).TryMarkProcessedAsync(messageId, consumerName);
+		}
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		await new EfCoreInboxStore<ShoppingDbContext>(context).TryMarkProcessedAsync(messageId, consumerName);
+
+		context.ChangeTracker.Entries<InboxMessage>().Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task TryMarkProcessedAsync_SameMessageDifferentConsumer_ReturnsTrueForBoth()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerA = $"consumer-a-{Guid.NewGuid():N}";
+		var consumerB = $"consumer-b-{Guid.NewGuid():N}";
+		recorded.Add((messageId, consumerA));
+		recorded.Add((messageId, consumerB));
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+
+		(await store.TryMarkProcessedAsync(messageId, consumerA)).Should().BeTrue();
+		(await store.TryMarkProcessedAsync(messageId, consumerB)).Should().BeTrue();
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/QueryCountingInterceptorTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/QueryCountingInterceptorTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+/// <summary>
+/// Verifies that each overridden hook increments the injected counter.
+/// A full EF Core wiring test lives in the Integration.Tests suite where a
+/// relational provider is available — these tests are the unit-level guard.
+/// </summary>
+public class QueryCountingInterceptorTests
+{
+	private readonly QueryCounter counter = new();
+	private readonly QueryCountingInterceptor interceptor;
+
+	public QueryCountingInterceptorTests()
+	{
+		interceptor = new QueryCountingInterceptor(counter);
+	}
+
+	[Fact]
+	public void ReaderExecuting_IncrementsCounter()
+	{
+		interceptor.ReaderExecuting(default!, default!, default);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ReaderExecutingAsync_IncrementsCounter()
+	{
+		await interceptor.ReaderExecutingAsync(default!, default!, default, CancellationToken.None);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public void NonQueryExecuting_IncrementsCounter()
+	{
+		interceptor.NonQueryExecuting(default!, default!, default);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task NonQueryExecutingAsync_IncrementsCounter()
+	{
+		await interceptor.NonQueryExecutingAsync(default!, default!, default, CancellationToken.None);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public void ScalarExecuting_IncrementsCounter()
+	{
+		interceptor.ScalarExecuting(default!, default!, default);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ScalarExecutingAsync_IncrementsCounter()
+	{
+		await interceptor.ScalarExecutingAsync(default!, default!, default, CancellationToken.None);
+
+		counter.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public void MixedHookCalls_AccumulateCount()
+	{
+		interceptor.ReaderExecuting(default!, default!, default);
+		interceptor.NonQueryExecuting(default!, default!, default);
+		interceptor.ScalarExecuting(default!, default!, default);
+
+		counter.Count.Should().Be(3);
+	}
+}


### PR DESCRIPTION
Closes #282. 11 new tests addressing the two real coverage gaps from the audit. The other bullets were already tested (extraction retry, ContentSanitizer) or are frontend code.

## Coverage
**QueryCountingInterceptorTests** (7 tests, \`Yumney.Shared.Tests\`) — each of the six hooks (reader/non-query/scalar × sync/async) calls \`counter.Increment()\`, plus a mixed-call accumulation test. Unit-level only; the full EF Core pipeline wiring is exercised transitively by integration tests whenever a relational provider is present.

**EfCoreInboxStoreTests** (4 tests, \`Yumney.Integration.Tests\`, real PostgreSQL via Aspire):
- New (messageId, consumerName) pair returns true and persists
- Duplicate pair returns false via unique-constraint path
- Failed insert detaches the tracked entity so subsequent saves aren't affected
- Same message for different consumers — both succeed

## Out of scope
- \`fix(shopping): guard merged-list load against stale in-flight responses\` — frontend/Angular, already has its own spec.
- End-to-end inbox dedup via IEventBus (flagged in #280 as follow-up) — requires Wolverine/RabbitMQ orchestration in tests; deserves its own ticket.

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] 7 interceptor tests pass
- [x] 4 inbox store tests pass against real PostgreSQL