### PR TITLE
ci(e2e): bump workflow timeout 30→45 min

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
       # mailpit, and the LLM provider setup, so fewer containers need to come up.


### PR DESCRIPTION
## Summary
Post-#337 (60s per-test timeout), the Playwright step burns its full budget on failing tests (60s × 2 on retry per failure). With ~40 broken tests, the suite now exceeds 30 min — runs 24887375315 and 24890364946 were both cancelled mid-suite, so we lost the results.xml and can't measure whether #336/#337/#338 actually shifted the numbers.

Bump timeout to 45 min as a stop-gap. Once remaining failures get triaged down, wall time should drop and we can revisit.

## Test plan
- [ ] Develop E2E completes (conclusion != cancelled)
- [ ] results.xml artifact is uploaded so we can measure the post-#338 baseline