### PR TITLE
ci(e2e): enforce integration + playwright test results

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -179,11 +179,9 @@ jobs:
           stamp "diagnostic step complete"
 
       - name: Run backend integration tests
-        continue-on-error: true
         run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
 
       - name: Run Playwright e2e tests
-        continue-on-error: true
         working-directory: client
         run: npx nx e2e shell-e2e
         env:


### PR DESCRIPTION
Follow-up to #308 and #309.

## What

Drops `continue-on-error: true` from the `Run backend integration tests` and `Run Playwright e2e tests` steps in `e2e.yml`. If either fails now, the gate fails.

## Why now

The flags existed because the stack rarely came up, so transient infra failures would block PRs. After #308 (supplied Aspire parameters) + #309 (re-registered the frontend), the post-merge artifact from run 24802617524 showed:

- shell, three MFEs, yumney-gateway all **Running/Healthy**
- All 3 probes returned `http 200` (Keycloak 64s, Gateway 133s, Shell 133s, no timeouts)
- Integration tests ran for real (3:09, not the prior ~1:40 against nothing)

No reason to keep swallowing real test failures. If a flake appears, fix it; don't hide it.

## Risk

If previously-hidden test failures exist in the current suite, this PR will expose them. That's the intent — better to know now than never. If a legitimate-but-obscure flake surfaces, we address it on its own merits.