### PR TITLE
test(e2e): bump Playwright test/hook timeout from 30s to 60s

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -17,7 +17,12 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
 
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
-  timeout: 30_000,
+  // Bumped from 30s to 60s: post-token-expiry-fix, fixture-heavy beforeAll
+  // hooks (openAuthenticatedPage + API POST under parallel worker pressure)
+  // started exceeding 30s. The real API calls themselves are ~1s; the budget
+  // is eaten by the `page.goto('/')` that scopes localStorage to the origin
+  // plus concurrent Angular bootstrap on the shared dev server.
+  timeout: 60_000,
   expect: { timeout: 10_000 },
   // On CI: retry once (not twice) — each retry on a 30s-timeout test can cost
   // a minute on top of the original. Transient flakes still get a second


### PR DESCRIPTION
## Summary
Post-#336, the 18 errors are now \`beforeAll hook timeout of 30000ms exceeded\` instead of the prior 401s — confirming the token lifespan fix worked but exposed the next layer: fixture-heavy beforeAll hooks exceed the 30s budget under parallel worker pressure (page.goto + API POST + concurrent Angular bootstrap on the shared dev server).

Bump top-level Playwright \`timeout\` from 30s → 60s. The API calls themselves are ~1s; the extra headroom absorbs parallel-bootstrap contention.

## Test plan
- [ ] beforeAll timeouts disappear from results.xml
- [ ] Total broken count drops from 40 toward the ~12-14 that are genuine feature regressions (profile-settings selector drift, recipe-list sort dropdown, etc.)