### PR TITLE
debug(e2e): route Playwright via gateway (same-origin)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -247,9 +247,17 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        run: npx nx e2e shell-e2e
+        # TEMP: scoped to profile-settings while validating same-origin
+        # routing via gateway. Revert to `npx nx e2e shell-e2e` after.
+        run: npx nx e2e shell-e2e -- src/account/profile-settings.spec.ts
         env:
-          BASE_URL: http://localhost:4200
+          # Route Playwright through the YARP gateway (same origin as APIs)
+          # to test the hypothesis that the cross-origin :4200→:5100 fetch
+          # is what's hanging in CI. Gateway's shell-route catches /dashboard
+          # etc. and proxies upstream to the shell dev server, while /api/*
+          # routes hit the API services. Browser sees everything as same
+          # origin → no CORS preflight, no cross-origin fetch quirks.
+          BASE_URL: http://localhost:5100
           GATEWAY_URL: http://localhost:5100
           E2E_TOKENS_FILE: /tmp/e2e-tokens.json
           CI: true


### PR DESCRIPTION
Last-mile diagnostic for #340. If the cross-origin :4200→:5100 hang is what's blocking the remaining 27 failures, routing Playwright through the gateway (where the shell-route proxies to the shell dev server AND /api/* routes to the APIs) makes everything same-origin.

Scoped to profile-settings only — should finish in ~5 min. If profile-settings turns green, we know the fix is to permanently route E2E via gateway.