### PR TITLE
debug(gateway): improve gateway-request-log diagnostics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,7 @@ jobs:
       # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
       # mailpit, and the LLM provider setup, so fewer containers need to come up.
       E2ETests: 'true'
+      GATEWAY_REQUEST_LOG: /tmp/gateway-requests.log
       # Aspire parameters. Aspire reads Parameters__<Name> as the param value
       # (the "__" is the configuration section separator). Values are local to
       # this ephemeral runner — no production secrets involved.

--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -46,27 +46,29 @@ app.UseCors();
 
 // DEBUG #340: log every incoming request so the E2E workflow can upload it
 // as an artifact. Tells us whether the hung browser fetches actually reach
-// the gateway, get stuck inside YARP, or never arrive at all.
-const string debugLog = "/tmp/gateway-requests.log";
+// the gateway, get stuck inside YARP, or never arrive at all. Path is
+// configurable via env so the workflow places it where upload-artifact can
+// find it; defaults to /tmp on Linux.
+var debugLog = Environment.GetEnvironmentVariable("GATEWAY_REQUEST_LOG")
+	?? "/tmp/gateway-requests.log";
+Console.Error.WriteLine($"[debug] gateway-request-log: {debugLog}");
 app.Use(async (context, next) =>
 {
 	var ts = DateTime.UtcNow;
 	var origin = context.Request.Headers.Origin.ToString();
 	var method = context.Request.Method;
 	var path = context.Request.Path + context.Request.QueryString;
-	try
-	{
-		await File.AppendAllTextAsync(debugLog, $"{ts:HH:mm:ss.fff} >> {method} {path} Origin={origin}\n");
-	}
-	catch { }
+	var startLine = $"{ts:HH:mm:ss.fff} >> {method} {path} Origin={origin}\n";
+	Console.Error.Write(startLine);
+	try { await File.AppendAllTextAsync(debugLog, startLine); }
+	catch (Exception ex) { Console.Error.WriteLine($"[debug] gateway-log write failed: {ex.Message}"); }
 
 	await next();
 
-	try
-	{
-		var elapsed = (DateTime.UtcNow - ts).TotalMilliseconds;
-		await File.AppendAllTextAsync(debugLog, $"{DateTime.UtcNow:HH:mm:ss.fff} << {context.Response.StatusCode} {method} {path} ({elapsed:0}ms)\n");
-	}
+	var elapsed = (DateTime.UtcNow - ts).TotalMilliseconds;
+	var endLine = $"{DateTime.UtcNow:HH:mm:ss.fff} << {context.Response.StatusCode} {method} {path} ({elapsed:0}ms)\n";
+	Console.Error.Write(endLine);
+	try { await File.AppendAllTextAsync(debugLog, endLine); }
 	catch { }
 });
 


### PR DESCRIPTION
Adds Console.Error logging and explicit catch error reporting to the gateway request log middleware so we can see WHY the file write fails (the previous run never produced gateway-requests.log).