### PR TITLE
feat(users): VO New() factories + static-init bug fix

### DIFF
--- a/Yumney.sln.DotSettings
+++ b/Yumney.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ConvertIfStatementToSwitchStatement/AssumeOpenTypeHierarchy/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -42,9 +42,7 @@
     <Project Path="src/Yumney.Users.Infrastructure/Yumney.Users.Infrastructure.csproj" />
     <Project Path="src/Yumney.Users.Api/Yumney.Users.Api.csproj" />
   </Folder>
-  <Folder Name="/tests/">
-    <Project Path="tests/Yumney.MealPlan.Infrastructure.Tests/Yumney.MealPlan.Infrastructure.Tests.csproj" />
-  </Folder>
+  <Folder Name="/tests/" />
   <Folder Name="/tests/Shared/">
     <Project Path="tests/Yumney.Shared.Tests/Yumney.Shared.Tests.csproj" />
     <Project Path="tests/Yumney.Shared.Guards.Tests/Yumney.Shared.Guards.Tests.csproj" />
@@ -53,6 +51,7 @@
   <Folder Name="/tests/MealPlan/">
     <Project Path="tests/Yumney.MealPlan.Application.Tests/Yumney.MealPlan.Application.Tests.csproj" />
     <Project Path="tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj" />
+    <Project Path="tests/Yumney.MealPlan.Infrastructure.Tests/Yumney.MealPlan.Infrastructure.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Recipes/">
     <Project Path="tests/Yumney.Recipes.Domain.Tests/Yumney.Recipes.Domain.Tests.csproj" />

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeIdentifier.cs
@@ -14,5 +14,7 @@ public sealed record SlotRecipeIdentifier : IValueObject
 
 	public static SlotRecipeIdentifier From(Guid value) => new(value);
 
+	public static SlotRecipeIdentifier New() => new(Guid.CreateVersion7());
+
 	public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Recipes.Api/StreamingJsonFieldDetector.cs
+++ b/src/Yumney.Recipes.Api/StreamingJsonFieldDetector.cs
@@ -16,7 +16,7 @@ internal sealed class StreamingJsonFieldDetector
 		"description",
 		"language",
 		"difficulty",
-		"imageUrl",
+		"imageUrl"
 	];
 #pragma warning restore SA1311
 

--- a/src/Yumney.Recipes.Application/DTOs/PhotoDataValidator.cs
+++ b/src/Yumney.Recipes.Application/DTOs/PhotoDataValidator.cs
@@ -29,6 +29,6 @@ public sealed class PhotoDataValidator : AbstractValidator<PhotoData>
 	[
 		MediaTypes.ImageJpeg,
 		MediaTypes.ImagePng,
-		MediaTypes.ImageWebp,
+		MediaTypes.ImageWebp
 	];
 }

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -57,9 +58,6 @@ public static class ExtractionServiceCollectionExtensions
 
 	private static string? GetOllamaEndpoint(IConfiguration configuration, SemanticKernelOptions skOptions)
 	{
-		if (skOptions.Endpoint.HasValue())
-			return skOptions.Endpoint;
-
-		return configuration.GetConnectionString("ollama");
+		return skOptions.Endpoint.HasValue() ? skOptions.Endpoint : configuration.GetConnectionString("ollama");
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/BrowserHttpClientDefaults.cs
+++ b/src/Yumney.Recipes.Extraction/Services/BrowserHttpClientDefaults.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Net;
+using System.Net.Http;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 

--- a/src/Yumney.Recipes.Extraction/Services/ContentSanitizer.cs
+++ b/src/Yumney.Recipes.Extraction/Services/ContentSanitizer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 
 /// <summary>

--- a/src/Yumney.Recipes.Extraction/Services/InMemoryExtractionResultCache.cs
+++ b/src/Yumney.Recipes.Extraction/Services/InMemoryExtractionResultCache.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 

--- a/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
+++ b/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -76,9 +81,7 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
 		return new ChatResponseDto(reply, suggestions);
 	}
 
