### PR TITLE
test(e2e): skip PWA service-worker tests in dev mode (#342)

### DIFF
--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '@playwright/test';
 import { setupKeycloakMock, waitForServiceWorker } from '../helpers/pwa.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
-test.describe('Offline Caching', () => {
+// Angular registers the service worker only in production builds
+// (provideServiceWorker enabled: !isDevMode()). E2E runs against
+// `nx serve shell` in dev mode, so the SW never installs and these tests
+// hang in beforeEach. Skip the suite until a prod-build E2E mode exists.
+test.describe.skip('Offline Caching', () => {
   test.beforeEach(async ({ page }) => {
     await setupKeycloakMock(page);
     await page.goto('/', { waitUntil: 'networkidle' });

--- a/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
@@ -39,7 +39,12 @@ test.describe('PWA Installation', () => {
     expect(icon512?.status()).toBe(200);
   });
 
-  test('should register a service worker', async ({ page }) => {
+  // Angular's provideServiceWorker is configured with `enabled: !isDevMode()`.
+  // The E2E suite runs against `nx serve shell` (dev mode), so no SW registers
+  // and this test can never pass against the dev pipeline. Either run against
+  // a built-and-served bundle or keep this skipped — the manifest/icons tests
+  // above already cover the static-asset side of PWA-readiness.
+  test.skip('should register a service worker', async ({ page }) => {
     await page.route('**/realms/**', (route) => route.abort());
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 


### PR DESCRIPTION
The PWA install \`should register a service worker\` and the entire \`Offline Caching\` describe require an active service worker. Angular's \`provideServiceWorker\` is configured with \`enabled: !isDevMode()\`, so the SW only installs against a production build. The E2E job runs \`nx serve shell\` in dev mode → SW never registers, both tests blocked.

## Changes
- \`pwa-install.spec.ts\`: skip \`should register a service worker\` test, keep manifest/icon/theme-color tests.
- \`offline.spec.ts\`: skip whole describe at the suite level — beforeEach's waitForServiceWorker hits 40s timeout, cascading every test to error.

## Follow-up
A future PR could spin up a prod-build serve (\`nx serve-static\` against \`dist/apps/shell\`) for a separate E2E run that exercises the SW path.

## Test plan
- [ ] pwa/pwa-install drops 1F → 0
- [ ] pwa/offline drops 2E → 0