### PR TITLE
feat(e2e): serve production build for PWA test coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,6 +106,14 @@ jobs:
       - name: Build solution (including AppHost)
         run: dotnet build Yumney.slnx --no-restore
 
+      - name: Build frontend bundle for E2E
+        # Pre-build all MFEs and merge them into dist/apps/shell/browser so
+        # the AppHost can serve a single static bundle in E2E mode (see
+        # serve:shell:dist). Production-mode build also enables Angular's
+        # provideServiceWorker — required by the PWA tests.
+        working-directory: client
+        run: yarn build:all
+
       - name: Start Aspire AppHost
         run: |
           aspire start --apphost src/Yumney.AppHost/Yumney.AppHost.csproj 2>&1 | tee /tmp/aspire.log

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "serve:shopping": "nx serve shopping",
     "serve:account": "nx serve account",
     "serve:all": "nx run-many --target=serve --projects=shell,recipes,shopping,account --parallel=4",
+    "serve:shell:dist": "node scripts/serve-shell-dist.mjs",
     "generate:validation": "node scripts/generate-validation-constants.mjs",
     "generate:api-types": "node scripts/generate-api-types.mjs",
     "build:all": "node scripts/generate-validation-constants.mjs && nx run-many --target=build --projects=shell,recipes,shopping,account --parallel=4 && node scripts/copy-remotes.mjs",

--- a/client/scripts/serve-shell-dist.mjs
+++ b/client/scripts/serve-shell-dist.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Static-file server for the built shell bundle. Used by the E2E pipeline
+ * so Playwright runs against a production-mode build rather than `nx serve`
+ * (Vite dev server). Production mode is what enables Angular's
+ * provideServiceWorker registration, so PWA tests need this path.
+ *
+ * After `yarn build:all`, scripts/copy-remotes.mjs has merged every MFE
+ * (`recipes`, `shopping`, `account`) into `dist/apps/shell/browser/{name}/`
+ * and replaced the federation manifest with the prod version, so a single
+ * static root serves the whole app.
+ *
+ * Tiny zero-dep Node http server with SPA fallback to index.html.
+ */
+import { createServer } from 'node:http';
+import { createReadStream, statSync } from 'node:fs';
+import { join, dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', 'dist', 'apps', 'shell', 'browser');
+const PORT = Number(process.env.PORT ?? 4200);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+};
+
+function serveFile(res, path) {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return false;
+    // Service-worker scripts must be served fresh so updates land — Angular
+    // SW versions itself via ngsw.json which is fetched on every check.
+    const isSwAsset =
+      path.endsWith('ngsw-worker.js') ||
+      path.endsWith('ngsw.json') ||
+      path.endsWith('safety-worker.js');
+    res.writeHead(200, {
+      'Content-Type': MIME[extname(path).toLowerCase()] ?? 'application/octet-stream',
+      'Content-Length': stat.size,
+      'Cache-Control': isSwAsset ? 'no-cache, no-store, must-revalidate' : 'public, max-age=300',
+    });
+    createReadStream(path).pipe(res);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const server = createServer((req, res) => {
+  let urlPath = (req.url ?? '/').split('?')[0];
+  if (urlPath.includes('..')) {
+    res.writeHead(400);
+    res.end('Bad Request');
+    return;
+  }
+  if (urlPath.endsWith('/')) urlPath += 'index.html';
+
+  const filePath = join(ROOT, urlPath);
+  if (serveFile(res, filePath)) return;
+
+  // SPA fallback: any path without a file extension falls back to index.html
+  // so client-side routes (/account, /recipes/:id, …) load the shell.
+  if (!extname(urlPath)) {
+    if (serveFile(res, join(ROOT, 'index.html'))) return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+});
+
+server.listen(PORT, () => {
+  console.log(`shell static server listening on http://localhost:${PORT} (root: ${ROOT})`);
+});

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -198,10 +198,21 @@ if (!options.DatabaseOnly)
 				.WithEnvironment("NX_ISOLATE_PLUGINS", "false")
 				.WithHttpEndpoint(targetPort: port);
 
-		var shell = addMfe("shell", "serve:shell", 4200);
-		var recipesMfe = addMfe("recipes-mfe", "serve:recipes", 4201);
-		var shoppingMfe = addMfe("shopping-mfe", "serve:shopping", 4202);
-		var accountMfe = addMfe("account-mfe", "serve:account", 4203);
+		// E2E mode runs against a production build so PWA tests (service
+		// worker, offline cache) and Vite-free fetch behaviour exercise the
+		// real shape. `yarn build:all` co-locates every MFE in
+		// `dist/apps/shell/browser`, then `serve:shell:dist` hands it out
+		// from a single static root.
+		var shell = options.E2ETests
+			? addMfe("shell", "serve:shell:dist", 4200)
+			: addMfe("shell", "serve:shell", 4200);
+
+		if (!options.E2ETests)
+		{
+			addMfe("recipes-mfe", "serve:recipes", 4201);
+			addMfe("shopping-mfe", "serve:shopping", 4202);
+			addMfe("account-mfe", "serve:account", 4203);
+		}
 
 		builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
 			.WithHttpEndpoint(port: 5100)


### PR DESCRIPTION
Switches the E2E pipeline from `nx serve` (Vite dev) to a static-served production build so Angular registers the service worker. PWA install + offline tests should go green.

Restoration of #364 (which was reverted because of bundle-loading races) — those races were actually caused by Aspire DCP HTTP/2 (fixed in #375). With h2 disabled in chromium, the production-build path should work cleanly.