### PR TITLE
test(e2e): replace skip-on-failure guards with shared-recipe helper (#403)

### DIFF
--- a/client/apps/shell-e2e/src/helpers/shared-recipe.ts
+++ b/client/apps/shell-e2e/src/helpers/shared-recipe.ts
@@ -1,0 +1,73 @@
+import { type TestType } from '@playwright/test';
+import {
+  uniqueTitle,
+  openAuthenticatedPage,
+  createTestRecipe,
+  deleteTestRecipe,
+} from './test-data.helper';
+
+export interface SharedRecipe {
+  title: string;
+  identifier: string;
+}
+
+type CreateRecipeOptions = Parameters<typeof createTestRecipe>[2];
+
+/**
+ * Registers a per-file shared recipe via beforeAll + afterAll on the supplied
+ * test object, and returns a getter the surrounding tests use to read the
+ * created identifier/title.
+ *
+ * Why this helper exists: the previous pattern in recipes/ and shopping/
+ * specs was a hand-rolled `let recipeIdentifier` + beforeAll + afterAll +
+ * `test.skip(!recipeIdentifier)` guard on every test. The skip guards were
+ * dead code — `createTestRecipe` already throws on failure and Playwright
+ * fails downstream tests with the beforeAll error — but they obscured intent
+ * and let real "silently undefined" failure modes hide. Centralising the
+ * boilerplate also wraps the teardown in try/finally so the auth context is
+ * closed even when DELETE returns non-404.
+ *
+ * Per-file (not per-test) is intentional: the existing specs treat the
+ * recipe as read-only fixture data and creating one per test would multiply
+ * API churn ~6x for no isolation benefit (most tests don't mutate it).
+ *
+ * Note: this still uses afterAll for cleanup. A true Playwright fixture with
+ * auto-teardown that survives test crashes is tracked under #406.
+ */
+export function setupSharedRecipe(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  test: TestType<any, any>,
+  prefix: string,
+  options?: CreateRecipeOptions,
+): () => SharedRecipe {
+  let recipe: SharedRecipe | undefined;
+  let setupPage: Awaited<ReturnType<typeof openAuthenticatedPage>> | undefined;
+
+  test.beforeAll(async ({ browser }) => {
+    setupPage = await openAuthenticatedPage(browser);
+    const title = uniqueTitle(prefix);
+    const identifier = await createTestRecipe(setupPage, title, options);
+    recipe = { title, identifier };
+  });
+
+  test.afterAll(async () => {
+    if (!setupPage) return;
+    try {
+      if (recipe?.identifier) {
+        await deleteTestRecipe(setupPage, recipe.identifier);
+      }
+    } finally {
+      await setupPage.context().close();
+    }
+  });
+
+  return () => {
+    if (!recipe) {
+      throw new Error(
+        'setupSharedRecipe: recipe accessed before beforeAll completed. ' +
+          'Either the test ran out of order or beforeAll silently no-opped.',
+      );
+    }
+    return recipe;
+  };
+}

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -75,14 +75,15 @@ export async function loginViaKeycloak(
 export async function createTestRecipe(
   page: Page,
   title: string,
-  options?: { ingredient?: string; step?: string; servings?: number },
+  options?: { ingredient?: string; step?: string; servings?: number; tags?: string[] },
 ): Promise<string> {
   const ingredient = options?.ingredient ?? 'Test Ingredient';
   const step = options?.step ?? 'Test Step';
   const servings = options?.servings ?? 4;
+  const tags = options?.tags ?? [];
 
   const identifier = await page.evaluate(
-    async ({ title, ingredient, step, servings, gatewayUrl }) => {
+    async ({ title, ingredient, step, servings, tags, gatewayUrl }) => {
       const token = localStorage.getItem('access_token');
       const res = await fetch(`${gatewayUrl}/api/v1/recipes`, {
         method: 'POST',
@@ -100,7 +101,7 @@ export async function createTestRecipe(
           cookTimeMinutes: null,
           difficulty: null,
           imageUrl: null,
-          tags: [],
+          tags,
         }),
       });
       if (!res.ok) {
@@ -109,7 +110,7 @@ export async function createTestRecipe(
       const body = (await res.json()) as { identifier: string };
       return body.identifier;
     },
-    { title, ingredient, step, servings, gatewayUrl: GATEWAY_URL },
+    { title, ingredient, step, servings, tags, gatewayUrl: GATEWAY_URL },
   );
 
   return identifier;

--- a/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
@@ -1,47 +1,30 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
-import {
-  uniqueTitle,
-  openAuthenticatedPage,
-  createTestRecipe,
-  deleteTestRecipe,
-} from '../helpers/test-data.helper';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
-  let recipeIdentifier: string;
-
-  test.beforeAll(async ({ browser }) => {
-    const page = await openAuthenticatedPage(browser);
-    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Detail Test'));
-    await page.context().close();
-  });
+  const recipe = setupSharedRecipe(test, 'E2E Detail Test');
 
   test('should display recipe title', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created in beforeAll');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await expect(detail.title).toBeVisible();
     await expect(detail.title).toContainText('E2E Detail Test');
   });
 
   test('should display ingredients and steps', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await expect(detail.ingredients).not.toHaveCount(0);
     await expect(detail.steps).not.toHaveCount(0);
   });
 
   test('should have edit, delete, and shopping list buttons', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await expect(detail.editButton).toBeVisible();
     await expect(detail.deleteButton).toBeVisible();
@@ -49,22 +32,18 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
   });
 
   test('should navigate to edit page (US-032)', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.editButton.click();
-    await expect(authenticatedPage).toHaveURL(new RegExp(`/recipes/${recipeIdentifier}/edit`));
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/recipes/${recipe().identifier}/edit`));
   });
 
   test('should show and dismiss delete confirmation dialog (US-033)', async ({
     authenticatedPage,
   }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.deleteButton.click();
     await expect(detail.confirmDialog).toBeVisible();
@@ -82,10 +61,8 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
   });
 
   test('should delete recipe and navigate to list (US-033)', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.deleteButton.click();
     await expect(detail.confirmDialog).toBeVisible();
@@ -98,22 +75,14 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
 });
 
 test.describe('Servings Scaling (US-050)', () => {
-  let recipeIdentifier: string;
-
-  test.beforeAll(async ({ browser }) => {
-    const page = await openAuthenticatedPage(browser);
-    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Scaling'), {
-      ingredient: 'Flour',
-      servings: 4,
-    });
-    await page.context().close();
+  const recipe = setupSharedRecipe(test, 'E2E Scaling', {
+    ingredient: 'Flour',
+    servings: 4,
   });
 
   test('should display servings controls', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await expect(detail.servingsValue).toHaveText('4');
     await expect(detail.increaseServingsButton).toBeVisible();
@@ -121,30 +90,24 @@ test.describe('Servings Scaling (US-050)', () => {
   });
 
   test('should increase servings', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.increaseServingsButton.click();
     await expect(detail.servingsValue).toHaveText('5');
   });
 
   test('should decrease servings', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.decreaseServingsButton.click();
     await expect(detail.servingsValue).toHaveText('3');
   });
 
   test('should reset to original servings', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await detail.increaseServingsButton.click();
     await detail.increaseServingsButton.click();
@@ -152,13 +115,5 @@ test.describe('Servings Scaling (US-050)', () => {
 
     await detail.resetServingsButton.click();
     await expect(detail.servingsValue).toHaveText('4');
-  });
-
-  test.afterAll(async ({ browser }) => {
-    if (!recipeIdentifier) return;
-
-    const page = await openAuthenticatedPage(browser);
-    await deleteTestRecipe(page, recipeIdentifier);
-    await page.context().close();
   });
 });

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -1,33 +1,23 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
 import { RecipeListPage } from '../pages/recipe-list.page';
-import { uniqueTitle, openAuthenticatedPage, createTestRecipe } from '../helpers/test-data.helper';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Favorite Recipes (US-071)', () => {
-  let recipeTitle: string;
-  let recipeIdentifier: string;
-
-  test.beforeAll(async ({ browser }) => {
-    const page = await openAuthenticatedPage(browser);
-
-    recipeTitle = uniqueTitle('E2E Favorite');
-    recipeIdentifier = await createTestRecipe(page, recipeTitle, {
-      ingredient: 'Salt',
-      step: 'Add salt to taste',
-    });
-
-    await page.context().close();
+  const recipe = setupSharedRecipe(test, 'E2E Favorite', {
+    ingredient: 'Salt',
+    step: 'Add salt to taste',
   });
 
   test('should toggle favorite from recipe list card', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created in beforeAll');
-
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
-    const heart = list.favoriteButtonOnCard(recipeTitle).first();
+    const heart = list.favoriteButtonOnCard(recipe().title).first();
     await expect(heart).toHaveAttribute('aria-pressed', 'false');
 
     await heart.click();
@@ -35,28 +25,30 @@ test.describe('Favorite Recipes (US-071)', () => {
   });
 
   test('should persist favorite state across reload', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
-    const heart = list.favoriteButtonOnCard(recipeTitle).first();
+    const heart = list.favoriteButtonOnCard(recipe().title).first();
     await expect(heart).toHaveAttribute('aria-pressed', 'true', { timeout: TIMEOUTS.short });
 
     await authenticatedPage.reload();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
     await expect(heart).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('should narrow list when "Show only favorites" filter is enabled', async ({
     authenticatedPage,
   }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
     await list.filterToggle.click();
     await list.favoritesFilterChip.click();
@@ -64,26 +56,22 @@ test.describe('Favorite Recipes (US-071)', () => {
     // Filter triggers a fresh GET with favoritesOnly=true; with retries:0
     // the previous toggle's POST may not have committed before the filter
     // refetch fires. Use the long timeout to absorb that.
-    await expect(list.recipeCard(recipeTitle).first()).toBeVisible({
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
       timeout: TIMEOUTS.long,
     });
   });
 
   test('should reflect favorite state on recipe detail page', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
 
     await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('should toggle favorite back off from recipe detail', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const detail = new RecipeDetailPage(authenticatedPage);
-    await detail.goto(recipeIdentifier);
+    await detail.goto(recipe().identifier);
     await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
 
     await detail.favoriteButton.click();

--- a/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-list.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeListPage } from '../pages/recipe-list.page';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe List (US-030, US-034)', () => {
   let recipeList: RecipeListPage;
+  // Seed a known recipe so the "navigate on click" test isn't gated on
+  // ambient DB state (previously skipped silently when DB was empty).
+  const recipe = setupSharedRecipe(test, 'E2E List Test');
 
   test.beforeEach(async ({ authenticatedPage }) => {
     recipeList = new RecipeListPage(authenticatedPage);
@@ -48,13 +52,11 @@ test.describe('Recipe List (US-030, US-034)', () => {
   });
 
   test('should navigate to recipe detail on card click', async ({ authenticatedPage }) => {
-    // Skip if no recipes exist
-    const cards = recipeList.recipeCards;
-    const count = await cards.count();
-    test.skip(count === 0, 'No recipes in database — cannot test navigation');
+    const card = recipeList.recipeCard(recipe().title).first();
+    await expect(card).toBeVisible({ timeout: TIMEOUTS.default });
 
-    await cards.first().click();
-    await expect(authenticatedPage).toHaveURL(/\/recipes\/.+/);
+    await card.click();
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/recipes/${recipe().identifier}`));
   });
 
   test('should change sort order', async () => {

--- a/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-tags.spec.ts
@@ -1,51 +1,17 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { RecipeDetailPage } from '../pages/recipe-detail.page';
-import { openAuthenticatedPage, deleteTestRecipe } from '../helpers/test-data.helper';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Recipe Tags (US-070)', () => {
-  let recipeIdentifier: string;
-
-  test.beforeAll(async ({ browser }) => {
-    const page = await openAuthenticatedPage(browser);
-
-    // Create recipe with tags via the API (through the Gateway — dev server
-    // on :4200 doesn't proxy /api/*). Storage-state provides the access token
-    // in localStorage.
-    const gatewayUrl = process.env['GATEWAY_URL'] ?? 'http://localhost:5100';
-    const response = await page.evaluate(async (gw) => {
-      const token = localStorage.getItem('access_token');
-      const res = await fetch(`${gw}/api/v1/recipes`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({
-          title: 'E2E Tag Test Recipe',
-          description: null,
-          ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
-          steps: [{ number: 1, description: 'Mix' }],
-          servings: 4,
-          prepTimeMinutes: null,
-          cookTimeMinutes: null,
-          difficulty: null,
-          imageUrl: null,
-          tags: ['italian', 'pasta', 'quick'],
-        }),
-      });
-      if (!res.ok) throw new Error(`tag recipe POST ${res.status}: ${await res.text()}`);
-      return res.json();
-    }, gatewayUrl);
-
-    recipeIdentifier = response.identifier;
-    await page.context().close();
+  const recipe = setupSharedRecipe(test, 'E2E Tag Test Recipe', {
+    ingredient: 'Flour',
+    step: 'Mix',
+    tags: ['italian', 'pasta', 'quick'],
   });
 
   test('should display tags on recipe detail page', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
-    await authenticatedPage.goto(`/recipes/${recipeIdentifier}`);
+    await authenticatedPage.goto(`/recipes/${recipe().identifier}`);
     const detailPage = new RecipeDetailPage(authenticatedPage);
     await expect(detailPage.title).toBeVisible({ timeout: TIMEOUTS.default });
 
@@ -54,9 +20,7 @@ test.describe('Recipe Tags (US-070)', () => {
   });
 
   test('should display tag text correctly', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
-    await authenticatedPage.goto(`/recipes/${recipeIdentifier}`);
+    await authenticatedPage.goto(`/recipes/${recipe().identifier}`);
     await expect(authenticatedPage.locator('.tag').first()).toBeVisible({
       timeout: TIMEOUTS.default,
     });
@@ -65,13 +29,5 @@ test.describe('Recipe Tags (US-070)', () => {
     expect(tagTexts).toContain('italian');
     expect(tagTexts).toContain('pasta');
     expect(tagTexts).toContain('quick');
-  });
-
-  test.afterAll(async ({ browser }) => {
-    if (!recipeIdentifier) return;
-
-    const page = await openAuthenticatedPage(browser);
-    await deleteTestRecipe(page, recipeIdentifier);
-    await page.context().close();
   });
 });

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -1,40 +1,25 @@
 import { test, expect } from '../fixtures/auth.fixture';
 import { ShoppingCreatePage } from '../pages/shopping-create.page';
 import { ShoppingDetailPage } from '../pages/shopping-detail.page';
-import {
-  uniqueTitle,
-  openAuthenticatedPage,
-  createTestRecipe,
-  deleteTestRecipe,
-} from '../helpers/test-data.helper';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Shopping List — Generate from Recipe (US-040)', () => {
-  let recipeIdentifier: string;
-
-  test.beforeAll(async ({ browser }) => {
-    const page = await openAuthenticatedPage(browser);
-    recipeIdentifier = await createTestRecipe(page, uniqueTitle('E2E Shopping'), {
-      ingredient: 'Butter',
-    });
-    await page.context().close();
+  const recipe = setupSharedRecipe(test, 'E2E Shopping', {
+    ingredient: 'Butter',
   });
 
   test('should load recipe ingredients on create page', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const createPage = new ShoppingCreatePage(authenticatedPage);
-    await createPage.goto(recipeIdentifier);
+    await createPage.goto(recipe().identifier);
 
     await expect(createPage.titleInput).toBeVisible();
     await expect(createPage.ingredientCheckboxes).not.toHaveCount(0);
   });
 
   test('should have all ingredients selected by default', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const createPage = new ShoppingCreatePage(authenticatedPage);
-    await createPage.goto(recipeIdentifier);
+    await createPage.goto(recipe().identifier);
 
     const checkboxes = await createPage.ingredientCheckboxes.all();
     for (const checkbox of checkboxes) {
@@ -43,10 +28,8 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   });
 
   test('should deselect and reselect all ingredients', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const createPage = new ShoppingCreatePage(authenticatedPage);
-    await createPage.goto(recipeIdentifier);
+    await createPage.goto(recipe().identifier);
 
     await createPage.deselectAllButton.click();
     const checkboxes = await createPage.ingredientCheckboxes.all();
@@ -63,20 +46,16 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should disable create button when no ingredients selected', async ({
     authenticatedPage,
   }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const createPage = new ShoppingCreatePage(authenticatedPage);
-    await createPage.goto(recipeIdentifier);
+    await createPage.goto(recipe().identifier);
 
     await createPage.deselectAllButton.click();
     await expect(createPage.createButton).toBeDisabled();
   });
 
   test('should create shopping list and navigate to detail', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     const createPage = new ShoppingCreatePage(authenticatedPage);
-    await createPage.goto(recipeIdentifier);
+    await createPage.goto(recipe().identifier);
 
     await createPage.createButton.click();
 
@@ -93,8 +72,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   });
 
   test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
@@ -110,8 +87,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   });
 
   test('should check all items and reset', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
@@ -133,8 +108,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   });
 
   test('should show progress counter', async ({ authenticatedPage }) => {
-    test.skip(!recipeIdentifier, 'No recipe created');
-
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
@@ -143,13 +116,5 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     const detailPage = new ShoppingDetailPage(authenticatedPage);
     await expect(detailPage.progress).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(detailPage.progress).toContainText('/');
-  });
-
-  test.afterAll(async ({ browser }) => {
-    if (!recipeIdentifier) return;
-
-    const page = await openAuthenticatedPage(browser);
-    await deleteTestRecipe(page, recipeIdentifier);
-    await page.context().close();
   });
 });


