### PR TITLE
test(shell): migrate success-banner to data-testid (#404 slice 5)

### DIFF
--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -1,6 +1,10 @@
 export const SELECTORS = {
   banners: {
-    success: '.success-banner',
+    success: '[data-testid="success-banner"]',
+    // error stays as the role-alert match — it's the canonical a11y
+    // attribute for the banner and gives us free rule-out for axe a11y
+    // checks. Multiple components render their own [role="alert"];
+    // tests scope by container as needed.
     error: '[role="alert"]',
   },
   form: {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -129,7 +129,7 @@
 
   @if (saveSuccess()) {
     <div class="save-success" role="status" aria-live="polite">
-      <div class="success-banner">
+      <div class="success-banner" data-testid="success-banner">
         {{ t('dashboard.save.success', { title: saveSuccess() }) }}
       </div>
       <button


### PR DESCRIPTION
Slice 5 of #404 — banners group (smallest one).

Two entries in \`SELECTORS.banners\`:
- \`success\` → \`[data-testid="success-banner"]\` (only the dashboard's save-success uses \`.success-banner\`)
- \`error\` → kept as \`[role="alert"]\` deliberately. Three reasons:
  - it's the canonical a11y attribute for the role
  - axe scans assert against role="alert" for free
  - multiple components render their own alert banners; tests scope by container as needed

After this slice, four of seven groups are migrated. Remaining: \`form\` (multi-element classes — most of them are container scopes for nested selectors, less benefit from data-testid) and \`profileSettings\` (mostly id-based already).

## Test plan

- [x] \`nx lint shell\` clean
- [x] \`nx lint shell-e2e\` clean
- [ ] CI: tests using \`success-banner\` (dashboard.import-recipe specs) still pass