### PR TITLE
ci: speed up e2e with Playwright cache + concurrency + Nx cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
     branches: [develop]
   workflow_dispatch:
 
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '22'
@@ -66,9 +70,23 @@ jobs:
         working-directory: client
         run: yarn install --immutable
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('client/yarn.lock') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
         working-directory: client
-        run: npx playwright install chromium --with-deps
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install chromium --with-deps
+          fi
 
       - name: Restore .NET packages
         run: dotnet restore Yumney.slnx
@@ -95,7 +113,7 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        run: npx nx e2e shell-e2e --skip-nx-cache
+        run: npx nx e2e shell-e2e
         env:
           BASE_URL: http://localhost:4200
           E2E_USER: testuser


### PR DESCRIPTION
## Summary
Three safe, additive speed-ups to the E2E workflow:

1. **Cache `~/.cache/ms-playwright`** — chromium binary (~200 MB) was redownloaded every run. Cache keyed on `client/yarn.lock`. On cache hit we still call `playwright install-deps` because apt deps can't survive between hosted runners.
2. **Drop `--skip-nx-cache`** from the Playwright nx task so the local Nx cache can help when inputs are unchanged.
3. **Add `concurrency:`** group so superseded PR runs cancel themselves — matches the pattern already in `ci.yml`.

## Expected wins
- Cache hit path: ~60–90s saved on chromium download/extraction
- Concurrency: avoids stacked runs on rapid pushes (bigger wins on active PRs)
- Nx cache: small, inputs-dependent

## Test plan
- [ ] First run of this PR is a cache miss — runtime should match baseline
- [ ] A follow-up push (or rerun) should show cache-hit and a visibly shorter "Install Playwright browsers" step
- [ ] Superseding push should cancel the prior run (visible in Actions UI)

## Not in scope
Originally proposed `dotnet test --parallel` was dropped — the flag doesn't do what the audit implied (xUnit already parallelizes within assemblies; cross-assembly parallelism needs a matrix or runsettings, worth a separate PR). `tee` on the Aspire log is actually fine.