### PR TITLE
test(e2e): mockApiError helper + dashboard save error-path tests (#408 → fixme'd pending #438)

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -22,7 +22,13 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await dashboard.goto();
   });
 
-  test('shows error banner when save returns 500', async ({ authenticatedPage }) => {
+  // fixme pending #438: dashboard's error banner is gated on the import
+  // section being expanded; a save-error from the manual-create flow has
+  // no visible surface for users. The test correctly fires the POST and
+  // gets the mocked 500 — the gap is in the dashboard template, not the
+  // test. Re-enable once the banner moves out of the importSectionExpanded
+  // @if and renders unconditionally on serverError().
+  test.fixme('shows error banner when save returns 500', async ({ authenticatedPage }) => {
     await mockApiError(authenticatedPage, '**/api/v1/recipes', 500, {
       detail: 'An unexpected error occurred.',
     });
@@ -53,7 +59,8 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await expect(authenticatedPage.locator('#preview-title')).toHaveValue('E2E 500 Test');
   });
 
-  test('shows error banner when save returns 422 with validation errors', async ({
+  // fixme pending #438: same banner-placement issue as the 500 case.
+  test.fixme('shows error banner when save returns 422 with validation errors', async ({
     authenticatedPage,
   }) => {
     await mockApiError(authenticatedPage, '**/api/v1/recipes', 422, {

--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -29,10 +29,24 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
 
     await dashboard.createButton.click();
     await expect(dashboard.recipePreview).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(authenticatedPage.locator('#preview-title')).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
     await fillMinimalRecipeForm(authenticatedPage, 'E2E 500 Test');
 
-    await authenticatedPage.locator('.save-btn').click();
+    // Scope save-btn to within the recipe-preview so we don't accidentally
+    // hit another .save-btn elsewhere on the dashboard. Wait for the
+    // POST response before asserting the banner so we know the click
+    // actually fired the request the mock is supposed to fulfill.
+    const savePost = authenticatedPage.waitForResponse(
+      (res) =>
+        new URL(res.url()).pathname === '/api/v1/recipes' &&
+        res.request().method() === 'POST',
+      { timeout: TIMEOUTS.default },
+    );
+    await dashboard.recipePreview.locator('.save-btn').click();
+    await savePost;
 
     await expect(dashboard.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
     // Form must survive the error so the user can retry without retyping.
@@ -51,10 +65,20 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
 
     await dashboard.createButton.click();
     await expect(dashboard.recipePreview).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(authenticatedPage.locator('#preview-title')).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
 
     await fillMinimalRecipeForm(authenticatedPage, 'E2E 422 Test');
 
-    await authenticatedPage.locator('.save-btn').click();
+    const savePost = authenticatedPage.waitForResponse(
+      (res) =>
+        new URL(res.url()).pathname === '/api/v1/recipes' &&
+        res.request().method() === 'POST',
+      { timeout: TIMEOUTS.default },
+    );
+    await dashboard.recipePreview.locator('.save-btn').click();
+    await savePost;
 
     await expect(dashboard.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
     await expect(authenticatedPage.locator('#preview-title')).toHaveValue('E2E 422 Test');

--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { DashboardPage } from '../pages/dashboard.page';
+import { mockApiError } from '../helpers/error-mock';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+/**
+ * Coverage for #408 — error paths on POST /api/v1/recipes (manual create
+ * → save). Previously every spec exercised happy-path saves only; users
+ * had no e2e safety net for what happens when the backend errors.
+ *
+ * Both tests use mockApiError to inject a ProblemDetails response and
+ * assert against the dashboard's error banner ([role="alert"]). The
+ * mock's body shape mirrors GlobalExceptionHandlerMiddleware /
+ * ValidationExtensions output so the frontend's error-mapping sees
+ * realistic input.
+ */
+test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
+  let dashboard: DashboardPage;
+
+  test.beforeEach(async ({ authenticatedPage }) => {
+    dashboard = new DashboardPage(authenticatedPage);
+    await dashboard.goto();
+  });
+
+  test('shows error banner when save returns 500', async ({ authenticatedPage }) => {
+    await mockApiError(authenticatedPage, '**/api/v1/recipes', 500, {
+      detail: 'An unexpected error occurred.',
+    });
+
+    await dashboard.createButton.click();
+    await expect(dashboard.recipePreview).toBeVisible({ timeout: TIMEOUTS.default });
+
+    await fillMinimalRecipeForm(authenticatedPage, 'E2E 500 Test');
+
+    await authenticatedPage.locator('.save-btn').click();
+
+    await expect(dashboard.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
+    // Form must survive the error so the user can retry without retyping.
+    await expect(authenticatedPage.locator('#preview-title')).toHaveValue('E2E 500 Test');
+  });
+
+  test('shows error banner when save returns 422 with validation errors', async ({
+    authenticatedPage,
+  }) => {
+    await mockApiError(authenticatedPage, '**/api/v1/recipes', 422, {
+      errors: {
+        title: ["'Title' must not be empty."],
+        'ingredients[0].name': ["'Name' must not be empty."],
+      },
+    });
+
+    await dashboard.createButton.click();
+    await expect(dashboard.recipePreview).toBeVisible({ timeout: TIMEOUTS.default });
+
+    await fillMinimalRecipeForm(authenticatedPage, 'E2E 422 Test');
+
+    await authenticatedPage.locator('.save-btn').click();
+
+    await expect(dashboard.errorBanner).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(authenticatedPage.locator('#preview-title')).toHaveValue('E2E 422 Test');
+  });
+});
+
+async function fillMinimalRecipeForm(
+  page: import('@playwright/test').Page,
+  title: string,
+): Promise<void> {
+  // The manual-create flow pre-populates one empty ingredient row and one
+  // empty step row; only need to fill them so client-side validation
+  // doesn't block the submit. Ingredient amount is optional per the form,
+  // but the name is not.
+  await page.locator('#preview-title').fill(title);
+  await page.locator('#preview-servings').fill('4');
+  // First ingredient + step rows exist by default; their inputs use
+  // formControlName="name" / "description" within their row containers.
+  await page.locator('input[formControlName="name"]').first().fill('Salt');
+  await page.locator('textarea[formControlName="description"]').first().fill('Mix everything.');
+}

--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -92,11 +92,19 @@ async function fillMinimalRecipeForm(
   // The manual-create flow pre-populates one empty ingredient row and one
   // empty step row; only need to fill them so client-side validation
   // doesn't block the submit. Ingredient amount is optional per the form,
-  // but the name is not.
+  // but ingredient.name and step.description are required.
+  //
+  // Scope ingredient/step selectors to their row containers — the recipe
+  // also has a top-level description textarea with formControlName="description"
+  // that would otherwise match before the step row.
   await page.locator('#preview-title').fill(title);
   await page.locator('#preview-servings').fill('4');
-  // First ingredient + step rows exist by default; their inputs use
-  // formControlName="name" / "description" within their row containers.
+  // formControlName="name" is unique to ingredient rows; .first() is fine.
   await page.locator('input[formControlName="name"]').first().fill('Salt');
-  await page.locator('textarea[formControlName="description"]').first().fill('Mix everything.');
+  // Scope description textarea to .step-fields — there is also a
+  // recipe-level textarea#preview-description with the same formControlName.
+  await page
+    .locator('.step-fields textarea[formControlName="description"]')
+    .first()
+    .fill('Mix everything.');
 }

--- a/client/apps/shell-e2e/src/helpers/error-mock.ts
+++ b/client/apps/shell-e2e/src/helpers/error-mock.ts
@@ -1,0 +1,49 @@
+import { type Page } from '@playwright/test';
+
+export interface ProblemDetails {
+  type?: string;
+  title?: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  errors?: Record<string, string[]>;
+}
+
+/**
+ * Inject a synthetic ProblemDetails response on the next request matching
+ * the given URL pattern. Used by error-path e2e tests to exercise the UI's
+ * 5xx / 422 / 409 handling without orchestrating real backend chaos.
+ *
+ * The body shape mirrors what GlobalExceptionHandlerMiddleware and
+ * ValidationExtensions produce in production (RFC 7807 problem+json), so
+ * the frontend's error-mapping logic sees realistic input.
+ */
+export async function mockApiError(
+  page: Page,
+  urlPattern: string | RegExp,
+  status: number,
+  problem: Partial<Omit<ProblemDetails, 'status'>> = {},
+): Promise<void> {
+  await page.route(urlPattern, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/problem+json',
+      body: JSON.stringify({
+        type: problem.type ?? `https://tools.ietf.org/html/rfc7231#section-${status}`,
+        title: problem.title ?? defaultTitleFor(status),
+        status,
+        ...(problem.detail !== undefined && { detail: problem.detail }),
+        ...(problem.instance !== undefined && { instance: problem.instance }),
+        ...(problem.errors !== undefined && { errors: problem.errors }),
+      }),
+    }),
+  );
+}
+
+function defaultTitleFor(status: number): string {
+  if (status === 409) return 'Conflict';
+  if (status === 422) return 'Validation error(s) occurred.';
+  if (status >= 500) return 'Internal Server Error';
+  if (status >= 400) return 'Bad Request';
+  return 'Error';
+}


### PR DESCRIPTION
First slice of #408 — and the e2e tests **caught a real product UX bug** along the way.

## What lands cleanly

\`helpers/error-mock.ts\` — the reusable \`mockApiError(page, urlPattern, status, problem?)\` helper. Body shape mirrors \`GlobalExceptionHandlerMiddleware\` and \`ValidationExtensions\` (RFC 7807 \`application/problem+json\`). Useful for the next slices: #409 optimistic-rollback, more error paths in shopping/meal-planner, etc.

## Tests written but \`fixme\`'d pending #438

\`dashboard/save-recipe-error-paths.spec.ts\` exercises:
- 500 on \`POST /api/v1/recipes\` → expect error banner + form preserved
- 422 with field-level errors → expect error banner + form preserved

Both fail because the dashboard's only error banner is **inside \`@if (importSectionExpanded())\`** — when the user is in the manual-create flow with the import section collapsed, a save error has zero user-visible feedback.

This is a real product UX bug. Filed [#438](https://github.com/smartsolutionslab/yumney/issues/438) with the proposed fix (move the banner out of the import-section gate). Tests \`test.fixme\`'d so they're easy to re-enable once #438 ships — and they document exactly which scenario the bug breaks.

## Why ship the helper anyway

\`mockApiError\` is the primitive that #409 (optimistic rollback) and the broader 5xx coverage rollout depend on. Landing it now unblocks that work; the dashboard-specific tests can come off fixme as soon as #438 lands.

## Test plan

- [x] \`nx lint shell-e2e\` clean
- [x] CI: 0 failures (the 2 fixme'd tests show as skipped)
- [x] Helper compiles and types correctly

## Acceptance criteria from #408

- [x] Reusable \`mockApiError\` helper
- [x] 5xx test written (currently fixme'd, blocked on #438)
- [x] 422 test written (currently fixme'd, blocked on #438)
- [ ] Banner + retained-input assertions verifiable — **after #438**
- [ ] Retry path test — deferred (no explicit retry button in UI; user re-clicks)

## Lesson logged

When an e2e test makes the right API call and gets the right response, but the assertion fails because the UI never shows feedback, **the test is doing its job — it's exposing a real UX gap.** \`test.fixme\` + a clear bug issue is the honest move; padding timeouts or removing the test would erase the signal.