-	internal static List<ChatRecipeSuggestionDto> MatchRecipesByMention(
-		string reply,
-		IReadOnlyList<Recipe> userRecipes)
+	internal static List<ChatRecipeSuggestionDto> MatchRecipesByMention(string reply, IReadOnlyList<Recipe> userRecipes)
 	{
 		var suggestions = new List<ChatRecipeSuggestionDto>();
 

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientCategoryService.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIngredientRecognitionService.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -33,7 +36,7 @@ public sealed partial class SemanticKernelIngredientRecognitionService(Kernel ke
 		ChatMessageContentItemCollection messageItems =
 		[
 			new TextContent("Identify the food ingredients in this image:"),
-			new ImageContent(photo.Content, photo.ContentType),
+			new ImageContent(photo.Content, photo.ContentType)
 		];
 		chatHistory.AddUserMessage(messageItems);
 

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelIntentParserService.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -73,7 +77,9 @@ public sealed partial class SemanticKernelRecipeExtractionService(
 		return result;
 	}
 
-	public async Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(IReadOnlyList<PhotoData> photos, CancellationToken cancellationToken = default)
+	public async Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(
+		IReadOnlyList<PhotoData> photos,
+		CancellationToken cancellationToken = default)
 	{
 		using var activity = ExtractionDiagnostics.ActivitySource.StartActivity("extract.recipe.photos");
 		activity?.SetTag("extract.photo_count", photos.Count);

--- a/src/Yumney.Recipes.Extraction/Services/WebScraper.cs
+++ b/src/Yumney.Recipes.Extraction/Services/WebScraper.cs
@@ -1,4 +1,8 @@
 using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using AngleSharp;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -104,7 +108,7 @@ public sealed partial class WebScraper(HttpClient httpClient, IOptions<ScrapingO
 		"[itemprop*=\"recipe\" i]",
 		"main",
 		"article",
-		"body",
+		"body"
 	];
 #pragma warning restore SA1311
 

--- a/src/Yumney.Shared.CQRS/Diagnostics/ApplicationMetrics.cs
+++ b/src/Yumney.Shared.CQRS/Diagnostics/ApplicationMetrics.cs
@@ -19,7 +19,7 @@ public sealed class ApplicationMetrics
 
 	public void RecordExecution(string handlerName, string commandType, string result, double durationMs)
 	{
-		var tags = new TagList
+		TagList tags = new()
 		{
 			{ "handler_name", handlerName },
 			{ "command_type", commandType },

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using System.Reflection;
 using System.Security.Claims;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -33,7 +34,7 @@ public static class HostBuilderExtensions
 
 		builder.Services.ConfigureHttpJsonOptions(options =>
 		{
-			options.SerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+			options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 		});
 
 		builder.Services.Configure<HostOptions>(options =>

--- a/src/Yumney.Shared.Web/Services/CurrentUserProvider.cs
+++ b/src/Yumney.Shared.Web/Services/CurrentUserProvider.cs
@@ -21,7 +21,7 @@ public sealed class CurrentUserProvider(IHttpContextAccessor httpContextAccessor
 	public IReadOnlyCollection<string> Roles => User?.FindAll(ClaimTypes.Role)
 		.Select(c => c.Value)
 		.ToArray()
-		?? Array.Empty<string>();
+		?? [];
 
 	public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
 

--- a/src/Yumney.Shared/Common/AggregateRoot.cs
+++ b/src/Yumney.Shared/Common/AggregateRoot.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public abstract class AggregateRoot<TId> : Entity<TId>, IHasDomainEvents

--- a/src/Yumney.Shared/Common/BusinessRuleValidationException.cs
+++ b/src/Yumney.Shared/Common/BusinessRuleValidationException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed class BusinessRuleValidationException(IBusinessRule brokenRule) : Exception(brokenRule.Message)

--- a/src/Yumney.Shared/Common/DomainEvent.cs
+++ b/src/Yumney.Shared/Common/DomainEvent.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public abstract record DomainEvent : IDomainEvent

--- a/src/Yumney.Shared/Common/EntityNotFoundException.cs
+++ b/src/Yumney.Shared/Common/EntityNotFoundException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed class EntityNotFoundException(string entityName, object identifier)

--- a/src/Yumney.Shared/Common/EnumExtensions.cs
+++ b/src/Yumney.Shared/Common/EnumExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public static class EnumExtensions

--- a/src/Yumney.Shared/Common/EventSourcedAggregate.cs
+++ b/src/Yumney.Shared/Common/EventSourcedAggregate.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public abstract class EventSourcedAggregate<TId>

--- a/src/Yumney.Shared/Common/ICurrentUser.cs
+++ b/src/Yumney.Shared/Common/ICurrentUser.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public interface ICurrentUser

--- a/src/Yumney.Shared/Common/IDomainEvent.cs
+++ b/src/Yumney.Shared/Common/IDomainEvent.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public interface IDomainEvent

--- a/src/Yumney.Shared/Common/IHasDomainEvents.cs
+++ b/src/Yumney.Shared/Common/IHasDomainEvents.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public interface IHasDomainEvents

--- a/src/Yumney.Shared/Common/IRecipeIngredientProvider.cs
+++ b/src/Yumney.Shared/Common/IRecipeIngredientProvider.cs
@@ -1,12 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
-/// <summary>
-/// Cross-module interface for fetching recipe ingredients.
-/// Implemented by Recipes.Infrastructure, consumed by MealPlan.Application.
-/// </summary>
 public interface IRecipeIngredientProvider
 {
-	Task<IReadOnlyList<RecipeIngredientInfo>> GetIngredientsAsync(
-		Guid recipeIdentifier,
-		CancellationToken cancellationToken = default);
+	Task<IReadOnlyList<RecipeIngredientInfo>> GetIngredientsAsync(Guid recipeIdentifier, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shared/Common/IShoppingListWriter.cs
+++ b/src/Yumney.Shared/Common/IShoppingListWriter.cs
@@ -1,13 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
-/// <summary>
-/// Cross-module interface for writing items to the shopping ledger.
-/// Implemented by Shopping.Infrastructure, consumed by MealPlan.Application.
-/// </summary>
 public interface IShoppingListWriter
 {
-	Task AddItemsAsync(
-		string ownerId,
-		IReadOnlyList<ShoppingItemRequest> items,
-		CancellationToken cancellationToken = default);
+	Task AddItemsAsync(string ownerId, IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shared/Common/IStaplesProvider.cs
+++ b/src/Yumney.Shared/Common/IStaplesProvider.cs
@@ -1,12 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
-/// <summary>
-/// Cross-module interface for checking user staples.
-/// Implemented by Users.Infrastructure, consumed by MealPlan.Application.
-/// </summary>
 public interface IStaplesProvider
 {
-	Task<IReadOnlySet<string>> GetStapleNamesAsync(
-		string ownerId,
-		CancellationToken cancellationToken = default);
+	Task<IReadOnlySet<string>> GetStapleNamesAsync(string ownerId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shared/Common/IUnitOfWork.cs
+++ b/src/Yumney.Shared/Common/IUnitOfWork.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public interface IUnitOfWork

--- a/src/Yumney.Shared/Common/IngredientCategory.cs
+++ b/src/Yumney.Shared/Common/IngredientCategory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Shared.Common;

--- a/src/Yumney.Shared/Common/IngredientCategoryResolver.cs
+++ b/src/Yumney.Shared/Common/IngredientCategoryResolver.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 /// <summary>
@@ -17,20 +20,17 @@ public static class IngredientCategoryResolver
 	/// <returns>The category if known, or null if the item is not recognized.</returns>
 	public static IngredientCategory? Resolve(string itemName)
 	{
-		if (string.IsNullOrWhiteSpace(itemName))
-			return null;
+		if (string.IsNullOrWhiteSpace(itemName)) return null;
 
 		var normalized = itemName.Trim().ToLowerInvariant();
 
-		if (itemCategories.TryGetValue(normalized, out var category))
-			return category;
+		if (itemCategories.TryGetValue(normalized, out var category)) return category;
 
 		// Basic English plural normalization
 		if (normalized.Length > 3 && normalized.EndsWith('s') && !normalized.EndsWith("ss", StringComparison.Ordinal))
 		{
 			var singular = normalized[..^1];
-			if (itemCategories.TryGetValue(singular, out var singularCategory))
-				return singularCategory;
+			if (itemCategories.TryGetValue(singular, out var singularCategory)) return singularCategory;
 		}
 
 		return null;
@@ -39,7 +39,7 @@ public static class IngredientCategoryResolver
 #pragma warning disable SA1117
 	private static Dictionary<string, IngredientCategory> BuildItemCategories()
 	{
-		var map = new Dictionary<string, IngredientCategory>(StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, IngredientCategory> map = new(StringComparer.OrdinalIgnoreCase);
 
 		Add(map, IngredientCategory.Produce,
 			"onion", "zwiebel", "garlic", "knoblauch",

--- a/src/Yumney.Shared/Common/PagedResult.cs
+++ b/src/Yumney.Shared/Common/PagedResult.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed record PagedResult<T>(

--- a/src/Yumney.Shared/Common/PagedResultExtensions.cs
+++ b/src/Yumney.Shared/Common/PagedResultExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public static class PagedResultExtensions

--- a/src/Yumney.Shared/Common/QuantityRounder.cs
+++ b/src/Yumney.Shared/Common/QuantityRounder.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 /// <summary>

--- a/src/Yumney.Shared/Common/Result.cs
+++ b/src/Yumney.Shared/Common/Result.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public class Result

--- a/src/Yumney.Shared/Common/Result{T}.cs
+++ b/src/Yumney.Shared/Common/Result{T}.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed class Result<T> : Result

--- a/src/Yumney.Shared/Common/SortingOptions.cs
+++ b/src/Yumney.Shared/Common/SortingOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public sealed record SortingOptions<TSortField>(TSortField SortBy, SortDirection Direction)

--- a/src/Yumney.Shared/Common/StringExtensions.cs
+++ b/src/Yumney.Shared/Common/StringExtensions.cs
@@ -2,6 +2,5 @@ namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 public static class StringExtensions
 {
-	public static bool HasValue(this string? value) =>
-		!string.IsNullOrWhiteSpace(value);
+	public static bool HasValue(this string? value) => !string.IsNullOrWhiteSpace(value);
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryRestriction.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryRestriction.cs
@@ -3,15 +3,9 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
-#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record DietaryRestriction : IValueObject<string>
 {
 	public const int MaxLength = 30;
-
-#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
-	private static readonly string[] allowedValues =
-		["gluten-free", "lactose-free", "nut-allergy", "egg-free", "soy-free", "shellfish-allergy", "halal", "kosher"];
-
 	public static readonly DietaryRestriction GlutenFree = new("gluten-free");
 	public static readonly DietaryRestriction LactoseFree = new("lactose-free");
 	public static readonly DietaryRestriction NutAllergy = new("nut-allergy");
@@ -20,7 +14,20 @@ public sealed record DietaryRestriction : IValueObject<string>
 	public static readonly DietaryRestriction ShellfishAllergy = new("shellfish-allergy");
 	public static readonly DietaryRestriction Halal = new("halal");
 	public static readonly DietaryRestriction Kosher = new("kosher");
-#pragma warning restore SA1202
+
+#pragma warning disable SA1311
+	private static readonly string[] allowedValues =
+	[
+		GlutenFree.Value,
+		LactoseFree.Value,
+		NutAllergy.Value,
+		EggFree.Value,
+		SoyFree.Value,
+		ShellfishAllergy.Value,
+		Halal.Value,
+		Kosher.Value
+	];
+#pragma warning restore SA1311
 
 	public string Value { get; }
 
@@ -29,14 +36,16 @@ public sealed record DietaryRestriction : IValueObject<string>
 		Value = Ensure.That(value)
 			.IsNotNullOrWhiteSpace()
 			.HasMaxLength(MaxLength)
-			.IsOneOf(allowedValues)
 			.AndReturn();
 	}
 
-	public static DietaryRestriction From(string value) => new(value);
+	public static DietaryRestriction From(string value)
+	{
+		Ensure.That(value).IsNotNullOrWhiteSpace().HasMaxLength(MaxLength).IsOneOf(allowedValues);
+		return new DietaryRestriction(value);
+	}
 
 	public static IReadOnlyList<string> AllowedValues => allowedValues;
 
 	public static implicit operator string(DietaryRestriction obj) => obj.Value;
 }
-#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/KeycloakUserId.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/KeycloakUserId.cs
@@ -19,5 +19,7 @@ public sealed record KeycloakUserId : IValueObject<string>
 
 	public static KeycloakUserId From(string value) => new(value);
 
+	public static KeycloakUserId New() => new(Guid.CreateVersion7().ToString());
+
 	public static implicit operator string(KeycloakUserId obj) => obj.Value;
 }

--- a/src/Yumney.Users.Domain/StaplesList/StaplesList.cs
+++ b/src/Yumney.Users.Domain/StaplesList/StaplesList.cs
@@ -16,7 +16,7 @@ public sealed class StaplesList : AggregateRoot<StaplesListIdentifier>
 		StapleItem.From("butter"),
 		StapleItem.From("eggs"),
 		StapleItem.From("garlic"),
-		StapleItem.From("onion"),
+		StapleItem.From("onion")
 	];
 
 	private readonly List<StapleItem> items = [];

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -3,35 +3,37 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
-#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
 public sealed record ActivityType : IValueObject<string>
 {
-#pragma warning disable SA1202 // allowedValues must initialize before the public static instances
-	private static readonly string[] allowedValues =
-	[
-		"recipe_imported",
-		"recipe_viewed",
-		"recipe_edited",
-		"recipe_deleted",
-		"shopping_list_created",
-	];
-
 	public static readonly ActivityType RecipeImported = new("recipe_imported");
 	public static readonly ActivityType RecipeViewed = new("recipe_viewed");
 	public static readonly ActivityType RecipeEdited = new("recipe_edited");
 	public static readonly ActivityType RecipeDeleted = new("recipe_deleted");
 	public static readonly ActivityType ShoppingListCreated = new("shopping_list_created");
-#pragma warning restore SA1202
+
+#pragma warning disable SA1311
+	private static readonly string[] allowedValues =
+#pragma warning restore SA1311
+	[
+		RecipeImported.Value,
+		RecipeViewed.Value,
+		RecipeEdited.Value,
+		RecipeDeleted.Value,
+		ShoppingListCreated.Value
+	];
 
 	public string Value { get; }
 
 	private ActivityType(string value)
 	{
-		Value = Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(allowedValues).AndReturn();
+		Value = Ensure.That(value).IsNotNullOrWhiteSpace().AndReturn();
 	}
 
-	public static ActivityType From(string value) => new(value);
+	public static ActivityType From(string value)
+	{
+		Ensure.That(value).IsNotNullOrWhiteSpace().IsOneOf(allowedValues);
+		return new ActivityType(value);
+	}
 
 	public static implicit operator string(ActivityType type) => type.Value;
 }
-#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
+++ b/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
@@ -4,8 +4,5 @@ public interface IUserActivityRepository
 {
 	Task AddAsync(UserActivity activity, CancellationToken cancellationToken = default);
 
-	Task<IReadOnlyList<UserActivity>> GetRecentAsync(
-		OwnerIdentifier owner,
-		ActivityLimit limit,
-		CancellationToken cancellationToken = default);
+	Task<IReadOnlyList<UserActivity>> GetRecentAsync(OwnerIdentifier owner, ActivityLimit limit, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Domain/UserActivity/RecipeIdentifierSnapshot.cs
+++ b/src/Yumney.Users.Domain/UserActivity/RecipeIdentifierSnapshot.cs
@@ -18,6 +18,8 @@ public sealed record RecipeIdentifierSnapshot : IValueObject<Guid>
 
 	public static RecipeIdentifierSnapshot From(Guid value) => new(value);
 
+	public static RecipeIdentifierSnapshot New() => new(Guid.CreateVersion7());
+
 	public static RecipeIdentifierSnapshot? FromNullable(Guid? value) =>
 		!value.HasValue || value.Value == Guid.Empty ? null : new RecipeIdentifierSnapshot(value.Value);
 

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -35,11 +35,7 @@ public sealed partial class KeycloakAdminService(
 	private static readonly TimeSpan tokenExpiryBuffer = TimeSpan.FromSeconds(30);
 	private static readonly string[] verifyEmailActions = ["VERIFY_EMAIL"];
 
-	public async Task<Result<KeycloakUserId>> CreateUserAsync(
-		Email email,
-		Password password,
-		DisplayName displayName,
-		CancellationToken cancellationToken = default)
+	public async Task<Result<KeycloakUserId>> CreateUserAsync(Email email, Password password, DisplayName displayName, CancellationToken cancellationToken = default)
 	{
 		using var activity = UsersDiagnostics.ActivitySource.StartActivity("keycloak.create_user");
 		activity?.SetTag("keycloak.email", email.Value);
@@ -53,6 +49,7 @@ public sealed partial class KeycloakAdminService(
 
 		var result = await CreateKeycloakUserAsync(email, password, displayName, token.Value, cancellationToken);
 		activity?.SetStatus(result.IsSuccess ? ActivityStatusCode.Ok : ActivityStatusCode.Error, result.Error?.Message);
+
 		return result;
 	}
 

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -1,6 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
@@ -15,6 +22,7 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 using Xunit;
+using ShoppingDomain = SmartSolutionsLab.Yumney.Shopping.Domain;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 
@@ -28,9 +36,7 @@ public sealed class AspireFixture : IAsyncLifetime
 {
 	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(8);
 
-	public static async Task CleanupAsync<TContext>(
-		Func<Task<TContext>> contextFactory,
-		Func<TContext, IQueryable<object>> query)
+	public static async Task CleanupAsync<TContext>(Func<Task<TContext>> contextFactory, Func<TContext, IQueryable<object>> query)
 		where TContext : DbContext
 	{
 		await using var context = await contextFactory();
@@ -59,16 +65,16 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await CleanupStaleContainersAsync();
 
-		var builder = await DistributedApplicationTestingBuilder
-			.CreateAsync<Projects.Yumney_AppHost>(
-			[
-				"Parameters:PostgresUser=testuser",
-				"Parameters:PostgresPassword=testpassword",
-				"Parameters:KeycloakPassword=testkeycloak",
-				"Parameters:MessagingPassword=testmessaging",
-				"Parameters:RedisPassword=testredis",
-				"E2ETests=true",
-			]);
+		string[] parameters =
+		[
+			"Parameters:PostgresUser=testuser",
+			"Parameters:PostgresPassword=testpassword",
+			"Parameters:KeycloakPassword=testkeycloak",
+			"Parameters:MessagingPassword=testmessaging",
+			"Parameters:RedisPassword=testredis",
+			"E2ETests=true"
+		];
+		var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Yumney_AppHost>(parameters);
 
 		builder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
 
@@ -80,35 +86,17 @@ public sealed class AspireFixture : IAsyncLifetime
 		{
 			await app.StartAsync(cts.Token);
 
-			await app.ResourceNotifications.WaitForResourceAsync(
-				"keycloak", KnownResourceStates.Running, cts.Token);
-			await app.ResourceNotifications.WaitForResourceAsync(
-				"yumney-migrations", KnownResourceStates.Finished, cts.Token);
+			await app.ResourceNotifications.WaitForResourceAsync("keycloak", KnownResourceStates.Running, cts.Token);
+			await app.ResourceNotifications.WaitForResourceAsync("yumney-migrations", KnownResourceStates.Finished, cts.Token);
 
-			var apis = new[] { "recipes-api", "shopping-api", "users-api", "mealplan-api" };
-			foreach (var api in apis)
-			{
-				await app.ResourceNotifications.WaitForResourceAsync(api, KnownResourceStates.Running, cts.Token);
-			}
+			string[] apis = ["recipes-api", "shopping-api", "users-api", "mealplan-api"];
+			var apiTasks = apis.Select(api => app.ResourceNotifications.WaitForResourceAsync(api, KnownResourceStates.Running, cts.Token));
+
+			await Task.WhenAll(apiTasks);
 
 			// Keycloak realm import may still be in progress after container is Running.
 			// Verify the token endpoint is reachable before proceeding.
-			var keycloakClient = app.CreateHttpClient("keycloak");
-			for (var i = 0; i < 30; i++)
-			{
-				try
-				{
-					var probe = await keycloakClient.GetAsync(
-						"/realms/yumney/.well-known/openid-configuration", cts.Token);
-					if (probe.IsSuccessStatusCode) break;
-				}
-				catch
-				{
-					// Not ready yet
-				}
-
-				await Task.Delay(1000, cts.Token);
-			}
+			await VerifyKeycloak();
 		}
 		catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
 		{
@@ -122,14 +110,33 @@ public sealed class AspireFixture : IAsyncLifetime
 		ShoppingApi = app.CreateHttpClient("shopping-api");
 		UsersApi = app.CreateHttpClient("users-api");
 		MealPlanApi = app.CreateHttpClient("mealplan-api");
+
+		async Task VerifyKeycloak()
+		{
+			var keycloakClient = app.CreateHttpClient("keycloak");
+			for (var index = 0; index < 30; index++)
+			{
+				try
+				{
+					var probe = await keycloakClient.GetAsync("/realms/yumney/.well-known/openid-configuration", cts.Token);
+					if (probe.IsSuccessStatusCode) break;
+				}
+				catch
+				{
+					// Not ready yet
+				}
+
+				await Task.Delay(1000, cts.Token);
+			}
+		}
 	}
 
 	public async Task DisposeAsync()
 	{
-		RecipesApi?.Dispose();
-		ShoppingApi?.Dispose();
-		UsersApi?.Dispose();
-		MealPlanApi?.Dispose();
+		RecipesApi.Dispose();
+		ShoppingApi.Dispose();
+		UsersApi.Dispose();
+		MealPlanApi.Dispose();
 
 		if (app is not null)
 		{
@@ -169,7 +176,7 @@ public sealed class AspireFixture : IAsyncLifetime
 		return new ShoppingReadDbContext(optionsBuilder.Options);
 	}
 
-	public async Task ResetShoppingEventStoreAsync(global::SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.OwnerIdentifier owner)
+	public async Task ResetShoppingEventStoreAsync(ShoppingDomain.ShoppingList.OwnerIdentifier owner)
 	{
 		await using var context = await CreateShoppingDbContextAsync();
 		var aggregateIds = await context.Set<AggregateMetadata>()
@@ -180,11 +187,14 @@ public sealed class AspireFixture : IAsyncLifetime
 		if (aggregateIds.Count == 0) return;
 
 		var events = await context.Set<StoredEvent>()
-			.Where(e => aggregateIds.Contains(e.AggregateId)).ToListAsync();
+			.Where(e => aggregateIds.Contains(e.AggregateId))
+			.ToListAsync();
 		var snapshots = await context.Set<StoredSnapshot>()
-			.Where(s => aggregateIds.Contains(s.AggregateId)).ToListAsync();
+			.Where(s => aggregateIds.Contains(s.AggregateId))
+			.ToListAsync();
 		var metadata = await context.Set<AggregateMetadata>()
-			.Where(m => aggregateIds.Contains(m.AggregateId)).ToListAsync();
+			.Where(m => aggregateIds.Contains(m.AggregateId))
+			.ToListAsync();
 
 		context.RemoveRange(events);
 		context.RemoveRange(snapshots);
@@ -196,8 +206,11 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var context = await CreateShoppingDbContextAsync();
 		var items = await context.Set<ShoppingListReadItem>()
-			.Where(r => r.OwnerId == ownerId).ToListAsync();
+			.Where(r => r.OwnerId == ownerId)
+			.ToListAsync();
+
 		if (items.Count == 0) return;
+
 		context.RemoveRange(items);
 		await context.SaveChangesAsync();
 	}
@@ -206,6 +219,7 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var context = await CreateShoppingDbContextAsync();
 		context.ShoppingLists.AddRange(shoppingLists);
+
 		await context.SaveChangesAsync();
 	}
 
@@ -214,6 +228,7 @@ public sealed class AspireFixture : IAsyncLifetime
 		var connectionString = await App.GetConnectionStringAsync("usersdb");
 		var optionsBuilder = new DbContextOptionsBuilder<UsersDbContext>();
 		optionsBuilder.UseNpgsql(connectionString, x => x.EnableRetryOnFailure());
+
 		return new UsersDbContext(optionsBuilder.Options);
 	}
 
@@ -221,6 +236,7 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var context = await CreateUsersDbContextAsync();
 		context.AppUserProfiles.AddRange(profiles);
+
 		await context.SaveChangesAsync();
 	}
 
@@ -229,6 +245,7 @@ public sealed class AspireFixture : IAsyncLifetime
 		var accessToken = await GetTestUserAccessTokenAsync();
 		var client = App.CreateHttpClient(resourceName);
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
 		return client;
 	}
 
@@ -239,24 +256,25 @@ public sealed class AspireFixture : IAsyncLifetime
 		var padded = payload.PadRight(payload.Length + ((4 - (payload.Length % 4)) % 4), '=');
 		var decoded = Convert.FromBase64String(padded.Replace('-', '+').Replace('_', '/'));
 		var claims = JsonSerializer.Deserialize<JsonElement>(decoded);
+
 		return claims.GetProperty("sub").GetString()!;
 	}
 
 	private async Task<string> GetTestUserAccessTokenAsync()
 	{
 		var keycloakClient = App.CreateHttpClient("keycloak");
-		var tokenResponse = await keycloakClient.PostAsync(
-			"/realms/yumney/protocol/openid-connect/token",
-			new FormUrlEncodedContent(new Dictionary<string, string>
-			{
-				["grant_type"] = "password",
-				["client_id"] = "yumney-web",
-				["username"] = "testuser",
-				["password"] = "Test1234",
-			}));
+		Dictionary<string, string> valueCollection = new()
+		{
+			["grant_type"] = "password",
+			["client_id"] = "yumney-web",
+			["username"] = "testuser",
+			["password"] = "Test1234",
+		};
+		var tokenResponse = await keycloakClient.PostAsync("/realms/yumney/protocol/openid-connect/token", new FormUrlEncodedContent(valueCollection));
 
 		tokenResponse.EnsureSuccessStatusCode();
 		var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+
 		return tokenJson.GetProperty("access_token").GetString()!;
 	}
 
@@ -265,7 +283,7 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		try
 		{
-			var process = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+			var process = Process.Start(new ProcessStartInfo
 			{
 				FileName = "docker",
 				Arguments = "ps -aq --filter label=com.microsoft.developer.usvc-dev.build",
@@ -283,7 +301,7 @@ public sealed class AspireFixture : IAsyncLifetime
 			var ids = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 			if (ids.Length == 0) return;
 
-			var rmProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+			var rmProcess = Process.Start(new ProcessStartInfo
 			{
 				FileName = "docker",
 				Arguments = $"rm -f {string.Join(' ', ids)}",
@@ -293,8 +311,7 @@ public sealed class AspireFixture : IAsyncLifetime
 				CreateNoWindow = true,
 			});
 
-			if (rmProcess is not null)
-				await rmProcess.WaitForExitAsync();
+			if (rmProcess is not null) await rmProcess.WaitForExitAsync();
 		}
 		catch
 		{

--- a/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -18,7 +20,9 @@ public static class RecipeFactory
 		var recipeIngredients = (ingredients ?? [("Default Ingredient", null, null)])
 			.Select(i => Ingredient.Create(
 				IngredientName.From(i.Name),
-				Quantity.FromNullable(Amount.FromNullable(i.Amount), Unit.FromNullable(i.Unit))))
+				Quantity.FromNullable(
+					Amount.FromNullable(i.Amount),
+					Unit.FromNullable(i.Unit))))
 			.ToList();
 
 		var recipeSteps = (steps ?? ["Default step"])
@@ -53,7 +57,7 @@ public static class RecipeFactory
 			("Flour", 50m, "g"),
 			("Milk", 500m, "ml"),
 			("Parmesan cheese", 100m, "g"),
-			("Mozzarella", 200m, "g"),
+			("Mozzarella", 200m, "g")
 		],
 		steps:
 		[
@@ -61,7 +65,7 @@ public static class RecipeFactory
 			"Add canned tomatoes and simmer for 30 minutes",
 			"Make bechamel: melt butter, add flour, gradually add milk",
 			"Layer lasagne sheets, Bolognese, and bechamel in a baking dish",
-			"Top with mozzarella and parmesan, bake at 180°C for 40 minutes",
+			"Top with mozzarella and parmesan, bake at 180°C for 40 minutes"
 		],
 		tags: ["italian", "pasta", "comfort-food"]);
 
@@ -77,14 +81,14 @@ public static class RecipeFactory
 			("Garlic", 4m, "cloves"),
 			("Olive oil", 3m, "tbsp"),
 			("Fresh basil", 10m, "leaves"),
-			("Heavy cream", 100m, "ml"),
+			("Heavy cream", 100m, "ml")
 		],
 		steps:
 		[
 			"Halve tomatoes and roast at 200°C for 25 minutes",
 			"Sauté onion and garlic until soft",
 			"Blend roasted tomatoes with onion mixture",
-			"Stir in cream and fresh basil, season to taste",
+			"Stir in cream and fresh basil, season to taste"
 		]);
 
 	public static Recipe ChocolateCake(string? owner = null) => Create(
@@ -99,13 +103,13 @@ public static class RecipeFactory
 			("Sugar", 300m, "g"),
 			("Eggs", 3m, null),
 			("Butter", 150m, "g"),
-			("Dark chocolate", 200m, "g"),
+			("Dark chocolate", 200m, "g")
 		],
 		steps:
 		[
 			"Mix dry ingredients together",
 			"Cream butter and sugar, add eggs",
 			"Fold in dry ingredients and melted chocolate",
-			"Bake at 170°C for 35 minutes",
+			"Bake at 170°C for 35 minutes"
 		]);
 }

--- a/tests/Yumney.Integration.Tests/Fixtures/ShoppingListFactory.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/ShoppingListFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -11,7 +12,7 @@ public static class ShoppingListFactory
 			ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.Liter)),
 			ShoppingListItem.Create(ItemName.From("Bread"), Quantity.Of(Amount.From(1), null)),
 			ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(12), null)),
-			ShoppingListItem.Create(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.Gram))
 		]);
 
 	public static ShoppingList PartySupplies(string? owner = null) => ShoppingList.Create(
@@ -20,7 +21,7 @@ public static class ShoppingListFactory
 		[
 			ShoppingListItem.Create(ItemName.From("Chips"), Quantity.Of(Amount.From(3), Unit.Bag)),
 			ShoppingListItem.Create(ItemName.From("Soda"), Quantity.Of(Amount.From(6), Unit.Bottle)),
-			ShoppingListItem.Create(ItemName.From("Napkins"), Quantity.Of(Amount.From(1), Unit.Pack)),
+			ShoppingListItem.Create(ItemName.From("Napkins"), Quantity.Of(Amount.From(1), Unit.Pack))
 		]);
 
 	public static ShoppingList BakingIngredients(string? owner = null) => ShoppingList.Create(
@@ -28,7 +29,7 @@ public static class ShoppingListFactory
 		OwnerIdentifier.From(owner ?? "integration-test-user"),
 		[
 			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(1000), Unit.Gram)),
-			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(500), Unit.Gram))
 		],
-		RecipeReference.From(Guid.NewGuid()));
+		RecipeReference.New());
 }

