### PR TITLE
fix(deps): bump OpenTelemetry 1.15.2 → 1.15.3 (clears CVE)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.5.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />


### PR DESCRIPTION
NuGet advisories flagged OpenTelemetry.Api / OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.2 with known moderate-severity vulnerabilities (GHSA-g94r-2vxg-569j, GHSA-mr8r-92fq-pj8p). With TreatWarningsAsErrors enabled, NU1902 escalates to an error and every develop restore now fails — including the E2E workflow's \`Restore .NET packages\` step.

1.15.3 is the latest stable and clears the advisories.

## Test plan
- [x] \`dotnet restore Yumney.slnx\` succeeds locally
- [ ] CI Backend/Frontend checks green
- [ ] E2E workflow's Restore step passes again