### PR TITLE
fix(gateway): YARP CORS policy + gate HttpsRedirect to prod (#340 real root)

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -15,18 +15,24 @@ builder.Services.AddResponseCompression(options =>
 builder.Services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Fastest);
 builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.SmallestSize);
 
+// Register the same policy under both the default slot (so app.UseCors()
+// applies it globally) and a named "default" slot (so YARP routes can
+// reference it via "CorsPolicy": "default" — without that, OPTIONS
+// preflights are forwarded to upstream APIs and the browser sees
+// "Failed to fetch").
 builder.Services.AddCors(options =>
 {
-	options.AddDefaultPolicy(policy =>
-	{
-		var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-			?? ["http://localhost:4200"];
+	var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+		?? ["http://localhost:4200"];
 
+	void Configure(Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder policy) =>
 		policy.WithOrigins(allowedOrigins)
 			.AllowAnyMethod()
 			.AllowAnyHeader()
 			.AllowCredentials();
-	});
+
+	options.AddDefaultPolicy(Configure);
+	options.AddPolicy("default", Configure);
 });
 
 builder.Services.AddReverseProxy()
@@ -38,11 +44,14 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
 	app.UseHsts();
+	app.UseHttpsRedirection();
 }
 
-app.UseHttpsRedirection();
-app.UseResponseCompression();
+// CORS must run BEFORE the reverse proxy so OPTIONS preflight short-circuits
+// here instead of being forwarded upstream (where most APIs return 405 and
+// the browser then blocks the actual request with "Failed to fetch").
 app.UseCors();
+app.UseResponseCompression();
 
 app.MapDefaultEndpoints()
 	.MapReverseProxy();

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -13,36 +13,42 @@
     "Routes": {
       "recipes-route": {
         "ClusterId": "recipes-api",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/recipes/{**remainder}"
         }
       },
       "shopping-route": {
         "ClusterId": "shopping-api",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/shopping-lists/{**remainder}"
         }
       },
       "users-auth-route": {
         "ClusterId": "users-api",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/auth/{**remainder}"
         }
       },
       "users-me-route": {
         "ClusterId": "users-api",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/users/{**remainder}"
         }
       },
       "mealplan-route": {
         "ClusterId": "mealplan-api",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
       "keycloak-route": {
         "ClusterId": "keycloak",
+        "CorsPolicy": "default",
         "Match": {
           "Path": "/realms/{**remainder}"
         }


### PR DESCRIPTION
**This is the actual root cause** behind the profile-settings / recipe-detail / shopping clusters.

## Diagnosis (from Playwright trace.zip)
- Browser threw \`TypeError: Failed to fetch\` synchronously
- Network log: status -1 on profile request
- Pattern is classic CORS preflight failure
- Warmup curl from CI worked because curl doesn't issue an OPTIONS preflight

## Fixes

### 1. YARP routes need explicit \`CorsPolicy\`
\`AddDefaultPolicy\` only applies via \`UseCors()\` middleware on routes with no explicit endpoint metadata. YARP doesn't pick up the default policy automatically — \`OPTIONS\` preflights were being forwarded to upstream APIs (which return 405) and the browser blocked the subsequent \`GET\`.

- Register the policy under a named slot \`"default"\` in addition to the default slot.
- Add \`"CorsPolicy": "default"\` to every YARP route.

### 2. Gate \`UseHttpsRedirection()\` behind production
The dev gateway listens on HTTP only. With redirection enabled, cross-origin requests can hit a 307 → HTTPS that doesn't exist, surfacing as another \`Failed to fetch\`. Move the redirect behind \`!IsDevelopment()\` and prepend \`UseCors\` for cleaner ordering.

## Why all the prior PRs still mattered
- #338 (JIT-provision) creates the row when missing
- #343/#346 (Transloco scope + interceptor) get the URL right
- #349 (YARP route for \`/api/v1/users/*\`) makes the path resolvable
- #350 (warmup) cuts the cold-start tail
- **This PR** unblocks the OPTIONS preflight that was silently killing every cross-origin call

## Test plan
- [ ] profile-settings 6F drops to 0
- [ ] recipe-detail/favorite/tags/chat clusters drop
- [ ] shopping-list / merged-list / mode drop
- [ ] auth/register / login drop