### PR TITLE
ci(e2e): warm up API endpoints via gateway before Playwright runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -220,6 +220,26 @@ jobs:
           done
           test -s /tmp/e2e-tokens.json
 
+      - name: Warm up API endpoints
+        # First call to each *.Api after Aspire startup pays a 5-15s JIT +
+        # EF-model-build cost. Playwright toBeVisible timeouts are 10s, so
+        # the first profile-settings test would fire before the response
+        # lands. Prewarm each API via the gateway with the test token.
+        run: |
+          set +e
+          token=$(python3 -c 'import json; print(json.load(open("/tmp/e2e-tokens.json"))["access_token"])')
+          for endpoint in \
+            "http://localhost:5100/api/v1/users/me/profile" \
+            "http://localhost:5100/api/v1/recipes?page=1&pageSize=1" \
+            "http://localhost:5100/api/v1/shopping-lists?page=1&pageSize=1" \
+            "http://localhost:5100/api/v1/meal-plans/current"; do
+            echo "warmup: $endpoint"
+            time curl -sk -o /dev/null -w "  status=%{http_code} time=%{time_total}s\n" \
+              --max-time 60 \
+              -H "Authorization: Bearer $token" \
+              "$endpoint"
+          done
+
       - name: Run backend integration tests
         continue-on-error: true
         run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj


### PR DESCRIPTION
Post-#349 the profile-settings cluster shows the page stuck on "Loading profile…" — the HTTP request routes correctly but \`users-api\`'s first call takes long enough that Playwright's 10s \`toBeVisible\` timeout fires before the response lands.

## Fix
Fire one authenticated GET at each \`/api/v1\` endpoint via the gateway after the Keycloak token is fetched. Cold-start cost (JIT, EF model build, DB connection) happens during setup rather than inside test timeouts.

Mirrors the existing Keycloak warmup pattern in the token-fetch step.

## Test plan
- [ ] profile-settings 6F finally drops
- [ ] Wall time returns toward ~24 min from ~30 min