### PR TITLE
test(e2e): wire dashboard import tests to redesigned import section (#342)

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
@@ -70,7 +70,8 @@ test.describe('Dashboard — Photo Import (US-130)', () => {
     await expect(dashboard.photoUploadInput).toHaveAttribute('multiple', '');
   });
 
-  test('should have camera capture attribute for mobile', async () => {
-    await expect(dashboard.photoUploadInput).toHaveAttribute('capture', 'environment');
-  });
+  // Camera capture is handled by a dedicated `Scan with camera` button now,
+  // not by a `capture="environment"` attribute on the file input. The button
+  // is only rendered when the browser exposes a camera API, which Playwright
+  // headless Chromium doesn't — so we just assert the file input still works.
 });

--- a/client/apps/shell-e2e/src/pages/dashboard.page.ts
+++ b/client/apps/shell-e2e/src/pages/dashboard.page.ts
@@ -2,6 +2,7 @@ import { type Page, type Locator } from '@playwright/test';
 
 export class DashboardPage {
   readonly heading: Locator;
+  readonly importToggle: Locator;
   readonly urlInput: Locator;
   readonly importButton: Locator;
   readonly createButton: Locator;
@@ -13,11 +14,12 @@ export class DashboardPage {
 
   constructor(private page: Page) {
     this.heading = page.getByRole('heading', { level: 1 });
+    this.importToggle = page.locator('[data-testid="import-toggle"]');
     this.urlInput = page.locator('#url');
     this.importButton = page.getByRole('button', { name: /import recipe/i });
-    this.createButton = page.getByRole('button', { name: /create recipe/i });
-    this.photoUploadInput = page.locator('.photo-import input[type="file"]');
-    this.photoUploadLabel = page.locator('.photo-upload-btn');
+    this.createButton = page.locator('[data-testid="create-recipe-btn"]');
+    this.photoUploadInput = page.locator('[data-testid="photo-upload-input"]');
+    this.photoUploadLabel = page.locator('[data-testid="photo-upload-btn"]');
     this.recipePreview = page.locator('yn-recipe-preview');
     this.successBanner = page.locator('.success-banner');
     this.errorBanner = page.locator('[role="alert"]');
@@ -25,6 +27,17 @@ export class DashboardPage {
 
   async goto(): Promise<void> {
     await this.page.goto('/dashboard');
+    // The import section is collapsed by default after the dashboard
+    // redesign. All import-related controls are hidden until expanded, so
+    // every E2E test that touches them needs to expand first.
+    await this.expandImportSection();
+  }
+
+  async expandImportSection(): Promise<void> {
+    const expanded = await this.importToggle.getAttribute('data-expanded');
+    if (expanded !== 'true') {
+      await this.importToggle.click();
+    }
   }
 
   fieldError(text: string | RegExp): Locator {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -33,8 +33,17 @@
     </section>
   }
 
-  <section class="import-section" [class.expanded]="importSectionExpanded()">
-    <button class="import-toggle" (click)="toggleImportSection()">
+  <section
+    class="import-section"
+    data-testid="import-section"
+    [class.expanded]="importSectionExpanded()"
+  >
+    <button
+      class="import-toggle"
+      data-testid="import-toggle"
+      [attr.data-expanded]="importSectionExpanded()"
+      (click)="toggleImportSection()"
+    >
       <h2>{{ t('dashboard.import.sectionTitle') }}</h2>
       <span class="toggle-chevron" [class.open]="importSectionExpanded()"
         ><lucide-icon name="chevron-down" [size]="18"
@@ -76,9 +85,14 @@
                 {{ t('dashboard.photoImport.scanIngredients') }}
               </button>
             }
-            <label class="btn-dashed" [class.disabled]="isLoading() || isSaving()">
+            <label
+              class="btn-dashed"
+              data-testid="photo-upload-btn"
+              [class.disabled]="isLoading() || isSaving()"
+            >
               <input
                 type="file"
+                data-testid="photo-upload-input"
                 accept="image/jpeg,image/png,image/webp"
                 multiple
                 [disabled]="isLoading() || isSaving()"
@@ -102,6 +116,7 @@
           <button
             type="button"
             class="btn-dashed create-btn"
+            data-testid="create-recipe-btn"
             [disabled]="isLoading() || isSaving() || extractedRecipe()"
             (click)="onCreateManually()"
           >


### PR DESCRIPTION
Closes part of #342 (cluster A — selector drift, 10 of the broken tests).

## Summary
Dashboard's import section was redesigned: collapsed by default, with URL / photo / manual-create flows behind an \`import-toggle\`. The 10 broken \`dashboard/import-recipe\` tests still expected a flat layout with \`.photo-upload-btn\`, direct \`#url\` access, and a \`capture="environment"\` attribute on the file input that no longer exists.

## Changes
- \`data-testid\` on \`import-toggle\` (with \`data-expanded\` mirror), \`photo-upload-btn\`, \`photo-upload-input\`, \`create-recipe-btn\`.
- \`DashboardPage.goto()\` now auto-expands the import section; added \`expandImportSection()\` helper.
- Page-object selectors switched to data-testid.
- Dropped the obsolete capture-attribute test — that flow moved to a dedicated "Scan with camera" button gated on browser camera support (not present in headless Chromium).

## Test plan
- [x] shell unit tests green locally
- [ ] dashboard/import-recipe drops from 10 broken