### PR TITLE
fix(users): JIT-provision AppUserProfile on first profile read (US-302)

### DIFF
--- a/src/Yumney.Users.Api/ProfileEndpoints.cs
+++ b/src/Yumney.Users.Api/ProfileEndpoints.cs
@@ -20,9 +20,15 @@ public static class ProfileEndpoints
 			.ProducesProblem(StatusCodes.Status404NotFound);
 
 		static async Task<IResult> GetProfile(
+			ICommandHandler<EnsureUserProfileCommand, Result> ensure,
 			IQueryHandler<GetUserProfileQuery, Result<UserProfileDto>> handler,
 			CancellationToken cancellationToken)
 		{
+			// Idempotent JIT-provisioning for Keycloak-authenticated users who
+			// have no AppUserProfile row yet (realm-seeded users, SSO, admin).
+			// Any failure cascades naturally to the query's 404.
+			await ensure.HandleAsync(new EnsureUserProfileCommand(), cancellationToken);
+
 			var result = await handler.HandleAsync(new GetUserProfileQuery(), cancellationToken);
 			return result.ToOk();
 		}

--- a/src/Yumney.Users.Application/Commands/EnsureUserProfileCommand.cs
+++ b/src/Yumney.Users.Application/Commands/EnsureUserProfileCommand.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
+
+/// <summary>
+/// Ensures the current authenticated user has an <c>AppUserProfile</c> row,
+/// creating one from JWT claims if missing. Idempotent — safe to call on
+/// every authenticated profile request.
+/// </summary>
+public sealed record EnsureUserProfileCommand : ICommand<Result>;

--- a/src/Yumney.Users.Application/Commands/Handlers/EnsureUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/EnsureUserProfileCommandHandler.cs
@@ -1,0 +1,27 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+
+public sealed class EnsureUserProfileCommandHandler(IUsersUnitOfWork unitOfWork, ICurrentUser currentUser)
+	: ICommandHandler<EnsureUserProfileCommand, Result>
+{
+	public async Task<Result> HandleAsync(EnsureUserProfileCommand command, CancellationToken cancellationToken = default)
+	{
+		var keycloakId = KeycloakUserId.From(currentUser.UserId);
+		var existing = await unitOfWork.Profiles.FindByKeycloakUserIdAsync(keycloakId, cancellationToken);
+		if (existing is not null) return Result.Success();
+
+		// JIT-provision from JWT claims. Users authenticated via Keycloak
+		// (realm-seeded test users, SSO providers, admin-created users) may
+		// not yet have an AppUserProfile row. Create one on first profile
+		// request so the app doesn't block on 404.
+		var displayName = DisplayName.From(
+			string.IsNullOrWhiteSpace(currentUser.DisplayName) ? currentUser.Email : currentUser.DisplayName);
+		var profile = AppUserProfile.Create(keycloakId, displayName);
+		await unitOfWork.Profiles.AddAsync(profile, cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
+		return Result.Success();
+	}
+}

--- a/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
@@ -35,13 +35,15 @@ public class ProfileEndpointsContractTests(AspireFixture fixture) : IAsyncLifeti
 	public Task DisposeAsync() => CleanupProfileAsync();
 
 	[Fact]
-	public async Task GetProfile_NoProfileRow_Returns404()
+	public async Task GetProfile_NoProfileRow_JitProvisionsFromClaims()
 	{
 		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
 
 		var response = await client.GetAsync(Endpoint);
 
-		response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("displayName").GetString().Should().NotBeNullOrWhiteSpace();
 	}
 
 	[Fact]

--- a/tests/Yumney.Users.Application.Tests/Commands/EnsureUserProfileCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/EnsureUserProfileCommandHandlerTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.Commands;
+
+public class EnsureUserProfileCommandHandlerTests
+{
+	private readonly IAppUserProfileRepository profiles = Substitute.For<IAppUserProfileRepository>();
+	private readonly IUsersUnitOfWork unitOfWork = Substitute.For<IUsersUnitOfWork>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly EnsureUserProfileCommandHandler handler;
+
+	public EnsureUserProfileCommandHandlerTests()
+	{
+		currentUser.UserId.Returns("kc-user-123");
+		currentUser.Email.Returns("test@yumney.dev");
+		currentUser.DisplayName.Returns("Test User");
+		unitOfWork.Profiles.Returns(profiles);
+		handler = new EnsureUserProfileCommandHandler(unitOfWork, currentUser);
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProfileExists_DoesNothing()
+	{
+		var existing = AppUserProfile.Create(
+			KeycloakUserId.From("kc-user-123"),
+			DisplayName.From("Existing"));
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(existing);
+
+		var result = await handler.HandleAsync(new EnsureUserProfileCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await profiles.DidNotReceive().AddAsync(Arg.Any<AppUserProfile>(), Arg.Any<CancellationToken>());
+		await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProfileMissing_CreatesFromDisplayNameClaim()
+	{
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns((AppUserProfile?)null);
+
+		var result = await handler.HandleAsync(new EnsureUserProfileCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await profiles.Received(1).AddAsync(
+			Arg.Is<AppUserProfile>(p => p.DisplayName.Value == "Test User"),
+			Arg.Any<CancellationToken>());
+		await unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProfileMissingAndBlankDisplayName_FallsBackToEmail()
+	{
+		currentUser.DisplayName.Returns(string.Empty);
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns((AppUserProfile?)null);
+
+		var result = await handler.HandleAsync(new EnsureUserProfileCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await profiles.Received(1).AddAsync(
+			Arg.Is<AppUserProfile>(p => p.DisplayName.Value == "test@yumney.dev"),
+			Arg.Any<CancellationToken>());
+	}
+}


### PR DESCRIPTION
## Summary
\`GetUserProfileQueryHandler\` returned 404 \`PROFILE_NOT_FOUND\` whenever an authenticated user had no \`AppUserProfile\` row. Only users who went through \`RegisterUserCommandHandler\` had one — realm-seeded test users and anyone who enters Keycloak outside our register flow (future SSO providers, admin-created users) were stuck on the settings page with a "Failed to load" alert and untranslated i18n keys.

Create the profile on first read from JWT claims (\`DisplayName\` with \`Email\` fallback) so a valid Keycloak session always yields a usable profile.

This was diagnosed as the root cause of the 6 \`account/profile-settings.spec.ts\` E2E failures (plus likely \`dashboard/language-switch\` and \`shopping/merged-list\` which also depend on profile data).

## Test plan
- [x] Existing passing test (profile exists) still passes; handler skips the save path
- [x] Missing profile → JIT-creates with claim-derived DisplayName + saves via UoW
- [x] Missing profile + empty DisplayName claim → falls back to Email
- [x] Dietary profile mapping unchanged
- [ ] E2E profile-settings spec failures drop from 6