### PR TITLE
debug(account): surface HttpErrorResponse details in profile loadFailed UI

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -111,8 +111,17 @@ export class ProfileSettingsComponent {
           this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
           this.loading.set(false);
         },
-        error: () => {
-          this.error.set(this.transloco.translate('account.settings.errors.loadFailed'));
+        error: (err) => {
+          // DEBUG: include actual error details in the UI so Playwright page
+          // snapshots reveal status code / URL / message. Will be reverted
+          // once the profile-settings E2E cluster is fixed.
+          const detail =
+            err && typeof err === 'object'
+              ? `${err.status ?? '?'} ${err.statusText ?? ''} ${err.url ?? ''} ${err.message ?? ''}`.trim()
+              : String(err);
+          this.error.set(
+            `${this.transloco.translate('account.settings.errors.loadFailed')} [debug: ${detail}]`,
+          );
           this.loading.set(false);
         },
       });


### PR DESCRIPTION
Temporary diagnostic probe for #340. Prints the actual HTTP error (status, url, message) into the rendered alert so the next E2E run's page snapshot reveals whether we're hitting 401/403/CORS/404 — information we can't see from Playwright artifacts otherwise.

Will revert after the real fix lands.