### PR TITLE
test(e2e): add global-teardown sweeper for orphaned E2E recipes (#406)

### DIFF
--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   // Refuse to start if BASE_URL/GATEWAY_URL points outside localhost. The
   // suite issues real writes; set E2E_ALLOW_REMOTE=true to override.
   globalSetup: require.resolve('./src/global-setup'),
+  // Sweep up any orphaned E2E-prefixed recipes left behind by tests that
+  // crashed (afterAll is bypassed on crash). See src/global-teardown.ts.
+  globalTeardown: require.resolve('./src/global-teardown'),
   // Bumped from 30s to 60s: post-token-expiry-fix, fixture-heavy beforeAll
   // hooks (openAuthenticatedPage + API POST under parallel worker pressure)
   // started exceeding 30s. The real API calls themselves are ~1s; the budget

--- a/client/apps/shell-e2e/src/global-teardown.ts
+++ b/client/apps/shell-e2e/src/global-teardown.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+
+const E2E_TITLE_PREFIX = 'E2E ';
+const PAGE_SIZE = 100;
+
+/**
+ * Backstop for orphaned test data (#406). The `setupSharedRecipe` helper
+ * pairs every \`beforeAll\` create with an \`afterAll\` delete, but afterAll
+ * is bypassed when a test crashes (or when beforeAll itself throws after
+ * partially succeeding). Without this sweeper, every crash leaves a
+ * stranded recipe in the dev DB; over time the seed data drifts and
+ * inter-spec ordering becomes unpredictable.
+ *
+ * Runs once after the entire suite finishes. Lists all recipes the test
+ * user owns, filters to those whose title starts with the well-known
+ * E2E prefix, and DELETEs them.
+ */
+export default async function globalTeardown(): Promise<void> {
+  // Skip when running against a non-local target — env-guard normally
+  // prevents that, but the teardown shouldn't issue mass DELETEs against
+  // anything but a localhost dev DB regardless.
+  const gatewayUrl = process.env['GATEWAY_URL'] ?? 'http://localhost:5100';
+  if (!gatewayUrl.includes('localhost') && !gatewayUrl.includes('127.0.0.1')) {
+    return;
+  }
+
+  const tokensFile = process.env['E2E_TOKENS_FILE'];
+  if (!tokensFile) {
+    // Local runs without a pre-fetched token dump — skip silently. The
+    // sweeper is a CI hygiene net, not a hard requirement.
+    return;
+  }
+
+  const accessToken = readAccessToken(tokensFile);
+  if (!accessToken) return;
+
+  const orphans = await listE2eRecipes(gatewayUrl, accessToken);
+  if (orphans.length === 0) {
+    console.log('[global-teardown] no orphaned E2E recipes to clean up');
+    return;
+  }
+
+  let deleted = 0;
+  let failed = 0;
+  for (const id of orphans) {
+    const ok = await deleteRecipe(gatewayUrl, accessToken, id);
+    if (ok) deleted += 1;
+    else failed += 1;
+  }
+  console.log(
+    `[global-teardown] swept ${deleted} orphaned E2E recipes` +
+      (failed > 0 ? ` (${failed} delete failures, ignored)` : ''),
+  );
+}
+
+function readAccessToken(file: string): string | null {
+  try {
+    const tokens = JSON.parse(readFileSync(file, 'utf8')) as { access_token?: string };
+    return tokens.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function listE2eRecipes(gatewayUrl: string, token: string): Promise<string[]> {
+  const orphans: string[] = [];
+  // Walk pages so a long-running suite that produces >PAGE_SIZE recipes
+  // still gets fully swept.
+  for (let page = 1; page <= 20; page += 1) {
+    const url = `${gatewayUrl}/api/v1/recipes?page=${page}&pageSize=${PAGE_SIZE}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) return orphans;
+
+    const body = (await res.json()) as {
+      items?: Array<{ identifier: string; title: string }>;
+      totalPages?: number;
+    };
+    const items = body.items ?? [];
+    for (const item of items) {
+      if (item.title.startsWith(E2E_TITLE_PREFIX)) {
+        orphans.push(item.identifier);
+      }
+    }
+
+    if (body.totalPages !== undefined && page >= body.totalPages) break;
+    if (items.length < PAGE_SIZE) break;
+  }
+  return orphans;
+}
+
+async function deleteRecipe(gatewayUrl: string, token: string, id: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${gatewayUrl}/api/v1/recipes/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return res.ok || res.status === 404;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #406.

## Why this matters

\`setupSharedRecipe\` pairs every \`beforeAll\` create with an \`afterAll\` delete, but **afterAll is bypassed when a test crashes** (or when beforeAll itself throws after partially succeeding). Each crash leaves a stranded recipe in the dev DB; over time the seed data drifts and inter-spec ordering becomes unpredictable.

## What lands

\`src/global-teardown.ts\`:

- runs once after the entire suite, in the Node process (not browser)
- reads the same \`E2E_TOKENS_FILE\` the auth.setup uses
- walks pages of \`GET /api/v1/recipes\` filtering by \`E2E \` title prefix
- \`DELETE\`s each match, treats 404 as already-clean
- skips silently against non-localhost gateway (defense-in-depth on top of #400's env-guard) and when no token file is configured (local runs without CI-style token dumps)

Wired via \`playwright.config.ts\` \`globalTeardown\` alongside the existing \`globalSetup\`.

## What it does NOT change

- The existing \`afterAll\` hooks stay as the **fast path** — they fire per-describe immediately after tests complete, keeping the dev DB clean during a normal run
- No spec-level changes — the sweeper is invisible to test authors
- No impact on local runs without a tokens file

## Test plan

- [x] \`nx lint shell-e2e\` clean
- [ ] CI run completes; teardown logs the count of swept recipes (should be 0 on a clean run, >0 only when tests crashed)
- [ ] Force a test to throw locally; verify the sweeper deletes the orphan on next run

## Acceptance criteria from #406

- [x] \`globalTeardown\` sweeper deletes recipes whose title starts with the well-known E2E prefix
- [ ] After a forced crash, the dev DB has zero leftover E2E recipes — verifiable post-merge with a deliberate-throw test
- [x] No CI workflow changes required; sweeper uses existing \`E2E_TOKENS_FILE\` + \`GATEWAY_URL\` env vars

## Why globalTeardown rather than per-fixture cleanup

Per-fixture cleanup is what \`afterAll\` already provides. The interesting case is the **failure paths** that bypass afterAll. A globalTeardown is the only Playwright lifecycle hook that's guaranteed to run regardless of test/worker outcome, so it's the right backstop.