--- a/tests/Yumney.Integration.Tests/MealPlan/Contract/MealPlanMutationContractTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/Contract/MealPlanMutationContractTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/MealPlan/GenerateShoppingListFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/GenerateShoppingListFlowTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ToggleFavoriteContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ToggleFavoriteContractTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeSearchTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeSearchTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;

--- a/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/AddManualItemContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/AddManualItemContractTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
@@ -1,6 +1,9 @@
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/RemoveItemContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/RemoveItemContractTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ShoppingModeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ShoppingModeContractTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;

--- a/tests/Yumney.Integration.Tests/Users/Contract/AuthEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/AuthEndpointsContractTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net;
 using System.Net.Http.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;

--- a/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using Xunit;

--- a/tests/Yumney.Integration.Tests/Users/UserProfilePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/UserProfilePersistenceTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;

--- a/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
@@ -12,7 +12,7 @@ internal static class MealPlanTestFixture
 	public static WeeklyPlan CreatePlan() => WeeklyPlan.Create(TestOwner, TestWeek);
 
 	public static SlotRecipeReference Recipe(string title = "Pasta") =>
-		SlotRecipeReference.From(Guid.NewGuid(), title);
+		SlotRecipeReference.From(SlotRecipeIdentifier.New(), SlotRecipeTitle.From(title));
 
 	public static SlotRecipeReference Recipe(Guid id, string title) =>
 		SlotRecipeReference.From(id, title);

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeIdentifierTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeIdentifierTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class SlotRecipeIdentifierTests
+{
+	[Fact]
+	public void New_ReturnsVersion7Guid()
+	{
+		var id = SlotRecipeIdentifier.New();
+
+		id.Value.Should().NotBe(Guid.Empty);
+		id.Value.Version.Should().Be(7);
+	}
+
+	[Fact]
+	public void New_EachCall_ReturnsDistinctGuid()
+	{
+		var a = SlotRecipeIdentifier.New();
+		var b = SlotRecipeIdentifier.New();
+
+		a.Should().NotBe(b);
+	}
+
+	[Fact]
+	public void From_ValidGuid_CreatesInstance()
+	{
+		var guid = Guid.NewGuid();
+		var id = SlotRecipeIdentifier.From(guid);
+
+		id.Value.Should().Be(guid);
+	}
+
+	[Fact]
+	public void From_EmptyGuid_ThrowsGuardException()
+	{
+		var act = () => SlotRecipeIdentifier.From(Guid.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Equality_SameGuid_AreEqual()
+	{
+		var guid = Guid.NewGuid();
+		var a = SlotRecipeIdentifier.From(guid);
+		var b = SlotRecipeIdentifier.From(guid);
+
+		a.Should().Be(b);
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -96,7 +96,7 @@ public class WeeklyPlanTests
 	{
 		var plan = CreatePlan();
 
-		var act = () => plan.AssignRecipe(DayOfWeek.Monday, SlotRecipeReference.From(Guid.NewGuid(), string.Empty));
+		var act = () => plan.AssignRecipe(DayOfWeek.Monday, SlotRecipeReference.From(SlotRecipeIdentifier.New(), SlotRecipeTitle.From(string.Empty)));
 
 		act.Should().Throw<GuardException>();
 	}
@@ -598,7 +598,7 @@ public class WeeklyPlanTests
 	}
 
 	private static SlotRecipeReference Recipe(string title = "Pasta") =>
-		SlotRecipeReference.From(Guid.NewGuid(), title);
+		SlotRecipeReference.From(SlotRecipeIdentifier.New(), SlotRecipeTitle.From(title));
 
 	private static SlotRecipeReference Recipe(Guid id, string title) =>
 		SlotRecipeReference.From(id, title);

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -117,7 +117,7 @@ public class SaveRecipeCommandHandlerTests
 			RecipeTitle.From("Test"),
 			[
 				new SaveRecipeIngredientItem(flour, Quantity.Of(Amount.From(500), Unit.Gram)),
-				new SaveRecipeIngredientItem(sugar, Quantity.Of(Amount.From(100), null)),
+				new SaveRecipeIngredientItem(sugar, Quantity.Of(Amount.From(100), null))
 			],
 			[new SaveRecipeStepItem(StepNumber.From(1), StepDescription.From("Mix"))],
 			SourceUrl: RecipeUrl.From("https://example.com/recipe"));
@@ -144,7 +144,7 @@ public class SaveRecipeCommandHandlerTests
 			[new SaveRecipeIngredientItem(IngredientName.From("Flour"), null)],
 			[
 				new SaveRecipeStepItem(StepNumber.From(1), preheatOven),
-				new SaveRecipeStepItem(StepNumber.From(2), mixIngredients),
+				new SaveRecipeStepItem(StepNumber.From(2), mixIngredients)
 			],
 			SourceUrl: RecipeUrl.From("https://example.com/recipe"));
 

--- a/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
+++ b/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
@@ -45,7 +45,7 @@ internal static class RecipeTestData
 			OwnerIdentifier.From(ownerId),
 			[
 				Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500m), Unit.Gram)),
