### PR TITLE
fix(gateway): add named CORS policy for YARP routes (minimal retry of #357)

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -17,16 +17,22 @@ builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Le
 
 builder.Services.AddCors(options =>
 {
-	options.AddDefaultPolicy(policy =>
-	{
-		var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-			?? ["http://localhost:4200"];
+	var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+		?? ["http://localhost:4200"];
 
+	void Configure(Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder policy) =>
 		policy.WithOrigins(allowedOrigins)
 			.AllowAnyMethod()
 			.AllowAnyHeader()
 			.AllowCredentials();
-	});
+
+	options.AddDefaultPolicy(Configure);
+
+	// YARP routes reference policies by name via "CorsPolicy" config — without
+	// a named registration, browser preflights fall through to the upstream
+	// API where most endpoints return 405 and the browser blocks the actual
+	// request with "TypeError: Failed to fetch". Mirrors the default policy.
+	options.AddPolicy("Default", Configure);
 });
 
 builder.Services.AddReverseProxy()

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -13,36 +13,42 @@
     "Routes": {
       "recipes-route": {
         "ClusterId": "recipes-api",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/recipes/{**remainder}"
         }
       },
       "shopping-route": {
         "ClusterId": "shopping-api",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/shopping-lists/{**remainder}"
         }
       },
       "users-auth-route": {
         "ClusterId": "users-api",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/auth/{**remainder}"
         }
       },
       "users-me-route": {
         "ClusterId": "users-api",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/users/{**remainder}"
         }
       },
       "mealplan-route": {
         "ClusterId": "mealplan-api",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
       "keycloak-route": {
         "ClusterId": "keycloak",
+        "CorsPolicy": "Default",
         "Match": {
           "Path": "/realms/{**remainder}"
         }


### PR DESCRIPTION
Surgical retry of #357 which broke the gateway entirely.

## What changed (minimal)
- Add a named CORS policy \`Default\` alongside the existing default-slot registration.
- Add \`"CorsPolicy": "Default"\` to each YARP route.

## What did NOT change
- Middleware ordering: \`UseHttpsRedirection\` → \`UseResponseCompression\` → \`UseCors\` → \`MapReverseProxy\` (unchanged).
- \`UseHttpsRedirection()\` still called in dev (not gated to prod).

This isolates the CORS-related piece from the middleware reordering / HTTPS-redirect change in #357 — one of those broke the gateway so curl warmup hung at 60s. With only the YARP CorsPolicy change, we test whether named-policy registration alone is enough to handle browser preflight.

## Diagnosis still standing
From the Playwright trace.zip (post-#356):
- Browser threw \`TypeError: Failed to fetch\` synchronously
- Network log: status -1 on profile request
- Curl warmup works because curl doesn't issue OPTIONS preflight

## Test plan
- [ ] curl warmup still works (no regression)
- [ ] profile-settings 6F drops
- [ ] recipe/shopping clusters drop