### PR TITLE
fix(e2e): raise auth.setup test timeout to 120s

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -5,6 +5,13 @@ const E2E_PASSWORD = process.env['E2E_PASSWORD'] ?? 'Test1234';
 
 const AUTH_STATE_PATH = 'src/.auth/user.json';
 
+// Cold-start budget: federation init + APP_INITIALIZER (Keycloak discovery +
+// language + theme) + vite on-demand compile of the /auth/* lazy chunk +
+// navigation to Keycloak + token exchange + return redirect. The global 30s
+// test timeout from playwright.config.ts is not enough on a CI runner that is
+// also running the full Aspire stack plus 4 Angular dev servers.
+setup.setTimeout(120_000);
+
 setup('authenticate via Keycloak', async ({ page }) => {
   // Capture token exchange responses
   page.on('response', (r) => {


### PR DESCRIPTION
Continuation of the auth-setup debugging chain (#310 → #311 → #312 → #313 → this).

## What the previous run showed

Run 24806762207 on develop (post-#313). Setup ran for 97s and erred with:

\`\`\`
Test timeout of 30000ms exceeded.
Error: locator.waitFor: Test timeout of 30000ms exceeded.
  - waiting for locator('yn-root > *').first() to be visible
\`\`\`

- \`failures=0, errors=1\` — the Sign-in button lookup didn't fail (render-wait fix from #313 is correct).
- But the test itself timed out. The \`timeout: 60_000\` I passed to \`waitFor\` was overridden by the global \`timeout: 30_000\` in \`playwright.config.ts\`. Per-op timeouts only apply within the test's overall budget.

## Fix

Add \`setup.setTimeout(120_000)\` at file scope of \`auth.setup.ts\`. Only this one test pays the cold-boot tax:

- Federation init (pulls 3 remoteEntry.json)
- APP_INITIALIZER: Keycloak discovery + language + theme
- Vite on-demand compile of the \`/auth/*\` lazy route chunk
- Keycloak redirect, login form, code exchange, return redirect

Downstream specs reuse the cached \`storageState\` and render against warmed-up chunks, so the 30s default still applies to them.

## Next

If this lands green, auth.setup should finally pass and the 134 previously-skipped tests will actually run. Some of those may then fail or flake on their own — expected, we'll address them one by one. Once the suite is stable end-to-end, un-draft #310 to enforce the gate.