### PR TITLE
test(recipes): migrate recipe-card + delete-btn to data-testid (#404 slice 2)

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -116,7 +116,12 @@
       <a class="btn-primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
       </a>
-      <button class="btn-danger" [disabled]="isDeleting()" (click)="onDelete()">
+      <button
+        class="btn-danger"
+        data-testid="recipe-delete-btn"
+        [disabled]="isDeleting()"
+        (click)="onDelete()"
+      >
         {{
           isDeleting() ? t('recipes.detail.delete.deleting') : t('recipes.detail.actions.delete')
         }}

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -1,5 +1,10 @@
 @if (assignMode()) {
-  <div class="recipe-card assign-card" (click)="onAssign($event)" *transloco="let t">
+  <div
+    class="recipe-card assign-card"
+    data-testid="recipe-card"
+    (click)="onAssign($event)"
+    *transloco="let t"
+  >
     @if (recipe().imageUrl) {
       <img
         [src]="recipe().imageUrl"
@@ -34,6 +39,7 @@
 } @else {
   <a
     class="recipe-card"
+    data-testid="recipe-card"
     [routerLink]="ROUTES.recipes.detail(recipe().identifier)"
     *transloco="let t"
   >

--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -9,9 +9,12 @@ export const SELECTORS = {
     steps: '.step-fields',
   },
   recipe: {
-    card: '.recipe-card',
+    card: '[data-testid="recipe-card"]',
     title: '.recipe-title',
-    deleteBtn: '.btn-danger',
+    deleteBtn: '[data-testid="recipe-delete-btn"]',
+    // confirmDelete is the modal confirmation button inside yn-confirm-dialog;
+    // shared component, scope-agnostic — keep CSS selector for now until the
+    // dialog gets its own data-testid in a follow-up.
     confirmDelete: '.btn-danger-filled',
   },
   chat: {


### PR DESCRIPTION
Second slice of #404. Pattern established in #445 — migrate selectors group by group as small focused PRs.

## What lands

- \`recipe-list/recipe-card.component.html\`: \`data-testid="recipe-card"\` on both rendered variants (assign-mode \`<div>\` and navigation \`<a>\`)
- \`recipe-detail.component.html\`: \`data-testid="recipe-delete-btn"\` on the destructive action
- \`selectors.ts\`: \`recipe.card\` and \`recipe.deleteBtn\` switched to \`data-testid\`

## What's deferred (intentional)

- \`recipe.title\` (\`.recipe-title\`) — used for \`hasText\` content matching, not target selection; equivalent risk
- \`recipe.confirmDelete\` (\`.btn-danger-filled\`) — modal button inside the shared \`yn-confirm-dialog\`; will migrate when we touch that component (kept here as a CSS selector with a comment so the next maintainer knows)

## Why slice by feature

A single big rewrite of \`selectors.ts\` would be unreviewable and high-risk. Per-feature slices keep diffs focused on one component family + its tests.

## Test plan

- [x] \`nx lint shell-e2e\` clean
- [x] \`nx lint recipes\` clean
- [ ] CI: recipe-list, recipe-detail, recipe-favorite, recipe-tags specs all still pass with the new selectors