### PR TITLE
ci: drop double-push and tighten integration-test filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet build Yumney.slnx --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test Yumney.slnx --no-build --configuration Release --filter "FullyQualifiedName!~Integration" --collect:"XPlat Code Coverage" --results-directory ./coverage
+        run: dotnet test Yumney.slnx --no-build --configuration Release --filter "FullyQualifiedName!~SmartSolutionsLab.Yumney.Integration.Tests" --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Integration Tests
         run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj --no-build --configuration Release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,27 +134,10 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Build and push images to GHCR
-        working-directory: src/Yumney.AppHost
-        run: aspire do push
-        env:
-          RegistryEndpoint: ghcr.io
-          RegistryRepository: ${{ github.repository }}
-          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          Azure__Location: ${{ vars.AZURE_LOCATION }}
-          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
-          Parameters__PostgresUser: ${{ vars.POSTGRES_USER }}
-          Parameters__PostgresPassword: ${{ secrets.POSTGRES_PASSWORD }}
-          Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
-          Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
-          Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
-          Parameters__RedisPassword: ${{ secrets.REDIS_PASSWORD }}
-          Parameters__KeycloakDbHost: ${{ vars.POSTGRES_HOST }}
-
       - name: Deploy to Azure
         working-directory: src/Yumney.AppHost
         run: |
-          aspire deploy --no-build \
+          aspire deploy \
             -- \
             RegistryEndpoint=ghcr.io \
             RegistryRepository=${{ github.repository }} \


### PR DESCRIPTION
Two small pipeline hygiene fixes, follow-up to the audit noted in #291.

## deploy.yml
Drop the standalone \`aspire do push\` step. \`aspire deploy\` already runs build + push before provisioning, so every image was being pushed twice per deploy (each with a fresh timestamped tag). This halves the GHCR surface — exactly the path that flaked on #280's first deploy attempt.

Also drop \`--no-build\` from \`aspire deploy\`: observed in logs that deploy rebuilds anyway because the timestamped tag differs run-to-run, so the flag was misleading.

## ci.yml
Tighten the unit-test filter.

Before:
\`\`\`
--filter "FullyQualifiedName!~Integration"
\`\`\`
A future class named \`AspireIntegrationRegistrationTests\` in any module would silently vanish from the unit run.

After:
\`\`\`
--filter "FullyQualifiedName!~SmartSolutionsLab.Yumney.Integration.Tests"
\`\`\`
Matches only the Integration.Tests project namespace.

## Test plan
- [x] Unit-test command shape preserved (still excludes Integration.Tests, nothing else changes).
- [ ] Deploy step actually deploys on first try — will be proven by this PR's own deploy run to staging.