### PR TITLE
test(e2e): wait for favorite POST to commit before downstream reads (#419)

### DIFF
--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -20,7 +20,21 @@ test.describe('Favorite Recipes (US-071)', () => {
     const heart = list.favoriteButtonOnCard(recipe().title).first();
     await expect(heart).toHaveAttribute('aria-pressed', 'false');
 
+    // Wait for POST /api/v1/recipes/{id}/favorite to commit before
+    // returning. Subsequent tests in this file (`persist favorite state
+    // across reload`, `reflect favorite state on recipe detail page`,
+    // …) refetch from the server and would race the un-committed write
+    // otherwise — see #419.
+    const favoriteCommitted = authenticatedPage.waitForResponse(
+      (res) =>
+        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
+        res.request().method() === 'POST' &&
+        res.ok(),
+      { timeout: TIMEOUTS.default },
+    );
     await heart.click();
+    await favoriteCommitted;
+
     await expect(heart).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -74,7 +88,18 @@ test.describe('Favorite Recipes (US-071)', () => {
     await detail.goto(recipe().identifier);
     await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
 
+    // Same race as in test 1 (#419): without waiting on the POST commit,
+    // a subsequent reload could still see aria-pressed='true'.
+    const favoriteCommitted = authenticatedPage.waitForResponse(
+      (res) =>
+        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
+        res.request().method() === 'POST' &&
+        res.ok(),
+      { timeout: TIMEOUTS.default },
+    );
     await detail.favoriteButton.click();
+    await favoriteCommitted;
+
     await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -74,6 +74,10 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
+    // The list created earlier in this file goes through Wolverine
+    // messaging + projection before showing up in /api/v1/shopping-lists.
+    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
+    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
@@ -89,6 +93,10 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check all items and reset', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
+    // The list created earlier in this file goes through Wolverine
+    // messaging + projection before showing up in /api/v1/shopping-lists.
+    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
+    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
@@ -110,6 +118,10 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should show progress counter', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
+    // The list created earlier in this file goes through Wolverine
+    // messaging + projection before showing up in /api/v1/shopping-lists.
+    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
+    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -74,10 +74,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
-    // The list created earlier in this file goes through Wolverine
-    // messaging + projection before showing up in /api/v1/shopping-lists.
-    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
-    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
@@ -93,10 +89,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should check all items and reset', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
-    // The list created earlier in this file goes through Wolverine
-    // messaging + projection before showing up in /api/v1/shopping-lists.
-    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
-    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 
@@ -118,10 +110,6 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
   test('should show progress counter', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
-    // The list created earlier in this file goes through Wolverine
-    // messaging + projection before showing up in /api/v1/shopping-lists.
-    // Without TIMEOUTS.long, the click times out on the empty state — see #419.
-    await expect(firstCard).toBeVisible({ timeout: TIMEOUTS.long });
     await firstCard.click();
     await authenticatedPage.waitForURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
 


### PR DESCRIPTION
Partial fix for #419 — handles the favorite race; everything else turned out to be backend bugs.

## What this PR keeps

\`recipes/recipe-favorite.spec.ts\` test 1 (\`should toggle favorite from recipe list card\`) and test 5 (\`should toggle favorite back off from recipe detail\`) now \`waitForResponse\` on \`POST /api/v1/recipes/{id}/favorite\` before the optimistic-UI assertion, so subsequent tests in the file see committed backend state.

This is genuine test hygiene — clicking before the write commits is a real race. Verified by CI: tests 1 + 2 + 3 of recipe-favorite now pass cleanly post-merge of #424.

## What this PR drops

The shopping-list visibility wait I initially added was treating a **symptom of a real backend bug**, not a flake. Investigation revealed:

- POST \`/api/v1/shopping-lists\` writes to the write DB
- GET \`/api/v1/shopping-lists\` reads from a read DB that **has no projection handler for \`ShoppingListCreatedEvent\`**
- Newly-created lists never appear in the GET endpoint, no matter how long the test waits

The 60-s timeout would have hidden a critical product bug behind "tests are flaky". Reverted, filed **[#426](https://github.com/smartsolutionslab/yumney/issues/426)** to fix the missing projection — production users would hit the same bug on the lists overview.

## Two related issues spawned

- **#426** — missing \`ShoppingListCreatedEvent\` projection (the shopping-list test failures will resolve when this lands)
- **#427** — favorite state diverges between \`/api/v1/recipes\` and \`/api/v1/recipes/{id}\` (the recipe-favorite test 4 + 5 failures; same family as #426)

## Acceptance criteria from #419

- [x] \`recipes/recipe-favorite.spec.ts\` test 1 fix is documented in a comment naming the race
- [x] No \`waitForTimeout\` reintroduced
- [x] \`shopping/merged-list.spec.ts:37\` audited — already passing as flaky-but-recovers (1 retry green)
- [ ] \`recipes/recipe-favorite.spec.ts:79\` passes 5/5 consecutive CI runs — **partial**: tests 1-3 + 5 (toggle-off) pass; tests 4 + 5 (detail-page state) blocked on #427

## Why land this anyway

The \`waitForResponse\` change is a sound improvement that helps even when #427 is fixed. The shopping-list revert avoids encoding "wait 60s for a bug" in the test suite. New issues #426 + #427 take the rest of the work to the right place — backend.