### PR TITLE
ci(e2e): include hidden files when uploading playwright-report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -219,4 +219,7 @@ jobs:
             client/test-results/
             client/apps/shell-e2e/playwright-report/
             client/dist/.playwright/
+          # The Nx playwright executor writes attachments under .playwright,
+          # which upload-artifact treats as a hidden dir and skips by default.
+          include-hidden-files: true
           retention-days: 14


### PR DESCRIPTION
Diagnostic Part II of the auth-setup debugging chain.

## Finding

The #311 post-merge E2E run (24804189413) showed the same missing attachments: `results.xml` references `../../dist/.playwright/...` but none of the PNG / webm / trace.zip / error-context.md files were in the artifact. Inspecting the upload step's log exposed the culprit:

```
with:
  ...
  include-hidden-files: false
```

`client/dist/.playwright/` starts with a dot. `actions/upload-artifact@v4` classifies dotted directories as hidden and skips them silently — no warning, no error. That's why #311 looked like it worked but actually uploaded zero new files.

## Fix

Add `include-hidden-files: true` to the upload step.

## After this lands

Re-trigger the workflow → the next failing run uploads the failure screenshot, video, full Playwright trace.zip, and Playwright's aria-snapshot `error-context.md`. That's what we need to figure out what `/auth/login` actually rendered at the moment the Sign-in button wasn't found.