### PR TITLE
chore(frontend): fix prettier drift blocking all open PRs

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -107,12 +107,7 @@
       </section>
 
       <div class="form-actions">
-        <button
-          type="submit"
-          class="save-btn"
-          data-testid="profile-save-btn"
-          [disabled]="saving()"
-        >
+        <button type="submit" class="save-btn" data-testid="profile-save-btn" [disabled]="saving()">
           {{ saving() ? t('account.settings.saving') : t('account.settings.save') }}
         </button>
         @if (saved()) {

--- a/client/apps/shell-e2e/src/auth/session-lifecycle.spec.ts
+++ b/client/apps/shell-e2e/src/auth/session-lifecycle.spec.ts
@@ -22,19 +22,19 @@ test.describe('Auth Session Lifecycle (#407)', () => {
   test('redirects to login when refresh is rejected by Keycloak', async ({ authenticatedPage }) => {
     // Intercept the refresh-token POST and reject it as Keycloak would when
     // the refresh token has been revoked or the session expired server-side.
-    await authenticatedPage.route(
-      '**/realms/yumney/protocol/openid-connect/token',
-      (route) => {
-        if (route.request().method() === 'POST') {
-          return route.fulfill({
-            status: 400,
-            contentType: 'application/json',
-            body: JSON.stringify({ error: 'invalid_grant', error_description: 'Token is not active' }),
-          });
-        }
-        return route.continue();
-      },
-    );
+    await authenticatedPage.route('**/realms/yumney/protocol/openid-connect/token', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Token is not active',
+          }),
+        });
+      }
+      return route.continue();
+    });
 
     // Force the stored access token to look expired so the auth lib /
     // authGuard sees no valid token. Use both expires_at and

--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -47,8 +47,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     // actually fired the request the mock is supposed to fulfill.
     const savePost = authenticatedPage.waitForResponse(
       (res) =>
-        new URL(res.url()).pathname === '/api/v1/recipes' &&
-        res.request().method() === 'POST',
+        new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
       { timeout: TIMEOUTS.default },
     );
     await dashboard.recipePreview.locator('.save-btn').click();
@@ -80,8 +79,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
 
     const savePost = authenticatedPage.waitForResponse(
       (res) =>
-        new URL(res.url()).pathname === '/api/v1/recipes' &&
-        res.request().method() === 'POST',
+        new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
       { timeout: TIMEOUTS.default },
     );
     await dashboard.recipePreview.locator('.save-btn').click();

--- a/client/apps/shell-e2e/src/i18n/i18n-parity.spec.ts
+++ b/client/apps/shell-e2e/src/i18n/i18n-parity.spec.ts
@@ -47,9 +47,7 @@ async function setLanguage(
 
 test.describe('i18n parity smoke (#413)', () => {
   for (const probe of PROBE_PAGES) {
-    test(`${probe.label} renders translated text in EN and DE`, async ({
-      authenticatedPage,
-    }) => {
+    test(`${probe.label} renders translated text in EN and DE`, async ({ authenticatedPage }) => {
       await setLanguage(authenticatedPage, 'en');
       await authenticatedPage.goto(probe.url);
       const enText = await readH1(authenticatedPage);

--- a/client/apps/shell-e2e/src/recipes/recipe-edit.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-edit.spec.ts
@@ -14,17 +14,20 @@ import { TIMEOUTS } from '../helpers/timeouts';
 test.describe('Recipe Edit Flow', () => {
   const recipe = setupSharedRecipe(test, 'E2E Edit Test');
 
-  test('navigates from list card to detail page with edit button', async ({ authenticatedPage }) => {
+  test('navigates from list card to detail page with edit button', async ({
+    authenticatedPage,
+  }) => {
     await authenticatedPage.goto('/recipes');
 
-    const card = authenticatedPage.locator(SELECTORS.recipe.card, { hasText: recipe().title }).first();
+    const card = authenticatedPage
+      .locator(SELECTORS.recipe.card, { hasText: recipe().title })
+      .first();
     await expect(card).toBeVisible({ timeout: TIMEOUTS.default });
     await card.click();
 
-    await expect(authenticatedPage).toHaveURL(
-      new RegExp(`/recipes/${recipe().identifier}`),
-      { timeout: TIMEOUTS.default },
-    );
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/recipes/${recipe().identifier}`), {
+      timeout: TIMEOUTS.default,
+    });
 
     // Edit is rendered as <a> with routerLink (role=link), not <button>.
     // The pre-#412 test used getByRole('button', /edit/i) and hid the

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -80,21 +80,22 @@ test.describe('Favorite Recipes (US-071)', () => {
   // endpoint returns isFavorite=true. Backend contract tests pass for
   // both endpoints; in-memory cache invalidated post-#427; NGSW freshness
   // timeout bump didn't help. Real root cause needs trace artifacts.
-  test.fixme(
-    'should reflect favorite state on recipe detail page',
-    async ({ authenticatedPage }) => {
-      const detail = new RecipeDetailPage(authenticatedPage);
-      await detail.goto(recipe().identifier);
+  test.fixme('should reflect favorite state on recipe detail page', async ({
+    authenticatedPage,
+  }) => {
+    const detail = new RecipeDetailPage(authenticatedPage);
+    await detail.goto(recipe().identifier);
 
-      await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
-      await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'true');
-    },
-  );
+    await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'true');
+  });
 
   // fixme pending #432: same family as the test above — depends on the
   // detail page reflecting the toggled-favorite state, which it doesn't
   // in CI for reasons not yet understood.
-  test.fixme('should toggle favorite back off from recipe detail', async ({ authenticatedPage }) => {
+  test.fixme('should toggle favorite back off from recipe detail', async ({
+    authenticatedPage,
+  }) => {
     const detail = new RecipeDetailPage(authenticatedPage);
     await detail.goto(recipe().identifier);
     await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });


### PR DESCRIPTION
## Summary

Six files on develop fail \`yarn prettier --check\`, causing the Frontend (Build + Test) gate to fail on every open PR. Apply \`prettier --write\` to clear the drift. No semantic changes.

Affected:
- \`apps/account/src/app/profile-settings/profile-settings.component.html\`
- \`apps/shell-e2e/src/auth/session-lifecycle.spec.ts\`
- \`apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts\`
- \`apps/shell-e2e/src/i18n/i18n-parity.spec.ts\`
- \`apps/shell-e2e/src/recipes/recipe-edit.spec.ts\`
- \`apps/shell-e2e/src/recipes/recipe-favorite.spec.ts\`

## Test plan

- [x] \`yarn prettier --check\` clean locally
- [ ] CI green
- [ ] Once merged, rebase open PRs (#453, #454)