### PR TITLE
fix(e2e): force chromium HTTP/1.1 — closes #340

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,6 @@ jobs:
       # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
       # mailpit, and the LLM provider setup, so fewer containers need to come up.
       E2ETests: 'true'
-      GATEWAY_REQUEST_LOG: /tmp/gateway-requests.log
       # Aspire parameters. Aspire reads Parameters__<Name> as the param value
       # (the "__" is the configuration section separator). Values are local to
       # this ephemeral runner — no production secrets involved.
@@ -248,8 +247,7 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        # TEMP scope while validating --disable-web-security hypothesis.
-        run: npx nx e2e shell-e2e -- src/account/profile-settings.spec.ts
+        run: npx nx e2e shell-e2e
         env:
           BASE_URL: http://localhost:4200
           GATEWAY_URL: http://localhost:5100
@@ -272,7 +270,6 @@ jobs:
           path: |
             /tmp/aspire.log
             /tmp/diag/
-            /tmp/gateway-requests.log
           retention-days: 7
 
       - name: Upload Playwright report

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -61,16 +61,15 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: 'src/.auth/user.json',
-        // DEBUG #340: gateway-requests.log proves browser GETs to :5100 never
-        // reach the gateway, while server-side calls (curl, page.evaluate) do.
-        // Headless Chromium negotiates HTTP/2 by default; Aspire's DCP proxy
-        // may not support it. Force HTTP/1.1 only to test that hypothesis.
+        // Force chromium to HTTP/1.1. Aspire's DCP localhost proxy doesn't
+        // round-trip HTTP/2 streams in our setup — browser-issued cross-origin
+        // fetches to the gateway silently failed when chromium negotiated h2,
+        // while curl/Playwright server-side fetches (HTTP/1.1 by default)
+        // worked. Confirmed by gateway request log: with --disable-http2 the
+        // GETs land and tests pass; without it, they never arrive. Keep this
+        // until DCP h2 support stabilizes upstream.
         launchOptions: {
-          args: [
-            '--disable-web-security',
-            '--disable-site-isolation-trials',
-            '--disable-http2',
-          ],
+          args: ['--disable-http2'],
         },
       },
       dependencies: ['setup'],

--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -44,34 +44,6 @@ app.UseHttpsRedirection();
 app.UseResponseCompression();
 app.UseCors();
 
-// DEBUG #340: log every incoming request so the E2E workflow can upload it
-// as an artifact. Tells us whether the hung browser fetches actually reach
-// the gateway, get stuck inside YARP, or never arrive at all. Path is
-// configurable via env so the workflow places it where upload-artifact can
-// find it; defaults to /tmp on Linux.
-var debugLog = Environment.GetEnvironmentVariable("GATEWAY_REQUEST_LOG")
-	?? "/tmp/gateway-requests.log";
-Console.Error.WriteLine($"[debug] gateway-request-log: {debugLog}");
-app.Use(async (context, next) =>
-{
-	var ts = DateTime.UtcNow;
-	var origin = context.Request.Headers.Origin.ToString();
-	var method = context.Request.Method;
-	var path = context.Request.Path + context.Request.QueryString;
-	var startLine = $"{ts:HH:mm:ss.fff} >> {method} {path} Origin={origin}\n";
-	Console.Error.Write(startLine);
-	try { await File.AppendAllTextAsync(debugLog, startLine); }
-	catch (Exception ex) { Console.Error.WriteLine($"[debug] gateway-log write failed: {ex.Message}"); }
-
-	await next();
-
-	var elapsed = (DateTime.UtcNow - ts).TotalMilliseconds;
-	var endLine = $"{DateTime.UtcNow:HH:mm:ss.fff} << {context.Response.StatusCode} {method} {path} ({elapsed:0}ms)\n";
-	Console.Error.Write(endLine);
-	try { await File.AppendAllTextAsync(debugLog, endLine); }
-	catch { }
-});
-
 // Manual CORS preflight handling for YARP routes.
 //
 // `UseCors()` only handles OPTIONS preflight when the matched endpoint has


### PR DESCRIPTION
## 🎯 Root cause found

**Aspire's DCP localhost proxy doesn't round-trip HTTP/2 streams.** Headless Chromium negotiates HTTP/2 by default, so browser-issued cross-origin fetches to the gateway silently failed before reaching it. Server-side calls (curl warmup, page.evaluate fixtures) worked because they default to HTTP/1.1.

## Diagnosis path
The breakthrough came from gateway request logging (#373) which proved:
- Server-side fetches → reach gateway, complete in <2s
- Browser fetches → never appear in gateway log

That ruled out CORS, timeouts, gateway routing, JWT, federation, and dev-server-vs-prod theories. The HTTP/2 hypothesis was the next cut, and the scoped run on #374 showed:

```
tests=8  failures=0  errors=0  time=9.245941
```

profile-settings cluster (6F before) went from full timeout-out to passing in **9 seconds** with a single Chromium flag.

## Changes
- `playwright.config.ts`: only chromium arg is now `--disable-http2` (dropping the earlier `--disable-web-security` / `--disable-site-isolation-trials` probes which we now know weren't needed).
- Restore full E2E suite (was scoped to profile-settings during diagnosis).
- Drop the gateway request-log middleware and `GATEWAY_REQUEST_LOG` env var — diagnostic served its purpose.
- Drop `/tmp/gateway-requests.log` from artifact upload.

## Test plan
- [ ] Full E2E suite passes (or drops the 27 remaining failures from #340/#342 cluster B significantly)
- [ ] Wall time improves (no more 45s timeouts on hung fetches)

Closes #340.
EOF