### PR TITLE
test(e2e): re-enable previously-skipped PWA tests

### DIFF
--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -2,11 +2,7 @@ import { test, expect } from '@playwright/test';
 import { setupKeycloakMock, waitForServiceWorker } from '../helpers/pwa.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
-// Angular registers the service worker only in production builds
-// (provideServiceWorker enabled: !isDevMode()). E2E runs against
-// `nx serve shell` in dev mode, so the SW never installs and these tests
-// hang in beforeEach. Skip the suite until a prod-build E2E mode exists.
-test.describe.skip('Offline Caching', () => {
+test.describe('Offline Caching', () => {
   test.beforeEach(async ({ page }) => {
     await setupKeycloakMock(page);
     await page.goto('/', { waitUntil: 'networkidle' });

--- a/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/pwa-install.spec.ts
@@ -39,12 +39,7 @@ test.describe('PWA Installation', () => {
     expect(icon512?.status()).toBe(200);
   });
 
-  // Angular's provideServiceWorker is configured with `enabled: !isDevMode()`.
-  // The E2E suite runs against `nx serve shell` (dev mode), so no SW registers
-  // and this test can never pass against the dev pipeline. Either run against
-  // a built-and-served bundle or keep this skipped — the manifest/icons tests
-  // above already cover the static-asset side of PWA-readiness.
-  test.skip('should register a service worker', async ({ page }) => {
+  test('should register a service worker', async ({ page }) => {
     await page.route('**/realms/**', (route) => route.abort());
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 


### PR DESCRIPTION
Skipped in #355. Re-enabling to test whether HTTP/2 and other fixes also unblocked the SW registration path.