### PR TITLE
perf(frontend): @defer ChatPanel + infinite-scroll story (US-294)

### DIFF
--- a/client/apps/shell/src/app/app.html
+++ b/client/apps/shell/src/app/app.html
@@ -5,6 +5,6 @@
 </main>
 <yn-command-fab />
 @defer (when chatState.isOpen()) {
-  <yn-chat-panel />
+<yn-chat-panel />
 }
 <yn-toast-host />

--- a/client/apps/shell/src/app/app.html
+++ b/client/apps/shell/src/app/app.html
@@ -4,5 +4,7 @@
   <router-outlet></router-outlet>
 </main>
 <yn-command-fab />
-<yn-chat-panel />
+@defer (when chatState.isOpen()) {
+  <yn-chat-panel />
+}
 <yn-toast-host />

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -7,6 +7,7 @@ import {
   HeaderComponent,
   ToastHostComponent,
 } from '@yumney/ui';
+import { ChatStateService } from '@yumney/shared/models';
 import { OfflineIndicatorComponent } from './layout/offline-indicator/offline-indicator.component';
 import { filter } from 'rxjs';
 
@@ -26,6 +27,7 @@ import { filter } from 'rxjs';
 })
 export class App implements OnInit {
   private readonly swUpdate = inject(SwUpdate);
+  protected readonly chatState = inject(ChatStateService);
 
   ngOnInit(): void {
     if (!this.swUpdate.isEnabled) return;

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.html
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.html
@@ -5,5 +5,7 @@
   <router-outlet />
 </main>
 @if (isStandalone) {
-  <yn-chat-panel />
+  @defer (when chatState.isOpen()) {
+    <yn-chat-panel />
+  }
 }

--- a/client/libs/ui/src/lib/app-layout/app-layout.component.ts
+++ b/client/libs/ui/src/lib/app-layout/app-layout.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { IS_STANDALONE } from '@yumney/shared/models';
+import { ChatStateService, IS_STANDALONE } from '@yumney/shared/models';
 import { HeaderComponent } from '../header/header.component';
 import { ChatPanelComponent } from '../chat-panel/chat-panel.component';
 
@@ -13,4 +13,5 @@ import { ChatPanelComponent } from '../chat-panel/chat-panel.component';
 })
 export class AppLayoutComponent {
   protected isStandalone = inject(IS_STANDALONE);
+  protected readonly chatState = inject(ChatStateService);
 }

--- a/client/libs/ui/src/lib/directives/infinite-scroll.directive.stories.ts
+++ b/client/libs/ui/src/lib/directives/infinite-scroll.directive.stories.ts
@@ -1,0 +1,69 @@
+import { Component, input, output } from '@angular/core';
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { expect, fn, within } from 'storybook/test';
+import { InfiniteScrollDirective } from './infinite-scroll.directive';
+
+@Component({
+  selector: 'yn-infinite-scroll-demo',
+  standalone: true,
+  imports: [InfiniteScrollDirective],
+  template: `
+    <div
+      style="height: 240px; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px;"
+    >
+      @for (n of items(); track n) {
+        <div style="padding: 12px 0; border-bottom: 1px solid #f3f4f6;">Item {{ n }}</div>
+      }
+      <div
+        ynInfiniteScroll
+        [enabled]="enabled()"
+        (loadMore)="loadMore.emit()"
+        style="height: 32px; display: flex; align-items: center; justify-content: center; color: #6b7280; font-size: 12px;"
+      >
+        {{ enabled() ? 'Scroll sentinel' : 'Disabled' }}
+      </div>
+    </div>
+  `,
+})
+class InfiniteScrollDemoComponent {
+  items = input<number[]>([]);
+  enabled = input(true);
+  loadMore = output<void>();
+}
+
+const meta: Meta<InfiniteScrollDemoComponent> = {
+  title: 'Directives/Infinite Scroll',
+  component: InfiniteScrollDemoComponent,
+  decorators: [moduleMetadata({ imports: [InfiniteScrollDirective] })],
+  argTypes: {
+    enabled: { control: 'boolean' },
+  },
+  args: {
+    items: Array.from({ length: 20 }, (_, i) => i + 1),
+    enabled: true,
+    loadMore: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<InfiniteScrollDemoComponent>;
+
+export const Enabled: Story = {};
+
+export const Disabled: Story = {
+  args: { enabled: false },
+};
+
+export const SentinelVisible_EmitsLoadMore: Story = {
+  args: {
+    items: [1, 2, 3],
+    enabled: true,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Scroll sentinel');
+    // IntersectionObserver fires asynchronously once the sentinel is visible.
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(args.loadMore).toHaveBeenCalled();
+  },
+};


### PR DESCRIPTION
Continues work on #294 nice-to-haves.

## Changes
### `perf` — @defer ChatPanelComponent
Chat panel is mounted in two always-on places (shell root + `AppLayoutComponent`) but is rarely the first thing a user interacts with. Wrapping both mounts in `@defer (when chatState.isOpen())` splits `ChatPanelComponent` + its deps (`ChatApiService`, `RecipeApiService`, Lucide icons, panel-specific Transloco keys) into a lazy chunk.

**Verified:** Angular build emits `chat-panel.component-*.js` as a separate chunk; it only loads the first time `ChatStateService.open()` fires. Initial shell bundle stays 91.34 kB.

### `docs` — Storybook story for `InfiniteScrollDirective`
Directives can't render a story on their own, so the story wraps it in a small scrollable host demonstrating enabled/disabled states plus an interaction play test that asserts `loadMore` fires when the sentinel enters view.

## Not in this PR (tracked on #294)
- `NgOptimizedImage` on recipe cards — marginal gain over today's `loading="lazy"` + explicit `width`/`height`; not worth it without a CDN/image loader
- Storybook story for `ChatPanelComponent` — needs mocks for `ChatApiService`/`RecipeApiService`/`ChatStateService`, larger effort; can come in a follow-up
- Cross-MFE E2E workflows

## Test plan
- [x] `yarn nx run-many -t lint test -p ui shell` green
- [x] `yarn nx build shell` green, confirmed lazy chunk
- [ ] Smoke test in browser that chat opens on first click and renders correctly after lazy load