### PR TITLE
fix(e2e): fetch Keycloak token via direct container port + warm-up

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,14 +182,55 @@ jobs:
         continue-on-error: true
         run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
 
+      - name: Fetch Keycloak token for E2E (direct container port)
+        # Bypass Aspire's DCP localhost proxy — every in-process HTTP client
+        # we've tried has failed against it. Docker maps Keycloak's 8080 to
+        # a random host port (shown in docker ps); hit that directly.
+        # curl from this workflow step reliably reaches the container.
+        run: |
+          set -e
+          kc=$(docker ps -q -f name=keycloak | head -1)
+          test -n "$kc" || { echo "keycloak container not found"; exit 1; }
+          kc_port=$(docker port "$kc" 8080/tcp | head -1 | sed -E 's/.*:([0-9]+)$/\1/')
+          test -n "$kc_port" || { echo "could not resolve keycloak host port"; exit 1; }
+          echo "keycloak mapped to host port $kc_port"
+
+          # Warm-up: first Keycloak request after startup takes 60-70s (JIT +
+          # realm metadata). Hit /realms/master first so the token endpoint
+          # afterwards is fast.
+          curl -sS --max-time 180 -o /dev/null \
+            "http://127.0.0.1:${kc_port}/realms/master" || true
+
+          for i in 1 2 3; do
+            echo "token attempt $i..."
+            response=$(curl -sS --max-time 180 \
+              -X POST "http://127.0.0.1:${kc_port}/realms/yumney/protocol/openid-connect/token" \
+              -H "Content-Type: application/x-www-form-urlencoded" \
+              -d "grant_type=password" \
+              -d "client_id=yumney-web" \
+              -d "username=testuser" \
+              -d "password=Test1234" \
+              -d "scope=openid profile email roles" \
+              -w "\n__HTTP_CODE__%{http_code}") || true
+            http_code=$(echo "$response" | sed -n 's/^__HTTP_CODE__//p')
+            body=$(echo "$response" | sed '/^__HTTP_CODE__/d')
+            if [ "$http_code" = "200" ]; then
+              echo "$body" > /tmp/e2e-tokens.json
+              echo "token fetch succeeded on attempt $i"
+              break
+            fi
+            echo "http=$http_code, body preview: $(echo "$body" | head -c 200)"
+            sleep 5
+          done
+          test -s /tmp/e2e-tokens.json
+
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
         run: npx nx e2e shell-e2e
         env:
           BASE_URL: http://localhost:4200
-          E2E_USER: testuser
-          E2E_PASSWORD: Test1234
+          E2E_TOKENS_FILE: /tmp/e2e-tokens.json
           CI: true
 
       - name: Stop Aspire

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,10 +178,6 @@ jobs:
 
           stamp "diagnostic step complete"
 
-      - name: Run backend integration tests
-        continue-on-error: true
-        run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
-
       - name: Fetch Keycloak token for E2E (direct container port)
         # Bypass Aspire's DCP localhost proxy — every in-process HTTP client
         # we've tried has failed against it. Docker maps Keycloak's 8080 to
@@ -223,6 +219,10 @@ jobs:
             sleep 5
           done
           test -s /tmp/e2e-tokens.json
+
+      - name: Run backend integration tests
+        continue-on-error: true
+        run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
 
       - name: Run Playwright e2e tests
         continue-on-error: true