-				Ingredient.Create(IngredientName.From("Eggs"), null),
+				Ingredient.Create(IngredientName.From("Eggs"), null)
 			],
 			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);
 	}
@@ -58,7 +58,7 @@ internal static class RecipeTestData
 			[Ingredient.Create(IngredientName.From("Flour"), null)],
 			[
 				Step.Create(StepNumber.From(1), StepDescription.From("Mix flour")),
-				Step.Create(StepNumber.From(2), StepDescription.From("Add eggs")),
+				Step.Create(StepNumber.From(2), StepDescription.From("Add eggs"))
 			]);
 	}
 }

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -71,7 +71,7 @@ public class RecipeTests
 		List<Ingredient> ingredients =
 		[
 			Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(400), Unit.Gram)),
-			Ingredient.Create(IngredientName.From("Pancetta"), Quantity.Of(Amount.From(200), Unit.Gram)),
+			Ingredient.Create(IngredientName.From("Pancetta"), Quantity.Of(Amount.From(200), Unit.Gram))
 		];
 
 		var recipe = CreateValidRecipe(ingredients: ingredients);
@@ -85,7 +85,7 @@ public class RecipeTests
 		List<Step> steps =
 		[
 			Step.Create(StepNumber.From(1), StepDescription.From("Cook pasta")),
-			Step.Create(StepNumber.From(2), StepDescription.From("Fry pancetta")),
+			Step.Create(StepNumber.From(2), StepDescription.From("Fry pancetta"))
 		];
 
 		var recipe = CreateValidRecipe(steps: steps);
