### PR TITLE
ci(e2e): remove continue-on-error so failing tests fail the workflow (#410)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -277,7 +277,6 @@ jobs:
           echo "guard fired as expected"
 
       - name: Run Playwright e2e tests
-        continue-on-error: true
         working-directory: client
         run: npx nx e2e shell-e2e
         env:


### PR DESCRIPTION
Partial fix for #410 — the failing-build half. Sharding is deferred to a follow-up so this change stays one-line.

## Summary

- Drop `continue-on-error: true` from the Playwright e2e step in `.github/workflows/e2e.yml`.
- A red e2e run now fails the workflow check and blocks merge into `develop` and `main`.

## Heads-up on consequences

Today's suite has known flake sources (10 hard sleeps, `networkidle` waits, beforeAll skips that mask failures — see #401, #402, #403). Removing the opt-out means those flakes will start blocking PRs. Two ways to absorb the impact:

1. **Land the flake fixes first** (#401 is the cheapest — replacing `waitForTimeout`).
2. **Land this PR alongside #401** so the gate goes hot only after the loudest sources are tamed.

I recommend option 1 — happy to do it as the next PR.

## Test plan

- [ ] First post-merge run on `develop` is green (or surfaces a real flake we then fix).
- [ ] A deliberately-broken test (in a follow-up dry-run branch) causes the workflow check to go red instead of green.

## Acceptance from #410 (full issue scope)

- [ ] Suite shards 4× — **deferred to follow-up**
- [x] `continue-on-error` removed
- [ ] Junit/HTML reports merged across shards — **deferred**
- [ ] Wall-time reduction measured — **deferred**