### PR TITLE
fix(gateway): force HTTP-only for Keycloak cluster

### DIFF
--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -89,7 +89,7 @@
       "keycloak": {
         "Destinations": {
           "primary": {
-            "Address": "https+http://keycloak"
+            "Address": "http://keycloak"
           }
         }
       },


### PR DESCRIPTION
## Why

Post-#323 run (24847693449):
- auth.setup POSTed to \`http://localhost:5100/realms/yumney/protocol/openid-connect/token\` (via Gateway)
- Gateway returned **504 Gateway Timeout**
- Keycloak docker log: still 17 startup-only lines — **request never reached Keycloak**

YARP proxied the request, tried to reach Keycloak, timed out in cert validation.

## Root cause

\`src/Yumney.Gateway/appsettings.json\` keycloak cluster:
\`\`\`json
"Address": "https+http://keycloak"
\`\`\`
Aspire service discovery picks HTTPS first when both schemes are offered. The Keycloak container listens on 8443 (HTTPS) with a self-signed dev cert. The Gateway's HttpClient doesn't trust it → cert validation stalls → YARP returns 504.

## Fix

One-line JSON change: \`"http://keycloak"\`. Container-to-container hop on Aspire's internal network doesn't need TLS. All other backend services already use plain HTTP to reach Keycloak.

## If this finally lands

Token POST returns real tokens, storageState is written, 134 downstream specs run for the first time.