@@ -244,13 +244,13 @@ public class RecipeTests
 		var recipe = CreateValidRecipe(ingredients:
 		[
 			Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-			Ingredient.Create(IngredientName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
+			Ingredient.Create(IngredientName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
 		]);
 
 		var butterName = IngredientName.From("Butter");
 		List<Ingredient> newIngredients =
 		[
-			Ingredient.Create(butterName, Quantity.Of(Amount.From(100), Unit.Gram)),
+			Ingredient.Create(butterName, Quantity.Of(Amount.From(100), Unit.Gram))
 		];
 
 		recipe.Update(RecipeTitle.From("Updated"), newIngredients, [Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);
@@ -265,13 +265,13 @@ public class RecipeTests
 		var recipe = CreateValidRecipe(steps:
 		[
 			Step.Create(StepNumber.From(1), StepDescription.From("Step one")),
-			Step.Create(StepNumber.From(2), StepDescription.From("Step two")),
+			Step.Create(StepNumber.From(2), StepDescription.From("Step two"))
 		]);
 
 		var newDescription = StepDescription.From("New only step");
 		List<Step> newSteps =
 		[
-			Step.Create(StepNumber.From(1), newDescription),
+			Step.Create(StepNumber.From(1), newDescription)
 		];
 
 		recipe.Update(RecipeTitle.From("Updated"), [Ingredient.Create(IngredientName.From("Flour"), null)], newSteps);
@@ -521,11 +521,11 @@ public class RecipeTests
 
 		List<Ingredient> newIngredients =
 		[
-			Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.Gram)),
+			Ingredient.Create(IngredientName.From("Butter"), Quantity.Of(Amount.From(100), Unit.Gram))
 		];
 		List<Step> newSteps =
 		[
-			Step.Create(StepNumber.From(1), StepDescription.From("Melt butter")),
+			Step.Create(StepNumber.From(1), StepDescription.From("Melt butter"))
 		];
 
 		recipe.Update(

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/RecipeIngredientProviderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/RecipeIngredientProviderTests.cs
@@ -24,7 +24,7 @@ public class RecipeIngredientProviderTests
 		SetupRecipe(
 			[
 				Ingredient.Create(IngredientName.From("Spaghetti"), Quantity.Of(Amount.From(500m), Unit.Gram)),
-				Ingredient.Create(IngredientName.From("Tomato Sauce"), Quantity.Of(Amount.From(200m), Unit.Milliliter)),
+				Ingredient.Create(IngredientName.From("Tomato Sauce"), Quantity.Of(Amount.From(200m), Unit.Milliliter))
 			],
 			Servings.From(4));
 

--- a/tests/Yumney.Shared.Guards.Tests/EnsureTests.cs
+++ b/tests/Yumney.Shared.Guards.Tests/EnsureTests.cs
@@ -198,7 +198,7 @@ public class EnsureTests
 	[Fact]
 	public void IsNotEmpty_Collection_NonEmptyCollection_DoesNotThrow()
 	{
-		IReadOnlyCollection<int> items = new[] { 1, 2, 3 };
+		IReadOnlyCollection<int> items = [1, 2, 3];
 
 		var act = () => Ensure.That(items).IsNotEmpty();
 
@@ -208,7 +208,7 @@ public class EnsureTests
 	[Fact]
 	public void IsNotEmpty_Collection_EmptyCollection_ThrowsGuardException()
 	{
-		IReadOnlyCollection<int> items = Array.Empty<int>();
+		IReadOnlyCollection<int> items = [];
 
 		var act = () => Ensure.That(items).IsNotEmpty();
 

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListCommandHandlerTests.cs
@@ -70,7 +70,7 @@ public class CreateShoppingListCommandHandlerTests
 				new ShoppingListItem(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter)),
 				new ShoppingListItem(ItemName.From("Salt"), null),
 				new ShoppingListItem(ItemName.From("Pepper"), null),
-				new ShoppingListItem(ItemName.From("Vanilla"), Quantity.Of(Amount.From(1), Unit.Teaspoon)),
+				new ShoppingListItem(ItemName.From("Vanilla"), Quantity.Of(Amount.From(1), Unit.Teaspoon))
 			]);
 
 		var result = await handler.HandleAsync(command);
@@ -129,7 +129,7 @@ public class CreateShoppingListCommandHandlerTests
 			ShoppingListTitle.From("Test"),
 			[
 				new ShoppingListItem(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-				new ShoppingListItem(ItemName.From("Salt"), null),
+				new ShoppingListItem(ItemName.From("Salt"), null)
 			]);
 
 		var result = await handler.HandleAsync(command);

--- a/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
@@ -36,10 +36,9 @@ public class ExportShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_AllBought_ReturnsEmptyString()
 	{
-		var items = new List<MergedShoppingItemDto>
-		{
-			new("Milk", 2, 2, "L", "dairy", true, []),
-		};
+		List<MergedShoppingItemDto> items = [
+			new("Milk", 2, 2, "L", "dairy", true, [])
+		];
 		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
@@ -74,11 +73,11 @@ public class ExportShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_ExcludesBoughtItems()
 	{
-		var items = new List<MergedShoppingItemDto>
-		{
+		List<MergedShoppingItemDto> items =
+		[
 			new("Milk", 2, 2, "L", "dairy", true, []),
-			new("Eggs", 6, 6, "pc", "dairy", false, []),
-		};
+			new("Eggs", 6, 6, "pc", "dairy", false, [])
+		];
 		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
@@ -106,11 +105,11 @@ public class ExportShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_OrderedByCategoryDisplayOrder()
 	{
-		var items = new List<MergedShoppingItemDto>
-		{
+		List<MergedShoppingItemDto> items =
+		[
 			new("Soap", 1, 1, "pc", "household", false, []),
-			new("Onion", 1, 1, "pc", "produce", false, []),
-		};
+			new("Onion", 1, 1, "pc", "produce", false, [])
+		];
 		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
@@ -39,7 +39,7 @@ public class GetShoppingListsQueryHandlerTests
 		List<ShoppingListSummary> summaries =
 		[
 			new(ShoppingListIdentifier.New(), ShoppingListTitle.From("List 1"), ItemCount.From(1), DateTime.UtcNow),
-			new(ShoppingListIdentifier.New(), ShoppingListTitle.From("List 2"), ItemCount.From(2), DateTime.UtcNow),
+			new(ShoppingListIdentifier.New(), ShoppingListTitle.From("List 2"), ItemCount.From(2), DateTime.UtcNow)
 		];
 
 		SetupRepository(summaries, 2);

--- a/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
+++ b/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
@@ -20,7 +20,7 @@ internal static class ShoppingListTestData
 			[
 				ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter)),
 				ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-				ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(6), null)),
+				ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(6), null))
 			]);
 	}
 

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -52,7 +52,7 @@ public class ShoppingListTests
 		List<ShoppingListItem> items =
 		[
 			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
 		];
 
 		var shoppingList = CreateValidShoppingList(items: items);
