### PR TITLE
chore(client): frontend audit follow-ups — a11y, OnPush, coverage floors (#294)

### DIFF
--- a/client/apps/account/vite.config.mts
+++ b/client/apps/account/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/apps/account',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 85,
+        branches: 50,
+        functions: 75,
+        lines: 90,
+      },
     },
   },
 }));

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -23,6 +23,7 @@
     "list": {
       "title": "Meine Rezepte",
       "assignTitle": "Rezept auswählen",
+      "back": "Zurück",
       "assign": "Zum Essensplan hinzufügen",
       "sortLabel": "Rezepte sortieren",
       "sort": {
@@ -129,6 +130,7 @@
       "next": "Weiter",
       "repeat": "Wiederholen",
       "ingredients": "Zutaten",
+      "closePanel": "Zutaten-Panel schließen",
       "mute": "Stumm",
       "unmute": "Ton an",
       "voiceToggle": "Sprachsteuerung umschalten",

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -23,6 +23,7 @@
     "list": {
       "title": "My Recipes",
       "assignTitle": "Select a recipe",
+      "back": "Back",
       "assign": "Assign to meal plan",
       "sortLabel": "Sort recipes",
       "sort": {
@@ -129,6 +130,7 @@
       "next": "Next",
       "repeat": "Repeat",
       "ingredients": "Ingredients",
+      "closePanel": "Close ingredients panel",
       "mute": "Mute",
       "unmute": "Unmute",
       "voiceToggle": "Toggle voice control",

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
@@ -89,7 +89,12 @@
         <aside class="ingredients-panel" role="dialog">
           <div class="panel-header">
             <h2>{{ t('recipes.cook.ingredients') }}</h2>
-            <button type="button" class="panel-close" (click)="toggleIngredientsPanel()">
+            <button
+              type="button"
+              class="panel-close"
+              (click)="toggleIngredientsPanel()"
+              [attr.aria-label]="t('recipes.cook.closePanel')"
+            >
               <lucide-icon name="x" [size]="18" />
             </button>
           </div>

--- a/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { MealPlanApiService, RecipeListItem } from '../api';
+import { RecipeAssignmentService } from './recipe-assignment.service';
+
+const recipe: RecipeListItem = {
+  identifier: 'abc-123',
+  title: 'Pasta Carbonara',
+  description: null,
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: null,
+  imageUrl: null,
+  createdAt: '2026-03-10T00:00:00Z',
+  tags: [],
+  isFavorite: false,
+};
+
+describe('RecipeAssignmentService', () => {
+  let assignRecipe: ReturnType<typeof vi.fn>;
+  let navigate: ReturnType<typeof vi.fn>;
+  let assignToParam: string | null;
+
+  const setup = (
+    initialParam: string | null = null,
+    apiResponse: ReturnType<typeof of> | ReturnType<typeof throwError> = of({}),
+  ) => {
+    assignToParam = initialParam;
+    assignRecipe = vi.fn().mockReturnValue(apiResponse);
+    navigate = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        RecipeAssignmentService,
+        { provide: MealPlanApiService, useValue: { assignRecipe } },
+        { provide: Router, useValue: { navigate } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: { get: () => assignToParam } } },
+        },
+      ],
+    });
+
+    return TestBed.inject(RecipeAssignmentService);
+  };
+
+  it('should be inactive by default', () => {
+    const service = setup();
+
+    expect(service.assignMode()).toBe(false);
+    expect(service.assignTo()).toBeNull();
+  });
+
+  it('should enter assign mode when route has an assignTo param', () => {
+    const service = setup('2026-W15-monday');
+    service.initFromRoute();
+
+    expect(service.assignMode()).toBe(true);
+    expect(service.assignTo()).toBe('2026-W15-monday');
+  });
+
+  it('should not call assignRecipe when not in assign mode', () => {
+    const service = setup();
+
+    service.assign(recipe);
+
+    expect(assignRecipe).not.toHaveBeenCalled();
+  });
+
+  it('should not call assignRecipe when assignTo param is malformed', () => {
+    const service = setup('totally-invalid');
+    service.initFromRoute();
+
+    service.assign(recipe);
+
+    expect(assignRecipe).not.toHaveBeenCalled();
+  });
+
+  it('should parse year/week/day and forward recipe identity to the API', () => {
+    const service = setup('2026-W15-monday');
+    service.initFromRoute();
+
+    service.assign(recipe);
+
+    expect(assignRecipe).toHaveBeenCalledWith(2026, 15, {
+      day: 'monday',
+      recipeIdentifier: 'abc-123',
+      recipeTitle: 'Pasta Carbonara',
+    });
+  });
+
+  it('should set assigning true while the request is in flight', () => {
+    assignRecipe = vi.fn().mockReturnValue(of({}));
+    const service = setup('2026-W1-tuesday');
+    service.initFromRoute();
+
+    service.assign(recipe);
+
+    expect(service.assigning()).toBe(true);
+  });
+
+  it('should navigate to the meal planner on success', () => {
+    const service = setup('2026-W1-tuesday');
+    service.initFromRoute();
+
+    service.assign(recipe);
+
+    expect(navigate).toHaveBeenCalledWith(['/meal-planner']);
+  });
+
+  it('should reset assigning on failure without navigating', () => {
+    const service = setup(
+      '2026-W1-tuesday',
+      throwError(() => new Error('nope')),
+    );
+    service.initFromRoute();
+
+    service.assign(recipe);
+
+    expect(service.assigning()).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('should navigate away when cancelled', () => {
+    const service = setup('2026-W1-tuesday');
+    service.initFromRoute();
+
+    service.cancel();
+
+    expect(navigate).toHaveBeenCalledWith(['/meal-planner']);
+  });
+});

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -2,7 +2,11 @@
   <div class="list-header">
     @if (assignment.assignMode()) {
       <div class="assign-header">
-        <button class="btn-back" (click)="assignment.cancel()">
+        <button
+          class="btn-back"
+          (click)="assignment.cancel()"
+          [attr.aria-label]="t('recipes.list.back')"
+        >
           <lucide-icon name="arrow-left" [size]="20" />
         </button>
         <h1>{{ t('recipes.list.assignTitle') }}</h1>

--- a/client/apps/recipes/vite.config.mts
+++ b/client/apps/recipes/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/apps/recipes',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 75,
+        branches: 55,
+        functions: 65,
+        lines: 75,
+      },
     },
   },
 }));

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -4,7 +4,7 @@
     <p class="subtitle">{{ t('auth.register.subtitle') }}</p>
 
     @if (isSuccess()) {
-      <div class="success-message">
+      <div class="success-message" role="status" aria-live="polite">
         <h2>{{ t('auth.register.success.title') }}</h2>
         <p>{{ t('auth.register.success.message') }}</p>
         <p class="resend-link">

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
@@ -4,7 +4,7 @@
     <p class="subtitle">{{ t('auth.resendVerification.subtitle') }}</p>
 
     @if (isSuccess()) {
-      <div class="success-message">
+      <div class="success-message" role="status" aria-live="polite">
         <h2>{{ t('auth.resendVerification.success.title') }}</h2>
         <p>{{ t('auth.resendVerification.success.message') }}</p>
       </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -113,7 +113,7 @@
   </section>
 
   @if (saveSuccess()) {
-    <div class="save-success" role="status">
+    <div class="save-success" role="status" aria-live="polite">
       <div class="success-banner">
         {{ t('dashboard.save.success', { title: saveSuccess() }) }}
       </div>

--- a/client/apps/shell/src/app/layout/offline-indicator/offline-status.service.spec.ts
+++ b/client/apps/shell/src/app/layout/offline-indicator/offline-status.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { UI } from '@yumney/shared/models';
+import { OfflineStatusService } from './offline-status.service';
+
+describe('OfflineStatusService', () => {
+  let originalDescriptor: PropertyDescriptor | undefined;
+  let onLineValue: boolean;
+
+  const setOnline = (value: boolean) => {
+    onLineValue = value;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'onLine',
+    );
+    onLineValue = true;
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => onLineValue,
+    });
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(Object.getPrototypeOf(navigator), 'onLine', originalDescriptor);
+    }
+    vi.useRealTimers();
+  });
+
+  const createService = () => {
+    TestBed.configureTestingModule({ providers: [OfflineStatusService] });
+    return TestBed.inject(OfflineStatusService);
+  };
+
+  it('should initialize isOffline from navigator.onLine', () => {
+    setOnline(false);
+
+    const service = createService();
+
+    expect(service.isOffline()).toBe(true);
+  });
+
+  it('should be online by default when navigator reports online', () => {
+    const service = createService();
+
+    expect(service.isOffline()).toBe(false);
+  });
+
+  it('should set isOffline true when offline event fires', () => {
+    const service = createService();
+
+    window.dispatchEvent(new Event('offline'));
+
+    expect(service.isOffline()).toBe(true);
+  });
+
+  it('should set isOffline false and flash justCameOnline when online event fires', () => {
+    setOnline(false);
+    const service = createService();
+    expect(service.isOffline()).toBe(true);
+
+    window.dispatchEvent(new Event('online'));
+
+    expect(service.isOffline()).toBe(false);
+    expect(service.justCameOnline()).toBe(true);
+  });
+
+  it('should clear justCameOnline after ONLINE_TOAST_DURATION_MS', () => {
+    setOnline(false);
+    const service = createService();
+    window.dispatchEvent(new Event('online'));
+    expect(service.justCameOnline()).toBe(true);
+
+    vi.advanceTimersByTime(UI.ONLINE_TOAST_DURATION_MS);
+
+    expect(service.justCameOnline()).toBe(false);
+  });
+});

