### PR TITLE
fix(e2e): wait for Angular render in auth.setup, not just load event

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -18,16 +18,20 @@ setup('authenticate via Keycloak', async ({ page }) => {
     if (msg.type() === 'error') console.log(`Console error: ${msg.text()}`);
   });
 
-  // 1. Go to login
-  await page.goto('/auth/login');
-  await page.waitForLoadState('load');
+  // 1. Go to login. Shell bootstrap chains federation init + APP_INITIALIZER
+  //    (Keycloak discovery + language + theme) + vite on-demand compile of the
+  //    /auth/* lazy chunk, all on the cold path in CI. `load` fires when bundles
+  //    finish downloading, not when Angular has rendered, so we explicitly wait
+  //    for content inside <yn-root> before asserting on the button.
+  await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.locator('yn-root > *').first().waitFor({ timeout: 60_000 });
 
   // 2. Click sign in
-  await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible({ timeout: 30_000 });
   await page.getByRole('button', { name: /sign in/i }).click();
 
   // 3. Wait for and fill Keycloak form
-  await page.waitForURL('**/realms/**', { timeout: 10_000 });
+  await page.waitForURL('**/realms/**', { timeout: 15_000 });
   await page.locator('#username').fill(E2E_USER);
   await page.locator('#password').fill(E2E_PASSWORD);
   await page.locator('#kc-login').click();


### PR DESCRIPTION
Closes out the auth-setup failure chain that started when #310 unhid it.

## Diagnosis (from run 24805288415's artifact)

- \`test-failed-1.png\` was entirely blank — the Yumney green body color only. \`<yn-root>\` never got replaced.
- Network trace: 87 × 200, everything downloaded. No 4xx/5xx.
- All 3 Playwright retries opened fresh browsers. Each hit the cold path independently.

The cold bootstrap chain on a CI runner that's also running 5 Node dev servers + a .NET stack:
1. Native Federation fetches \`remoteEntry.json\` from :4201/:4202/:4203
2. \`APP_INITIALIZER\` awaits \`AuthService.initialize()\` → Keycloak discovery doc + \`LanguageService\` + \`ThemeService\`
3. Vite on-demand compiles the \`/auth/*\` lazy route chunk on first navigation
4. Angular hydrates \`<yn-root>\`

All that together exceeded the previous 10 s \`toBeVisible\` budget. And \`waitForLoadState('load')\` only waits for bundles to download, not for Angular to render.

## Fix

\`apps/shell-e2e/src/auth.setup.ts\`:
- Navigate with \`waitUntil: 'domcontentloaded'\` + \`timeout: 60_000\`.
- Wait explicitly for \`yn-root > *\` — concrete signal Angular rendered.
- Bump \`toBeVisible\` to 30 s and the Keycloak hand-off \`waitForURL\` to 15 s for consistent cold-start headroom.

Stack itself is fine (every service Running/Healthy per the earlier describe), this was only a render-timing race.

## After this lands

Will flow naturally into un-drafting and merging #310 (which removes \`continue-on-error: true\` from both test steps) so the gate finally becomes real.