### PR TITLE
test(e2e): gate BASE_URL/GATEWAY_URL to localhost (#400)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -252,6 +252,30 @@ jobs:
       # (Backend Build + Test). Skipping here to keep the E2E run focused on
       # browser-level coverage and reduce wall time.
 
+      - name: Verify BASE_URL guard rejects remote targets
+        # Smoke-check the safety guard from helpers/env-guard.ts: pointing
+        # BASE_URL at a non-local host MUST fail before any worker spins up.
+        # We use --grep with a sentinel that matches no test so globalSetup
+        # runs (--list skips it) but no actual tests do. The step succeeds
+        # only if Playwright exits non-zero AND the error contains our
+        # [e2e-guard] tag (distinguishes guard failure from "no tests found").
+        working-directory: client/apps/shell-e2e
+        run: |
+          set +e
+          output=$(BASE_URL=https://example.com GATEWAY_URL=http://localhost:5100 \
+            npx playwright test --grep "__never_match_e2e_guard__" 2>&1)
+          rc=$?
+          echo "$output"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::BASE_URL guard did not fire — exit code was 0"
+            exit 1
+          fi
+          if ! echo "$output" | grep -q "e2e-guard"; then
+            echo "::error::Playwright failed but not due to the e2e-guard"
+            exit 1
+          fi
+          echo "guard fired as expected"
+
       - name: Run Playwright e2e tests
         continue-on-error: true
         working-directory: client

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -17,6 +17,9 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
 
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
+  // Refuse to start if BASE_URL/GATEWAY_URL points outside localhost. The
+  // suite issues real writes; set E2E_ALLOW_REMOTE=true to override.
+  globalSetup: require.resolve('./src/global-setup'),
   // Bumped from 30s to 60s: post-token-expiry-fix, fixture-heavy beforeAll
   // hooks (openAuthenticatedPage + API POST under parallel worker pressure)
   // started exceeding 30s. The real API calls themselves are ~1s; the budget

--- a/client/apps/shell-e2e/src/global-setup.ts
+++ b/client/apps/shell-e2e/src/global-setup.ts
@@ -1,0 +1,7 @@
+import { assertLocalE2eTarget } from './helpers/env-guard';
+
+// Runs once before any worker starts. We use it solely to fail fast when the
+// suite would target a non-local environment — see helpers/env-guard.ts.
+export default function globalSetup(): void {
+  assertLocalE2eTarget();
+}

--- a/client/apps/shell-e2e/src/helpers/env-guard.ts
+++ b/client/apps/shell-e2e/src/helpers/env-guard.ts
@@ -1,0 +1,40 @@
+// Safety guard: refuse to run e2e against anything but localhost.
+//
+// The suite issues real POST/DELETE against /api/v1/recipes and mutates the
+// authenticated user's profile. A misconfigured BASE_URL pointing at staging
+// or production would corrupt data with no easy way to roll back.
+//
+// Set E2E_ALLOW_REMOTE=true to opt out (only intended for one-off staging
+// smoke runs by a human who has read the consequences).
+
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+export function assertLocalE2eTarget(env: NodeJS.ProcessEnv = process.env): void {
+  if (env['E2E_ALLOW_REMOTE'] === 'true') return;
+
+  const baseUrl = env['BASE_URL'] ?? 'http://localhost:4200';
+  const gatewayUrl = env['GATEWAY_URL'] ?? 'http://localhost:5100';
+
+  assertLocalHostname('BASE_URL', baseUrl);
+  assertLocalHostname('GATEWAY_URL', gatewayUrl);
+}
+
+function assertLocalHostname(varName: string, rawUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(
+      `[e2e-guard] ${varName}=${rawUrl} is not a valid URL. Expected http(s)://localhost:port`,
+    );
+  }
+
+  if (!LOCAL_HOSTNAMES.has(parsed.hostname)) {
+    throw new Error(
+      `[e2e-guard] Refusing to run e2e against ${varName}=${rawUrl}.\n` +
+        `        The suite issues real writes (POST/DELETE recipes, mutates the test user)\n` +
+        `        and must only target localhost. To override for a one-off staging smoke,\n` +
+        `        set E2E_ALLOW_REMOTE=true (and accept the consequences).`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #400.

## Summary

- E2E suite issues real `POST/DELETE /api/v1/recipes` and mutates the test user's profile. A misconfigured `BASE_URL` pointing at staging/prod would corrupt data with no easy rollback.
- New Playwright `globalSetup` validates `BASE_URL` and `GATEWAY_URL` hostnames against `localhost` / `127.0.0.1` / `::1` and throws otherwise.
- `E2E_ALLOW_REMOTE=true` opts out for one-off staging smoke runs.
- CI gains a verification step that proves the guard fires.

## Implementation

- `src/helpers/env-guard.ts` — pure `assertLocalE2eTarget()` (testable in isolation, no Playwright deps).
- `src/global-setup.ts` — wired via `playwright.config.ts` `globalSetup`.
- `.github/workflows/e2e.yml` — runs Playwright with `BASE_URL=https://example.com` and `--grep "__never_match__"` so `globalSetup` runs but no tests do (`--list` skips `globalSetup`, so it can't be used). Asserts non-zero exit AND `[e2e-guard]` in stderr to distinguish guard failure from "no tests found".

## Verified locally

- `BASE_URL=https://example.com` → Playwright exits 1 with the `[e2e-guard]` error
- `BASE_URL=http://localhost:4200` → globalSetup passes
- `E2E_ALLOW_REMOTE=true` → bypass works
- `nx lint shell-e2e` clean

## Test plan

- [ ] CI verification step fails as designed (visible in workflow log)
- [ ] Existing e2e suite continues to pass on the localhost path
- [ ] No behaviour change for developers running locally with default env

## Acceptance criteria from #400

- [x] `globalSetup` parses `BASE_URL`/`GATEWAY_URL` and throws on non-local hostname with a clear message
- [x] `E2E_ALLOW_REMOTE=true` opt-out documented in the guard's source comment
- [x] CI step proves the guard fires (asserts non-zero exit + `[e2e-guard]` text)
- [x] CI workflow unchanged in behaviour for the localhost path