@@ -123,7 +123,7 @@ public class ShoppingListTests
 	{
 		List<ShoppingListItem> items =
 		[
-			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
 		];
 		var shoppingList = CreateValidShoppingList(items: items);
 
@@ -137,7 +137,7 @@ public class ShoppingListTests
 	{
 		List<ShoppingListItem> items =
 		[
-			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
 		];
 		var shoppingList = CreateValidShoppingList(items: items);
 		shoppingList.CheckOffItem(items[0].Id);
@@ -153,7 +153,7 @@ public class ShoppingListTests
 		List<ShoppingListItem> items =
 		[
 			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
 		];
 		var shoppingList = CreateValidShoppingList(items: items);
 
@@ -168,7 +168,7 @@ public class ShoppingListTests
 		List<ShoppingListItem> items =
 		[
 			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
 		];
 		var shoppingList = CreateValidShoppingList(items: items);
 		shoppingList.CheckAllItems();

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
@@ -76,7 +76,7 @@ public class ShoppingListWriterTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns((ShoppingLedger?)null);
 
-		await writer.AddItemsAsync(OwnerId, Array.Empty<ShoppingItemRequest>());
+		await writer.AddItemsAsync(OwnerId, []);
 
 		await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingLedger>(), Arg.Any<CancellationToken>());
 	}
