### PR TITLE
fix(pwa): bump NGSW freshness timeout 3s → 15s (#432)

### DIFF
--- a/client/apps/shell/ngsw-config.json
+++ b/client/apps/shell/ngsw-config.json
@@ -39,7 +39,7 @@
         "maxSize": 100,
         "maxAge": "7d",
         "strategy": "freshness",
-        "timeout": "3s"
+        "timeout": "15s"
       }
     },
     {
@@ -49,7 +49,7 @@
         "maxSize": 50,
         "maxAge": "1d",
         "strategy": "freshness",
-        "timeout": "3s"
+        "timeout": "15s"
       }
     },
     {


### PR DESCRIPTION
Most-likely-root-cause attempt for #432. One-line config change; if e2e goes green it confirms the diagnosis.

## Hypothesis

\`recipes-api\` and \`shopping-api\` data groups use \`strategy: freshness, timeout: 3s\`. Under busy CI load the API regularly takes >3 s, NGSW falls back to its previously-cached snapshot, tests see stale data. This is the only common denominator across the 5 remaining e2e flakes:

- \`shopping/shopping-list.spec.ts:74\` strikethrough
- \`shopping/shopping-list.spec.ts:93\` check-all-and-reset
- \`shopping/shopping-list.spec.ts:118\` progress-counter
- \`recipes/recipe-favorite.spec.ts:78\` reflect-favorite-on-detail
- \`recipes/recipe-favorite.spec.ts:86\` toggle-back-off-from-detail

All five share: mutation-then-read-back, backend contract tests pass, frontend no in-memory cache (or properly invalidated post-#427).

## Trade-off

Users on flaky cellular get a 15 s wait before NGSW falls back to cache (vs 3 s before this change). Acceptable: the live-data path now works reliably; the genuine-offline path is slightly slower but still functions. Most users care about the former.

If 15 s turns out to harm offline UX, alternatives:
- Drop \`/api/v1/recipes\` (list) from data groups; keep \`/*\` (detail) — list is less useful offline anyway
- Disable SW under E2E mode via build flag
- Separate timeout per data group based on use-case

## Test plan

- [ ] CI run on this branch shows the 5 listed failures pass
- [ ] No regression in PWA offline tests (\`pwa/offline.spec.ts\`)
- [ ] No regression in suite total runtime

## Acceptance criteria from #432 (revised)

- [ ] All five flakes pass 5/5 consecutive CI runs
- [x] Fix is minimal and reversible
- [ ] Trace artifact confirmation deferred — if green, no need; if not, dig deeper

## What if it doesn't fix the flakes

Then the root cause is NOT NGSW freshness fallback. Most likely alternative: the per-test browser context creates a fresh SW that races its own activation. Next experiment: \`page.context.unrouteAll()\` + \`unregister()\` of any inherited SW at test start, or disable the SW for the affected specs.