### PR TITLE
fix(gateway): manual CORS preflight middleware (sidesteps YARP CorsPolicy)

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -44,6 +44,45 @@ app.UseHttpsRedirection();
 app.UseResponseCompression();
 app.UseCors();
 
+// Manual CORS preflight handling for YARP routes.
+//
+// `UseCors()` only handles OPTIONS preflight when the matched endpoint has
+// CORS metadata. YARP routes don't carry that metadata by default, and our
+// experiments wiring `CorsPolicy` into YARP route config (#357 v1, #359 v2)
+// crashed the gateway at startup. So we handle preflight ourselves before
+// `MapReverseProxy` ever sees the request: respond 204 with the right
+// Access-Control-* headers when the origin matches our allow-list.
+//
+// Curl warmup is unaffected — those requests have no `Origin` header, so
+// this middleware is a no-op for them.
+var corsAllowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+	?? ["http://localhost:4200"];
+
+app.Use(async (context, next) =>
+{
+	var origin = context.Request.Headers.Origin.ToString();
+	if (!string.IsNullOrEmpty(origin) && corsAllowedOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase))
+	{
+		context.Response.Headers["Access-Control-Allow-Origin"] = origin;
+		context.Response.Headers["Access-Control-Allow-Credentials"] = "true";
+		context.Response.Headers.Append("Vary", "Origin");
+
+		if (HttpMethods.IsOptions(context.Request.Method))
+		{
+			context.Response.Headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, PATCH, OPTIONS";
+			var requestHeaders = context.Request.Headers["Access-Control-Request-Headers"].ToString();
+			context.Response.Headers["Access-Control-Allow-Headers"] = string.IsNullOrEmpty(requestHeaders)
+				? "*"
+				: requestHeaders;
+			context.Response.Headers["Access-Control-Max-Age"] = "600";
+			context.Response.StatusCode = StatusCodes.Status204NoContent;
+			return;
+		}
+	}
+
+	await next();
+});
+
 app.MapDefaultEndpoints()
 	.MapReverseProxy();
 


### PR DESCRIPTION
Third attempt at fixing the CORS preflight blocker — this time without touching YARP's \`CorsPolicy\` config (which crashed the gateway at startup in #357 + #359, both reverted).

## Why YARP CorsPolicy keeps crashing
The Aspire describe output showed \`yumney-gateway: Finished\` after both attempts — the gateway crashed at startup, which is why curl warmup hung at \`status=000\`. We don't have stdout from the project process so the exact exception isn't recoverable from CI artifacts.

## What this does instead
Adds a small middleware **before** \`MapReverseProxy\` that handles the OPTIONS preflight directly:
- Inspects the \`Origin\` header against the configured allow-list
- For OPTIONS: returns 204 with \`Access-Control-Allow-*\` headers
- For other methods: appends \`Allow-Origin\` / \`Allow-Credentials\` / \`Vary\` and falls through

\`UseCors()\` stays in place — it's harmless for non-CORS paths and acts as a fallback for any in-process endpoints that get CORS metadata via \`[EnableCors]\`.

Curl warmup is unaffected because curl doesn't send \`Origin\`.

## Diagnosis (from #356 trace.zip)
- Browser: \`TypeError: Failed to fetch\` synchronously
- Network log: status -1
- Curl warmup: 200 OK in 1.8s
- Classic CORS preflight failure pattern

## Test plan
- [ ] curl warmup still 200 (gateway alive, no startup crash)
- [ ] profile-settings 6F drops
- [ ] recipe-detail / favorite / tags / chat / list clusters drop
- [ ] shopping-list / merged-list / mode drops
- [ ] auth/register / login / resend-verification drops