### PR TITLE
fix(recipes): surface SSE timeout to subscribers (#430)

### DIFF
--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -31,7 +31,18 @@ export class RecipeApiService {
   importRecipeStream(url: string): Observable<ImportStreamEvent> {
     return new Observable((subscriber) => {
       const abortController = new AbortController();
-      const timeout = setTimeout(() => abortController.abort(), RecipeApiService.SSE_TIMEOUT_MS);
+      // Have the timeout itself surface an error to subscribers. Without
+      // this, the catch blocks in fetchSseStream / readSseBody guard
+      // subscriber.error with `if (!signal.aborted)` — and a timeout-
+      // induced abort sets signal.aborted=true, so the guard skips the
+      // error and the Observable hangs forever (#430). Calling
+      // subscriber.error from the timeout pre-empts the catch; if the
+      // stream completed normally, RxJS makes subsequent error/complete
+      // calls no-ops so this is safe.
+      const timeout = setTimeout(() => {
+        abortController.abort();
+        subscriber.error(new Error('Import timed out'));
+      }, RecipeApiService.SSE_TIMEOUT_MS);
 
       this.fetchSseStream(url, abortController, subscriber).finally(() => clearTimeout(timeout));
 


### PR DESCRIPTION
Closes #430.

## Problem

\`importRecipeStream\`'s 60s timeout aborted the request but never surfaced an error to the user. The catch blocks in \`fetchSseStream\` / \`readSseBody\` guard \`subscriber.error\` with \`if (!signal.aborted)\`, and a timeout-induced abort sets \`signal.aborted = true\` → guard skips the error → Observable hangs → \`isLoading\` stays true → **no banner is ever shown**.

End user experience on a flaky URL: spinner forever, no feedback. E2E test \`dashboard/import-recipe.spec.ts:28\` is \`fixme\`'d (PR #428) until this lands.

## Fix

Have the timeout itself call \`subscriber.error('Import timed out')\` immediately before aborting:

\`\`\`ts
const timeout = setTimeout(() => {
  abortController.abort();
  subscriber.error(new Error('Import timed out'));
}, RecipeApiService.SSE_TIMEOUT_MS);
\`\`\`

RxJS makes subsequent error/complete calls no-ops on a closed subscriber, so this is safe even if the stream finished naturally just before the timeout fired. The cleanup function still \`clearTimeout\`'s the handler, so a user navigating away during a fast import does not produce a phantom error.

## Test plan

- [x] Existing \`recipe-api.service.spec.ts\` (12 tests) all pass
- [x] \`nx lint shared-api-client\` clean
- [ ] After merge: open follow-up to remove the \`test.fixme\` in \`dashboard/import-recipe.spec.ts:28\` and verify it passes in <2 s

## Acceptance criteria from #430

- [x] Timeout / network failure surfaces an error
- [x] User navigation away during import still aborts silently (clearTimeout cancels the would-fire callback)
- [ ] \`recipe-api.service.spec.ts\` covers the timeout path — **deferred**: vi.useFakeTimers doesn't compose with zone.js scheduling. Documented in commit body. The e2e test (post-fixme-removal) will cover it.
- [ ] \`dashboard/import-recipe.spec.ts:28\` passes 5/5 — verify in the fixme-removal follow-up

## Why ship without a unit test

The fix is one line of behaviour and clearly mirrors the existing \`if (!signal.aborted)\` semantics. Investing in a zone.js-aware fake-timer harness for one test is disproportionate; the e2e coverage path is shorter.