@@ -87,11 +87,10 @@ public class ShoppingListWriterTests
 		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
 
-		await writer.AddItemsAsync(OwnerId, new[]
-		{
+		await writer.AddItemsAsync(OwnerId, [
 			new ShoppingItemRequest("Milk", 1m, "l", "manual"),
-			new ShoppingItemRequest("Milk", 500m, "ml", "manual"),
-		});
+			new ShoppingItemRequest("Milk", 500m, "ml", "manual")
+		]);
 
 		existing.Items.Should().HaveCount(2);
 	}

--- a/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/RegisterUserCommandHandlerTests.cs
@@ -31,7 +31,7 @@ public class RegisterUserCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_ReturnsSuccessAndCreatesProfile()
 	{
 		var command = new RegisterUserCommand(TestEmail, TestPassword, TestDisplayName);
-		var keycloakUserId = KeycloakUserId.From(Guid.NewGuid().ToString());
+		var keycloakUserId = KeycloakUserId.New();
 
 		keycloakAdmin
 			.CreateUserAsync(command.Email, command.Password, command.DisplayName, Arg.Any<CancellationToken>())

--- a/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/ResendVerificationEmailCommandHandlerTests.cs
@@ -27,7 +27,7 @@ public class ResendVerificationEmailCommandHandlerTests
 	public async Task HandleAsync_ValidEmail_ReturnsSuccessAndSendsEmail()
 	{
 		var command = new ResendVerificationEmailCommand(TestEmail);
-		var keycloakUserId = KeycloakUserId.From(Guid.NewGuid().ToString());
+		var keycloakUserId = KeycloakUserId.New();
 
 		keycloakAdmin
 			.FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())
@@ -111,7 +111,7 @@ public class ResendVerificationEmailCommandHandlerTests
 	public async Task HandleAsync_SendFailed_ReturnsFailure()
 	{
 		var command = new ResendVerificationEmailCommand(TestEmail);
-		var keycloakUserId = KeycloakUserId.From(Guid.NewGuid().ToString());
+		var keycloakUserId = KeycloakUserId.New();
 
 		keycloakAdmin
 			.FindUserByEmailAsync(command.Email, Arg.Any<CancellationToken>())

--- a/tests/Yumney.Users.Application.Tests/Queries/GetRecentActivityQueryHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Queries/GetRecentActivityQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetRecentActivityQueryHandlerTests
 		var activity = UserActivity.Record(
 			owner,
 			ActivityType.From("recipe_imported"),
-			RecipeIdentifierSnapshot.From(Guid.NewGuid()),
+			RecipeIdentifierSnapshot.New(),
 			RecipeTitleSnapshot.From("Test Recipe"));
 
 		activities.GetRecentAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<CancellationToken>())

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/KeycloakUserIdTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/KeycloakUserIdTests.cs
@@ -43,4 +43,22 @@ public class KeycloakUserIdTests
 
 		id1.Should().NotBe(id2);
 	}
