### PR TITLE
debug(gateway): log every request + drop integration tests from E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -240,9 +240,9 @@ jobs:
               "$endpoint"
           done
 
-      - name: Run backend integration tests
-        continue-on-error: true
-        run: dotnet test tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+      # Backend integration tests are exercised by the dedicated CI workflow
+      # (Backend Build + Test). Skipping here to keep the E2E run focused on
+      # browser-level coverage and reduce wall time.
 
       - name: Run Playwright e2e tests
         continue-on-error: true
@@ -271,6 +271,7 @@ jobs:
           path: |
             /tmp/aspire.log
             /tmp/diag/
+            /tmp/gateway-requests.log
           retention-days: 7
 
       - name: Upload Playwright report

--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -44,6 +44,32 @@ app.UseHttpsRedirection();
 app.UseResponseCompression();
 app.UseCors();
 
+// DEBUG #340: log every incoming request so the E2E workflow can upload it
+// as an artifact. Tells us whether the hung browser fetches actually reach
+// the gateway, get stuck inside YARP, or never arrive at all.
+const string debugLog = "/tmp/gateway-requests.log";
+app.Use(async (context, next) =>
+{
+	var ts = DateTime.UtcNow;
+	var origin = context.Request.Headers.Origin.ToString();
+	var method = context.Request.Method;
+	var path = context.Request.Path + context.Request.QueryString;
+	try
+	{
+		await File.AppendAllTextAsync(debugLog, $"{ts:HH:mm:ss.fff} >> {method} {path} Origin={origin}\n");
+	}
+	catch { }
+
+	await next();
+
+	try
+	{
+		var elapsed = (DateTime.UtcNow - ts).TotalMilliseconds;
+		await File.AppendAllTextAsync(debugLog, $"{DateTime.UtcNow:HH:mm:ss.fff} << {context.Response.StatusCode} {method} {path} ({elapsed:0}ms)\n");
+	}
+	catch { }
+});
+
 // Manual CORS preflight handling for YARP routes.
 //
 // `UseCors()` only handles OPTIONS preflight when the matched endpoint has


### PR DESCRIPTION
Two changes for #340 diagnostic + cycle-time:

1. Gateway logs every request method/path/origin + status to `/tmp/gateway-requests.log` (uploaded as artifact). Distinguishes whether hung browser fetches arrive at the gateway vs get stuck before it.
2. Drop backend integration tests from E2E pipeline — already covered in the Backend CI workflow, they were doubling wall time for no extra signal.