### PR TITLE
fix(e2e): register the frontend + gateway when E2ETests=true

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -185,8 +185,12 @@ if (!options.DatabaseOnly)
 	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
 	migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
 
-	if (isRunMode && !options.E2ETests)
+	if (isRunMode)
 	{
+		// Run mode (including E2E) spawns the Angular dev servers and the gateway
+		// project so the full federated stack is reachable on localhost. The E2E
+		// flag above still toggles persistent volumes and optional sidecars
+		// (pgAdmin, mailpit); it doesn't affect whether the frontend is registered.
 		var addMfe = (string name, string script, int port) =>
 			builder.AddJavaScriptApp(name, "../../client", script)
 				.WithYarn()


### PR DESCRIPTION
Follow-up to #308.

## Diagnosis

Pulled the post-#308 E2E artifact. Containers and backend came up cleanly this time:

✅ keycloak, postgres, redis, rabbitmq (all Running/Healthy)
✅ 4 databases (recipesdb, shoppingdb, usersdb, mealplandb)
✅ recipes-api, shopping-api, users-api, mealplan-api (all Healthy)
✅ yumney-migrations Finished
✅ poll-keycloak: ready after 48s (http 200)

But `aspire describe` had no entries for **shell, recipes-mfe, shopping-mfe, account-mfe, yumney-gateway**. The frontend was simply never registered. Polls against `:5100` and `:4200` eat their full 540s timeout because nothing is listening.

## Root cause

`src/Yumney.AppHost/Program.cs:188` gated the frontend + gateway registration on:

```csharp
if (isRunMode && !options.E2ETests)
```

The sister `else if (!isRunMode)` branch handles publish mode (Dockerfile frontend + YARP). E2E mode fell through both: `isRunMode=true` blocks the publish branch, `E2ETests=true` blocks the run branch.

## Fix

Drop `&& !options.E2ETests`. The E2E guards that matter (persistent volumes, pgAdmin, mailpit, LLM provider) all live in earlier blocks with their own gates. This one was just wrong.

## Expected impact

Next E2E run's "Wait for services to be ready" should land at ~60–120s (Angular dev-server startup) instead of the current 9 min (three 540s poll timeouts). Brings full E2E job time into the ~5–6 min range.

## Test plan

- [x] `dotnet build src/Yumney.AppHost -p:TreatWarningsAsErrors=true` green
- [ ] Post-merge E2E run: aspire-describe-final.log lists shell + three MFEs + yumney-gateway as Running
- [ ] poll-gateway and poll-shell both return `http 200` within ~2 min
- [ ] Real integration + playwright tests execute against a reachable stack