### PR TITLE
debug(e2e): chromium --disable-web-security

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -247,7 +247,8 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        run: npx nx e2e shell-e2e
+        # TEMP scope while validating --disable-web-security hypothesis.
+        run: npx nx e2e shell-e2e -- src/account/profile-settings.spec.ts
         env:
           BASE_URL: http://localhost:4200
           GATEWAY_URL: http://localhost:5100

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -61,6 +61,13 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: 'src/.auth/user.json',
+        // DEBUG #340: --disable-web-security removes CORS / COEP / COOP /
+        // mixed-content checks. If browser-side security is what's hanging
+        // the cross-origin fetches in CI, this should unblock the suite.
+        // Will be reverted once we know whether security is the cause.
+        launchOptions: {
+          args: ['--disable-web-security', '--disable-site-isolation-trials'],
+        },
       },
       dependencies: ['setup'],
     },


### PR DESCRIPTION
Removes CORS/COEP/COOP/site-isolation. If profile-settings turns green, browser security was the cause and we configure it permanently. If it still fails, all browser-side theories are eliminated.