### PR TITLE
fix(e2e): serve pre-built bundle in E2E mode (no Vite dev-server)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,6 +106,14 @@ jobs:
       - name: Build solution (including AppHost)
         run: dotnet build Yumney.slnx --no-restore
 
+      - name: Build frontend bundle for E2E
+        # Pre-build all MFEs and merge them into dist/apps/shell/browser so
+        # the AppHost can serve a single static bundle in E2E mode (see
+        # serve:shell:dist). Avoids the per-test Vite dev-server cold-start
+        # that made browser-side API calls time out (#356–#363).
+        working-directory: client
+        run: yarn build:all
+
       - name: Start Aspire AppHost
         run: |
           aspire start --apphost src/Yumney.AppHost/Yumney.AppHost.csproj 2>&1 | tee /tmp/aspire.log

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "serve:shopping": "nx serve shopping",
     "serve:account": "nx serve account",
     "serve:all": "nx run-many --target=serve --projects=shell,recipes,shopping,account --parallel=4",
+    "serve:shell:dist": "node scripts/serve-shell-dist.mjs",
     "generate:validation": "node scripts/generate-validation-constants.mjs",
     "generate:api-types": "node scripts/generate-api-types.mjs",
     "build:all": "node scripts/generate-validation-constants.mjs && nx run-many --target=build --projects=shell,recipes,shopping,account --parallel=4 && node scripts/copy-remotes.mjs",

