### PR TITLE
test(e2e): add per-step markers inside AuthService.initialize

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -61,6 +61,15 @@ setup('authenticate via Keycloak', async ({ page }) => {
         bootstrapImported: w['__ynBootstrapImported'],
         bootstrapCalled: w['__ynBootstrapCalled'],
         bootstrapDone: w['__ynBootstrapDone'],
+        authEnter: w['__ynAuth_enter'],
+        authLoadAppConfig: w['__ynAuth_afterLoadAppConfig'],
+        authConfigure: w['__ynAuth_afterConfigure'],
+        authSilentRefresh: w['__ynAuth_afterSetupSilentRefresh'],
+        authEventsSub: w['__ynAuth_afterEventsSub'],
+        authLoadDiscovery: w['__ynAuth_afterLoadDiscoveryDocument'],
+        authTryLogin: w['__ynAuth_afterTryLogin'],
+        authCaught: w['__ynAuth_caughtError'],
+        authFinally: w['__ynAuth_finally'],
       };
     });
     console.log('DIAG', JSON.stringify(diag));

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -36,28 +36,46 @@ export class AuthService {
   constructor(private oauthService: OAuthService) {}
 
   async initialize(): Promise<void> {
+    const g = globalThis as Record<string, unknown>;
+    const mark = (name: string) => {
+      g[`__ynAuth_${name}`] = Date.now();
+      console.log(`[auth] ${name}`);
+    };
+    mark('enter');
+
     const { keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl } = await this.loadAppConfig();
+    mark('afterLoadAppConfig');
+
     const authConfig = createAuthConfig(keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl);
 
     this.oauthService.configure(authConfig);
+    mark('afterConfigure');
+
     this.oauthService.setupAutomaticSilentRefresh();
+    mark('afterSetupSilentRefresh');
 
     this.oauthService.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.updateAuthState();
     });
+    mark('afterEventsSub');
 
     try {
       await this.oauthService.loadDiscoveryDocument();
+      mark('afterLoadDiscoveryDocument');
       // Override token endpoint to route through Gateway (avoids DCP port proxy 504s)
       if (gatewayUrl) {
         this.oauthService.tokenEndpoint = `${gatewayUrl}/realms/${keycloakRealm}/protocol/openid-connect/token`;
       }
       await this.oauthService.tryLogin();
+      mark('afterTryLogin');
       this.updateAuthState();
-    } catch {
+    } catch (err) {
       // Keycloak unreachable — app continues unauthenticated
+      mark('caughtError');
+      console.warn('[auth] caughtError details:', err);
     } finally {
       this.isLoading.set(false);
+      mark('finally');
     }
   }
 


### PR DESCRIPTION
Next step in the auth-setup debug chain.

## Diagnosis so far (from #316)

DIAG dump showed timestamps in order for:

- \`__ynMainStart\` ✅
- \`__ynFederationReady\` ✅
- \`__ynBootstrapImported\` ✅
- \`__ynBootstrapCalled\` ✅
- **\`__ynBootstrapDone\` ❌ (all 3 retries)**

So \`bootstrapApplication(App, appConfig)\` is called and hangs. That narrows the culprit to an \`APP_INITIALIZER\` promise that never resolves. \`LanguageService.initialize()\` and \`ThemeService.initialize()\` are synchronous, so \`AuthService.initialize()\` is the suspect.

## What this PR adds

Markers at every \`await\` in \`AuthService.initialize()\`:

1. enter
2. afterLoadAppConfig (fetch \`/assets/config/app-config.json\`)
3. afterConfigure (\`oauthService.configure\`)
4. afterSetupSilentRefresh (\`setupAutomaticSilentRefresh\`)
5. afterEventsSub
6. afterLoadDiscoveryDocument (Keycloak \`.well-known\`)
7. afterTryLogin
8. caughtError (if the catch fires — also now logs the error details, previously silent)
9. finally

Whichever marker is last in the DIAG is the step that hung.

## Bonus

The original \`catch {}\` swallowed the error without logging. Added \`console.warn('[auth] caughtError details:', err)\` so a silent Keycloak-unreachable scenario becomes visible.