### PR TITLE
test(account): migrate profile-settings selectors to data-testid (#404 slice 6)

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -1,5 +1,5 @@
 <div class="profile-settings" *transloco="let t">
-  <h1>{{ t('account.settings.title') }}</h1>
+  <h1 data-testid="profile-settings-title">{{ t('account.settings.title') }}</h1>
 
   <yn-async-state
     [loading]="loading()"
@@ -11,7 +11,7 @@
 
   @if (profile(); as p) {
     <form (submit)="$event.preventDefault(); onSave()">
-      <section class="settings-section">
+      <section class="settings-section" data-testid="profile-settings-section">
         <h2>{{ t('account.settings.household') }}</h2>
         <div class="form-field">
           <label for="servings">{{ t('account.settings.defaultServings') }}</label>
@@ -27,7 +27,7 @@
         </div>
       </section>
 
-      <section class="settings-section">
+      <section class="settings-section" data-testid="profile-settings-section">
         <h2>{{ t('account.settings.dietary') }}</h2>
         <div class="form-field">
           <label for="dietaryType">{{ t('account.settings.dietaryType') }}</label>
@@ -76,7 +76,7 @@
         </div>
       </section>
 
-      <section class="settings-section">
+      <section class="settings-section" data-testid="profile-settings-section">
         <h2>{{ t('account.settings.weeklyGoals') }}</h2>
         <div class="form-row">
           <div class="form-field">
@@ -107,11 +107,18 @@
       </section>
 
       <div class="form-actions">
-        <button type="submit" class="save-btn" [disabled]="saving()">
+        <button
+          type="submit"
+          class="save-btn"
+          data-testid="profile-save-btn"
+          [disabled]="saving()"
+        >
           {{ saving() ? t('account.settings.saving') : t('account.settings.save') }}
         </button>
         @if (saved()) {
-          <span class="saved-indicator">{{ t('account.settings.saved') }}</span>
+          <span class="saved-indicator" data-testid="profile-saved-indicator">{{
+            t('account.settings.saved')
+          }}</span>
         }
       </div>
     </form>

--- a/client/apps/shell-e2e/src/helpers/selectors.ts
+++ b/client/apps/shell-e2e/src/helpers/selectors.ts
@@ -60,14 +60,17 @@ export const SELECTORS = {
     retryBtn: '.retry-btn',
   },
   profileSettings: {
-    title: '.profile-settings h1',
+    title: '[data-testid="profile-settings-title"]',
     servingsInput: '#servings',
     dietaryTypeSelect: '#dietaryType',
     cookingEffortSelect: '#cookingEffort',
     checkboxLabel: '.checkbox-label',
-    saveBtn: '.save-btn',
-    savedIndicator: '.saved-indicator',
-    settingsSection: '.settings-section',
+    saveBtn: '[data-testid="profile-save-btn"]',
+    savedIndicator: '[data-testid="profile-saved-indicator"]',
+    settingsSection: '[data-testid="profile-settings-section"]',
+    // loading/error/retryBtn are rendered by the shared yn-async-state
+    // component — kept on class selectors until that component gets
+    // its own data-testid in a follow-up.
     loading: '.loading',
     error: '.error',
     retryBtn: '.retry-btn',


### PR DESCRIPTION
Slice 6 of #404 — profile-settings group.

## What lands

| Selector | Old | New |
|----------|-----|-----|
| title | \`.profile-settings h1\` (descendant selector) | \`profile-settings-title\` |
| settings-section | \`.settings-section\` | \`profile-settings-section\` |
| save | \`.save-btn\` (clashed with recipe-preview's save-btn earlier) | \`profile-save-btn\` |
| saved indicator | \`.saved-indicator\` | \`profile-saved-indicator\` |

## Kept as-is (intentional)

- \`servings/dietary/cookingEffort\` — already on stable \`id\` attributes
- \`checkbox-label\` — shared utility class with multi-element semantics
- \`loading/error/retryBtn\` — rendered by shared \`yn-async-state\` component, migrate that as a separate slice

## Status after this slice

**Six of seven selector groups migrated**:
- ✅ mealPlanner (#445), recipe (#446), shopping (#447), chat (#448), banner (slice 5 in flight #449), profileSettings (this PR)
- ⏸ form — most entries (\`.ingredient-fields\`, \`.step-fields\`) are scope containers used with descendant selectors, not direct targets. Lower migration value; close #404 with what we have.

## Test plan

- [x] \`nx lint account\` clean
- [x] \`nx lint shell-e2e\` clean
- [ ] CI: profile-settings.spec.ts passes with the new selectors