### PR TITLE
fix(frontend): route browser API calls through Gateway via interceptor (#340)

### DIFF
--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -9,7 +9,7 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideTransloco } from '@jsverse/transloco';
-import { authInterceptor, provideAuth } from '@yumney/shared/auth';
+import { apiBaseInterceptor, authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { provideYumneyIcons } from '@yumney/ui';
 import { appRoutes } from './app.routes';
 import {
@@ -28,7 +28,10 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
     provideYumneyIcons(),
-    provideHttpClient(withFetch(), withInterceptors([authInterceptor, globalErrorInterceptor])),
+    provideHttpClient(
+      withFetch(),
+      withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor]),
+    ),
     provideAuth(),
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),

--- a/client/libs/shared/auth/src/index.ts
+++ b/client/libs/shared/auth/src/index.ts
@@ -3,5 +3,7 @@ export type { AuthUser } from './lib/auth-user';
 export { authGuard } from './lib/auth.guard';
 export { guestGuard } from './lib/guest.guard';
 export { authInterceptor } from './lib/auth.interceptor';
+export { apiBaseInterceptor } from './lib/api-base.interceptor';
+export { AppConfigService } from './lib/app-config.service';
 export { provideAuth } from './lib/provide-auth';
 export { authStorageFactory } from './lib/auth-storage.factory';

--- a/client/libs/shared/auth/src/lib/api-base.interceptor.ts
+++ b/client/libs/shared/auth/src/lib/api-base.interceptor.ts
@@ -1,0 +1,24 @@
+import { inject } from '@angular/core';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { AppConfigService } from './app-config.service';
+
+/**
+ * Rewrites relative `/api/*` URLs to absolute URLs on the Gateway so browser
+ * fetches from the Angular dev server (which has no /api proxy) reach the
+ * YARP gateway directly. In production the frontend is served through the
+ * gateway, so gatewayUrl is empty and URLs stay relative.
+ *
+ * Must run BEFORE authInterceptor so the Authorization header is added after
+ * the final URL is resolved.
+ */
+export const apiBaseInterceptor: HttpInterceptorFn = (req, next) => {
+  if (!req.url.startsWith('/api/') && !req.url.startsWith('/realms/')) {
+    return next(req);
+  }
+
+  const config = inject(AppConfigService);
+  const base = config.gatewayUrl;
+  if (!base) return next(req);
+
+  return next(req.clone({ url: `${base}${req.url}` }));
+};

--- a/client/libs/shared/auth/src/lib/app-config.service.ts
+++ b/client/libs/shared/auth/src/lib/app-config.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import type { AppConfig } from './auth-config';
+
+const DEFAULT_CONFIG: AppConfig = {
+  keycloakUrl: 'http://localhost:8080',
+  keycloakRealm: 'yumney',
+  keycloakClientId: 'yumney-web',
+};
+
+/**
+ * Loads `/assets/config/app-config.json` once at bootstrap and exposes the
+ * result to the rest of the app. Kept in the auth lib because it already
+ * owns the AppConfig type; promote to its own lib if more non-auth consumers
+ * show up.
+ */
+@Injectable({ providedIn: 'root' })
+export class AppConfigService {
+  private config: AppConfig = DEFAULT_CONFIG;
+
+  async load(): Promise<void> {
+    try {
+      const response = await fetch('/assets/config/app-config.json');
+      if (response.ok) {
+        this.config = (await response.json()) as AppConfig;
+      }
+    } catch {
+      // Config file unavailable — keep defaults.
+    }
+  }
+
+  get(): AppConfig {
+    return this.config;
+  }
+
+  /** Gateway base URL (no trailing slash). Falls back to empty string when
+   * not configured — relative `/api/*` URLs then hit the current origin. */
+  get gatewayUrl(): string {
+    return (this.config.gatewayUrl ?? '').replace(/\/+$/, '');
+  }
+}

--- a/client/libs/shared/auth/src/lib/auth.service.spec.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { Subject } from 'rxjs';
 import { AuthService } from './auth.service';
+import { AppConfigService } from './app-config.service';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -46,9 +47,11 @@ describe('AuthService', () => {
     };
 
     TestBed.configureTestingModule({
-      providers: [AuthService, { provide: OAuthService, useValue: oauthMock }],
+      providers: [AuthService, AppConfigService, { provide: OAuthService, useValue: oauthMock }],
     });
 
+    // AppConfigService is usually loaded via APP_INITIALIZER; do it by hand here.
+    TestBed.inject(AppConfigService);
     service = TestBed.inject(AuthService);
   });
 

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -1,15 +1,10 @@
 import { Injectable, signal, computed, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OAuthService } from 'angular-oauth2-oidc';
-import { AppConfig, createAuthConfig } from './auth-config';
+import { createAuthConfig } from './auth-config';
+import { AppConfigService } from './app-config.service';
 import { REMEMBER_ME_KEY } from './auth-storage.factory';
 import type { AuthUser } from './auth-user';
-
-const DEFAULT_CONFIG: AppConfig = {
-  keycloakUrl: 'http://localhost:8080',
-  keycloakRealm: 'yumney',
-  keycloakClientId: 'yumney-web',
-};
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
@@ -40,11 +35,14 @@ export class AuthService {
   });
 
   private destroyRef = inject(DestroyRef);
