### PR TITLE
perf(e2e): drop retries + parallelise install steps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,10 +78,6 @@ jobs:
           restore-keys: |
             yarn-${{ runner.os }}-
 
-      - name: Install frontend dependencies
-        working-directory: client
-        run: yarn install --immutable
-
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
@@ -91,17 +87,26 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
 
-      - name: Install Playwright browsers
-        working-directory: client
+      - name: Install dependencies in parallel (yarn + dotnet + playwright)
         run: |
-          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            npx playwright install-deps chromium
-          else
-            npx playwright install chromium --with-deps
-          fi
-
-      - name: Restore .NET packages
-        run: dotnet restore Yumney.slnx
+          set -e
+          # yarn install
+          (cd client && yarn install --immutable) &
+          PID_YARN=$!
+          # dotnet restore
+          (dotnet restore Yumney.slnx) &
+          PID_DOTNET=$!
+          # playwright browsers — install-deps needs sudo, run in foreground
+          # but only deps; the browsers themselves should already be cached.
+          wait $PID_YARN
+          (cd client && \
+            if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then \
+              npx playwright install-deps chromium; \
+            else \
+              npx playwright install chromium --with-deps; \
+            fi) &
+          PID_PW=$!
+          wait $PID_DOTNET $PID_PW
 
       - name: Build solution (including AppHost)
         run: dotnet build Yumney.slnx --no-restore

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -26,10 +26,11 @@ export default defineConfig({
   // 45s mirrors TIMEOUTS.default — covers MFE federation cold-start under
   // parallel worker pressure (see helpers/timeouts.ts).
   expect: { timeout: 45_000 },
-  // On CI: retry once (not twice) — each retry on a 30s-timeout test can cost
-  // a minute on top of the original. Transient flakes still get a second
-  // chance; systemic failures fail faster.
-  retries: process.env['CI'] ? 1 : 0,
+  // No retries in CI. With 45s expect timeouts each retry costs another
+  // 45s on every failure; with the current 5 known systemic failures
+  // that was burning ~4 min of wall time per run on retry waste. If we
+  // start seeing genuine flakes that pass on retry, lift to 1.
+  retries: 0,
   // File-level parallelism on CI. fullyParallel stays false so tests inside
   // a spec file still run sequentially on their assigned worker — the
   // recipes/shopping specs use beforeAll to create shared DB fixtures and


### PR DESCRIPTION
Drops retries from 1 to 0 (saves ~4 min on current 5-failure runs) and parallelises yarn/dotnet/playwright installs (saves ~25s).