### PR TITLE
fix(auth): race loadDiscoveryDocument with a 10s timeout

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -39,42 +39,7 @@ setup('authenticate via Keycloak', async ({ page }) => {
   //    for content inside <yn-root> before asserting on the button.
   await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
-  try {
-    await page.locator('yn-root > *').first().waitFor({ timeout: 60_000 });
-  } catch (err) {
-    // Dump the current DOM + key window globals so we can figure out what
-    // Angular is stuck on. Without this the screenshot is a blank page.
-    const diag = await page.evaluate(() => {
-      const root = document.querySelector('yn-root');
-      const w = window as unknown as Record<string, unknown>;
-      // Timestamps written by main.ts / bootstrap.ts at each hop; absence
-      // tells us exactly where the chain stalled.
-      return {
-        url: window.location.href,
-        readyState: document.readyState,
-        rootOuter: root?.outerHTML?.slice(0, 500),
-        rootChildren: root?.childElementCount ?? 0,
-        bodyText: document.body.innerText.slice(0, 200),
-        ngExists: Reflect.has(window, 'ng') ? 'yes' : 'no',
-        mainStart: w['__ynMainStart'],
-        federationReady: w['__ynFederationReady'],
-        bootstrapImported: w['__ynBootstrapImported'],
-        bootstrapCalled: w['__ynBootstrapCalled'],
-        bootstrapDone: w['__ynBootstrapDone'],
-        authEnter: w['__ynAuth_enter'],
-        authLoadAppConfig: w['__ynAuth_afterLoadAppConfig'],
-        authConfigure: w['__ynAuth_afterConfigure'],
-        authSilentRefresh: w['__ynAuth_afterSetupSilentRefresh'],
-        authEventsSub: w['__ynAuth_afterEventsSub'],
-        authLoadDiscovery: w['__ynAuth_afterLoadDiscoveryDocument'],
-        authTryLogin: w['__ynAuth_afterTryLogin'],
-        authCaught: w['__ynAuth_caughtError'],
-        authFinally: w['__ynAuth_finally'],
-      };
-    });
-    console.log('DIAG', JSON.stringify(diag));
-    throw err;
-  }
+  await page.locator('yn-root > *').first().waitFor({ timeout: 60_000 });
 
   // 2. Click sign in
   await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible({ timeout: 30_000 });

--- a/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/auth.service.spec.ts
@@ -108,6 +108,21 @@ describe('AuthService', () => {
       expect(service.isLoading()).toBe(false);
     });
 
+    it('should time out and continue when discovery document hangs indefinitely', async () => {
+      vi.useFakeTimers();
+      // The hang seen in CI: the promise never resolves or rejects.
+      oauthMock.loadDiscoveryDocument.mockReturnValue(new Promise(() => undefined));
+
+      const done = service.initialize();
+      // Race the 10s timeout built into initialize.
+      await vi.advanceTimersByTimeAsync(10_000);
+      await done;
+
+      expect(service.isLoading()).toBe(false);
+      expect(service.isAuthenticated()).toBe(false);
+      vi.useRealTimers();
+    });
+
     it('should not update currentUser when token is valid but claims are null', async () => {
       oauthMock.hasValidAccessToken.mockReturnValue(true);
       oauthMock.getIdentityClaims.mockReturnValue(null);

--- a/client/apps/shell/src/bootstrap.ts
+++ b/client/apps/shell/src/bootstrap.ts
@@ -2,12 +2,4 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
-console.log('[shell] bootstrap: calling bootstrapApplication');
-(globalThis as Record<string, unknown>)['__ynBootstrapCalled'] = Date.now();
-
-bootstrapApplication(App, appConfig)
-  .then(() => {
-    console.log('[shell] bootstrap: bootstrapApplication resolved');
-    (globalThis as Record<string, unknown>)['__ynBootstrapDone'] = Date.now();
-  })
-  .catch((err) => console.error('[shell] bootstrap: bootstrapApplication rejected', err));
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));

--- a/client/apps/shell/src/main.ts
+++ b/client/apps/shell/src/main.ts
@@ -4,25 +4,7 @@ import { initFederation } from '@angular-architects/native-federation';
 // Native Federation loads bundles where this global may not yet exist.
 (globalThis as Record<string, unknown>)['ngDevMode'] ??= false;
 
-// Diagnostic markers so E2E can tell where bootstrap stalls.
-(globalThis as Record<string, unknown>)['__ynMainStart'] = Date.now();
-console.log('[shell] main: initFederation start');
-
 initFederation('/assets/federation.manifest.json')
-  .then(() => {
-    console.log('[shell] main: initFederation resolved');
-    (globalThis as Record<string, unknown>)['__ynFederationReady'] = Date.now();
-  })
-  .catch((err) => {
-    console.error('[shell] main: initFederation rejected', err);
-    throw err;
-  })
-  .then(() => {
-    console.log('[shell] main: importing bootstrap');
-    return import('./bootstrap');
-  })
-  .then(() => {
-    console.log('[shell] main: bootstrap import resolved');
-    (globalThis as Record<string, unknown>)['__ynBootstrapImported'] = Date.now();
-  })
-  .catch((err) => console.error('[shell] main: bootstrap import failed', err));
+  .catch((err) => console.error(err))
+  .then(() => import('./bootstrap'))
+  .catch((err) => console.error(err));

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -11,6 +11,14 @@ const DEFAULT_CONFIG: AppConfig = {
   keycloakClientId: 'yumney-web',
 };
 
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   isLoading = signal(true);
@@ -36,46 +44,38 @@ export class AuthService {
   constructor(private oauthService: OAuthService) {}
 
   async initialize(): Promise<void> {
-    const g = globalThis as Record<string, unknown>;
-    const mark = (name: string) => {
-      g[`__ynAuth_${name}`] = Date.now();
-      console.log(`[auth] ${name}`);
-    };
-    mark('enter');
-
     const { keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl } = await this.loadAppConfig();
-    mark('afterLoadAppConfig');
-
     const authConfig = createAuthConfig(keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl);
 
     this.oauthService.configure(authConfig);
-    mark('afterConfigure');
-
     this.oauthService.setupAutomaticSilentRefresh();
-    mark('afterSetupSilentRefresh');
 
     this.oauthService.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.updateAuthState();
     });
-    mark('afterEventsSub');
 
     try {
-      await this.oauthService.loadDiscoveryDocument();
-      mark('afterLoadDiscoveryDocument');
+      // Race with a timeout: angular-oauth2-oidc's loadDiscoveryDocument is
+      // observed to hang indefinitely in CI (the HTTP fetch of the discovery
+      // document returns 200, but some downstream step — likely JWKS — never
+      // resolves or rejects). Without this, bootstrapApplication waits on
+      // this APP_INITIALIZER forever and <yn-root> never renders. 10s is a
+      // generous budget for the happy path; if we hit it, the app carries on
+      // unauthenticated and the user sees the login page instead of a blank
+      // screen.
+      await withTimeout(this.oauthService.loadDiscoveryDocument(), 10_000, 'loadDiscoveryDocument');
       // Override token endpoint to route through Gateway (avoids DCP port proxy 504s)
       if (gatewayUrl) {
         this.oauthService.tokenEndpoint = `${gatewayUrl}/realms/${keycloakRealm}/protocol/openid-connect/token`;
       }
-      await this.oauthService.tryLogin();
-      mark('afterTryLogin');
+      await withTimeout(this.oauthService.tryLogin(), 10_000, 'tryLogin');
       this.updateAuthState();
     } catch (err) {
-      // Keycloak unreachable — app continues unauthenticated
-      mark('caughtError');
-      console.warn('[auth] caughtError details:', err);
+      // Keycloak unreachable or OIDC discovery stalled — app continues
+      // unauthenticated. Logging the cause helps future CI debugging.
+      console.warn('[auth] initialize failed:', err);
     } finally {
       this.isLoading.set(false);
-      mark('finally');
     }
   }
 


### PR DESCRIPTION
Closes the root-cause loop on the auth-setup chain started by #310.

## Root cause (from the marker chain)

Five diagnostic PRs (#316, #317) narrowed the hang step by step:

1. #316 markers showed \`bootstrapApplication\` was called but never resolved
2. #317 markers showed \`AuthService.initialize()\` enters, runs through \`loadAppConfig\` / \`configure\` / \`setupAutomaticSilentRefresh\` / events-sub, then:
   - **\`await oauthService.loadDiscoveryDocument()\` never settles** — no log, no exception, no catch, no finally

The HTTP fetch of the OIDC discovery document returns 200 (visible in the network trace), but something downstream in \`angular-oauth2-oidc\` — almost certainly the JWKS fetch during discovery validation — hangs. Because the promise never rejects, the \`catch {}\` block that was meant to handle Keycloak being unreachable never fires, \`bootstrapApplication\` waits forever, \`<yn-root>\` stays empty.

## Fix

Wrap both \`loadDiscoveryDocument\` and \`tryLogin\` with \`Promise.race\` against a 10-second timeout. On timeout we reject with a clear label, the existing \`catch\` block catches it, \`isLoading.set(false)\` runs in \`finally\`, the app continues unauthenticated. User sees the login page instead of a blank screen.

10s is generous for the happy path and comfortably short inside the 120s \`auth.setup\` test budget from #314.

## Also in this PR

- Revert the diagnostic markers in \`main.ts\`, \`bootstrap.ts\`, \`auth.setup.ts\` back to their pre-debug state. The per-step markers inside \`AuthService.initialize\` are gone too. The catch block still \`console.warn\`s the error so future silent regressions surface in logs.
- New spec: \`should time out and continue when discovery document hangs indefinitely\` — mock \`loadDiscoveryDocument\` to never resolve, advance fake timers 10s, verify \`initialize\` resolves with \`isLoading=false\` and \`isAuthenticated=false\`.

## Test plan

- [x] \`yarn nx test shell\` → 219/219 (added timeout spec)
- [x] \`yarn nx test shared-auth\` / \`shell-e2e\` green
- [ ] Post-merge E2E auth.setup passes on develop (should finally go from 0 of 134 to 134 of 134 running, minus whatever downstream flakes exist)
- [ ] After that lands green, un-draft #310 to enforce the gate