### PR TITLE
revert(gateway): YARP CORS changes broke the gateway entirely

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -15,24 +15,18 @@ builder.Services.AddResponseCompression(options =>
 builder.Services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Fastest);
 builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.SmallestSize);
 
-// Register the same policy under both the default slot (so app.UseCors()
-// applies it globally) and a named "default" slot (so YARP routes can
-// reference it via "CorsPolicy": "default" — without that, OPTIONS
-// preflights are forwarded to upstream APIs and the browser sees
-// "Failed to fetch").
 builder.Services.AddCors(options =>
 {
-	var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-		?? ["http://localhost:4200"];
+	options.AddDefaultPolicy(policy =>
+	{
+		var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+			?? ["http://localhost:4200"];
 
-	void Configure(Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder policy) =>
 		policy.WithOrigins(allowedOrigins)
 			.AllowAnyMethod()
 			.AllowAnyHeader()
 			.AllowCredentials();
-
-	options.AddDefaultPolicy(Configure);
-	options.AddPolicy("default", Configure);
+	});
 });
 
 builder.Services.AddReverseProxy()
@@ -44,14 +38,11 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
 	app.UseHsts();
-	app.UseHttpsRedirection();
 }
 
-// CORS must run BEFORE the reverse proxy so OPTIONS preflight short-circuits
-// here instead of being forwarded upstream (where most APIs return 405 and
-// the browser then blocks the actual request with "Failed to fetch").
-app.UseCors();
+app.UseHttpsRedirection();
 app.UseResponseCompression();
+app.UseCors();
 
 app.MapDefaultEndpoints()
 	.MapReverseProxy();

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -13,42 +13,36 @@
     "Routes": {
       "recipes-route": {
         "ClusterId": "recipes-api",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/recipes/{**remainder}"
         }
       },
       "shopping-route": {
         "ClusterId": "shopping-api",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/shopping-lists/{**remainder}"
         }
       },
       "users-auth-route": {
         "ClusterId": "users-api",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/auth/{**remainder}"
         }
       },
       "users-me-route": {
         "ClusterId": "users-api",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/users/{**remainder}"
         }
       },
       "mealplan-route": {
         "ClusterId": "mealplan-api",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
       "keycloak-route": {
         "ClusterId": "keycloak",
-        "CorsPolicy": "default",
         "Match": {
           "Path": "/realms/{**remainder}"
         }


### PR DESCRIPTION
PR #357 broke the gateway — curl warmup (which doesn't even trigger CORS) now times out at 60s with status=000 across all endpoints. Reverting to restore the working state.

The CORS preflight diagnosis from the trace was correct, but the fix needs more thought — adding `CorsPolicy` on YARP routes plus reordering middleware caused the gateway to stop responding entirely. Will retry with a more surgical change once we understand what specifically broke.