### PR DESCRIPTION
Closes #403.

## Summary

Five spec files used the same hand-rolled pattern: `let recipeIdentifier` in describe scope, `beforeAll` calling `createTestRecipe`, every test gated by `test.skip(!recipeIdentifier, 'No recipe created')`, plus an `afterAll` that deletes if the identifier is set.

The skip guards were dead code in practice — `createTestRecipe` throws on any non-2xx and Playwright fails downstream tests with the beforeAll error — but they obscured the contract and let any real "silently undefined" mode hide. The recipe-list spec also had a `test.skip(count === 0, ...)` guard that genuinely could turn a green-on-empty-DB scenario into false confidence.

## What changed

- New `helpers/shared-recipe.ts` exporting `setupSharedRecipe(test, prefix, options?)`. It registers beforeAll/afterAll on the supplied test object, wraps teardown in try/finally so the auth context is always closed, and the returned getter throws if accessed before beforeAll completed — turning a previously-silent "recipe undefined" into a loud error.
- Migrated 5 files, removing **25 skip guards** total:
  | File | Skips removed |
  |------|---------------|
  | `recipes/recipe-detail.spec.ts` | 10 (across 2 describes) |
  | `recipes/recipe-favorite.spec.ts` | 5 |
  | `recipes/recipe-tags.spec.ts` | 2 |
  | `recipes/recipe-list.spec.ts` | 1 (count === 0 → seeded recipe + identifier-specific URL assertion) |
  | `shopping/shopping-list.spec.ts` | 8 |
