### PR TITLE
chore(events): drop stale MassTransit mention in InProcess docs (#461)

### DIFF
--- a/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
+++ b/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ public static class EventingServiceCollectionExtensions
 {
 	/// <summary>
 	/// Registers in-process domain event dispatcher and in-process event bus.
-	/// When using a distributed event bus (e.g. MassTransit), call this first for domain events,
+	/// When using a distributed event bus (e.g. Wolverine), call this first for domain events,
 	/// then register the distributed IEventBus which will override the in-process one.
 	/// </summary>
 	/// <param name="services">The service collection.</param>


### PR DESCRIPTION
## Summary
- Closes #461.
- The `Yumney.Shared.Events.MassTransit` project itself was already removed in 7f2ce9aa (MassTransit → Wolverine swap). Only a stale XML-doc reference remained in `EventingServiceCollectionExtensions.cs` — updated to name Wolverine, which is what is actually wired.
- The empty `src/Yumney.Shared.Events.MassTransit/` directory on disk was untracked stale `obj/` build output; nothing to remove from git.
- `Directory.Packages.props` already has no MassTransit entries.

`CLAUDE.md` / `README.md` mentions of MassTransit are kept out of scope here — those belong to the documentation-reconciliation work in #465.

## Test plan
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet test tests/Yumney.Architecture.Tests` — 117/117 passed
- [x] `dotnet test tests/Yumney.Shared.Events.Tests` — 12/12 passed
- [x] `dotnet format Yumney.slnx --verify-no-changes` — clean