### PR TITLE
test(e2e): replace hardcoded 10s timeouts with TIMEOUTS.default

### DIFF
--- a/client/apps/shell-e2e/src/auth/resend-verification.spec.ts
+++ b/client/apps/shell-e2e/src/auth/resend-verification.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { ResendVerificationPage } from '../pages/resend-verification.page';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 // Pre-authentication flow — reset the storage state planted by auth.setup.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -39,7 +40,7 @@ test.describe('Resend Verification Page', () => {
     await resendPage.emailInput.fill('test@yumney.dev');
     await resendPage.submitButton.click();
 
-    await expect(resendPage.successHeading).toBeVisible({ timeout: 10_000 });
+    await expect(resendPage.successHeading).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
   test('should have back to registration link', async ({ page }) => {

--- a/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeListPage } from '../pages/recipe-list.page';
+import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe List (US-030, US-034)', () => {
   let recipeList: RecipeListPage;
@@ -23,27 +24,27 @@ test.describe('Recipe List (US-030, US-034)', () => {
     const cards = recipeList.recipeCards;
     const empty = recipeList.emptyState;
 
-    await expect(cards.or(empty).first()).toBeVisible({ timeout: 10_000 });
+    await expect(cards.or(empty).first()).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
   test('should show no results for gibberish search', async ({ authenticatedPage }) => {
     await recipeList.searchInput.fill('xyznonexistent12345');
     await authenticatedPage.waitForTimeout(500); // debounce
 
-    await expect(recipeList.emptyState).toBeVisible({ timeout: 10_000 });
+    await expect(recipeList.emptyState).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
   test('should clear search and restore results', async ({ authenticatedPage }) => {
     await recipeList.searchInput.fill('xyznonexistent12345');
     await authenticatedPage.waitForTimeout(500);
-    await expect(recipeList.emptyState).toBeVisible({ timeout: 10_000 });
+    await expect(recipeList.emptyState).toBeVisible({ timeout: TIMEOUTS.default });
 
     await recipeList.searchClearButton.click();
 
     // Either cards or original empty state should reappear
     const cards = recipeList.recipeCards;
     const empty = recipeList.emptyState;
-    await expect(cards.or(empty).first()).toBeVisible({ timeout: 10_000 });
+    await expect(cards.or(empty).first()).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
   test('should navigate to recipe detail on card click', async ({ authenticatedPage }) => {


### PR DESCRIPTION
\`#356\` bumped the default \`toBeVisible\` timeout from 10s to 25s to cover MFE federation cold-start. But two specs still had \`timeout: 10_000\` hardcoded inline — those overrode the global default and continued to time out at 10s, contributing to the recipe-list and resend-verification failures.

## Changes
- \`recipes/recipe-list.spec.ts\` — 4 sites
- \`auth/resend-verification.spec.ts\` — 1 site

Replace with \`TIMEOUTS.default\` so the global bump applies. No other changes.

## Test plan
- [ ] recipes/recipe-list 3F drops (or at least decreases)
- [ ] auth/resend-verification 1F drops