### PR TITLE
fix(e2e): reset storageState for login/register/resend specs

### DIFF
--- a/client/apps/shell-e2e/src/auth/login.spec.ts
+++ b/client/apps/shell-e2e/src/auth/login.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@playwright/test';
 import { LoginPage } from '../pages/login.page';
 import { TEST_USER } from '../helpers/test-data.helper';
 
+// Pre-authentication flow — override the default storageState (set by
+// auth.setup) so the auth guard doesn't redirect this test away from
+// /auth/login.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe('Login Page (US-002)', () => {
   let loginPage: LoginPage;
 

--- a/client/apps/shell-e2e/src/auth/register.spec.ts
+++ b/client/apps/shell-e2e/src/auth/register.spec.ts
@@ -3,6 +3,9 @@ import { RegisterPage } from '../pages/register.page';
 import { uniqueEmail } from '../helpers/test-data.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
+// Pre-authentication flow — reset the storage state planted by auth.setup.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe('Register Page (US-001)', () => {
   let registerPage: RegisterPage;
 

--- a/client/apps/shell-e2e/src/auth/resend-verification.spec.ts
+++ b/client/apps/shell-e2e/src/auth/resend-verification.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { ResendVerificationPage } from '../pages/resend-verification.page';
 
+// Pre-authentication flow — reset the storage state planted by auth.setup.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe('Resend Verification Page', () => {
   let resendPage: ResendVerificationPage;
 


### PR DESCRIPTION
Post-#329 run: auth.setup works ✅, but the three pre-auth spec files (login, register, resend-verification) fail because the authenticated \`storageState\` from \`auth.setup\` made the auth guard redirect them from \`/auth/login\` to \`/dashboard\`.

## Fix

\`test.use({ storageState: { cookies: [], origins: [] } })\` at the top of each of the three spec files. This is Playwright's standard pattern for specs that need a logged-out starting state even when a project-level auth dependency has planted a session.

Expected improvement: auth/* tests go from 15 failing to mostly passing. Remaining failures will be feature-level (account/dashboard), not auth-state-related.