### PR TITLE
fix(frontend): 44px touch targets on servings + unit-menu (US-302)

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -112,8 +112,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border: 1px solid var(--yn-primary);
   border-radius: var(--yn-radius-circle);
   background: transparent;

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.scss
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.scss
@@ -158,7 +158,10 @@
 }
 
 .unit-menu-item {
-  padding: 0.4375rem var(--yn-space-4);
+  display: flex;
+  align-items: center;
+  min-height: 2.75rem;
+  padding: var(--yn-space-2) var(--yn-space-4);
   font-size: var(--yn-text-base);
   cursor: pointer;
   white-space: nowrap;


### PR DESCRIPTION
Finishes off the out-of-scope items left on #302.

## Changes
- **`apps/recipes/.../recipe-detail.component.scss:115-116`** — `.servings-button` was `1.75rem` (28 px). Bumped to `2.75rem` (44 px) matching iOS HIG. Layout already reserves gap, no crowding.
- **`libs/ui/.../unit-select.component.scss:160-165`** — `.unit-menu-item` was padded to `0.4375rem` (~24 px tall). Toggle was already 44 px and the clear-X already expands via a `::before` pseudo, but dropdown options themselves were too small. Set `min-height: 2.75rem` with flex alignment.

No HTML/TS changes.

## Test plan
- [x] `yarn nx run-many -t lint test -p ui recipes` green
- [ ] Manual: open recipe detail on 375 px viewport, tap +/- reliably with thumb
- [ ] Manual: open a unit dropdown on mobile, tap individual items without mis-hits