### PR TITLE
fix(recipes): invalidate recipe cache on favorite toggle (#427)

### DIFF
--- a/client/libs/shared/api-client/src/lib/recipe-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.spec.ts
@@ -155,6 +155,32 @@ describe('RecipeApiService', () => {
     });
   });
 
+  describe('toggleFavorite', () => {
+    it('should POST /api/v1/recipes/:identifier/favorite', () => {
+      service.toggleFavorite('recipe-abc').subscribe();
+
+      const req = httpTesting.expectOne('/api/v1/recipes/recipe-abc/favorite');
+      expect(req.request.method).toBe('POST');
+      req.flush({ isFavorite: true });
+    });
+
+    it('should invalidate the recipe cache so a subsequent getRecipeById refetches (#427)', () => {
+      // Prime the in-memory shareReplay cache.
+      service.getRecipeById('recipe-abc').subscribe();
+      httpTesting.expectOne('/api/v1/recipes/recipe-abc').flush(mockRecipeDetail);
+
+      service.toggleFavorite('recipe-abc').subscribe();
+      httpTesting.expectOne('/api/v1/recipes/recipe-abc/favorite').flush({ isFavorite: true });
+
+      // After toggle, getRecipeById must hit the network again — the cached
+      // observable would replay stale isFavorite without invalidation.
+      service.getRecipeById('recipe-abc').subscribe();
+      const refetch = httpTesting.expectOne('/api/v1/recipes/recipe-abc');
+      expect(refetch.request.method).toBe('GET');
+      refetch.flush({ ...mockRecipeDetail });
+    });
+  });
+
   describe('getRecipes', () => {
     const mockListResponse: RecipeListResponse = {
       items: [

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -201,6 +201,12 @@ export class RecipeApiService {
   }
 
   toggleFavorite(identifier: string): Observable<FavoriteState> {
-    return this.http.post<FavoriteState>(API_ENDPOINTS.recipes.favorite(identifier), {});
+    // Invalidate the in-memory shareReplay cache so a subsequent
+    // getRecipeById refetches with the new isFavorite — without this the
+    // detail page replays the pre-toggle response and shows aria-pressed
+    // wrong on the favorite button (#427).
+    return this.http
+      .post<FavoriteState>(API_ENDPOINTS.recipes.favorite(identifier), {})
+      .pipe(tap(() => this.invalidateRecipeCache(identifier)));
   }
 }


### PR DESCRIPTION
Closes #427.

## Root cause

\`RecipeApiService.getRecipeById\` (\`client/libs/shared/api-client/src/lib/recipe-api.service.ts:170\`) uses an in-memory \`shareReplay(1)\` cache keyed by identifier:

\`\`\`ts
getRecipeById(identifier: string): Observable<RecipeDetail> {
  if (!this.recipeCache.has(identifier)) {
    this.recipeCache.set(
      identifier,
      this.http.get<RecipeDetail>(...).pipe(shareReplay(1)),
    );
  }
  return this.recipeCache.get(identifier)!;
}
\`\`\`

\`updateRecipe\` and \`deleteRecipe\` invalidate that cache via \`tap(invalidateRecipeCache)\`. **\`toggleFavorite\` does not** — so after a favorite toggle, the next navigation to the detail page replays the *pre-toggle* response and shows the wrong \`aria-pressed\` on the favorite button.

This was the cause of recipe-favorite e2e tests 4 + 5 flaking post-#424. The NGSW SAFE_MODE fix didn't introduce the bug; it just made it visible because the SW now correctly serves the same stale response from its own cache when the in-memory cache misses.

## Fix

One-line addition to \`toggleFavorite\`:

\`\`\`ts
toggleFavorite(identifier: string): Observable<FavoriteState> {
  return this.http
    .post<FavoriteState>(API_ENDPOINTS.recipes.favorite(identifier), {})
    .pipe(tap(() => this.invalidateRecipeCache(identifier)));
}
\`\`\`

Mirrors the existing \`updateRecipe\` / \`deleteRecipe\` pattern.

## Test

New unit test in \`recipe-api.service.spec.ts\` primes the cache, toggles favorite, and asserts the next \`getRecipeById\` hits the network again. Without the fix this test fails (the second \`getRecipeById\` returns the cached observable and \`httpTesting.expectOne\` finds zero requests).

\`yarn nx test shared-api-client\` → 12/12 passing locally.

## Test plan

- [x] Unit test added and passing
- [x] \`nx lint shared-api-client\` clean
- [ ] E2E run: \`recipes/recipe-favorite.spec.ts\` tests 4 + 5 pass

## Acceptance criteria from #427

- [x] Root cause identified — in-memory \`shareReplay\` cache + missing invalidation in \`toggleFavorite\`
- [x] Fix on the frontend (no backend change needed; the API contract already returns correct \`isFavorite\`)
- [ ] E2E tests \`recipe-favorite.spec.ts:78\` + \`:86\` pass 5/5 consecutive CI runs (will verify)

## Why a frontend-only fix sufficed

The investigation under #426 revealed both the list and detail backend handlers use the same shared DB and read the canonical \`RecipeFavorites\` table. The contract is correct. The bug was the frontend consumer caching a response and never invalidating it on the mutation.