### PR TITLE
fix(ci): make integration tests actually gate merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
   workflow_call:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -15,6 +17,7 @@ jobs:
   backend:
     name: Backend (Build + Test)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +51,6 @@ jobs:
         run: dotnet test Yumney.slnx --no-build --configuration Release --filter "FullyQualifiedName!~Integration" --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Integration Tests
-        continue-on-error: true
         run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj --no-build --configuration Release
 
       - name: Upload coverage
@@ -60,6 +62,7 @@ jobs:
   frontend:
     name: Frontend (Build + Test)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     defaults:
       run:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,12 @@ name: Deploy
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
     tags: ['v*']
+
+concurrency:
+  group: deploy-${{ github.ref_type == 'tag' && 'production' || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   id-token: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 30
 
     steps:

--- a/tests/Yumney.Integration.Tests/MealPlan/Contract/MealPlanMutationContractTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/Contract/MealPlanMutationContractTests.cs
@@ -128,6 +128,10 @@ public class MealPlanMutationContractTests(AspireFixture fixture)
 	[Fact]
 	public async Task ConfirmMeal_SlotExists_Returns200()
 	{
+		// Uses state=2 (Skipped) instead of 1 (Cooked) — Cooked triggers the
+		// cross-module ingredient lookup added in #280, which needs a real
+		// recipe. End-to-end Cooked propagation belongs in a dedicated
+		// cross-module test, not this contract test.
 		using var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
 		var week = WeekPath(14);
 		await client.PostAsJsonAsync(week + "/slots", new
@@ -143,7 +147,7 @@ public class MealPlanMutationContractTests(AspireFixture fixture)
 		{
 			day = DayOfWeek.Wednesday,
 			mealType = 0,
-			state = 1,
+			state = 2,
 		});
 
 		response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
@@ -43,11 +43,23 @@ public class ExportShoppingListContractTests(AspireFixture fixture) : IAsyncLife
 			"/api/v1/shopping-lists/items",
 			new { name = "Strawberries", quantity = 500m, unit = "g" });
 
-		var response = await client.GetAsync(Endpoint);
+		// The shopping read-model projection is driven async by Wolverine, so
+		// the export may not see the new item immediately after the POST returns.
+		var deadline = DateTime.UtcNow.AddSeconds(15);
+		string body = string.Empty;
+		HttpResponseMessage? response = null;
+		while (DateTime.UtcNow < deadline)
+		{
+			response?.Dispose();
+			response = await client.GetAsync(Endpoint);
+			body = await response.Content.ReadAsStringAsync();
+			if (body.Contains("Strawberries", StringComparison.Ordinal)) break;
+			await Task.Delay(250);
+		}
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		var body = await response.Content.ReadAsStringAsync();
+		response!.StatusCode.Should().Be(HttpStatusCode.OK);
 		body.Should().Contain("Strawberries");
+		response.Dispose();
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
@@ -47,13 +47,24 @@ public class GetMergedShoppingListContractTests(AspireFixture fixture) : IAsyncL
 		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
 		await client.PostAsJsonAsync("/api/v1/shopping-lists/items", new { name = "Oranges", quantity = 4m });
 
-		var response = await client.GetAsync(Endpoint);
+		// Shopping read-model projection is driven async by Wolverine; poll.
+		var deadline = DateTime.UtcNow.AddSeconds(15);
+		JsonElement body = default;
+		HttpResponseMessage? response = null;
+		while (DateTime.UtcNow < deadline)
+		{
+			response?.Dispose();
+			response = await client.GetAsync(Endpoint);
+			body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			if (body.GetProperty("items").GetArrayLength() > 0) break;
+			await Task.Delay(250);
+		}
 
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		response!.StatusCode.Should().Be(HttpStatusCode.OK);
 		var items = body.GetProperty("items");
 		items.GetArrayLength().Should().Be(1);
 		items[0].GetProperty("itemName").GetString().Should().Be("Oranges");
+		response.Dispose();
 	}
 
 	[Fact]


### PR DESCRIPTION
## Why
While auditing the deploy pipeline I noticed \`ci.yml:51\` had \`continue-on-error: true\` on the integration-test step, and \`e2e.yml:18\` had the same on the E2E job. That meant any integration-test failure shipped silently to develop.

Grepped the last deploy-run log and, sure enough, \`Yumney.Integration.Tests\` reports \`Failed: 1, Passed: 179\` on develop right now — masked. The failing test is \`ConfirmMeal_SlotExists_Returns200\` (a contract test I wrote in #279 that broke once #280 added cross-module ingredient lookup for the Cooked transition; the test uses a random GUID that doesn't resolve to a real recipe).

## What changes

**Fix the broken test**
- \`ConfirmMeal_SlotExists_Returns200\` now uses \`state=Skipped\` (2) instead of \`Cooked\` (1). Cooked triggers cross-module behaviour that belongs in a dedicated propagation test, not a contract smoke test. Comment in-place explains the why.

**Stop hiding regressions**
- Drop \`continue-on-error: true\` from the CI integration-tests step and the E2E job.

**Pipeline hygiene**
- \`ci.yml\`: remove \`push\` trigger (keep \`pull_request\` + \`workflow_call\`) so CI doesn't double-run on pushes that also trigger deploy.yml (which calls CI as a reusable workflow).
- \`ci.yml\`: add \`concurrency\` (cancel older PR runs) and \`timeout-minutes\` on both jobs.
- \`deploy.yml\`: add \`concurrency\` keyed on environment — no parallel deploys to the same target.
- \`deploy.yml\`: drop \`main\` from the push trigger. Tags (\`v*\`) are the sole production trigger; develop pushes still auto-deploy to staging.

## Not in this PR (deliberate)
- Post-deploy health check — needs gateway URL + endpoint decision.
- Removing the explicit \`aspire do push\` step that duplicates what \`aspire deploy\` already does — riskier change to deploy logic; separate PR.
- Silent-skip guard \`if: vars.AZURE_CLIENT_ID != ''\` — useful for forks, leaving for now.

## Test plan
- [x] Failing test fixed locally (passes against real Aspire stack)
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean (no code style changes)
- [ ] CI now actually fails if integration tests fail — will be proven by this very PR's CI run