### PR TITLE
test(e2e): wire recipe-list sort tests to new yn-sort-menu (#341)

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
+++ b/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
@@ -2,6 +2,8 @@
   <button
     type="button"
     class="sort-toggle"
+    data-testid="sort-toggle"
+    [attr.data-current-value]="currentValue()"
     (click)="toggle()"
     [attr.aria-label]="ariaLabel()"
     [attr.aria-expanded]="open()"
@@ -17,6 +19,7 @@
         <li
           role="option"
           class="sort-menu-item"
+          [attr.data-testid]="'sort-option-' + option.value"
           [class.active]="currentValue() === option.value"
           (click)="select(option.value)"
         >

--- a/client/apps/shell-e2e/src/pages/recipe-list.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-list.page.ts
@@ -4,7 +4,7 @@ export class RecipeListPage {
   readonly heading: Locator;
   readonly searchInput: Locator;
   readonly searchClearButton: Locator;
-  readonly sortSelect: Locator;
+  readonly sortToggle: Locator;
   readonly recipeCards: Locator;
   readonly emptyState: Locator;
   readonly ctaButton: Locator;
@@ -17,7 +17,7 @@ export class RecipeListPage {
     this.heading = page.getByRole('heading', { level: 1 });
     this.searchInput = page.locator('.search-input');
     this.searchClearButton = page.locator('.search-clear');
-    this.sortSelect = page.locator('.sort-select');
+    this.sortToggle = page.locator('[data-testid="sort-toggle"]');
     this.recipeCards = page.locator('.recipe-card');
     this.emptyState = page.locator('.empty-state');
     this.ctaButton = page.locator('.cta-button');
@@ -39,5 +39,19 @@ export class RecipeListPage {
 
   favoriteButtonOnCard(title: string): Locator {
     return this.recipeCard(title).locator('.favorite-overlay .favorite-button');
+  }
+
+  /**
+   * Open the sort dropdown and pick an option by its sort value (e.g.
+   * 'name-asc'). Mirrors the old `sortSelect.selectOption(value)` API.
+   */
+  async chooseSortOption(value: string): Promise<void> {
+    await this.sortToggle.click();
+    await this.page.locator(`[data-testid="sort-option-${value}"]`).click();
+  }
+
+  /** Currently-selected sort value, exposed via data-current-value on the toggle. */
+  currentSortValue(): Promise<string | null> {
+    return this.sortToggle.getAttribute('data-current-value');
   }
 }

--- a/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
@@ -13,9 +13,9 @@ test.describe('Recipe List (US-030, US-034)', () => {
     await expect(recipeList.heading).toBeVisible();
   });
 
-  test('should display search input and sort select', async () => {
+  test('should display search input and sort toggle', async () => {
     await expect(recipeList.searchInput).toBeVisible();
-    await expect(recipeList.sortSelect).toBeVisible();
+    await expect(recipeList.sortToggle).toBeVisible();
   });
 
   test('should show empty state or recipe cards', async () => {
@@ -57,8 +57,9 @@ test.describe('Recipe List (US-030, US-034)', () => {
   });
 
   test('should change sort order', async () => {
-    await recipeList.sortSelect.selectOption('name-asc');
-    // Just verify the select changed — results depend on data
-    await expect(recipeList.sortSelect).toHaveValue('name-asc');
+    await recipeList.chooseSortOption('name-asc');
+    // The custom dropdown exposes the current value via data-current-value
+    // on the toggle. Poll for the attribute change rather than reading once.
+    await expect(recipeList.sortToggle).toHaveAttribute('data-current-value', 'name-asc');
   });
 });


### PR DESCRIPTION
Closes #341.

## Summary
The sort UI was redesigned from a native \`<select>\` (\`.sort-select\`) into a custom button+dropdown (\`yn-sort-menu\`). The E2E tests still looked for the old class and used \`.selectOption()\`/\`.toHaveValue()\`, so all 4 recipe-list sort failures were selector drift.

## Changes
- Added \`data-testid="sort-toggle"\` on the toggle button and \`data-testid="sort-option-{value}"\` on each menu item so tests have a stable hook independent of styling and i18n.
- Mirrored the current value back as \`data-current-value\` attr on the toggle so tests can assert state without reading internal labels.
- Replaced \`RecipeListPage.sortSelect\` with \`sortToggle\` and added a \`chooseSortOption(value)\` helper.
- Updated the two affected tests accordingly.

## Test plan
- [ ] \`recipes/recipe-list.spec.ts\` failures drop from 4F
- [ ] No regression on other specs