--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -18,10 +18,7 @@ setup.setTimeout(60_000);
 // This test reads it and plants the tokens into sessionStorage in the keys
 // angular-oauth2-oidc reads on startup.
 setup('authenticate via pre-fetched Keycloak tokens', async ({ page }) => {
-  expect(
-    TOKENS_FILE,
-    'E2E_TOKENS_FILE env var must point at a JSON token dump',
-  ).toBeDefined();
+  expect(TOKENS_FILE, 'E2E_TOKENS_FILE env var must point at a JSON token dump').toBeDefined();
 
   const tokens = JSON.parse(readFileSync(TOKENS_FILE as string, 'utf8')) as {
     access_token: string;

--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -1,45 +1,29 @@
 import { test as setup, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
 
-const E2E_USER = process.env['E2E_USER'] ?? 'testuser';
-const E2E_PASSWORD = process.env['E2E_PASSWORD'] ?? 'Test1234';
-// Route Keycloak traffic through the Yumney Gateway (YARP) rather than the
-// direct container port. Hitting localhost:8080 from either the browser or
-// Playwright's Node request context reliably hangs on CI — Aspire's DCP
-// localhost-proxy appears to drop that particular combination. Gateway port
-// 5100 is a plain ASP.NET endpoint that YARP then routes to the keycloak
-// service via Aspire service discovery (container-network hop), which works.
-// This also matches how the production Angular code routes token exchanges
-// (see AuthService.initialize overriding oauthService.tokenEndpoint).
-const GATEWAY_URL = process.env['GATEWAY_URL'] ?? 'http://localhost:5100';
-const KEYCLOAK_REALM = 'yumney';
-const KEYCLOAK_CLIENT = 'yumney-web';
 const AUTH_STATE_PATH = 'src/.auth/user.json';
+const TOKENS_FILE = process.env['E2E_TOKENS_FILE'];
 
-setup.setTimeout(180_000);
+setup.setTimeout(60_000);
 
-setup('authenticate via Keycloak direct grant', async ({ page, request }) => {
-  // 1. Obtain tokens directly (through the Gateway, not direct Keycloak).
-  //    The wait-for-services poll observed Keycloak's first 200 response
-  //    taking ~65s on a cold CI runner; the token endpoint is similarly
-  //    cold on first real hit. Give it 120s headroom so we don't give up
-  //    before Keycloak warms up.
-  const tokenResponse = await request.post(
-    `${GATEWAY_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
-    {
-      form: {
-        grant_type: 'password',
-        client_id: KEYCLOAK_CLIENT,
-        username: E2E_USER,
-        password: E2E_PASSWORD,
-        scope: 'openid profile email roles',
-      },
-      timeout: 120_000,
-    },
-  );
-  expect(tokenResponse.ok(), `Keycloak token endpoint returned ${tokenResponse.status()}`).toBe(
-    true,
-  );
-  const tokens = (await tokenResponse.json()) as {
+// The CI network (Aspire DCP + GitHub runner) has been a nightmare for any
+// in-process HTTP client trying to reach Keycloak: browser navigations abort
+// (net::ERR_ABORTED), Playwright's Node request context times out, YARP
+// routing returns 504, even curl to localhost:8080 (DCP proxy port) often
+// stalls. What reliably works is curl directly to the Docker-mapped host
+// port for Keycloak's container.
+//
+// So the e2e.yml workflow discovers that port via `docker port`, fetches
+// the token via password grant, and writes the JSON to /tmp/e2e-tokens.json.
+// This test reads it and plants the tokens into sessionStorage in the keys
+// angular-oauth2-oidc reads on startup.
+setup('authenticate via pre-fetched Keycloak tokens', async ({ page }) => {
+  expect(
+    TOKENS_FILE,
+    'E2E_TOKENS_FILE env var must point at a JSON token dump',
+  ).toBeDefined();
+
+  const tokens = JSON.parse(readFileSync(TOKENS_FILE as string, 'utf8')) as {
     access_token: string;
     id_token: string;
     refresh_token?: string;
@@ -47,7 +31,7 @@ setup('authenticate via Keycloak direct grant', async ({ page, request }) => {
     scope?: string;
   };
 
-  // 2. Decode id_token claims for angular-oauth2-oidc's id_token_claims_obj.
+  // Decode id_token claims for angular-oauth2-oidc's id_token_claims_obj.
   const idClaims = decodeJwtPayload(tokens.id_token);
   const now = Date.now();
   const expiresAt = (now + tokens.expires_in * 1000).toString();
@@ -55,12 +39,9 @@ setup('authenticate via Keycloak direct grant', async ({ page, request }) => {
     typeof idClaims['exp'] === 'number' ? idClaims['exp'] * 1000 : now + tokens.expires_in * 1000
   ).toString();
 
-  // 3. Load the app shell once so we can write sessionStorage for its origin.
-  //    domcontentloaded is enough here — we're not interacting with the app,
-  //    just scribbling into its storage before the next test opens the page.
+  // Navigate to the origin once so sessionStorage is scoped correctly.
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
-  // 4. Plant the entries angular-oauth2-oidc reads on startup.
   await page.evaluate(
     ({ accessToken, idToken, refreshToken, expiresAt, idTokenExpiresAt, idClaims, scope }) => {
       const s = sessionStorage;


### PR DESCRIPTION
Follow-up to #327 which had to be closed without merging.

## What #327 CI showed

Even \`curl\` from the workflow shell to \`localhost:8080\` timed out — 6 attempts × 60s = 360s, all \`curl: (28) Operation timed out\`. Plus \`docker ps\` in the artifact revealed:
\`\`\`
keycloak-fsgnefgv  127.0.0.1:32773->8080/tcp
\`\`\`
Keycloak is bound to port **32773**, not 8080. \`localhost:8080\` is Aspire DCP's proxy — the exact layer that's been stalling on \`/realms/yumney/...\` paths on CI.

## Fix

1. **Bypass DCP entirely** — discover Keycloak's actual Docker-mapped host port via \`docker port <container> 8080/tcp\` and curl that. Docker port-mapping works reliably.
2. **Warm-up request** to \`/realms/master\` first (which we've seen take ~70s cold) so the token POST hits an already-warm JVM.
3. Per-curl \`--max-time\` raised 60s → 180s for the cold path.

Step fails fast if port discovery or curl both fail, so Playwright doesn't run against no tokens.