### PR TITLE
fix(e2e): bump timeouts on eventual-consistency-racing tests

### DIFF
--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -60,9 +60,13 @@ test.describe('Favorite Recipes (US-071)', () => {
 
     await list.filterToggle.click();
     await list.favoritesFilterChip.click();
-    await authenticatedPage.waitForTimeout(500);
 
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible();
+    // Filter triggers a fresh GET with favoritesOnly=true; with retries:0
+    // the previous toggle's POST may not have committed before the filter
+    // refetch fires. Use the long timeout to absorb that.
+    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({
+      timeout: TIMEOUTS.long,
+    });
   });
 
   test('should reflect favorite state on recipe detail page', async ({ authenticatedPage }) => {

--- a/client/apps/shell-e2e/src/shopping/merged-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/merged-list.spec.ts
@@ -30,8 +30,12 @@ test.describe('Merged Shopping List (US-312-318)', () => {
     await input.fill('Test E2E Item');
     await input.press('Enter');
 
+    // Adding goes through the messaging bus (Wolverine) and a projection
+    // update before the merged-list view sees it. TIMEOUTS.long covers
+    // the projection round-trip; without it the test was racing the
+    // eventual-consistency window when retries:1 was disabled.
     await expect(authenticatedPage.getByText('Test E2E Item')).toBeVisible({
-      timeout: TIMEOUTS.default,
+      timeout: TIMEOUTS.long,
     });
   });
 


### PR DESCRIPTION
Two tests started failing visibly after retries:0 in #389. Both race async backend paths (messaging + projection, post-then-refetch). Bump to TIMEOUTS.long instead of TIMEOUTS.default.