### PR TITLE
fix(infra): extend Keycloak access token lifespan to 1h for E2E

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -2,6 +2,7 @@
   "realm": "yumney",
   "enabled": true,
   "sslRequired": "none",
+  "accessTokenLifespan": 3600,
   "registrationAllowed": true,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,


### PR DESCRIPTION
## Summary
- Realm default accessTokenLifespan is 300s. E2E fetches one token at workflow start and reuses it for the whole ~900s suite.
- Later-running specs' beforeAll hooks (e.g. recipe-tags, recipe-favorite, recipe-detail) hit 401 on their inline \`POST /api/v1/recipes\` once the token expires.
- Set \`accessTokenLifespan: 3600\` so a single token covers the full E2E run.

Diagnosed from run 24884718483: 18 errors concentrated in late-running recipe/shopping specs, error-context.md shows \`tag recipe POST 401\`.

## Test plan
- [ ] E2E run drops 401 errors in beforeAll hooks
- [ ] Total failure count drops from 40