### PR TITLE
fix(recipes): symmetric SaveChangesAsync in toggle-favorite

### DIFF
--- a/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
@@ -28,6 +28,7 @@ public sealed class ToggleFavoriteCommandHandler(
 		if (alreadyFavorited)
 		{
 			await unitOfWork.Favorites.RemoveAsync(owner, identifier, cancellationToken);
+			await unitOfWork.SaveChangesAsync(cancellationToken);
 			return new FavoriteStateDto(identifier.Value, false);
 		}
 


### PR DESCRIPTION
Defensive cleanup. Doesn't change current behavior (RemoveAsync uses ExecuteDeleteAsync which bypasses the tracker), but pairs the save call with both branches in case the repo implementation changes.