### PR TITLE
debug(e2e): scope workflow to profile-settings only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -247,7 +247,9 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        run: npx nx e2e shell-e2e
+        # TEMP: scoped to profile-settings only while debugging the
+        # cross-origin fetch hang. Restore `npx nx e2e shell-e2e` after.
+        run: npx nx e2e shell-e2e -- src/account/profile-settings.spec.ts
         env:
           BASE_URL: http://localhost:4200
           GATEWAY_URL: http://localhost:5100


### PR DESCRIPTION
Temporary while diagnosing #340. Reduces E2E runtime from ~25 min to a few minutes per iteration so the probe in #366 yields actionable signal without waiting on the full suite. Revert to `npx nx e2e shell-e2e` after root cause is identified.