### PR TITLE
test(shopping): migrate merged-list selectors to data-testid (#404 slice 3)

### DIFF
--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -47,11 +47,11 @@ export const SELECTORS = {
     retryBtn: '.retry-btn',
   },
   shopping: {
-    categoryGroup: '.category-group',
+    categoryGroup: '[data-testid="shopping-category-group"]',
     itemName: '.item-name',
-    addInput: '.add-input',
-    emptyState: '.empty-state',
-    progressBar: '.progress-bar',
+    addInput: '[data-testid="shopping-add-input"]',
+    emptyState: '[data-testid="shopping-empty-state"]',
+    progressBar: '[data-testid="shopping-progress-bar"]',
     retryBtn: '.retry-btn',
   },
   profileSettings: {

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -23,7 +23,7 @@
   </div>
 
   @if (totalItems() > 0) {
-    <div class="progress-bar">
+    <div class="progress-bar" data-testid="shopping-progress-bar">
       {{ boughtItems() }} / {{ totalItems() }} {{ t('shopping.checked') }}
     </div>
   }
@@ -36,6 +36,7 @@
       (keydown)="onKeydown($event)"
       [placeholder]="t('shopping.addPlaceholder')"
       class="add-input"
+      data-testid="shopping-add-input"
     />
     <button
       class="add-btn"
@@ -56,7 +57,7 @@
   />
 
   @for (group of categoryGroups(); track group.category) {
-    <div class="category-group">
+    <div class="category-group" data-testid="shopping-category-group">
       <h2 class="category-header">{{ categoryLabels()[group.category] ?? group.category }}</h2>
 
       @for (item of group.items; track item.itemName) {
@@ -80,7 +81,7 @@
   }
 
   @if (!loading() && totalItems() === 0) {
-    <div class="empty-state">
+    <div class="empty-state" data-testid="shopping-empty-state">
       <p>{{ t(showPastPurchases() ? 'shopping.history.empty' : 'shopping.empty') }}</p>
     </div>
   }


### PR DESCRIPTION
Slice 3 of #404. Continuing the data-testid migration group by group.

## What lands

\`merged-list.component.html\`: \`data-testid\` on four controls used by e2e:
| Selector | Old (CSS) | New (data-testid) |
|----------|-----------|-------------------|
| add input | \`.add-input\` | \`shopping-add-input\` |
| progress bar | \`.progress-bar\` | \`shopping-progress-bar\` |
| empty state | \`.empty-state\` | \`shopping-empty-state\` |
| category group | \`.category-group\` | \`shopping-category-group\` |

\`selectors.ts\` \`SELECTORS.shopping\` switched accordingly.

## Deferred (intentional)

- \`itemName\` — matched by \`hasText\` for content, not target selection
- \`retryBtn\` — rendered by \`yn-async-state\` (shared component); will migrate when we touch that

## Test plan

- [x] \`nx lint shopping\` clean
- [x] \`nx lint shell-e2e\` clean
- [ ] CI: shopping-mode + merged-list specs still pass with the new selectors