### PR TITLE
fix(frontend): provide recipes/shopping Transloco scopes at route level (#342)

### DIFF
--- a/client/apps/recipes/src/app/recipes.routes.ts
+++ b/client/apps/recipes/src/app/recipes.routes.ts
@@ -1,26 +1,37 @@
 import { Route } from '@angular/router';
+import { provideTranslocoScope } from '@jsverse/transloco';
+
+// Native federation only loads the routes export, not the MFE's app.config.
+// Register the Transloco scope at the route level so recipes.* keys resolve
+// whether the app runs standalone or as a federated remote (mirrors the
+// account fix in #343 / account.routes.ts).
+const RECIPES_SCOPE_PROVIDERS = [provideTranslocoScope('recipes')];
 
 export const recipesRoutes: Route[] = [
   {
     path: ':identifier/edit',
     title: 'Edit Recipe — Yumney',
+    providers: RECIPES_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./recipe-edit/recipe-edit.component').then((m) => m.RecipeEditComponent),
   },
   {
     path: ':identifier/cook',
     title: 'Cook Mode — Yumney',
+    providers: RECIPES_SCOPE_PROVIDERS,
     loadComponent: () => import('./cook-mode/cook-mode.component').then((m) => m.CookModeComponent),
   },
   {
     path: ':identifier',
     title: 'Recipe — Yumney',
+    providers: RECIPES_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./recipe-detail/recipe-detail.component').then((m) => m.RecipeDetailComponent),
   },
   {
     path: '',
     title: 'My Recipes — Yumney',
+    providers: RECIPES_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./recipe-list/recipe-list.component').then((m) => m.RecipeListComponent),
   },

--- a/client/apps/shell-e2e/src/shopping/merged-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/merged-list.spec.ts
@@ -6,7 +6,9 @@ test.describe('Merged Shopping List (US-312-318)', () => {
   test('should display the shopping page', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping');
 
-    await expect(authenticatedPage.locator('.merged-list, .empty-state, .loading')).toBeVisible({
+    await expect(
+      authenticatedPage.locator('.merged-list, .empty-state, .loading').first(),
+    ).toBeVisible({
       timeout: TIMEOUTS.default,
     });
   });

--- a/client/apps/shopping/src/app/shopping.routes.ts
+++ b/client/apps/shopping/src/app/shopping.routes.ts
@@ -1,27 +1,38 @@
 import { Route } from '@angular/router';
+import { provideTranslocoScope } from '@jsverse/transloco';
+
+// Native federation only loads the routes export, not the MFE's app.config.
+// Register the Transloco scope at the route level so shopping.* keys
+// resolve whether the app runs standalone or as a federated remote
+// (mirrors the account fix in #343 / account.routes.ts).
+const SHOPPING_SCOPE_PROVIDERS = [provideTranslocoScope('shopping')];
 
 export const shoppingRoutes: Route[] = [
   {
     path: 'create/:recipeIdentifier',
     title: 'Create Shopping List — Yumney',
+    providers: SHOPPING_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./shopping-create/shopping-create.component').then((m) => m.ShoppingCreateComponent),
   },
   {
     path: 'lists/:identifier',
     title: 'Shopping List — Yumney',
+    providers: SHOPPING_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./shopping-detail/shopping-detail.component').then((m) => m.ShoppingDetailComponent),
   },
   {
     path: 'lists',
     title: 'Shopping Lists — Yumney',
+    providers: SHOPPING_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./shopping-list/shopping-list.component').then((m) => m.ShoppingListComponent),
   },
   {
     path: '',
     title: 'Shopping — Yumney',
+    providers: SHOPPING_SCOPE_PROVIDERS,
     loadComponent: () =>
       import('./merged-list/merged-list.component').then((m) => m.MergedListComponent),
   },


### PR DESCRIPTION
Mirror of the account scope fix in #343 for the other two federated MFEs.

## Problem
Native federation only loads each MFE's \`routes\` export — not its \`app.config\` providers. So \`provideTranslocoScope('recipes')\` / \`provideTranslocoScope('shopping')\` never ran when those MFEs were federated by the shell.

In the post-#353 E2E run, \`shopping/merged-list\` page snapshots showed literal i18n keys like \`shopping.title\` / \`shopping.loading\` rendered as plain text. Same root cause as #343 fixed for account.

## Changes
- Move \`provideTranslocoScope('shopping')\` from the MFE's \`app.config\` to a route-level providers array (covers all 4 routes).
- Same for \`provideTranslocoScope('recipes')\` (covers all 4 routes).
- Fix a strict-mode violation in \`merged-list.spec.ts > should display the shopping page\` where the OR-locator \`.merged-list, .empty-state, .loading\` matches two elements during loading — add \`.first()\`.

## Test plan
- [ ] Shopping/recipes pages render translated text under E2E
- [ ] Some of merged-list 3F clears (the strict-mode one definitely; others depend on whether the API path also works)