- Extended `createTestRecipe` to accept a `tags?: string[]` option so the tags spec uses the standard helper instead of a duplicated inline POST.

Net: −198 / +138 LOC.

## Design choices

- **Per-file (not per-test) recipe**: matches existing behaviour; most specs read the recipe and creating one per test would multiply API churn ~6× for no isolation benefit.
- **afterAll, not a true Playwright fixture**: per-file shared state isn't a native fixture concept. afterAll suffices for the fail-loud goal. Auto-cleanup that survives a beforeAll throw (the orphan-recipe-on-crash case) is the explicit scope of #406, deliberately deferred.
- **Stronger assertion in recipe-list**: the navigation test now asserts URL contains the seeded recipe's identifier, not a regex matching any recipe URL.

## Test plan

- [x] `nx lint shell-e2e` clean
- [x] `playwright test --list` reports 134 tests (unchanged) and parses all spec files
- [ ] CI green — same number of tests reported, none skipped on the happy path

## Acceptance criteria from #403

- [x] No conditional `test.skip(!recipeId, ...)` (or similar) patterns remain in `recipes/` and `shopping/` specs
- [x] Shared per-file recipe creation is centralised in a single helper
- [x] Fixture-style errors surface as test failures with the original error message (the getter throws; createTestRecipe throws on non-2xx)
- [ ] Teardown guaranteed via fixture auto-cleanup — **partial**: cleanup runs in afterAll with try/finally; the crash-resilient version is #406
- [x] Same number of tests reported as before, none skipped on the happy path