--- a/client/apps/shell/vite.config.mts
+++ b/client/apps/shell/vite.config.mts
@@ -24,6 +24,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/apps/shell',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 75,
+        branches: 55,
+        functions: 65,
+        lines: 75,
+      },
     },
   },
 }));

--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -58,6 +58,7 @@
     "loading": "Wird geladen...",
     "empty": "Deine Einkaufsliste ist leer. Füge Artikel hinzu oder plane Mahlzeiten.",
     "addPlaceholder": "Artikel hinzufügen...",
+    "addItem": "Artikel hinzufügen",
     "export": {
       "button": "Liste exportieren",
       "copied": "In Zwischenablage kopiert",

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -58,6 +58,7 @@
     "loading": "Loading...",
     "empty": "Your shopping list is empty. Add items or plan meals.",
     "addPlaceholder": "Add an item...",
+    "addItem": "Add item",
     "export": {
       "button": "Export list",
       "copied": "Copied to clipboard",

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -37,7 +37,12 @@
       [placeholder]="t('shopping.addPlaceholder')"
       class="add-input"
     />
-    <button class="add-btn" (click)="onAddItem()" [disabled]="!newItemName().trim()">
+    <button
+      class="add-btn"
+      (click)="onAddItem()"
+      [disabled]="!newItemName().trim()"
+      [attr.aria-label]="t('shopping.addItem')"
+    >
       <lucide-icon name="plus" [size]="18" />
     </button>
   </div>

--- a/client/apps/shopping/vite.config.mts
+++ b/client/apps/shopping/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/apps/shopping',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 75,
+        branches: 55,
+        functions: 65,
+        lines: 75,
+      },
     },
   },
 }));

