### PR TITLE
fix(e2e): confirm-dialog confirm button class

### DIFF
--- a/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
@@ -90,7 +90,7 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
     await detail.deleteButton.click();
     await expect(detail.confirmDialog).toBeVisible();
 
-    const confirmButton = detail.confirmDialog.locator('.btn-danger');
+    const confirmButton = detail.confirmDialog.locator('.btn-danger-filled');
     await confirmButton.click();
 
     await expect(authenticatedPage).toHaveURL(/\/recipes$/, { timeout: TIMEOUTS.default });


### PR DESCRIPTION
Recipe-detail delete spec was looking for .btn-danger inside the dialog overlay, but the dialog template uses .btn-danger-filled. Fixes the last delete-flow test.