### PR TITLE
refactor(e2e): reuse storageState in beforeAll, enable workers: 2

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -23,12 +23,15 @@ export default defineConfig({
   // a minute on top of the original. Transient flakes still get a second
   // chance; systemic failures fail faster.
   retries: process.env['CI'] ? 1 : 0,
-  // Serial runs. File-level parallelism was tried (#331) and broke the
-  // recipes + shopping suites — those specs share DB state across tests in
-  // a file via test.beforeAll, and two files running concurrently corrupted
-  // each other's fixtures. Revisit once those specs are refactored to use
-  // per-test fixtures.
-  workers: 1,
+  // File-level parallelism on CI. fullyParallel stays false so tests inside
+  // a spec file still run sequentially on their assigned worker — the
+  // recipes/shopping specs use beforeAll to create shared DB fixtures and
+  // rely on that order. Inter-file safety: each beforeAll uses
+  // uniqueTitle() with a random suffix so two files' setups don't clash
+  // when they run concurrently on different workers, and each beforeAll
+  // reuses auth.setup's storageState via openAuthenticatedPage() rather
+  // than replaying the brittle Keycloak UI login flow.
+  workers: process.env['CI'] ? 2 : undefined,
   reporter: process.env['CI']
     ? [
         ['html', { open: 'never' }],

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -1,7 +1,9 @@
-import { type Page, expect } from '@playwright/test';
+import { type Browser, type Page, expect } from '@playwright/test';
 import { DashboardPage } from '../pages/dashboard.page';
 import { SELECTORS } from './selectors';
 import { TIMEOUTS } from './timeouts';
+
+const STORAGE_STATE_PATH = 'src/.auth/user.json';
 
 /**
  * Test constants for E2E tests against the real system.
@@ -15,7 +17,21 @@ export const TEST_USER = {
 };
 
 export function uniqueTitle(prefix: string): string {
-  return `${prefix} ${Date.now()}`;
+  // Include a random suffix so two specs calling uniqueTitle in the same
+  // millisecond (possible with parallel workers) produce distinct values.
+  return `${prefix} ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Open an authenticated page in a fresh context that reuses the storageState
+ * planted by auth.setup. Use in beforeAll/afterAll blocks that need a short
+ * authenticated session for test data setup or cleanup — cheaper and more
+ * reliable than running `loginViaKeycloak` which replays the brittle UI
+ * redirect flow.
+ */
+export async function openAuthenticatedPage(browser: Browser): Promise<Page> {
+  const context = await browser.newContext({ storageState: STORAGE_STATE_PATH });
+  return context.newPage();
 }
 
 export function uniqueEmail(prefix = 'e2e'): string {

--- a/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
 import {
   uniqueTitle,
-  loginViaKeycloak,
+  openAuthenticatedPage,
   createTestRecipe,
   deleteTestRecipe,
 } from '../helpers/test-data.helper';
@@ -12,10 +12,9 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
   let recipeIdentifier: string;
 
   test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Detail Test'));
-    await page.close();
+    await page.context().close();
   });
 
   test('should display recipe title', async ({ authenticatedPage }) => {
@@ -102,13 +101,12 @@ test.describe('Servings Scaling (US-050)', () => {
   let recipeIdentifier: string;
 
   test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Scaling'), {
       ingredient: 'Flour',
       servings: 4,
     });
-    await page.close();
+    await page.context().close();
   });
 
   test('should display servings controls', async ({ authenticatedPage }) => {
@@ -159,9 +157,8 @@ test.describe('Servings Scaling (US-050)', () => {
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     await deleteTestRecipe(page, recipeIdentifier);
-    await page.close();
+    await page.context().close();
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
 import { RecipeListPage } from '../pages/recipe-list.page';
-import { uniqueTitle, loginViaKeycloak, createTestRecipe } from '../helpers/test-data.helper';
+import { uniqueTitle, openAuthenticatedPage, createTestRecipe } from '../helpers/test-data.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Favorite Recipes (US-071)', () => {
@@ -9,8 +9,7 @@ test.describe('Favorite Recipes (US-071)', () => {
   let recipeIdentifier: string;
 
   test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
 
     recipeTitle = uniqueTitle('E2E Favorite');
     recipeIdentifier = await createTestRecipe(page, recipeTitle, {
@@ -18,7 +17,7 @@ test.describe('Favorite Recipes (US-071)', () => {
       step: 'Add salt to taste',
     });
 
-    await page.close();
+    await page.context().close();
   });
 
   test('should toggle favorite from recipe list card', async ({ authenticatedPage }) => {

--- a/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
@@ -1,16 +1,15 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
-import { loginViaKeycloak, deleteTestRecipe } from '../helpers/test-data.helper';
+import { openAuthenticatedPage, deleteTestRecipe } from '../helpers/test-data.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe Tags (US-070)', () => {
   let recipeIdentifier: string;
 
   test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
 
-    // Create recipe with tags via API (authenticated session from loginViaKeycloak)
+    // Create recipe with tags via API (authenticated session from storage state).
     const response = await page.evaluate(async () => {
       const res = await fetch('/api/v1/recipes', {
         method: 'POST',
@@ -32,7 +31,7 @@ test.describe('Recipe Tags (US-070)', () => {
     });
 
     recipeIdentifier = response.identifier;
-    await page.close();
+    await page.context().close();
   });
 
   test('should display tags on recipe detail page', async ({ authenticatedPage }) => {
@@ -63,9 +62,8 @@ test.describe('Recipe Tags (US-070)', () => {
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     await deleteTestRecipe(page, recipeIdentifier);
-    await page.close();
+    await page.context().close();
   });
 });

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -3,7 +3,7 @@ import { ShoppingCreatePage } from '../pages/shopping-create.page';
 import { ShoppingDetailPage } from '../pages/shopping-detail.page';
 import {
   uniqueTitle,
-  loginViaKeycloak,
+  openAuthenticatedPage,
   createTestRecipe,
   deleteTestRecipe,
 } from '../helpers/test-data.helper';
@@ -13,12 +13,11 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   let recipeIdentifier: string;
 
   test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Shopping'), {
       ingredient: 'Butter',
     });
-    await page.close();
+    await page.context().close();
   });
 
   test('should load recipe ingredients on create page', async ({ authenticatedPage }) => {
@@ -149,9 +148,8 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test.afterAll(async ({ browser }) => {
     if (!recipeIdentifier) return;
 
-    const page = await browser.newPage();
-    await loginViaKeycloak(page);
+    const page = await openAuthenticatedPage(browser);
     await deleteTestRecipe(page, recipeIdentifier);
-    await page.close();
+    await page.context().close();
   });
 });


### PR DESCRIPTION
Second attempt at parallel Playwright, done properly this time.

## Why #331 really failed (beyond what I said at the time)

The real story wasn't DB state collisions — it was the \`beforeAll\` blocks in recipes + shopping specs: each opened a fresh \`browser.newPage()\` (no storage state), then ran \`loginViaKeycloak\` — the exact UI redirect flow that #319 → #328 spent 10 PRs bypassing in \`auth.setup\`. Under parallelism every file hit that broken flow at once, tests timed out, failures ballooned.

## Fix

1. New helper \`openAuthenticatedPage(browser)\` opens a context loaded from \`src/.auth/user.json\` (the storageState auth.setup plants) and returns a page. Production-equivalent auth without the UI redirect.
2. Four spec files refactored to use it:
   - \`recipes/recipe-detail.spec.ts\` (both describe blocks + afterAll)
   - \`recipes/recipe-favorite.spec.ts\`
   - \`recipes/recipe-tags.spec.ts\` (both beforeAll + afterAll)
   - \`shopping/shopping-list.spec.ts\` (beforeAll + afterAll)
3. \`uniqueTitle()\` now appends a random 6-char suffix so two files' beforeAlls creating recipes in the same millisecond on different workers can't collide.
4. \`loginViaKeycloak\` stays exported for future specs that need to exercise the login UI intentionally (none today).

## Re-enable parallelism

\`playwright.config.ts\`:
- \`workers: 2\` on CI
- \`fullyParallel\` stays **false** so tests within a file still run sequentially. Each file is on one worker; beforeAll state is safe within-file.

## Expected impact

| Run | Playwright time | Failures |
|---|---|---|
| pre-#331 baseline | 14:52 | 17 |
| #331 (broken parallel) | 15:29 | 40 |
| **this PR** | **~8 min target** | **≤17** (ideally drops since beforeAll now uses reliable storage state) |

If failures still hang around the mid-teens, they're real feature bugs (not auth-flow flakes) and we triage them individually.