+  private appConfig = inject(AppConfigService);
 
   constructor(private oauthService: OAuthService) {}
 
   async initialize(): Promise<void> {
-    const { keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl } = await this.loadAppConfig();
+    // AppConfigService is loaded via APP_INITIALIZER before this runs, so
+    // reading synchronously is safe.
+    const { keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl } = this.appConfig.get();
     const authConfig = createAuthConfig(keycloakUrl, keycloakRealm, keycloakClientId, gatewayUrl);
 
     this.oauthService.configure(authConfig);
@@ -96,18 +94,6 @@ export class AuthService {
 
   forgotPassword(): void {
     this.oauthService.initCodeFlow('', { kc_action: 'UPDATE_PASSWORD' });
-  }
-
-  private async loadAppConfig(): Promise<AppConfig> {
-    try {
-      const response = await fetch('/assets/config/app-config.json');
-      if (response.ok) {
-        return await response.json();
-      }
-    } catch {
-      // Config file unavailable — use defaults
-    }
-    return DEFAULT_CONFIG;
   }
 
   private updateAuthState(): void {

--- a/client/libs/shared/auth/src/lib/provide-auth.ts
+++ b/client/libs/shared/auth/src/lib/provide-auth.ts
@@ -1,10 +1,21 @@
 import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { provideOAuthClient, OAuthStorage } from 'angular-oauth2-oidc';
+import { AppConfigService } from './app-config.service';
 import { AuthService } from './auth.service';
 import { authStorageFactory } from './auth-storage.factory';
 
-function initializeAuth(authService: AuthService): () => Promise<void> {
-  return () => authService.initialize();
+function initializeAuth(
+  appConfig: AppConfigService,
+  authService: AuthService,
+): () => Promise<void> {
+  // Load app-config.json first so AuthService and apiBaseInterceptor both
+  // see the resolved gatewayUrl at runtime. Sequencing matters: if a
+  // component fires an HTTP request during AuthService.initialize(), the
+  // interceptor needs gatewayUrl already populated.
+  return async () => {
+    await appConfig.load();
+    await authService.initialize();
+  };
 }
 
 export function provideAuth(): EnvironmentProviders {
@@ -14,7 +25,7 @@ export function provideAuth(): EnvironmentProviders {
     {
       provide: APP_INITIALIZER,
       useFactory: initializeAuth,
-      deps: [AuthService],
+      deps: [AppConfigService, AuthService],
       multi: true,
     },
   ]);

--- a/client/libs/shared/models/src/lib/mfe-app-config.ts
+++ b/client/libs/shared/models/src/lib/mfe-app-config.ts
@@ -9,7 +9,7 @@ import {
 import { provideRouter, Routes } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideTransloco, provideTranslocoScope } from '@jsverse/transloco';
-import { authInterceptor, provideAuth } from '@yumney/shared/auth';
+import { apiBaseInterceptor, authInterceptor, provideAuth } from '@yumney/shared/auth';
 import { TranslocoHttpLoader } from './transloco-loader';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './language-code';
 import { globalErrorInterceptor } from './global-error.interceptor';
@@ -38,7 +38,10 @@ export function createMfeAppConfig(
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withFetch(), withInterceptors([authInterceptor, globalErrorInterceptor])),
+    provideHttpClient(
+      withFetch(),
+      withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor]),
+    ),
     provideAuth(),
     provideTransloco({
       config: {


### PR DESCRIPTION
Closes part of #340.

## Summary
Alternative to the dev-server-proxy attempt in #343 (reverted in #344 because adding \`options\` to \`serve-original\` broke the serve wrapper's port-4200 inheritance).

### Problems
- \`api-endpoints.ts\` hardcodes \`API_BASE = '/api/v1'\` (relative).
- In dev, browser fetches to \`http://localhost:4200/api/...\` hit the Angular dev server, which has no \`/api\` proxy and 404s.
- In prod the frontend is served via the gateway so relative URLs work naturally.

### Fix
- Extract app-config loading out of \`AuthService\` into a shared \`AppConfigService\`; load it via \`APP_INITIALIZER\` before auth init.
- Add \`apiBaseInterceptor\` that rewrites \`/api/*\` and \`/realms/*\` to \`\${gatewayUrl}/\${path}\` when \`gatewayUrl\` is configured; no-op in prod where \`gatewayUrl\` is empty/same-origin.
- Register the interceptor in both the shell's \`app.config\` and \`createMfeAppConfig\` (so federated MFEs pick it up). Order it before \`authInterceptor\` so the Authorization header lands on the rewritten URL.

No dev-server proxy needed. Works identically across MFEs because they share the interceptor chain.

## Test plan
- [ ] E2E \`account/profile-settings.spec.ts\` 6 failures drop out (API call now reaches the gateway, JIT-provision from #338 fires, page renders)
- [ ] Dashboard/language-switch failures drop (same root cause)
- [ ] No CONNECTION_REFUSED cascade — shell dev server binding unaffected (unlike #343)

## Related
- Reverted PR #343 (wrong fix via dev-server proxy) + PR #344 (the revert).
- Depends on #338 (server-side JIT profile provisioning) to actually return a profile.