### PR TITLE
test(domain): AssertionScope + fix DateTime.UtcNow races (partial #283)

### DIFF
--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 using SmartSolutionsLab.Yumney.Shared.Guards;
@@ -47,14 +48,13 @@ public class RecipeTests
 	}
 
 	[Fact]
-	public void Create_ValidInput_SetsCreatedAt()
+	public void Create_ValidInput_SetsCreatedAtCloseToNow()
 	{
 		var before = DateTime.UtcNow;
 
 		var recipe = CreateValidRecipe();
 
-		recipe.CreatedAt.Should().BeOnOrAfter(before);
-		recipe.CreatedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+		recipe.CreatedAt.Should().BeCloseTo(before, TimeSpan.FromSeconds(5));
 	}
 
 	[Fact]
@@ -111,6 +111,7 @@ public class RecipeTests
 			difficulty: difficulty,
 			imageUrl: imageUrl);
 
+		using var scope = new AssertionScope();
 		recipe.Description.Should().Be(description);
 		recipe.Servings.Should().Be(servings);
 		recipe.Timing?.Preparation.Should().Be(preparationTime);
@@ -124,6 +125,7 @@ public class RecipeTests
 	{
 		var recipe = CreateValidRecipe();
 
+		using var scope = new AssertionScope();
 		recipe.Description.Should().BeNull();
 		recipe.Servings.Should().BeNull();
 		recipe.Timing?.Preparation.Should().BeNull();

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/ShoppingLedgerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
@@ -17,6 +18,7 @@ public class ShoppingLedgerTests
 
 		var ledger = Domain.ShoppingLedger.ShoppingLedger.Create(owner);
 
+		using var scope = new AssertionScope();
 		ledger.OwnerId.Should().Be(owner);
 		ledger.Items.Should().BeEmpty();
 		ledger.Version.Should().Be(AggregateVersion.Zero());

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -37,14 +37,13 @@ public class ShoppingListTests
 	}
 
 	[Fact]
-	public void Create_ValidInput_SetsCreatedAt()
+	public void Create_ValidInput_SetsCreatedAtCloseToNow()
 	{
 		var before = DateTime.UtcNow;
 
 		var shoppingList = CreateValidShoppingList();
 
-		shoppingList.CreatedAt.Should().BeOnOrAfter(before);
-		shoppingList.CreatedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+		shoppingList.CreatedAt.Should().BeCloseTo(before, TimeSpan.FromSeconds(5));
 	}
 
 	[Fact]


### PR DESCRIPTION
Partial progress on #283 — the two surgical wins from the test-quality audit.

## What changes

**AssertionScope on 3 worst multi-assertion tests** so all assertion failures are reported in a single run instead of stopping at the first:
- \`RecipeTests.Create_WithOptionalFields_SetsAllFields\` (6 chains)
- \`RecipeTests.Create_WithoutOptionalFields_LeavesNullable\` (6 chains)
- \`ShoppingLedgerTests.Create_ValidOwner_ReturnsEmptyLedger\` (4 chains)

**Two \`DateTime.UtcNow\` race fixes**. The pattern \`actual.Should().BeOnOrBefore(DateTime.UtcNow)\` captures "now" at assertion time, which on a slow runner can drift behind the constructor's \`UtcNow\` and fail spuriously. Replaced with \`BeCloseTo(before, 5s)\`:
- \`RecipeTests.Create_ValidInput_SetsCreatedAt\`
- \`ShoppingListTests.Create_ValidInput_SetsCreatedAt\`

(\`UserActivityTests\` already uses \`BeCloseTo\` with 2s tolerance — left as-is.)

## Deferred

- **Fluent test builders**. The audit recommended \`RecipeTestBuilder().WithTitle(...).Build()\` per aggregate, but each Domain.Tests project already has local \`CreateValidXxx\` helpers. Converting them to fluent builders is churn without a corresponding coverage gain. I'd revisit only when a real duplication pattern emerges.
- **\`[Theory]\` edge-case expansion** (empty / null / max-length). Per-aggregate audit; deserves its own scoped PR.

## Test plan
- [x] 233 Recipes.Domain.Tests pass
- [x] 166 Shopping.Domain.Tests pass
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean