### PR TITLE
fix(e2e): plant tokens in localStorage, not sessionStorage

### DIFF
--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -39,9 +39,15 @@ setup('authenticate via pre-fetched Keycloak tokens', async ({ page }) => {
   // Navigate to the origin once so sessionStorage is scoped correctly.
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
+  // Use localStorage, not sessionStorage. Playwright's storageState persists
+  // localStorage + cookies but NOT sessionStorage (tab-scoped), so anything
+  // we plant in sessionStorage here would be gone by the time downstream
+  // specs open the app. authStorageFactory routes to localStorage when
+  // yn_remember_me is 'true', so set that flag too.
   await page.evaluate(
     ({ accessToken, idToken, refreshToken, expiresAt, idTokenExpiresAt, idClaims, scope }) => {
-      const s = sessionStorage;
+      const s = localStorage;
+      s.setItem('yn_remember_me', 'true');
       s.setItem('access_token', accessToken);
       s.setItem('access_token_stored_at', String(Date.now()));
       s.setItem('expires_at', expiresAt);


### PR DESCRIPTION
The #328 post-merge run finally got past auth.setup and ran the 134 downstream specs — but 24 of them failed. Sampling the failure artifacts: every failed test's page snapshot showed the \`/auth/login\` page with "Welcome back" + a "Sign in with Keycloak" button. The user was not authenticated.

## Root cause

Playwright's \`storageState({ path })\` serialises **localStorage** + cookies. It does **not** persist \`sessionStorage\` — that storage area is tab-scoped. My auth.setup planted tokens in \`sessionStorage\`, saved \`storageState\`, and then downstream specs opened fresh contexts with empty sessionStorage.

\`authStorageFactory\` in \`libs/shared/auth\` routes to \`localStorage\` when \`yn_remember_me === 'true'\`, otherwise \`sessionStorage\`.

## Fix

Set \`yn_remember_me=true\` in localStorage and plant all token entries there. Now the tokens survive \`storageState\` serialisation and the production \`authStorageFactory\` picks localStorage on startup.

No changes in downstream specs — they already inherit \`storageState\` via \`playwright.config.ts\`.