### PR TITLE
fix(frontend): store app-config on globalThis for federation-safe access (#340)

### DIFF
--- a/client/libs/shared/auth/src/lib/api-base.interceptor.ts
+++ b/client/libs/shared/auth/src/lib/api-base.interceptor.ts
@@ -1,6 +1,5 @@
-import { inject } from '@angular/core';
 import { HttpInterceptorFn } from '@angular/common/http';
-import { AppConfigService } from './app-config.service';
+import { getAppConfigGatewayUrl } from './app-config.service';
 
 /**
  * Rewrites relative `/api/*` URLs to absolute URLs on the Gateway so browser
@@ -8,16 +7,21 @@ import { AppConfigService } from './app-config.service';
  * YARP gateway directly. In production the frontend is served through the
  * gateway, so gatewayUrl is empty and URLs stay relative.
  *
- * Must run BEFORE authInterceptor so the Authorization header is added after
- * the final URL is resolved.
+ * Reads gatewayUrl via a module-level global (see app-config.service.ts)
+ * rather than injection — native federation bundles workspace libs per-MFE,
+ * so `inject(AppConfigService)` in an MFE resolves to a different class
+ * token than the one the shell populated, and DI lookup returns an empty
+ * instance. The global is federation-safe.
+ *
+ * Order matters: register this before authInterceptor so the Authorization
+ * header lands on the rewritten absolute URL.
  */
 export const apiBaseInterceptor: HttpInterceptorFn = (req, next) => {
   if (!req.url.startsWith('/api/') && !req.url.startsWith('/realms/')) {
     return next(req);
   }
 
-  const config = inject(AppConfigService);
-  const base = config.gatewayUrl;
+  const base = getAppConfigGatewayUrl();
   if (!base) return next(req);
 
   return next(req.clone({ url: `${base}${req.url}` }));

--- a/client/libs/shared/auth/src/lib/app-config.service.ts
+++ b/client/libs/shared/auth/src/lib/app-config.service.ts
@@ -7,34 +7,54 @@ const DEFAULT_CONFIG: AppConfig = {
   keycloakClientId: 'yumney-web',
 };
 
+const GLOBAL_KEY = '__yumneyAppConfig';
+
+interface GlobalAppConfigHost {
+  [GLOBAL_KEY]?: AppConfig;
+}
+
+function globalHost(): GlobalAppConfigHost | undefined {
+  return typeof globalThis === 'undefined' ? undefined : (globalThis as GlobalAppConfigHost);
+}
+
 /**
- * Loads `/assets/config/app-config.json` once at bootstrap and exposes the
- * result to the rest of the app. Kept in the auth lib because it already
- * owns the AppConfig type; promote to its own lib if more non-auth consumers
- * show up.
+ * Loads `/assets/config/app-config.json` once at bootstrap and stores the
+ * result on globalThis so every federated MFE reads the same value — even
+ * ones whose bundles hold their own copy of this class (native-federation
+ * bundles workspace libs per-MFE, so DI singletons break across bundles).
+ * Interceptors read via {@link getAppConfigGatewayUrl} which bypasses DI
+ * entirely.
  */
 @Injectable({ providedIn: 'root' })
 export class AppConfigService {
-  private config: AppConfig = DEFAULT_CONFIG;
-
   async load(): Promise<void> {
     try {
       const response = await fetch('/assets/config/app-config.json');
       if (response.ok) {
-        this.config = (await response.json()) as AppConfig;
+        const cfg = (await response.json()) as AppConfig;
+        const host = globalHost();
+        if (host) host[GLOBAL_KEY] = cfg;
+        return;
       }
     } catch {
       // Config file unavailable — keep defaults.
     }
+    const host = globalHost();
+    if (host) host[GLOBAL_KEY] = DEFAULT_CONFIG;
   }
 
   get(): AppConfig {
-    return this.config;
+    return globalHost()?.[GLOBAL_KEY] ?? DEFAULT_CONFIG;
   }
 
-  /** Gateway base URL (no trailing slash). Falls back to empty string when
-   * not configured — relative `/api/*` URLs then hit the current origin. */
   get gatewayUrl(): string {
-    return (this.config.gatewayUrl ?? '').replace(/\/+$/, '');
+    return getAppConfigGatewayUrl();
   }
+}
+
+/** Synchronous lookup usable from interceptors that may be instantiated in
+ * MFE bundles separate from the shell. Returns empty string when not yet
+ * loaded or not configured. */
+export function getAppConfigGatewayUrl(): string {
+  return (globalHost()?.[GLOBAL_KEY]?.gatewayUrl ?? '').replace(/\/+$/, '');
 }


### PR DESCRIPTION
Follow-up to #345. The \`apiBaseInterceptor\` was reading gatewayUrl via \`inject(AppConfigService)\`. Native federation bundles \`@yumney/shared/auth\` per-MFE, so each MFE has its own \`AppConfigService\` class token — \`inject()\` in an MFE resolves to a different singleton than the shell-loaded one (empty gatewayUrl), and the interceptor no-ops.

## Fix
Store the loaded config on \`globalThis.__yumneyAppConfig\` at bootstrap. Interceptor reads via a plain function (\`getAppConfigGatewayUrl\`) — no DI, federation-safe.

\`AppConfigService\` kept as the \`APP_INITIALIZER\` entry point so bootstrap ordering is unchanged; its \`.get()\` / \`.gatewayUrl\` delegate to the global.

## Evidence from previous run (#345 post-merge)
- Account MFE now renders translated strings ("Profile Settings", "Failed to load profile.") — so federation + Transloco are fine.
- But API call still errors → hypothesis: interceptor didn't fire/rewrite for the MFE's request.

## Test plan
- [ ] profile-settings 6F drops
- [ ] language-switch (2F+2E) likely drops too (same profile-dependent path)
- [ ] No regression on other specs

Related: #340, #343, #344, #345.