### PR TITLE
revert(e2e): drop Playwright parallelism, keep retries at 1

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -23,11 +23,12 @@ export default defineConfig({
   // a minute on top of the original. Transient flakes still get a second
   // chance; systemic failures fail faster.
   retries: process.env['CI'] ? 1 : 0,
-  // File-level parallelism: each spec file runs on its own worker, tests
-  // inside a file run sequentially (preserves any beforeAll shared state).
-  // Cuts Playwright wall-time ~50% on a 2-vCPU CI runner.
-  fullyParallel: true,
-  workers: process.env['CI'] ? 2 : undefined,
+  // Serial runs. File-level parallelism was tried (#331) and broke the
+  // recipes + shopping suites — those specs share DB state across tests in
+  // a file via test.beforeAll, and two files running concurrently corrupted
+  // each other's fixtures. Revisit once those specs are refactored to use
+  // per-test fixtures.
+  workers: 1,
   reporter: process.env['CI']
     ? [
         ['html', { open: 'never' }],


### PR DESCRIPTION
Partial revert of #331.

## What happened

| Run | Failures | Playwright time |
|---|---|---|
| pre-#331 (serial, retries 2) | 17 | 14:52 |
| post-#331 (parallel, retries 1) | **40** | **15:29** |

\`fullyParallel: true\` with \`workers: 2\` broke the recipes + shopping specs. Those use \`test.beforeAll\` to create shared DB rows, and two files running concurrently step on each other. New failures: +13 recipes, +7 shopping, +3 pwa.

## This PR

- \`workers: 1\`, remove \`fullyParallel\` (revert that half of #331).
- **Keep** \`retries: 2 → 1\`. That was a pure win — known failures used to cost 3× their timeout.

## Proper parallelism later

Two paths, not in this PR:

1. Refactor recipes + shopping specs to per-test fixtures (\`beforeEach\` instead of \`beforeAll\`, unique IDs per test) so files don't share DB state.
2. Or shard by spec-group across a GitHub Actions matrix so colliding files never co-schedule.