### PR TITLE
test(e2e): wire language-switch tests to user-menu dropdown (#342)

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/language-switch.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/language-switch.spec.ts
@@ -12,28 +12,36 @@ test.describe('Language Switching (US-060)', () => {
     await dashboard.goto();
   });
 
-  test('should display language toggle button', async () => {
-    await expect(header.langToggle).toBeVisible();
+  test('should display language switch in user menu', async () => {
+    await header.openMenu();
+    await expect(header.langSwitch).toBeVisible();
   });
 
   test('should switch from EN to DE', async () => {
-    await expect(header.langToggle).toContainText('DE');
+    await header.openMenu();
+    await expect(header.langSwitch).toHaveAttribute('data-current-lang', 'en');
 
-    await header.langToggle.click();
-    await expect(header.langToggle).toContainText('EN');
+    await header.switchLanguage();
+    await header.openMenu();
+    await expect(header.langSwitch).toHaveAttribute('data-current-lang', 'de');
   });
 
   test('should translate UI after switching language', async () => {
-    await header.langToggle.click();
+    await header.switchLanguage();
 
+    // Logout label is one of the items that re-renders on lang change.
+    await header.openMenu();
     await expect(header.logoutButton).toContainText('Abmelden');
   });
 
   test('should persist language after page reload', async ({ authenticatedPage }) => {
-    await header.langToggle.click();
-    await expect(header.langToggle).toContainText('EN');
+    await header.switchLanguage();
+    await header.openMenu();
+    await expect(header.langSwitch).toHaveAttribute('data-current-lang', 'de');
 
     await authenticatedPage.reload();
-    await expect(header.langToggle).toContainText('EN');
+
+    await header.openMenu();
+    await expect(header.langSwitch).toHaveAttribute('data-current-lang', 'de');
   });
 });

--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -68,8 +68,9 @@ export const SELECTORS = {
     retryBtn: '.retry-btn',
   },
   header: {
-    langToggle: '.lang-toggle',
-    logout: '.logout-button',
+    userMenuToggle: '[data-testid="user-menu-toggle"]',
+    langSwitch: '[data-testid="lang-switch"]',
+    logout: '[data-testid="logout"]',
   },
   keycloak: {
     username: '#username',

--- a/client/apps/shell-e2e/src/pages/header.page.ts
+++ b/client/apps/shell-e2e/src/pages/header.page.ts
@@ -1,12 +1,33 @@
-import { type Page, type Locator } from '@playwright/test';
+import { type Page, type Locator, expect } from '@playwright/test';
 import { SELECTORS } from '../helpers/selectors';
 
+/**
+ * Wraps the header avatar dropdown which now hosts the language and logout
+ * controls (was a flat .lang-toggle / .logout-button before the redesign).
+ */
 export class HeaderPage {
-  readonly langToggle: Locator;
+  readonly userMenuToggle: Locator;
+  readonly langSwitch: Locator;
   readonly logoutButton: Locator;
 
   constructor(private page: Page) {
-    this.langToggle = page.locator(SELECTORS.header.langToggle);
+    this.userMenuToggle = page.locator(SELECTORS.header.userMenuToggle);
+    this.langSwitch = page.locator(SELECTORS.header.langSwitch);
     this.logoutButton = page.locator(SELECTORS.header.logout);
+  }
+
+  /** Open the avatar dropdown menu. Idempotent. */
+  async openMenu(): Promise<void> {
+    if (await this.langSwitch.isVisible()) return;
+    await this.userMenuToggle.click();
+    await expect(this.langSwitch).toBeVisible();
+  }
+
+  /** Open menu, click the language switch item, then return the new active lang. */
+  async switchLanguage(): Promise<void> {
+    await this.openMenu();
+    await this.langSwitch.click();
+    // Click closes the dropdown. Caller should re-openMenu() if they need to
+    // assert against the new state.
   }
 }

--- a/client/apps/shell/src/app/layout/header/header.component.spec.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.spec.ts
@@ -50,7 +50,12 @@ describe('HeaderComponent', () => {
       userInitial: signal<string | null>(null),
       logout: vi.fn(),
     };
-    const languageServiceMock = { activeLang: 'en', nextLanguage: 'de', switchTo: vi.fn() };
+    const languageServiceMock = {
+      activeLang: 'en',
+      activeLangSignal: signal('en'),
+      nextLanguage: 'de',
+      switchTo: vi.fn(),
+    };
     const themeServiceMock = { theme: signal('light'), toggle: vi.fn(), initialize: vi.fn() };
     const chatStateMock = { toggle: vi.fn() };
 

--- a/client/libs/shared/models/src/lib/language.service.ts
+++ b/client/libs/shared/models/src/lib/language.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { TranslocoService } from '@jsverse/transloco';
 import { type LanguageCode, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './language-code';
 
@@ -10,11 +10,17 @@ function isSupportedLanguage(lang: string): lang is LanguageCode {
 
 @Injectable({ providedIn: 'root' })
 export class LanguageService {
+  // Mirrors transloco's active language as a signal so components can react
+  // via computed() without RxJS subscriptions. Updated in initialize() and
+  // switchTo().
+  readonly activeLangSignal = signal<LanguageCode>(DEFAULT_LANGUAGE);
+
   constructor(private transloco: TranslocoService) {}
 
   initialize(): void {
     const lang = this.getStoredLanguage() ?? this.detectBrowserLanguage();
     this.transloco.setActiveLang(lang);
+    this.activeLangSignal.set(lang);
   }
 
   get activeLang(): LanguageCode {
@@ -33,6 +39,7 @@ export class LanguageService {
 
     this.transloco.setActiveLang(lang);
     localStorage.setItem(LANGUAGE_KEY, lang);
+    this.activeLangSignal.set(lang);
   }
 
   private getStoredLanguage(): LanguageCode | null {

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -28,6 +28,7 @@
         <div class="avatar-wrapper">
           <button
             class="avatar-button"
+            data-testid="user-menu-toggle"
             (click)="onToggleMenu()"
             [attr.aria-expanded]="menuOpen()"
             [attr.aria-label]="t('layout.header.settings')"
@@ -53,7 +54,14 @@
                 }
               </button>
 
-              <button class="dropdown-item" (click)="onSwitchLanguage()" role="menuitem">
+              <button
+                class="dropdown-item"
+                data-testid="lang-switch"
+                [attr.data-current-lang]="currentLanguage()"
+                [attr.data-next-lang]="nextLanguage()"
+                (click)="onSwitchLanguage()"
+                role="menuitem"
+              >
                 <lucide-icon name="languages" [size]="18" />
                 <span>{{ t(nextLanguageKey()) }}</span>
               </button>
@@ -62,6 +70,7 @@
 
               <button
                 class="dropdown-item dropdown-item--danger"
+                data-testid="logout"
                 (click)="onLogout()"
                 role="menuitem"
               >

--- a/client/libs/ui/src/lib/header/header.component.spec.ts
+++ b/client/libs/ui/src/lib/header/header.component.spec.ts
@@ -53,6 +53,8 @@ describe('HeaderComponent', () => {
     };
 
     languageMock = {
+      activeLang: 'en',
+      activeLangSignal: signal('en'),
       nextLanguage: 'de',
       switchTo: vi.fn(),
     };

--- a/client/libs/ui/src/lib/header/header.component.ts
+++ b/client/libs/ui/src/lib/header/header.component.ts
@@ -34,8 +34,21 @@ export class HeaderComponent {
   protected isDark = computed(() => this.themeService.theme() === 'dark');
 
   protected nextLanguageKey = computed(() => {
-    const lang = this.languageService.nextLanguage;
+    const lang = this.nextLanguage();
     return `layout.header.language${lang[0].toUpperCase()}${lang.slice(1)}`;
+  });
+
+  // Exposed for E2E selectors via data-current-lang / data-next-lang. Reads
+  // the same signal Transloco re-renders on, so the data attributes update
+  // when language changes — tests can poll without re-opening the menu.
+  protected currentLanguage = computed(() => {
+    // Touch the transloco signal so this re-evaluates on language change.
+    void this.languageService.activeLangSignal();
+    return this.languageService.activeLang;
+  });
+  protected nextLanguage = computed(() => {
+    void this.languageService.activeLangSignal();
+    return this.languageService.nextLanguage;
   });
 
   @HostListener('document:keydown.escape')


### PR DESCRIPTION
Closes part of #342 (cluster A — selector drift).

## Summary
The header was redesigned: language toggle moved from a flat \`.lang-toggle\` button into the avatar dropdown. The 4 \`dashboard/language-switch\` E2E failures (2F+2E) were selector drift on a UI that no longer exists.

## Changes
- Add \`data-testid\` on \`user-menu-toggle\`, \`lang-switch\`, \`logout\`. Tests now address these stably regardless of styling.
- Surface the current and next language as \`data-current-lang\` / \`data-next-lang\` on the lang-switch item so tests can assert state without re-reading translated labels.
- Add \`LanguageService.activeLangSignal\` so the header can react to language changes via \`computed()\` (the previous getter wasn't reactive).
- Replace \`HeaderPage.langToggle\` with \`userMenuToggle\` / \`langSwitch\` + \`openMenu()\` / \`switchLanguage()\` helpers. The dropdown auto-closes after each click; helpers re-open as needed.
- Rewrite the four language-switch tests to drive the new flow.

## Test plan
- [x] \`shared-models\` + \`ui\` Vitest suites green locally
- [ ] dashboard/language-switch 4 broken drops out
- [ ] Other specs unaffected