### PR TITLE
fix(e2e): shopping-list spec routing + select-all strict mode

### DIFF
--- a/client/apps/shell-e2e/src/pages/shopping-create.page.ts
+++ b/client/apps/shell-e2e/src/pages/shopping-create.page.ts
@@ -14,8 +14,10 @@ export class ShoppingCreatePage {
     this.heading = page.getByRole('heading', { level: 1 });
     this.titleInput = page.locator('#shopping-list-title');
     this.ingredientCheckboxes = page.locator('input[type="checkbox"]');
-    this.selectAllButton = page.getByRole('button', { name: /select all/i });
-    this.deselectAllButton = page.getByRole('button', { name: /deselect all/i });
+    // Exact match — case-insensitive /select all/i also matches "Deselect all"
+    // and triggers Playwright's strict-mode violation.
+    this.selectAllButton = page.getByRole('button', { name: 'Select all', exact: true });
+    this.deselectAllButton = page.getByRole('button', { name: 'Deselect all', exact: true });
     this.createButton = page.locator('.create-button');
     this.errorBanner = page.locator('[role="alert"]');
     this.backLink = page.locator('.back-link');

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -85,7 +85,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   });
 
   test('should display shopping lists on overview page', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/shopping');
+    await authenticatedPage.goto('/shopping/lists');
 
     const cards = authenticatedPage.locator('.list-card');
     const empty = authenticatedPage.locator('.empty-state');
@@ -95,7 +95,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
-    await authenticatedPage.goto('/shopping');
+    await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
@@ -112,7 +112,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check all items and reset', async ({ authenticatedPage }) => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
-    await authenticatedPage.goto('/shopping');
+    await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
@@ -135,7 +135,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should show progress counter', async ({ authenticatedPage }) => {
     test.skip(!recipeIdentifier, 'No recipe created');
 
-    await authenticatedPage.goto('/shopping');
+    await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });


### PR DESCRIPTION
Now that #375 (--disable-http2) lets browser fetches actually land at the gateway, the shopping-list tests progress further and reveal two pre-existing issues:

1. Spec navigated to `/shopping` (merged-list page) but expected `.list-card` which only renders on `/shopping/lists` (overview). Fixed in 4 sites.
2. `ShoppingCreatePage.selectAllButton` used `/select all/i` — that case-insensitive regex matches both 'Select all' AND 'Deselect all', triggering strict-mode violations. Switched to exact match.

Should clear most of the shopping/shopping-list 5 broken (1F + 4E).