### PR TITLE
ci(e2e): include dist/.playwright in the uploaded report artifact

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,4 +218,5 @@ jobs:
           path: |
             client/test-results/
             client/apps/shell-e2e/playwright-report/
+            client/dist/.playwright/
           retention-days: 14


### PR DESCRIPTION
Prep PR so we can diagnose the failure surfaced by #310.

## Why

Nx's `@nx/playwright` executor writes failure attachments under `client/dist/.playwright/apps/shell-e2e/test-output/` — the JUnit XML already points to them with `../../dist/.playwright/...` paths. But the current upload only grabs `client/test-results/` and `client/apps/shell-e2e/playwright-report/`, so when a test fails we see the stack trace but no screenshot / video / trace.zip / error-context.md. Those are exactly what we need to diagnose the auth.setup failure #310 exposed.

## Change

One-line addition to the upload path.

## After this lands

Re-trigger the #310 run (or a fresh push) → next failure artifact will include the visual evidence. From there I can figure out whether the "Sign in" button was missing because of Transloco race, Angular cold-compile, or an unexpected redirect.