### PR TITLE
fix(e2e): recipe-detail delete + shopping progress selectors

### DIFF
--- a/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
@@ -28,7 +28,7 @@ export class RecipeDetailPage {
     this.decreaseServingsButton = page.getByLabel(/decrease servings/i);
     this.resetServingsButton = page.getByRole('button', { name: /reset/i });
     this.editButton = page.getByRole('link', { name: /edit/i });
-    this.deleteButton = page.locator('.action-button--danger');
+    this.deleteButton = page.locator('.btn-danger');
     this.shoppingListButton = page.getByRole('link', { name: /shopping list/i });
     this.sourceLink = page.locator('.source-link a');
     this.confirmDialog = page.locator('yn-confirm-dialog');

--- a/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/shopping-detail.page.ts
@@ -17,7 +17,7 @@ export class ShoppingDetailPage {
     this.checkedItems = page.locator('.items-list li.checked');
     this.checkAllButton = page.getByRole('button', { name: /check all/i });
     this.resetButton = page.getByRole('button', { name: /reset/i });
-    this.progress = page.locator('.progress');
+    this.progress = page.locator('.progress-text');
     this.backLink = page.locator('.back-link');
   }
 


### PR DESCRIPTION
Selector drift exposed by #375. - RecipeDetailPage.deleteButton: .action-button--danger -> .btn-danger - ShoppingDetailPage.progress: .progress -> .progress-text