### PR TITLE
fix(e2e): force chat send-button click past animation

### DIFF
--- a/client/apps/shell-e2e/src/pages/chat.page.ts
+++ b/client/apps/shell-e2e/src/pages/chat.page.ts
@@ -34,7 +34,10 @@ export class ChatPage {
 
   async sendMessage(text: string): Promise<void> {
     await this.input.fill(text);
-    await this.sendButton.click();
+    // Chat panel slides in with a CSS transition; the send button can be
+    // mid-animation when Playwright tries to click and triggers
+    // "element is not stable" retries until test timeout. Force the click.
+    await this.sendButton.click({ force: true });
   }
 
   userMessage(index = 0): Locator {


### PR DESCRIPTION
Fixes recipes/recipe-chat 'should send a message and receive a response' test which timed out at 90s with 'element is not stable'. The chat panel slide-in CSS transition was causing Playwright's click stability retries to spin.