### PR TITLE
test(e2e): drop networkidle waits from offline.spec (#402)

### DIFF
--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -9,10 +9,13 @@ import { TIMEOUTS } from '../helpers/timeouts';
 test.describe('Offline Caching', () => {
   test.beforeEach(async ({ page }) => {
     await setupKeycloakMock(page);
-    await page.goto('/', { waitUntil: 'networkidle' });
+    // domcontentloaded is enough — the real readiness signals are the SW
+    // helpers below. networkidle is a known anti-pattern under our Aspire
+    // stack: OTLP/log streams keep the network busy and it can never fire.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await waitForServiceWorker(page);
     // Reload so the now-active SW claims the page as a client.
-    await page.reload({ waitUntil: 'networkidle' });
+    await page.reload({ waitUntil: 'domcontentloaded' });
     // Wait until the SW actually controls fetches AND prime the cache for
     // the URLs the offline tests care about. Without this the tests race
     // the lazy NGSW cache population and see nothing.
@@ -20,8 +23,8 @@ test.describe('Offline Caching', () => {
   });
 
   test('should serve cached app shell when offline', async ({ page, context }) => {
-    await page.waitForLoadState('networkidle');
-
+    // beforeEach has already awaited SW control and primed the cache, so we
+    // can go offline immediately — no extra wait needed.
     await context.setOffline(true);
     await page.reload({ waitUntil: 'domcontentloaded' });
 
@@ -30,8 +33,13 @@ test.describe('Offline Caching', () => {
   });
 
   test('should serve cached i18n translations when offline', async ({ page, context }) => {
-    await page.evaluate(() => fetch('/assets/i18n/en.json'));
-    await page.waitForLoadState('networkidle');
+    // Read the body so the SW fetch handler completes the cache write before
+    // we go offline. Awaiting only the Response headers (or relying on
+    // networkidle) leaves a race where the cache may not be populated yet.
+    await page.evaluate(async () => {
+      const res = await fetch('/assets/i18n/en.json');
+      await res.text();
+    });
 
     await context.setOffline(true);
 


### PR DESCRIPTION
Closes #402.

## Summary

`networkidle` is a known anti-pattern under our Aspire stack — OTLP and log streams keep the network busy after page load, so the wait can race or stall. All four uses were in `pwa/offline.spec.ts` and each was redundant with a stronger SW-level signal already present in the `beforeEach`.

## Replacements

| Line | Before | After |
|------|--------|-------|
| 12 | `goto('/', { waitUntil: 'networkidle' })` | `domcontentloaded` — `waitForServiceWorker` (next call) is the real readiness signal. |
| 15 | `reload({ waitUntil: 'networkidle' })` | `domcontentloaded` — `waitForServiceWorkerControl` (next call) primes cache. |
| 23 | `waitForLoadState('networkidle')` before going offline | Removed. `beforeEach` already awaited SW control + cache priming. |
| 34 | `waitForLoadState('networkidle')` after a prefetch | `await res.text()` so the SW fetch handler has completed the cache write. Networkidle never guaranteed that — only that requests were idle, not that the SW had finished writing. |

## Test plan

- [x] `nx lint shell-e2e` clean
- [ ] PWA offline spec passes in CI (offline shell + i18n cache hit)
- [ ] No regression in offline-spec runtime

## Acceptance criteria from #402

- [x] No `waitUntil: 'networkidle'` in `client/apps/shell-e2e/src/**`
- [x] Each replaced wait is followed by an assertion of the readiness signal that test actually needs
- [x] Offline spec still validates: SW caches the shell, app boots offline, i18n cache hit
- [ ] No regression in PWA spec runtime (recorded after first CI run)

## Follow-up

A `no-restricted-syntax` lint guard against `'networkidle'` would slot naturally next to the `waitForTimeout` rule from #401. I deferred it so this PR stays single-purpose and to avoid a textual conflict on `eslint.config.mjs`. Happy to add it once #401 lands.