### PR TITLE
fix(e2e): context.route in mockApiError, un-fixme save-recipe error tests (closes #442)

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -22,13 +22,9 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await dashboard.goto();
   });
 
-  // fixme pending #442: page.route does not intercept POST
-  // /api/v1/recipes — diagnostic confirmed response status=201 and
-  // [mockApiError] never logged. The dashboard banner placement
-  // (#438) IS fixed by this PR; the test just can't drive the
-  // failure path until #442 figures out why route patterns don't
-  // match this URL family.
-  test.fixme('shows error banner when save returns 500', async ({ authenticatedPage }) => {
+  // Re-enabled — mockApiError now uses context.route, which intercepts
+  // cross-origin requests (page on :4200, fetch on :5100). See #442.
+  test('shows error banner when save returns 500', async ({ authenticatedPage }) => {
     await mockApiError(authenticatedPage, '**/api/v1/recipes', 500, {
       detail: 'An unexpected error occurred.',
     });
@@ -58,8 +54,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await expect(authenticatedPage.locator('#preview-title')).toHaveValue('E2E 500 Test');
   });
 
-  // fixme pending #442: same Playwright route-matching issue as above.
-  test.fixme('shows error banner when save returns 422 with validation errors', async ({
+  test('shows error banner when save returns 422 with validation errors', async ({
     authenticatedPage,
   }) => {
     await mockApiError(authenticatedPage, '**/api/v1/recipes', 422, {

--- a/client/apps/shell-e2e/src/helpers/error-mock.ts
+++ b/client/apps/shell-e2e/src/helpers/error-mock.ts
@@ -14,6 +14,12 @@ export interface ProblemDetails {
  * the given URL pattern. Used by error-path e2e tests to exercise the UI's
  * 5xx / 422 / 409 handling without orchestrating real backend chaos.
  *
+ * Routes are registered on the browser context, not the page. The shell
+ * runs at :4200 but fetches go to :5100 via apiBaseInterceptor — those
+ * are cross-origin from the page's perspective, and `page.route` only
+ * intercepts same-origin requests. `context.route` covers any origin
+ * the page navigates to or fetches from. See #442.
+ *
  * The body shape mirrors what GlobalExceptionHandlerMiddleware and
  * ValidationExtensions produce in production (RFC 7807 problem+json), so
  * the frontend's error-mapping logic sees realistic input.
@@ -24,7 +30,7 @@ export async function mockApiError(
   status: number,
   problem: Partial<Omit<ProblemDetails, 'status'>> = {},
 ): Promise<void> {
-  await page.route(urlPattern, (route) =>
+  await page.context().route(urlPattern, (route) =>
     route.fulfill({
       status,
       contentType: 'application/problem+json',


### PR DESCRIPTION
## Summary

#453 confirmed the cross-origin route hypothesis: the shell runs at \`:4200\` and api fetches go to \`:5100\` via \`apiBaseInterceptor\`, so requests are cross-origin and page-scoped routes never see them. Apply the same fix to \`mockApiError\` — switching to \`context.route\` — which fixes the helper for every test that uses it.

Also un-fixme's the two save-recipe error path tests from #408 that were parked pending this resolution. They drive POST \`/api/v1/recipes\` failure modes (500 + 422) and assert on the dashboard error banner.

Closes #442.

## Test plan

- [x] \`yarn nx lint shell-e2e\` clean
- [ ] CI green — proves both un-fixme'd save-recipe tests now pass with the context.route helper
- [ ] If green, both #408 and #442 close