--- a/client/libs/shared/api-client/vite.config.mts
+++ b/client/libs/shared/api-client/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/api-client',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 45,
+        branches: 28,
+        functions: 60,
+        lines: 45,
+      },
     },
   },
 }));

--- a/client/libs/shared/models/src/lib/toast.service.spec.ts
+++ b/client/libs/shared/models/src/lib/toast.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { ToastService } from './toast.service';
+
+describe('ToastService', () => {
+  let service: ToastService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({ providers: [ToastService] });
+    service = TestBed.inject(ToastService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should add a toast with kind info by default', () => {
+    service.show({ messageKey: 'hello' });
+
+    expect(service.toasts()).toHaveLength(1);
+    expect(service.toasts()[0].kind).toBe('info');
+  });
+
+  it('should assign unique incrementing ids', () => {
+    const a = service.show({ messageKey: 'a' });
+    const b = service.show({ messageKey: 'b' });
+
+    expect(b).toBe(a + 1);
+  });
+
+  it('should use success kind when calling success()', () => {
+    service.success('saved');
+
+    expect(service.toasts()[0].kind).toBe('success');
+  });
+
+  it('should use error kind when calling error()', () => {
+    service.error('boom');
+
+    expect(service.toasts()[0].kind).toBe('error');
+  });
+
+  it('should use warning kind when calling warning()', () => {
+    service.warning('careful');
+
+    expect(service.toasts()[0].kind).toBe('warning');
+  });
+
+  it('should use info kind when calling info()', () => {
+    service.info('hello');
+
+    expect(service.toasts()[0].kind).toBe('info');
+  });
+
+  it('should forward params onto the toast', () => {
+    service.show({ messageKey: 'greet', params: { name: 'Ada' } });
+
+    expect(service.toasts()[0].params).toEqual({ name: 'Ada' });
+  });
+
+  it('should auto-dismiss after the configured duration', () => {
+    service.show({ messageKey: 'hi', durationMs: 1000 });
+    expect(service.toasts()).toHaveLength(1);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(service.toasts()).toHaveLength(0);
+  });
+
+  it('should not auto-dismiss when durationMs is zero', () => {
+    service.show({ messageKey: 'sticky', durationMs: 0 });
+    vi.advanceTimersByTime(60_000);
+
+    expect(service.toasts()).toHaveLength(1);
+  });
+
+  it('should remove only the toast with the given id on dismiss', () => {
+    const a = service.show({ messageKey: 'a', durationMs: 0 });
+    service.show({ messageKey: 'b', durationMs: 0 });
+
+    service.dismiss(a);
+
+    expect(service.toasts()).toHaveLength(1);
+    expect(service.toasts()[0].messageKey).toBe('b');
+  });
+
+  it('should remove all toasts on clear', () => {
+    service.show({ messageKey: 'a', durationMs: 0 });
+    service.show({ messageKey: 'b', durationMs: 0 });
+
+    service.clear();
+
+    expect(service.toasts()).toEqual([]);
+  });
+});

