### PR TITLE
fix(frontend): proxy /api + /realms to Gateway; scope-provide account i18n (#340)

### DIFF
--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -1,9 +1,16 @@
 import { Route } from '@angular/router';
+import { provideTranslocoScope } from '@jsverse/transloco';
 
 export const accountRoutes: Route[] = [
   {
     path: '',
     title: 'Profile Settings — Yumney',
+    // Register the Transloco scope at the route level so it applies whether
+    // the app runs standalone (own app.config) or is loaded by the shell via
+    // native federation — federation only pulls in the routes, not the MFE's
+    // root providers. Without this, keys like account.settings.title render
+    // as their literal path.
+    providers: [provideTranslocoScope('account')],
     loadComponent: () =>
       import('./profile-settings/profile-settings.component').then(
         (m) => m.ProfileSettingsComponent,

--- a/client/apps/shell/project.json
+++ b/client/apps/shell/project.json
@@ -92,6 +92,9 @@
     },
     "serve-original": {
       "executor": "@angular/build:dev-server",
+      "options": {
+        "proxyConfig": "apps/shell/proxy.conf.json"
+      },
       "configurations": {
         "production": {
           "buildTarget": "shell:esbuild:production"

--- a/client/apps/shell/proxy.conf.json
+++ b/client/apps/shell/proxy.conf.json
@@ -1,0 +1,14 @@
+{
+  "/api": {
+    "target": "http://localhost:5100",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "warn"
+  },
+  "/realms": {
+    "target": "http://localhost:5100",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "warn"
+  }
+}


### PR DESCRIPTION
Closes #340.

## Summary
Two linked bugs behind the \`account/profile-settings\` E2E failures (6/40 of the remaining E2E failures on develop):

### 1. Dev server had no \`/api\` proxy
- \`client/libs/shared/api-client/src/lib/api-endpoints.ts\` uses relative URLs (\`/api/v1/**\`).
- From the browser at \`http://localhost:4200\`, those hit the Angular dev server, which 404s \`/api/*\`.
- Added \`client/apps/shell/proxy.conf.json\` and wired \`proxyConfig\` into the shell's \`serve-original\` target.
- \`/realms\` also proxied so OIDC discovery (when we re-enable it) and direct realm lookups also route through the gateway.

### 2. Account MFE's Transloco scope never registered under federation
- Native federation loads only the remote's \`routes\` array — the MFE's \`app.config\` providers (including \`provideTranslocoScope('account')\`) never run in the shell's injector.
- Keys like \`account.settings.title\` therefore rendered as the literal path (visible in the E2E page snapshots).
- Moved \`provideTranslocoScope('account')\` to the \`account.routes.ts\` route definition so it applies whether the app runs standalone or federated.

Recipes/shopping MFEs use the same pattern but their strings live in the shell's root dictionary, so they weren't visibly broken. Worth the same treatment later for consistency.

## Test plan
- [ ] E2E \`account/profile-settings.spec.ts\` 6 failures drop out
- [ ] \`dashboard/language-switch.spec.ts\` failures drop (depends on profile)
- [ ] No regression in recipes/shopping specs

Related PRs in the E2E recovery thread: #335, #336, #337, #338, #339.