### PR TITLE
test(domain): introduce fluent test data builders for the four aggregates (#283)

### DIFF
--- a/tests/Yumney.MealPlan.Domain.Tests/Builders/WeeklyPlanBuilder.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/Builders/WeeklyPlanBuilder.cs
@@ -1,0 +1,56 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using WeeklyPlanAggregate = SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.Builders;
+
+public sealed class WeeklyPlanBuilder
+{
+	private OwnerIdentifier owner = OwnerIdentifier.From("user-123");
+	private WeekIdentifier week = WeekIdentifier.From(2026, 17);
+	private SlotServings? defaultServings;
+	private bool extendedMode;
+
+	public WeeklyPlanBuilder OwnedBy(string ownerId) => OwnedBy(OwnerIdentifier.From(ownerId));
+
+	public WeeklyPlanBuilder OwnedBy(OwnerIdentifier value)
+	{
+		owner = value;
+		return this;
+	}
+
+	public WeeklyPlanBuilder ForWeek(int year, int weekNumber)
+	{
+		week = WeekIdentifier.From(year, weekNumber);
+		return this;
+	}
+
+	public WeeklyPlanBuilder ForWeek(WeekIdentifier value)
+	{
+		week = value;
+		return this;
+	}
+
+	public WeeklyPlanBuilder WithDefaultServings(int value)
+	{
+		defaultServings = SlotServings.From(value);
+		return this;
+	}
+
+	public WeeklyPlanBuilder InExtendedMode()
+	{
+		extendedMode = true;
+		return this;
+	}
+
+	public WeeklyPlanAggregate Build()
+	{
+		var plan = WeeklyPlanAggregate.Create(owner, week, defaultServings);
+		if (extendedMode)
+		{
+			plan.EnableExtendedMode(defaultServings);
+		}
+
+		return plan;
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeBuilder.cs
@@ -1,0 +1,136 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using RecipeAggregate = SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class RecipeBuilder
+{
+	private readonly List<Ingredient> ingredients = [];
+	private readonly List<Step> steps = [];
+	private readonly List<RecipeTag> tags = [];
+	private RecipeTitle title = RecipeTitle.From("Test Recipe");
+	private OwnerIdentifier owner = OwnerIdentifier.From("user-123");
+	private RecipeDescription? description;
+	private Servings? servings;
+	private TimingInfo? timing;
+	private Difficulty? difficulty;
+	private ImageUrl? imageUrl;
+	private RecipeLanguage? language;
+	private RecipeUrl? sourceUrl;
+
+	public RecipeBuilder WithTitle(string value) => WithTitle(RecipeTitle.From(value));
+
+	public RecipeBuilder WithTitle(RecipeTitle value)
+	{
+		title = value;
+		return this;
+	}
+
+	public RecipeBuilder OwnedBy(string ownerId) => OwnedBy(OwnerIdentifier.From(ownerId));
+
+	public RecipeBuilder OwnedBy(OwnerIdentifier value)
+	{
+		owner = value;
+		return this;
+	}
+
+	public RecipeBuilder WithIngredient(string name, decimal? amount = null, string? unit = null)
+	{
+		var quantity = Quantity.FromNullable(Amount.FromNullable(amount), Unit.FromNullable(unit));
+		ingredients.Add(Ingredient.Create(IngredientName.From(name), quantity));
+		return this;
+	}
+
+	public RecipeBuilder WithIngredient(Ingredient ingredient)
+	{
+		ingredients.Add(ingredient);
+		return this;
+	}
+
+	public RecipeBuilder WithStep(string description)
+	{
+		steps.Add(Step.Create(StepNumber.From(steps.Count + 1), StepDescription.From(description)));
+		return this;
+	}
+
+	public RecipeBuilder WithStep(Step step)
+	{
+		steps.Add(step);
+		return this;
+	}
+
+	public RecipeBuilder WithDescription(string value)
+	{
+		description = RecipeDescription.From(value);
+		return this;
+	}
+
+	public RecipeBuilder WithServings(int value)
+	{
+		servings = Servings.From(value);
+		return this;
+	}
+
+	public RecipeBuilder WithTiming(int prepMinutes, int cookMinutes)
+	{
+		timing = TimingInfo.Of(PreparationTime.From(prepMinutes), CookingTime.From(cookMinutes));
+		return this;
+	}
+
+	public RecipeBuilder WithDifficulty(string value)
+	{
+		difficulty = Difficulty.From(value);
+		return this;
+	}
+
+	public RecipeBuilder WithImageUrl(string url)
+	{
+		imageUrl = ImageUrl.From(url);
+		return this;
+	}
+
+	public RecipeBuilder WithLanguage(string code)
+	{
+		language = RecipeLanguage.From(code);
+		return this;
+	}
+
+	public RecipeBuilder WithSourceUrl(string url)
+	{
+		sourceUrl = RecipeUrl.From(url);
+		return this;
+	}
+
+	public RecipeBuilder WithTag(string value)
+	{
+		tags.Add(RecipeTag.From(value));
+		return this;
+	}
+
+	public RecipeAggregate Build()
+	{
+		if (ingredients.Count == 0)
+		{
+			ingredients.Add(Ingredient.Create(IngredientName.From("Flour"), null));
+		}
+
+		if (steps.Count == 0)
+		{
+			steps.Add(Step.Create(StepNumber.From(1), StepDescription.From("Mix")));
+		}
+
+		return RecipeAggregate.Create(
+			title,
+			owner,
+			ingredients,
+			steps,
+			description,
+			servings,
+			timing,
+			difficulty,
+			imageUrl,
+			language,
+			sourceUrl,
+			tags.Count == 0 ? null : tags);
+	}
+}

--- a/tests/Yumney.Shopping.Domain.Tests/Builders/ShoppingListBuilder.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/Builders/ShoppingListBuilder.cs
@@ -1,0 +1,58 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using ShoppingListAggregate = SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.Builders;
+
+public sealed class ShoppingListBuilder
+{
+	private readonly List<ShoppingListItem> items = [];
+	private ShoppingListTitle title = ShoppingListTitle.From("Test Shopping List");
+	private OwnerIdentifier owner = OwnerIdentifier.From("user-123");
+	private RecipeReference? recipeReference;
+
+	public ShoppingListBuilder WithTitle(string value) => WithTitle(ShoppingListTitle.From(value));
+
+	public ShoppingListBuilder WithTitle(ShoppingListTitle value)
+	{
+		title = value;
+		return this;
+	}
+
+	public ShoppingListBuilder OwnedBy(string ownerId) => OwnedBy(OwnerIdentifier.From(ownerId));
+
+	public ShoppingListBuilder OwnedBy(OwnerIdentifier value)
+	{
+		owner = value;
+		return this;
+	}
+
+	public ShoppingListBuilder WithItem(string name, decimal? amount = null, Unit? unit = null)
+	{
+		var quantity = Quantity.FromNullable(Amount.FromNullable(amount), unit);
+		items.Add(ShoppingListItem.Create(ItemName.From(name), quantity));
+		return this;
+	}
+
+	public ShoppingListBuilder WithItem(ShoppingListItem item)
+	{
+		items.Add(item);
+		return this;
+	}
+
+	public ShoppingListBuilder FromRecipe(Guid recipeIdentifier)
+	{
+		recipeReference = RecipeReference.From(recipeIdentifier);
+		return this;
+	}
+
+	public ShoppingListAggregate Build()
+	{
+		if (items.Count == 0)
+		{
+			items.Add(ShoppingListItem.Create(ItemName.From("Default Item"), null));
+		}
+
+		return ShoppingListAggregate.Create(title, owner, items, recipeReference);
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/Builders/AppUserProfileBuilder.cs
+++ b/tests/Yumney.Users.Domain.Tests/Builders/AppUserProfileBuilder.cs
@@ -1,0 +1,82 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using AppUserProfileAggregate = SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.Builders;
+
+public sealed class AppUserProfileBuilder
+{
+	private KeycloakUserId keycloakUserId = KeycloakUserId.From("kc-user-123");
+	private DisplayName displayName = DisplayName.From("Test User");
+	private PreferredLanguage? language;
+	private PreferredUnitSystem? unitSystem;
+	private DefaultServings? defaultServings;
+	private DietaryProfile? dietaryProfile;
+
+	public AppUserProfileBuilder WithKeycloakUserId(string value) =>
+		WithKeycloakUserId(KeycloakUserId.From(value));
+
+	public AppUserProfileBuilder WithKeycloakUserId(KeycloakUserId value)
+	{
+		keycloakUserId = value;
+		return this;
+	}
+
+	public AppUserProfileBuilder Named(string value) => Named(DisplayName.From(value));
+
+	public AppUserProfileBuilder Named(DisplayName value)
+	{
+		displayName = value;
+		return this;
+	}
+
+	public AppUserProfileBuilder PreferringLanguage(string code)
+	{
+		language = PreferredLanguage.From(code);
+		return this;
+	}
+
+	public AppUserProfileBuilder PreferringUnitSystem(string code)
+	{
+		unitSystem = PreferredUnitSystem.From(code);
+		return this;
+	}
+
+	public AppUserProfileBuilder WithDefaultServings(int value)
+	{
+		defaultServings = DefaultServings.From(value);
+		return this;
+	}
+
+	public AppUserProfileBuilder WithDietaryProfile(DietaryProfile value)
+	{
+		dietaryProfile = value;
+		return this;
+	}
+
+	public AppUserProfileAggregate Build()
+	{
+		var profile = AppUserProfileAggregate.Create(keycloakUserId, displayName);
+		if (language is not null)
+		{
+			profile.SwitchLanguageTo(language);
+		}
+
+		if (unitSystem is not null)
+		{
+			profile.SwitchUnitSystemTo(unitSystem);
+		}
+
+		if (defaultServings is not null)
+		{
+			profile.AdjustDefaultServingsTo(defaultServings);
+		}
+
+		if (dietaryProfile is not null)
+		{
+			profile.UpdateDietaryProfile(dietaryProfile);
+		}
+
+		return profile;
+	}
+}


### PR DESCRIPTION
Closes #283 (partial — builders criterion).

## Summary
Adds fluent test data builders for the four aggregates called out in #283:

- \`RecipeBuilder\` (Yumney.Recipes.Domain.Tests/Builders)
- \`ShoppingListBuilder\` (Yumney.Shopping.Domain.Tests/Builders)
- \`WeeklyPlanBuilder\` (Yumney.MealPlan.Domain.Tests/Builders)
- \`AppUserProfileBuilder\` (Yumney.Users.Domain.Tests/Builders)

Each builder defaults to a valid minimal aggregate and exposes \`With…\` / \`OwnedBy\` style methods so tests can compose variants without primitive-obsessed arrange blocks.

Example:

\`\`\`csharp
var recipe = new RecipeBuilder()
    .WithTitle("Pasta Carbonara")
    .OwnedBy("user-42")
    .WithIngredient("Spaghetti", 400m, "g")
    .WithStep("Cook pasta")
    .WithServings(4)
    .Build();
\`\`\`

## Why fluent + co-existence with static factories
The existing static factories (\`RecipeTestData\`, \`RecipeFactory\`, local \`CreateValidRecipe\` helpers) cover default+override but not composability. Builders shine when tests vary multiple fields. Both styles co-exist; tests can adopt builders organically.

## Test plan
- [x] All four Domain.Tests projects build with \`TreatWarningsAsErrors=true\` (StyleCop clean)
- [x] All 700 domain tests still pass:
  - Recipes.Domain.Tests: 233 passed
  - Shopping.Domain.Tests: 166 passed
  - MealPlan.Domain.Tests: 82 passed
  - Users.Domain.Tests: 219 passed

## Out of scope
- Migrating existing tests to the new builders — left as follow-up so this PR stays small and reviewable.
- The DateTime.UtcNow + AssertionScope criteria from #283 were already addressed in commit \`a35552d9\`.