### PR TITLE
test(e2e): bump default toBeVisible timeout 10s → 25s

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   // is eaten by the `page.goto('/')` that scopes localStorage to the origin
   // plus concurrent Angular bootstrap on the shared dev server.
   timeout: 60_000,
-  expect: { timeout: 10_000 },
+  // 25s mirrors TIMEOUTS.default — covers MFE federation cold-start on
+  // first visits in dev mode (see helpers/timeouts.ts).
+  expect: { timeout: 25_000 },
   // On CI: retry once (not twice) — each retry on a 30s-timeout test can cost
   // a minute on top of the original. Transient flakes still get a second
   // chance; systemic failures fail faster.

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -32,10 +32,13 @@ export function uniqueTitle(prefix: string): string {
 export async function openAuthenticatedPage(browser: Browser): Promise<Page> {
   const context = await browser.newContext({ storageState: STORAGE_STATE_PATH });
   const page = await context.newPage();
-  // Navigate to the app so the page is on-origin — createTestRecipe uses
-  // relative-URL fetches against the gateway and needs localStorage tokens
-  // in scope.
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  // Navigate to a tiny static asset on the :4200 origin so the page is
+  // on-origin (createTestRecipe reads access_token from localStorage and
+  // does relative fetches against the gateway). Avoids the 5–10s federation
+  // cold-start that `page.goto('/')` triggers in dev mode — beforeAll hooks
+  // were timing out at 60s when 30s+ was burned on Angular bootstrap before
+  // a single API call could fire.
+  await page.goto('/assets/config/app-config.json', { waitUntil: 'domcontentloaded' });
   return page;
 }
 

--- a/client/apps/shell-e2e/src/helpers/timeouts.ts
+++ b/client/apps/shell-e2e/src/helpers/timeouts.ts
@@ -1,6 +1,19 @@
+// Centralised waits for E2E.
+//
+// The `default` timeout was raised 10s → 25s after diagnosing the
+// profile-settings cluster: each test gets a fresh browser context, and on
+// first visit to a federated MFE route (account/recipes/shopping) the
+// browser has to fetch the remoteEntry, the route bundle and any deps
+// from the MFE's own Vite dev server before the component constructs and
+// triggers its first API call. In dev mode that whole chain regularly
+// takes 5–10s on top of the 1–2s API request itself, so a 10s
+// toBeVisible was racing the cold-start of the MFE.
+//
+// `long` covers chains where a UI action triggers a backend write that
+// then has to round-trip through projections / event handlers.
 export const TIMEOUTS = {
   short: 5_000,
-  default: 10_000,
-  long: 15_000,
-  veryLong: 30_000,
+  default: 25_000,
+  long: 35_000,
+  veryLong: 60_000,
 } as const;


### PR DESCRIPTION
Local-DevTools follow-up promised on #340.

## Diagnosis (via extracted Playwright trace.zip)
- Interceptor **is** rewriting \`/api\` → \`http://localhost:5100\` correctly.
- Authorization header is present, JWT shape is fine (\`aud: yumney-api\`).
- Each test gets a fresh browser context (Playwright default), and on first visit to a federated MFE route the browser has to fetch the remoteEntry + route bundle + deps from the MFE's own Vite dev server before the component constructs and triggers the first API call.
- In dev mode that chain regularly takes 5–10s.
- Trace shows the profile fetch firing ~900ms after \`toBeVisible\` starts, then the response not arriving inside the 10s window.

The 1.8s warmup curl bypasses the federation/Angular layer entirely, which is why API endpoints look fast from CI but slow from the browser.

## Fix
- \`TIMEOUTS.default\`: 10s → 25s
- Playwright global \`expect.timeout\`: 10s → 25s
- \`long\` and \`veryLong\` bumped proportionally so cascade waits don't undershoot the new default.

## Test plan
- [ ] account/profile-settings 6F clears
- [ ] recipes (recipe-detail/favorite/tags/chat/list) cluster drops
- [ ] shopping (merged-list/shopping-list/mode) drops
- [ ] auth (register/login/resend-verification) drops