### PR TITLE
perf(e2e): parallelize Playwright + drop retries 2→1

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -19,8 +19,15 @@ export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
   timeout: 30_000,
   expect: { timeout: 10_000 },
-  retries: process.env['CI'] ? 2 : 0,
-  workers: 1, // serial — tests may share DB state
+  // On CI: retry once (not twice) — each retry on a 30s-timeout test can cost
+  // a minute on top of the original. Transient flakes still get a second
+  // chance; systemic failures fail faster.
+  retries: process.env['CI'] ? 1 : 0,
+  // File-level parallelism: each spec file runs on its own worker, tests
+  // inside a file run sequentially (preserves any beforeAll shared state).
+  // Cuts Playwright wall-time ~50% on a 2-vCPU CI runner.
+  fullyParallel: true,
+  workers: process.env['CI'] ? 2 : undefined,
   reporter: process.env['CI']
     ? [
         ['html', { open: 'never' }],


### PR DESCRIPTION
## Why

Last successful develop E2E run breakdown:

| Step | Duration |
|---|---|
| infra / setup | ~2 min |
| Wait for services | 2:00 |
| Build | 0:36 |
| Integration tests | 3:07 |
| **Playwright e2e** | **14:52** ← 64% of total |
| total | 23:10 |

Playwright runs \`workers: 1\` (serial) and \`retries: 2\` (3× cost per failure). The current 17 failing specs each eat ~30s × 3 = 90s in retries alone — ~25 min of retry budget spent on known failures.

## Changes

\`client/apps/shell-e2e/playwright.config.ts\`:

- \`retries: 2 → 1\` on CI. Enough to mask transient flakes; systemic failures fail/report sooner.
- \`workers: 1 → 2\` + \`fullyParallel: true\`. File-level parallelism — each spec file gets its own worker, tests inside a file still run sequentially so \`beforeAll\`/\`afterAll\` shared DB state in recipes/shopping specs stays intact. GitHub's default Ubuntu runner has 2 vCPUs; workers: 2 saturates without thrashing.

## Expected impact

- Wall-time on Playwright step: ~15 min → ~7-8 min on current failure set
- Full job: ~23 min → ~15-16 min
- Further drops as the 17 remaining failing tests get fixed