### PR TITLE
fix(e2e): raise token POST timeout for cold Keycloak JVM

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -15,10 +15,14 @@ const KEYCLOAK_REALM = 'yumney';
 const KEYCLOAK_CLIENT = 'yumney-web';
 const AUTH_STATE_PATH = 'src/.auth/user.json';
 
-setup.setTimeout(60_000);
+setup.setTimeout(180_000);
 
 setup('authenticate via Keycloak direct grant', async ({ page, request }) => {
   // 1. Obtain tokens directly (through the Gateway, not direct Keycloak).
+  //    The wait-for-services poll observed Keycloak's first 200 response
+  //    taking ~65s on a cold CI runner; the token endpoint is similarly
+  //    cold on first real hit. Give it 120s headroom so we don't give up
+  //    before Keycloak warms up.
   const tokenResponse = await request.post(
     `${GATEWAY_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
     {
@@ -29,7 +33,7 @@ setup('authenticate via Keycloak direct grant', async ({ page, request }) => {
         password: E2E_PASSWORD,
         scope: 'openid profile email roles',
       },
-      timeout: 30_000,
+      timeout: 120_000,
     },
   );
   expect(tokenResponse.ok(), `Keycloak token endpoint returned ${tokenResponse.status()}`).toBe(


### PR DESCRIPTION
Post-#324 run: the gateway-prefixed POST cleared the 504 issue but Playwright's client timed out at 30s.

## Evidence

- Error: \`apiRequestContext.post: Timeout 30000ms exceeded\` on \`http://localhost:5100/realms/yumney/protocol/openid-connect/token\`
- Keycloak docker log: no request entries — request still in flight when Playwright gave up
- Separate probe (\`poll-keycloak\`) on the same runner: first 200 response took ~65s

The token endpoint on a cold Keycloak JVM takes similarly long for its first real hit (JIT warm-up + realm metadata). 30s is too tight.

## Fix

- POST timeout: 30s → 120s
- setup.setTimeout: 60s → 180s

Subsequent hits are fast once Keycloak has answered once.