### PR TITLE
fix(e2e): wait for SW control + prime cache before offline tests

### DIFF
--- a/client/apps/shell-e2e/src/helpers/pwa.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/pwa.helper.ts
@@ -34,7 +34,10 @@ export async function setupKeycloakMock(page: Page): Promise<void> {
 }
 
 /**
- * Wait for the service worker to become activated.
+ * Wait for the service worker to become activated AND control the page.
+ * For Angular's NGSW the controller is only set on the next navigation
+ * after registration, so callers should reload after this resolves if
+ * they need the SW to actually serve subsequent fetches.
  */
 export async function waitForServiceWorker(page: Page, timeout = 40_000): Promise<void> {
   await page.evaluate(async (ms) => {
@@ -46,6 +49,33 @@ export async function waitForServiceWorker(page: Page, timeout = 40_000): Promis
       if (active) return;
       await new Promise((r) => setTimeout(r, 500));
     }
+  }, timeout);
+}
+
+/**
+ * Wait until the page is being controlled by an active service worker.
+ * Required after a reload following SW activation: NGSW sets
+ * navigator.serviceWorker.controller asynchronously and the offline
+ * tests need a controlled fetch path. Also primes a few well-known
+ * URLs so the SW has them cached before the test goes offline.
+ */
+export async function waitForServiceWorkerControl(page: Page, timeout = 40_000): Promise<void> {
+  await page.evaluate(async (ms) => {
+    if (!('serviceWorker' in navigator)) return;
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline && !navigator.serviceWorker.controller) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    // Prime the cache for the URLs the offline tests care about. The Angular
+    // SW asset/data groups are populated lazily on first fetch through the
+    // SW; without this, an immediate setOffline + reload races the cache
+    // and serves nothing.
+    const warmupUrls = ['/', '/index.html', '/assets/i18n/en.json'];
+    await Promise.all(
+      warmupUrls.map((url) =>
+        fetch(url, { cache: 'no-store' }).catch(() => undefined),
+      ),
+    );
   }, timeout);
 }
 

--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { setupKeycloakMock, waitForServiceWorker } from '../helpers/pwa.helper';
+import {
+  setupKeycloakMock,
+  waitForServiceWorker,
+  waitForServiceWorkerControl,
+} from '../helpers/pwa.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Offline Caching', () => {
@@ -7,7 +11,12 @@ test.describe('Offline Caching', () => {
     await setupKeycloakMock(page);
     await page.goto('/', { waitUntil: 'networkidle' });
     await waitForServiceWorker(page);
+    // Reload so the now-active SW claims the page as a client.
     await page.reload({ waitUntil: 'networkidle' });
+    // Wait until the SW actually controls fetches AND prime the cache for
+    // the URLs the offline tests care about. Without this the tests race
+    // the lazy NGSW cache population and see nothing.
+    await waitForServiceWorkerControl(page);
   });
 
   test('should serve cached app shell when offline', async ({ page, context }) => {


### PR DESCRIPTION
Fixes both pwa/offline tests by ensuring NGSW has actually claimed the page and warmed the cache before going offline.