### PR TITLE
test(e2e): dump DOM + pageerror when auth.setup stalls

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -25,13 +25,39 @@ setup('authenticate via Keycloak', async ({ page }) => {
     if (msg.type() === 'error') console.log(`Console error: ${msg.text()}`);
   });
 
+  // Capture page errors (uncaught exceptions, promise rejections) which
+  // the 'console' listener misses.
+  page.on('pageerror', (err) => console.log(`PageError: ${err.message}`));
+  page.on('requestfailed', (req) =>
+    console.log(`RequestFailed: ${req.failure()?.errorText} ${req.url()}`),
+  );
+
   // 1. Go to login. Shell bootstrap chains federation init + APP_INITIALIZER
   //    (Keycloak discovery + language + theme) + vite on-demand compile of the
   //    /auth/* lazy chunk, all on the cold path in CI. `load` fires when bundles
   //    finish downloading, not when Angular has rendered, so we explicitly wait
   //    for content inside <yn-root> before asserting on the button.
   await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60_000 });
-  await page.locator('yn-root > *').first().waitFor({ timeout: 60_000 });
+
+  try {
+    await page.locator('yn-root > *').first().waitFor({ timeout: 60_000 });
+  } catch (err) {
+    // Dump the current DOM + key window globals so we can figure out what
+    // Angular is stuck on. Without this the screenshot is a blank page.
+    const diag = await page.evaluate(() => {
+      const root = document.querySelector('yn-root');
+      return {
+        url: window.location.href,
+        readyState: document.readyState,
+        rootOuter: root?.outerHTML?.slice(0, 500),
+        rootChildren: root?.childElementCount ?? 0,
+        bodyText: document.body.innerText.slice(0, 200),
+        ngExists: Reflect.has(window, 'ng') ? 'yes' : 'no',
+      };
+    });
+    console.log('DIAG', JSON.stringify(diag));
+    throw err;
+  }
 
   // 2. Click sign in
   await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
Instrument auth.setup to capture what Angular is actually stuck on.

## Why

Run 24807834869 on develop with #314's 120s budget showed:
- test budget ample, waitFor ran its full 60s
- screenshot still entirely blank — \`<yn-root>\` empty for 60+ seconds
- network: 87 × 200 (everything downloads), \`main.js\` + \`polyfills.js\` loaded
- zero console errors surfaced by our \`page.on('console', ...)\` listener
- \`ThemeService\` *did* run (\`data-theme="light"\` applied to \`<html>\`)
- but \`<yn-root>\` never got populated

Angular bootstrap partially progressed, then silently stalled. The existing listener doesn't catch uncaught exceptions or promise rejections.

## What this PR adds

- \`pageerror\` listener: catches uncaught exceptions
- \`requestfailed\` listener: catches CORS / network-abort failures
- try/catch around the \`waitFor\` that dumps the live DOM + window state (\`rootChildren\` count, \`document.readyState\`, URL, first 200 chars of body text, whether \`window.ng\` exists). Printed to the Playwright step log.

Purely diagnostic; no behavior change for successful runs. Next E2E run will tell us concretely which \`APP_INITIALIZER\` promise is blocking.