### PR TITLE
fix(keycloak): set sslRequired=none on the yumney realm

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -1,7 +1,7 @@
 {
   "realm": "yumney",
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": true,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,


### PR DESCRIPTION
## What the latest E2E run showed

Post-#320 run on develop: auth.setup still timed out, but now we have the full picture. Playwright captured:

\`\`\`
RequestFailed: net::ERR_ABORTED http://localhost:8080/realms/yumney/protocol/openid-connect/auth?...
\`\`\`

And the Keycloak container logs from the same run showed only startup entries — **zero request-handling logs**. The auth redirect was aborted at the network layer and never reached Keycloak.

## Root cause

The yumney realm had \`sslRequired: "external"\`. Requests arriving through Aspire's DCP localhost proxy look external to Keycloak's IP classification, so Keycloak responded with a redirect to HTTPS. Chromium then aborted the chain — likely because of the self-signed cert on the upstream HTTPS endpoint (port 38035, untrusted in headless mode).

## Fix

Set \`sslRequired: "none"\` on the realm. One-line JSON change.

The realm is a dev fixture committed to git with test credentials for the local Aspire stack + CI. It's never served to real users. Production runs behind a TLS-terminating reverse proxy and is provisioned from separate configuration — this realm is the Aspire-local version only.

## If this finally passes

The 134 downstream specs run for real for the first time. Some may have their own flakes — expected. I'll iterate. Once auth.setup is reliably green, un-draft #310 to make the gate enforce.