### PR TITLE
perf(e2e): split E2E into 2 parallel matrix shards

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,9 +17,13 @@ env:
 
 jobs:
   e2e:
-    name: E2E Tests
+    name: E2E Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       # Opt the AppHost into E2E mode — skips persistent volumes, pgAdmin,
       # mailpit, and the LLM provider setup, so fewer containers need to come up.
@@ -247,7 +251,7 @@ jobs:
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client
-        run: npx nx e2e shell-e2e
+        run: npx nx e2e shell-e2e -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           BASE_URL: http://localhost:4200
           GATEWAY_URL: http://localhost:5100
@@ -266,7 +270,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: aspire-logs
+          # Suffix per-shard so parallel jobs don't fight over the same artifact name.
+          name: aspire-logs-shard-${{ matrix.shard }}
           path: |
             /tmp/aspire.log
             /tmp/diag/
@@ -276,7 +281,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: |
             client/test-results/
             client/apps/shell-e2e/playwright-report/


### PR DESCRIPTION
Cuts wall time roughly in half (~6 min → ~4 min). Each shard pays the Aspire startup cost (~3 min) but tests run in parallel, so wall time = startup + tests/2.

Trade-off: runner-minute cost roughly doubles. Worth it for faster PR feedback.

Artifacts are suffixed per-shard (`aspire-logs-shard-1`, `playwright-report-shard-2`, etc.) so parallel uploads don't collide. Diagnostic pulls need to know which shard a failing test landed in.