### PR TITLE
fix(ci): supply E2E Aspire parameters so containers actually start

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,18 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
+      # mailpit, and the LLM provider setup, so fewer containers need to come up.
+      E2ETests: 'true'
+      # Aspire parameters. Aspire reads Parameters__<Name> as the param value
+      # (the "__" is the configuration section separator). Values are local to
+      # this ephemeral runner — no production secrets involved.
+      Parameters__PostgresUser: yumney
+      Parameters__PostgresPassword: yumney-e2e
+      Parameters__KeycloakPassword: keycloak-e2e
+      Parameters__MessagingPassword: messaging-e2e
+      Parameters__RedisPassword: redis-e2e
 
     steps:
       - uses: actions/checkout@v6
@@ -118,8 +130,10 @@ jobs:
             stamp "poll-start $name $url (timeout ${timeout}s)"
             while [ "$(date +%s)" -lt "$deadline" ]; do
               local code
-              code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 3 "$url" || echo 000)
-              if [ "$code" != "000" ] && [ "$code" -lt 500 ]; then
+              code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 3 "$url" 2>/dev/null || echo 000)
+              # Treat the status as 3-digit; use base-10 arithmetic to avoid
+              # bash's leading-zero-octal interpretation. 000 = not ready.
+              if [ "${#code}" -eq 3 ] && [ "$((10#$code))" -ge 200 ] && [ "$((10#$code))" -lt 500 ]; then
                 stamp "poll-ready $name after $(( $(date +%s) - t0 ))s (http $code)"
                 return 0
               fi


### PR DESCRIPTION
Closes the loop on #297 (the E2E diagnostic PR).

## Root cause

Pulled the `aspire-logs` artifact from the last successful E2E run on develop. `aspire describe` showed six parameters as **`Value missing`**:

- `PostgresUser`, `PostgresPassword`
- `KeycloakPassword`, `MessagingPassword`, `RedisPassword`
- `OpenAiApiKey`

Without credentials, Aspire can't materialize the containers. Every database / message broker / auth service stays in `Starting` state indefinitely. `docker ps` confirmed **zero containers running** at both checkpoints. `aspire wait` then eats its full 600s timeout, `|| true` swallows it, tests run against an empty stack, and `continue-on-error: true` on both test steps masks the outcome. That's where the 10:01 on "Wait for services to be ready" came from.

## Fixes

1. **`E2ETests=true` on the job env** — the AppHost already guards the LLM provider setup, `pgAdmin`, `mailpit`, and persistent volumes behind this flag (`src/Yumney.AppHost/Program.cs:80,188`). Drops `OpenAiApiKey` and a handful of optional containers from the required set.
2. **Supply the 5 credential parameters via `Parameters__<Name>` env vars**. Aspire reads these via the standard config section-separator pattern. Values are ephemeral per runner — no production secrets involved.
3. **Fix the false-positive ready detection** in the instrumented wait loop (introduced by #297). The prior check `[ "$code" -lt 500 ]` with `code="000"` triggered bash's leading-zero-as-octal interpretation (`0 -lt 500` = true) and counted a failed curl as "ready" on the first iteration. Now forces base-10 via `$((10#$code))` and requires `status >= 200`.

## Expected impact

Wait step should complete in ~60–90s (actual container startup) instead of the ~10 min timeout. Full E2E job time drops from ~15 min to ~6–7 min.

## Follow-up (not in this PR)

Remove `continue-on-error: true` from both the integration-test and playwright-test steps so real failures actually fail the gate. Keeping it for this PR because it's the first run with containers actually running; we may discover previously-hidden test failures and I want to land the infra fix cleanly first.

## Test plan

- [ ] CI passes (unit tests unaffected, only e2e.yml touched)
- [ ] E2E run shows containers in `Running` state in the `aspire describe` diagnostic output
- [ ] Wait step duration drops from ~10 min to ~1–2 min
- [ ] Actual integration + playwright tests execute against a real stack