### PR TITLE
fix(shell): aria-label on meal-planner empty slots (#443 slice 1)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -304,6 +304,7 @@
     "loading": "Essensplan wird geladen...",
     "servings": "Portionen",
     "clearSlot": "Slot leeren",
+    "addMeal": "Mahlzeit für {{day}} hinzufügen",
     "retry": "Erneut versuchen",
     "generateShoppingList": "Einkaufsliste erstellen",
     "generatingList": "Wird erstellt...",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -304,6 +304,7 @@
     "loading": "Loading meal plan...",
     "servings": "servings",
     "clearSlot": "Clear this slot",
+    "addMeal": "Add meal for {{day}}",
     "retry": "Retry",
     "generateShoppingList": "Generate Shopping List",
     "generatingList": "Generating...",

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -91,6 +91,7 @@
             class="empty-slot"
             tabindex="0"
             role="button"
+            [attr.aria-label]="t('mealPlanner.addMeal', { day: entry.day })"
             (click)="onSelectSlot(entry.day)"
             (keydown.enter)="onSelectSlot(entry.day)"
           >


### PR DESCRIPTION
## Summary

- Adds `aria-label` to the seven `[role="button"]` empty meal slots on `/meal-planner`. The slot is icon-only (lucide `plus`) so axe-core flagged each occurrence under `aria-command-name` (WCAG 4.1.2 A, serious).
- Label includes the day so AT users can distinguish the seven slots: \"Add meal for Monday\", etc.
- Adds matching `mealPlanner.addMeal` key to `de.json` and `en.json` (kept in lockstep).

This is **slice 1 of #443**. Color-contrast violations on this and other pages remain tracked by the parent issue and are not touched here.

## Test plan

- [x] `yarn nx lint shell` clean (only the pre-existing non-null assertion warning in the meal-planner spec)
- [ ] CI green (frontend build + e2e)
- [ ] Once #443 fully closes, drop `aria-command-name` from `DISABLED_RULES_PENDING_443` in `a11y-smoke.spec.ts`