### PR TITLE
fix(gateway): route /api/v1/users/* to users-api (#340 real fix)

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -111,17 +111,8 @@ export class ProfileSettingsComponent {
           this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
           this.loading.set(false);
         },
-        error: (err) => {
-          // DEBUG: include actual error details in the UI so Playwright page
-          // snapshots reveal status code / URL / message. Will be reverted
-          // once the profile-settings E2E cluster is fixed.
-          const detail =
-            err && typeof err === 'object'
-              ? `${err.status ?? '?'} ${err.statusText ?? ''} ${err.url ?? ''} ${err.message ?? ''}`.trim()
-              : String(err);
-          this.error.set(
-            `${this.transloco.translate('account.settings.errors.loadFailed')} [debug: ${detail}]`,
-          );
+        error: () => {
+          this.error.set(this.transloco.translate('account.settings.errors.loadFailed'));
           this.loading.set(false);
         },
       });

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -23,10 +23,16 @@
           "Path": "/api/v1/shopping-lists/{**remainder}"
         }
       },
-      "users-route": {
+      "users-auth-route": {
         "ClusterId": "users-api",
         "Match": {
           "Path": "/api/v1/auth/{**remainder}"
+        }
+      },
+      "users-me-route": {
+        "ClusterId": "users-api",
+        "Match": {
+          "Path": "/api/v1/users/{**remainder}"
         }
       },
       "mealplan-route": {


### PR DESCRIPTION
Closes #340.

## Root cause
The debug probe in #347 finally revealed it: profile API hits returned \`200 OK\` with **HTML** (the Angular SPA index.html), not JSON. Angular's \`http.get<UserProfile>()\` then failed with \`Http failure during parsing\`.

**Why:** YARP had no route for \`/api/v1/users/{**remainder}\`. The \`shell-route\` catch-all (\`Order: 1000\`) matched instead, serving the shell MFE's static output. The only users-api route was \`/api/v1/auth/{**remainder}\`, so \`/api/v1/users/me/profile\` fell through.

## Fix
Split \`users-route\` into two:
- \`users-auth-route\` → \`/api/v1/auth/{**remainder}\` (unchanged)
- \`users-me-route\` → \`/api/v1/users/{**remainder}\` (new)

Both point at the same \`users-api\` cluster.

Also reverts the temporary debug probe in \`profile-settings.component.ts\` from #347.

## Why the earlier fixes still needed to land
Eleven PRs into this thread, this was the actual bug the whole time — not the interceptor (#345/346), not the Transloco scope (#343), not federation. **But every earlier fix still had to land for the full chain to work**:
- #338 JIT-provisions the profile row on first read
- #343 registers the account Transloco scope at route level (federation-safe)
- #345/#346 route browser \`/api/*\` requests to the gateway via interceptor + globalThis

Without any one of these, the profile page still breaks. This PR is the missing last mile.

## Test plan
- [ ] profile-settings 6F drops
- [ ] language-switch (2F+2E) drops
- [ ] No regression on other specs

Debug probe from #347 stays reverted.