### PR TITLE
revert(gateway): YARP CorsPolicy still breaks gateway (v2)

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -17,22 +17,16 @@ builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Le
 
 builder.Services.AddCors(options =>
 {
-	var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-		?? ["http://localhost:4200"];
+	options.AddDefaultPolicy(policy =>
+	{
+		var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+			?? ["http://localhost:4200"];
 
-	void Configure(Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder policy) =>
 		policy.WithOrigins(allowedOrigins)
 			.AllowAnyMethod()
 			.AllowAnyHeader()
 			.AllowCredentials();
-
-	options.AddDefaultPolicy(Configure);
-
-	// YARP routes reference policies by name via "CorsPolicy" config — without
-	// a named registration, browser preflights fall through to the upstream
-	// API where most endpoints return 405 and the browser blocks the actual
-	// request with "TypeError: Failed to fetch". Mirrors the default policy.
-	options.AddPolicy("Default", Configure);
+	});
 });
 
 builder.Services.AddReverseProxy()

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -13,42 +13,36 @@
     "Routes": {
       "recipes-route": {
         "ClusterId": "recipes-api",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/recipes/{**remainder}"
         }
       },
       "shopping-route": {
         "ClusterId": "shopping-api",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/shopping-lists/{**remainder}"
         }
       },
       "users-auth-route": {
         "ClusterId": "users-api",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/auth/{**remainder}"
         }
       },
       "users-me-route": {
         "ClusterId": "users-api",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/users/{**remainder}"
         }
       },
       "mealplan-route": {
         "ClusterId": "mealplan-api",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
       "keycloak-route": {
         "ClusterId": "keycloak",
-        "CorsPolicy": "Default",
         "Match": {
           "Path": "/realms/{**remainder}"
         }


### PR DESCRIPTION
Even the minimal CORS retry in #359 (just adding named policy + CorsPolicy on YARP routes, no middleware reordering) hangs the gateway with status=000 on warmup.

Conclusion: YARP's `CorsPolicy` route metadata is doing something that breaks routing entirely in our setup, regardless of middleware ordering. The fix needs different approach — possibly per-route OPTIONS handling registered before YARP, or a custom middleware that handles preflight outside the YARP route table.

Reverting to restore the working 27-broken baseline.