--- a/client/scripts/serve-shell-dist.mjs
+++ b/client/scripts/serve-shell-dist.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Static-file server for the built shell bundle. Used by the E2E pipeline
+ * so Playwright doesn't run against `nx serve` (Vite dev server) which
+ * proved unreliable under parallel-worker pressure with on-demand module
+ * loading and federated MFEs. After `yarn build:all`, every MFE has been
+ * copied into `dist/apps/shell/browser/{name}` (see scripts/copy-remotes.mjs)
+ * so a single static root serves the whole app.
+ *
+ * Tiny zero-dep Node http server with SPA fallback to index.html.
+ */
+import { createServer } from 'node:http';
+import { createReadStream, statSync } from 'node:fs';
+import { join, dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', 'dist', 'apps', 'shell', 'browser');
+const PORT = Number(process.env.PORT ?? 4200);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+};
+
+function serveFile(res, path) {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return false;
+    res.writeHead(200, {
+      'Content-Type': MIME[extname(path).toLowerCase()] ?? 'application/octet-stream',
+      'Content-Length': stat.size,
+      'Cache-Control': 'no-cache',
+    });
+    createReadStream(path).pipe(res);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const server = createServer((req, res) => {
+  // Strip query string; reject path traversal.
+  let urlPath = (req.url ?? '/').split('?')[0];
+  if (urlPath.includes('..')) {
+    res.writeHead(400);
+    res.end('Bad Request');
+    return;
+  }
+  if (urlPath.endsWith('/')) urlPath += 'index.html';
+
+  const filePath = join(ROOT, urlPath);
+  if (serveFile(res, filePath)) return;
+
+  // SPA fallback: any path without a file extension falls back to index.html
+  // so client-side routes (e.g. /account, /recipes/:id) load the shell.
+  if (!extname(urlPath)) {
+    if (serveFile(res, join(ROOT, 'index.html'))) return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+});
+
+server.listen(PORT, () => {
+  console.log(`shell static server listening on http://localhost:${PORT} (root: ${ROOT})`);
+});

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -70,16 +70,23 @@ if (!options.DatabaseOnly)
 
 	if (isRunMode && !options.E2ETests)
 	{
-		redis.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
-		messaging.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
-		keycloak.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
+		redis
+			.WithLifetime(ContainerLifetime.Persistent)
+			.WithDataVolume();
+		messaging
+			.WithLifetime(ContainerLifetime.Persistent)
+			.WithDataVolume();
+		keycloak
+			.WithLifetime(ContainerLifetime.Persistent)
+			.WithDataVolume();
 	}
 
 	keycloak.WithRealmImport("Realms");
 
 	if (isRunMode && !options.E2ETests)
 	{
-		builder.AddContainer("mailpit", "axllent/mailpit", "v1.22")
+		builder
+			.AddContainer("mailpit", "axllent/mailpit", "v1.22")
 			.WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
 			.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
 			.WithLifetime(ContainerLifetime.Persistent);
@@ -188,9 +195,7 @@ if (!options.DatabaseOnly)
 	if (isRunMode)
 	{
 		// Run mode (including E2E) spawns the Angular dev servers and the gateway
-		// project so the full federated stack is reachable on localhost. The E2E
-		// flag above still toggles persistent volumes and optional sidecars
-		// (pgAdmin, mailpit); it doesn't affect whether the frontend is registered.
+		// project so the full federated stack is reachable on localhost.
 		var addMfe = (string name, string script, int port) =>
 			builder.AddJavaScriptApp(name, "../../client", script)
 				.WithYarn()
@@ -198,10 +203,23 @@ if (!options.DatabaseOnly)
 				.WithEnvironment("NX_ISOLATE_PLUGINS", "false")
 				.WithHttpEndpoint(targetPort: port);
 
-		var shell = addMfe("shell", "serve:shell", 4200);
-		var recipesMfe = addMfe("recipes-mfe", "serve:recipes", 4201);
-		var shoppingMfe = addMfe("shopping-mfe", "serve:shopping", 4202);
-		var accountMfe = addMfe("account-mfe", "serve:account", 4203);
+		// In E2E mode serve a pre-built bundle instead of `nx serve`. Vite dev
+		// mode + federated MFEs + fresh-Playwright-context-per-test produced
+		// unreliable MFE bundle loads under parallel pressure; every test
+		// paid the cold-start tax and timed out before API responses landed
+		// (see PRs #356–#363). The CI workflow runs `yarn build:all` upfront
+		// so dist/apps/shell/browser contains every MFE co-located, then a
+		// tiny static server hands it out — same shape production will see.
+		var shell = options.E2ETests
+			? addMfe("shell", "serve:shell:dist", 4200)
+			: addMfe("shell", "serve:shell", 4200);
+
+		if (!options.E2ETests)
+		{
+			addMfe("recipes-mfe", "serve:recipes", 4201);
+			addMfe("shopping-mfe", "serve:shopping", 4202);
+			addMfe("account-mfe", "serve:account", 4203);
+		}
 
 		builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
 			.WithHttpEndpoint(port: 5100)


### PR DESCRIPTION
**Structural fix for the remaining 27 E2E failures.**

## Root cause (proven)
Every Playwright test gets a fresh browser context, and the first navigation to a federated MFE route triggers Vite dev-server to compile and serve every module on demand. Under parallel worker pressure, the API call fires but the response doesn't land before the test window closes. We bumped timeouts up to 45s/90s in #363 — still 27 broken (#363 wall time +11 min wasted on timeouts).

## What this changes
1. **Workflow**: \`yarn build:all\` runs after the .NET build. This compiles every MFE and merges them into \`dist/apps/shell/browser/{name}\` (already wired by \`scripts/copy-remotes.mjs\`), plus swaps in the prod federation manifest.
2. **New \`serve:shell:dist\` script**: \`scripts/serve-shell-dist.mjs\` — tiny zero-dep Node http server on port 4200 with SPA fallback to \`index.html\`.
3. **AppHost**: when \`E2ETests=true\`, register only the static-served shell on 4200. Skip the per-MFE \`nx serve\` (recipes/shopping/account) — every MFE bundle is co-located inside the shell dist now.

Same shape production will see. No Vite, no per-context cold-start.

## Why prior CORS/timeout work stays
- #338, #343, #346, #349, #352, #354 are real fixes that production also needs.
- #362's manual CORS preflight middleware is harmless (no-op for non-Origin requests) and a defensive depth measure.
- #356/#363 timeout bumps still help if any test hits a real backend slow-path.

## Test plan
- [ ] curl warmup still 200 (gateway alive)
- [ ] profile-settings 6F clears
- [ ] recipe-detail / favorite / tags / chat clusters clear
- [ ] shopping-list / merged-list / mode clear
- [ ] auth/register / login / resend-verification clear
- [ ] Wall time roughly maintained or reduced (no Vite compile-on-demand)