### PR TITLE
fix(infra): skip cert validation for the Keycloak YARP cluster

### DIFF
--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -87,9 +87,12 @@
         }
       },
       "keycloak": {
+        "HttpClient": {
+          "DangerousAcceptAnyServerCertificate": true
+        },
         "Destinations": {
           "primary": {
-            "Address": "http://keycloak"
+            "Address": "https+http://keycloak"
           }
         }
       },


### PR DESCRIPTION
Circles back on the Keycloak routing issue.

## What happened

- **#324** changed \`"https+http://keycloak"\` → \`"http://keycloak"\` to avoid the self-signed cert issue.
- **Post-#325 run** showed every request to the keycloak cluster still returned 504, no entries in Keycloak's docker log. Aspire service discovery apparently doesn't match plain \`"http://keycloak"\` to Keycloak's exposed HTTP endpoint the way \`"https+http://"\` does.

## Fix

- Revert address to \`"https+http://keycloak"\` so service discovery resolves correctly.
- Set \`DangerousAcceptAnyServerCertificate: true\` on the keycloak cluster's HttpClient so the self-signed dev cert doesn't stall the hop.

Container-to-container on Aspire's ephemeral test network, no real TLS trust concerns.