### PR TITLE
test(e2e): try context.route for favorite rollback (#442 hypothesis test)

### DIFF
--- a/client/apps/shell-e2e/src/recipes/recipe-favorite-rollback.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite-rollback.spec.ts
@@ -22,14 +22,11 @@ test.describe('Favorite Recipes — Optimistic Rollback (#409)', () => {
     ingredient: 'Pepper',
   });
 
-  // Fixme'd pending #442: page.route does not intercept the POST to
-  // /api/v1/recipes/{id}/favorite — neither glob, regex, nor URL-
-  // predicate patterns matched. The diagnostic version of this test
-  // proved handlerFireCount=0 in three CI runs. The favorite-toggle
-  // rollback logic itself is implemented correctly in
-  // libs/shared/models/src/lib/favorite-toggle.ts; the test just
-  // can't drive it via mocked failure until #442 is figured out.
-  test.fixme('reverts aria-pressed when the favorite POST fails', async ({ authenticatedPage }) => {
+  // Re-enabled — using context.route instead of page.route so the
+  // mock intercepts cross-origin requests (page is on :4200, fetch
+  // targets :5100 via apiBaseInterceptor). Page-scoped routes don't
+  // catch those; context-scoped do. See #442.
+  test('reverts aria-pressed when the favorite POST fails', async ({ authenticatedPage }) => {
     // Delay the rejected response so the optimistic flip is observable
     // before the rollback. 800ms is enough for Playwright's auto-retry
     // toHaveAttribute to land on the 'true' state at least once.
@@ -43,7 +40,11 @@ test.describe('Favorite Recipes — Optimistic Rollback (#409)', () => {
     // handler ran or the request hit the real backend.
     const targetIdentifier = recipe().identifier;
     let handlerFireCount = 0;
-    await authenticatedPage.route(
+    // context.route, not page.route — see #442. The frontend rewrites
+    // /api/v1/* to ${gatewayUrl}/api/v1/* via apiBaseInterceptor, so
+    // these requests cross from :4200 to :5100 and page-scoped routes
+    // don't intercept them.
+    await authenticatedPage.context().route(
       (url) =>
         url.pathname === `/api/v1/recipes/${targetIdentifier}/favorite` ||
         url.pathname.endsWith(`/api/v1/recipes/${targetIdentifier}/favorite`),


### PR DESCRIPTION
**Hypothesis test for #442.** Draft because if this works, the right move is a broader fix that touches multiple specs + a CLAUDE.md note.

## What this changes

Single line: \`authenticatedPage.route(...)\` → \`authenticatedPage.context().route(...)\` in \`recipe-favorite-rollback.spec.ts\`. Re-enables the fixme'd test.

## Why this might work

The frontend's \`apiBaseInterceptor\` rewrites relative \`/api/v1/...\` URLs to the gateway: \`http://localhost:5100/api/v1/...\`. The page is loaded from \`http://localhost:4200\`. Requests are cross-origin.

\`page.route\` is documented to intercept requests **initiated by the page on its current origin**. Cross-origin requests need \`browserContext.route\` for reliable interception. The session-long mystery in #442 — \`handlerFireCount=0\` across three pattern variants — is a textbook match for this.

## What "success" looks like

CI run completes with the test passing — confirms the hypothesis. Then I'll:
1. Apply the same one-line fix to \`save-recipe-error-paths.spec.ts\` (un-fixme its 2 tests)
2. Add \`mockApiError\` from helpers/error-mock.ts to take \`Page\` and use \`context.route\` internally so future specs don't have to remember
3. Document in CLAUDE.md or a helper-pattern doc that \`page.route\` doesn't catch cross-origin API calls in this stack

## What "failure" looks like

The test still fails the same way (\`handlerFireCount=0\`). Hypothesis is wrong, file the disproof in #442 and move on to the next theory (try registering against the absolute URL with port, then trace inspection).