### PR TITLE
debug(e2e): timestamp markers for each shell bootstrap hop

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -46,6 +46,9 @@ setup('authenticate via Keycloak', async ({ page }) => {
     // Angular is stuck on. Without this the screenshot is a blank page.
     const diag = await page.evaluate(() => {
       const root = document.querySelector('yn-root');
+      const w = window as unknown as Record<string, unknown>;
+      // Timestamps written by main.ts / bootstrap.ts at each hop; absence
+      // tells us exactly where the chain stalled.
       return {
         url: window.location.href,
         readyState: document.readyState,
@@ -53,6 +56,11 @@ setup('authenticate via Keycloak', async ({ page }) => {
         rootChildren: root?.childElementCount ?? 0,
         bodyText: document.body.innerText.slice(0, 200),
         ngExists: Reflect.has(window, 'ng') ? 'yes' : 'no',
+        mainStart: w['__ynMainStart'],
+        federationReady: w['__ynFederationReady'],
+        bootstrapImported: w['__ynBootstrapImported'],
+        bootstrapCalled: w['__ynBootstrapCalled'],
+        bootstrapDone: w['__ynBootstrapDone'],
       };
     });
     console.log('DIAG', JSON.stringify(diag));

--- a/client/apps/shell/src/bootstrap.ts
+++ b/client/apps/shell/src/bootstrap.ts
@@ -2,4 +2,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
-bootstrapApplication(App, appConfig).catch((err) => console.error(err));
+console.log('[shell] bootstrap: calling bootstrapApplication');
+(globalThis as Record<string, unknown>)['__ynBootstrapCalled'] = Date.now();
+
+bootstrapApplication(App, appConfig)
+  .then(() => {
+    console.log('[shell] bootstrap: bootstrapApplication resolved');
+    (globalThis as Record<string, unknown>)['__ynBootstrapDone'] = Date.now();
+  })
+  .catch((err) => console.error('[shell] bootstrap: bootstrapApplication rejected', err));

--- a/client/apps/shell/src/main.ts
+++ b/client/apps/shell/src/main.ts
@@ -4,7 +4,25 @@ import { initFederation } from '@angular-architects/native-federation';
 // Native Federation loads bundles where this global may not yet exist.
 (globalThis as Record<string, unknown>)['ngDevMode'] ??= false;
 
+// Diagnostic markers so E2E can tell where bootstrap stalls.
+(globalThis as Record<string, unknown>)['__ynMainStart'] = Date.now();
+console.log('[shell] main: initFederation start');
+
 initFederation('/assets/federation.manifest.json')
-  .catch((err) => console.error(err))
-  .then(() => import('./bootstrap'))
-  .catch((err) => console.error(err));
+  .then(() => {
+    console.log('[shell] main: initFederation resolved');
+    (globalThis as Record<string, unknown>)['__ynFederationReady'] = Date.now();
+  })
+  .catch((err) => {
+    console.error('[shell] main: initFederation rejected', err);
+    throw err;
+  })
+  .then(() => {
+    console.log('[shell] main: importing bootstrap');
+    return import('./bootstrap');
+  })
+  .then(() => {
+    console.log('[shell] main: bootstrap import resolved');
+    (globalThis as Record<string, unknown>)['__ynBootstrapImported'] = Date.now();
+  })
+  .catch((err) => console.error('[shell] main: bootstrap import failed', err));


### PR DESCRIPTION
Next diagnostic in the auth-setup chain.

## Why

Post-#315 run showed:
- \`window.ng\` exists → Angular runtime loaded
- \`<yn-root></yn-root>\` empty → App component never instantiated
- Zero \`PageError:\` lines, zero console errors → nothing thrown

\`APP_INITIALIZER\` stall is the probable cause, but we can't confirm without seeing which specific hop completed last.

## What this PR adds

Timestamp markers on \`window\` at each step:

- \`__ynMainStart\` — \`main.ts\` entered
- \`__ynFederationReady\` — \`initFederation\` resolved
- \`__ynBootstrapImported\` — \`import('./bootstrap')\` resolved
- \`__ynBootstrapCalled\` — bootstrap.ts entered, \`bootstrapApplication\` about to be called
- \`__ynBootstrapDone\` — \`bootstrapApplication\` resolved

Each hop also logs \`[shell] main: ...\` / \`[shell] bootstrap: ...\` to the console. \`auth.setup.ts\`'s DIAG dump now includes all five markers.

Whichever marker is MISSING from the DIAG is the hop that stalled.

## Not a behavior change

Happy path is unaffected — successful bootstrap replaces \`<yn-root>\` before the test ever hits the waitFor catch branch.