### PR TITLE
test(e2e): bump timeouts to cover Vite dev-server slowness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
       # mailpit, and the LLM provider setup, so fewer containers need to come up.

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
   // started exceeding 30s. The real API calls themselves are ~1s; the budget
   // is eaten by the `page.goto('/')` that scopes localStorage to the origin
   // plus concurrent Angular bootstrap on the shared dev server.
-  timeout: 60_000,
-  // 25s mirrors TIMEOUTS.default — covers MFE federation cold-start on
-  // first visits in dev mode (see helpers/timeouts.ts).
-  expect: { timeout: 25_000 },
+  timeout: 90_000,
+  // 45s mirrors TIMEOUTS.default — covers MFE federation cold-start under
+  // parallel worker pressure (see helpers/timeouts.ts).
+  expect: { timeout: 45_000 },
   // On CI: retry once (not twice) — each retry on a 30s-timeout test can cost
   // a minute on top of the original. Transient flakes still get a second
   // chance; systemic failures fail faster.

--- a/client/apps/shell-e2e/src/helpers/timeouts.ts
+++ b/client/apps/shell-e2e/src/helpers/timeouts.ts
@@ -1,19 +1,17 @@
 // Centralised waits for E2E.
 //
-// The `default` timeout was raised 10s → 25s after diagnosing the
-// profile-settings cluster: each test gets a fresh browser context, and on
-// first visit to a federated MFE route (account/recipes/shopping) the
-// browser has to fetch the remoteEntry, the route bundle and any deps
-// from the MFE's own Vite dev server before the component constructs and
-// triggers its first API call. In dev mode that whole chain regularly
-// takes 5–10s on top of the 1–2s API request itself, so a 10s
-// toBeVisible was racing the cold-start of the MFE.
+// `default` is intentionally generous because we run against `nx serve shell`
+// in dev mode. On a fresh browser context, the first navigation to a federated
+// MFE route (account / recipes / shopping) triggers Vite to compile and serve
+// the remoteEntry, the route bundle, every shared dep, plus the @vite/client
+// HMR runtime — all on demand. Under parallel-worker pressure that easily
+// stretches past the 10s most assertions used to allow.
 //
-// `long` covers chains where a UI action triggers a backend write that
-// then has to round-trip through projections / event handlers.
+// `long` covers UI flows that trigger a backend write that round-trips through
+// projections / event handlers before the result is visible.
 export const TIMEOUTS = {
   short: 5_000,
-  default: 25_000,
-  long: 35_000,
-  veryLong: 60_000,
+  default: 45_000,
+  long: 60_000,
+  veryLong: 90_000,
 } as const;


### PR DESCRIPTION
Local trace from #362 confirmed the gateway is healthy (warmup curl 200 in 1.8s; manual CORS preflight middleware in place) but the browser path takes much longer than 25s on first MFE navigation in a fresh context — Vite serves every module on demand, and each parallel worker hits the dev server independently.

## Bumps
| | Before | After |
|---|---|---|
| \`TIMEOUTS.default\` | 25s | 45s |
| \`TIMEOUTS.long\` | 35s | 60s |
| \`TIMEOUTS.veryLong\` | 60s | 90s |
| Playwright \`timeout\` | 60s | 90s |
| Playwright \`expect.timeout\` | 25s | 45s |
| Workflow \`timeout-minutes\` | 45 | 60 |

If 45s isn't enough either, the right fix is switching the E2E job to a production build via \`nx serve-static\` against \`dist/apps/shell\` (no Vite dev server in the loop).

## Test plan
- [ ] profile-settings 6F drops
- [ ] recipe / shopping clusters drop