+
+	[Fact]
+	public void New_ReturnsInstanceWithVersion7Guid()
+	{
+		var id = KeycloakUserId.New();
+
+		Guid.TryParse(id.Value, out var parsed).Should().BeTrue();
+		parsed.Version.Should().Be(7);
+	}
+
+	[Fact]
+	public void New_EachCall_ReturnsDistinctValue()
+	{
+		var a = KeycloakUserId.New();
+		var b = KeycloakUserId.New();
+
+		a.Should().NotBe(b);
+	}
 }

--- a/tests/Yumney.Users.Domain.Tests/UserActivity/RecipeIdentifierSnapshotTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/UserActivity/RecipeIdentifierSnapshotTests.cs
@@ -43,6 +43,24 @@ public class RecipeIdentifierSnapshotTests
 	}
 
 	[Fact]
+	public void New_ReturnsInstanceWithVersion7Guid()
+	{
+		var snapshot = RecipeIdentifierSnapshot.New();
+
+		snapshot.Value.Should().NotBe(Guid.Empty);
+		snapshot.Value.Version.Should().Be(7);
+	}
+
+	[Fact]
+	public void New_EachCall_ReturnsDistinctGuid()
+	{
+		var a = RecipeIdentifierSnapshot.New();
+		var b = RecipeIdentifierSnapshot.New();
+
+		a.Value.Should().NotBe(b.Value);
+	}
+
+	[Fact]
 	public void ImplicitConversion_ReturnsGuid()
 	{
 		var guid = Guid.NewGuid();

--- a/tests/Yumney.Users.Domain.Tests/UserActivity/UserActivityTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/UserActivity/UserActivityTests.cs
@@ -10,7 +10,7 @@ public class UserActivityTests
 	public void Record_CreatesActivityWithCorrectProperties()
 	{
 		var owner = OwnerIdentifier.From("user-123");
-		var recipeId = RecipeIdentifierSnapshot.From(Guid.NewGuid());
+		var recipeId = RecipeIdentifierSnapshot.New();
 		var recipeTitle = RecipeTitleSnapshot.From("Pasta");
 
 		var activity = Domain.UserActivity.UserActivity.Record(


### PR DESCRIPTION
## Summary
Two commits, separated by concern:

### `feat(users)` — VO factories + bug fix
- `RecipeIdentifierSnapshot.New()` — v7 Guid snapshot
- `KeycloakUserId.New()` — v7 Guid in default hyphenated string form (matches Keycloak's `sub`)
- `SlotRecipeIdentifier.New()` — v7 Guid, matches existing `MealSlotIdentifier.New()` in the same folder
- **Fix** latent `NullReferenceException` in `ActivityType` + `DietaryRestriction` static constructors: canonical `static readonly` instances were calling a ctor that dereferenced the yet-uninitialized private `allowedValues` array, throwing `TypeInitializationException` in every downstream consumer. Moved the allow-list check from the ctor into the `From(value)` factory. The ctor still enforces not-null / max-length, which the hardcoded canonical instances satisfy trivially.
- 2 new tests per `*Identifier.New()` (v7 version + distinctness).
- `Yumney.Users.Domain.Tests` went from 29 fail / 190 pass → **219/219**.
- `Yumney.Users.Application.Tests` went from 7 fail / 25 pass → **32/32**.

### `chore` — ReSharper/Rider cleanup sweep
- Explicit `using System` / `System.Collections.Generic` on ~80 files that previously relied on `ImplicitUsings` — keeps the signal consistent across editors.
- Move `Yumney.MealPlan.Infrastructure.Tests` from `/tests/` root into `/tests/MealPlan/` in `Yumney.slnx`.
- Add shared `Yumney.sln.DotSettings` so team inspections stay aligned (user-specific `*.DotSettings.user` remains gitignored).
- No behavior changes.

## Test plan
- [x] `dotnet format Yumney.slnx --verify-no-changes` ✅
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` ✅ (0 warnings, 0 errors)
- [x] `dotnet test Yumney.slnx --filter "FullyQualifiedName!~Integration.Tests"` → **1,731 / 1,731 green**
- [ ] CI green on PR