--- a/client/libs/shared/models/vite.config.mts
+++ b/client/libs/shared/models/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/models',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 60,
+        branches: 50,
+        functions: 55,
+        lines: 60,
+      },
     },
   },
 }));

--- a/client/libs/ui/src/lib/async-state/async-state.component.ts
+++ b/client/libs/ui/src/lib/async-state/async-state.component.ts
@@ -7,7 +7,7 @@ import { TranslocoModule } from '@jsverse/transloco';
   imports: [TranslocoModule],
   template: `
     @if (loading()) {
-      <div class="loading">{{ loadingKey() | transloco }}</div>
+      <div class="loading" role="status" aria-live="polite">{{ loadingKey() | transloco }}</div>
     }
     @if (error(); as err) {
       <div class="error" role="alert">

--- a/client/libs/ui/src/lib/form-field/form-field.component.ts
+++ b/client/libs/ui/src/lib/form-field/form-field.component.ts
@@ -1,7 +1,9 @@
 import { Component, ChangeDetectionStrategy, ViewEncapsulation, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { KeyValuePipe } from '@angular/common';
+import { of, startWith, switchMap } from 'rxjs';
 
 @Component({
   selector: 'yn-form-field',
@@ -9,7 +11,7 @@ import { KeyValuePipe } from '@angular/common';
   templateUrl: './form-field.component.html',
   styleUrl: './form-field.component.scss',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.Default,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormFieldComponent {
   label = input('');
@@ -19,12 +21,26 @@ export class FormFieldComponent {
   group = input<FormGroup | undefined>(undefined);
   groupErrors = input<Record<string, string>>({});
 
+  // Track control/group events so OnPush re-renders on touched/status changes
+  // triggered by ancestors (e.g. markAllAsTouched on submit).
+  private readonly controlEvents = toSignal(
+    toObservable(this.control).pipe(switchMap((c) => c.events.pipe(startWith(null)))),
+  );
+  private readonly groupEvents = toSignal(
+    toObservable(this.group).pipe(
+      switchMap((g) => (g ? g.events.pipe(startWith(null)) : of(null))),
+    ),
+  );
+
   hasControlError(errorKey: string): boolean {
+    this.controlEvents();
     const ctrl = this.control();
     return ctrl.hasError(errorKey) && ctrl.touched;
   }
 
   hasGroupError(errorKey: string): boolean {
+    this.controlEvents();
+    this.groupEvents();
     const grp = this.group();
     const ctrl = this.control();
     return !!grp?.hasError(errorKey) && ctrl.touched;

--- a/client/libs/ui/vite.config.mts
+++ b/client/libs/ui/vite.config.mts
@@ -19,6 +19,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/libs/ui',
       provider: 'v8' as const,
+      thresholds: {
+        statements: 85,
+        branches: 60,
+        functions: 85,
+        lines: 85,
+      },
     },
   },
 }));


### PR DESCRIPTION
Closes #294.

## Summary
- **form-field** → OnPush with reactive wiring via `AbstractControl.events` so errors still render on `markAllAsTouched` from ancestors
- **a11y**: added `role="status"` + `aria-live="polite"` on async-state loading and three success banners (dashboard, register, resend-verification); aria-label + EN/DE transloco keys on three previously-unlabeled icon-only buttons (cook-mode close, recipe-list back, merged-list add)
- **specs** for the three untested services: `ToastService`, `OfflineStatusService`, `RecipeAssignmentService`
- **Vitest coverage thresholds** ratcheted to current baseline on every project — CI already runs `--coverage`, so regressions now fail the build. Honest per-project floors (ui 85/60/85/85, shared-api-client 45/28/60/45, etc.); the 80/70 targets from #294 remain the next ratchet step

## Audit notes
- Confirm-dialog was flagged but already fully compliant (alertdialog + aria-modal + aria-labelledby + Escape handler); audit was wrong
- All error banners already had `role="alert"`; only success banners needed polite live regions

## Out of scope (tracked on #294)
- `@defer` for chat panel + recipe preview
- `NgOptimizedImage` for recipe images
- Storybook stories for `InfiniteScrollDirective`, `ChatPanelComponent`
- Cross-MFE E2E workflows

## Test plan
- [x] `yarn nx run-many -t lint test` green (all projects)
- [x] `yarn nx run-many -t test --coverage` green with thresholds enforced
- [ ] Manual axe DevTools sweep on shell, recipes, shopping, confirm-dialog