### PR TITLE
perf(e2e): restore retries:1 for stable signal

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -26,11 +26,11 @@ export default defineConfig({
   // 45s mirrors TIMEOUTS.default — covers MFE federation cold-start under
   // parallel worker pressure (see helpers/timeouts.ts).
   expect: { timeout: 45_000 },
-  // No retries in CI. With 45s expect timeouts each retry costs another
-  // 45s on every failure; with the current 5 known systemic failures
-  // that was burning ~4 min of wall time per run on retry waste. If we
-  // start seeing genuine flakes that pass on retry, lift to 1.
-  retries: 0,
+  // 1 retry in CI: backend writes through Wolverine messaging + projections
+  // create eventual-consistency races that pass on retry. The 4 min cost
+  // is worth the stable signal — without it, transient flakes look like
+  // real failures and noise dominates the CI summary.
+  retries: process.env['CI'] ? 1 : 0,
   // File-level parallelism on CI. fullyParallel stays false so tests inside
   // a spec file still run sequentially on their assigned worker — the
   // recipes/shopping specs use beforeAll to create shared DB fixtures and


### PR DESCRIPTION
Reverts the retries:0 change from #389. Stable test signal trumps the 4 min savings — eventual-consistency flakes were dominating the noise.