### PR TITLE
fix(users): source Keycloak client secret from Aspire parameter (#458)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,7 @@ jobs:
           Parameters__PostgresUser: ${{ vars.POSTGRES_USER }}
           Parameters__PostgresPassword: ${{ secrets.POSTGRES_PASSWORD }}
           Parameters__KeycloakPassword: ${{ secrets.KEYCLOAK_PASSWORD }}
+          Parameters__YumneyApiClientSecret: ${{ secrets.YUMNEY_API_CLIENT_SECRET }}
           Parameters__OpenAiApiKey: ${{ secrets.OPENAI_API_KEY }}
           Parameters__MessagingPassword: ${{ secrets.MESSAGING_PASSWORD }}
           Parameters__RedisPassword: ${{ secrets.REDIS_PASSWORD }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,6 +14,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  GITLEAKS_VERSION: '8.18.4'
+
 jobs:
   gitleaks:
     name: Gitleaks
@@ -25,9 +28,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_ENABLE_SUMMARY: true
+      - name: Install gitleaks
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        if: github.event_name == 'pull_request'
+        run: |
+          gitleaks detect \
+            --source . \
+            --no-banner \
+            --redact \
+            --verbose \
+            --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
+      - name: Scan pushed commits
+        if: github.event_name == 'push'
+        run: |
+          gitleaks detect \
+            --source . \
+            --no-banner \
+            --redact \
+            --verbose \
+            --log-opts "${{ github.event.before }}..${{ github.sha }}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  workflow_call:
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -686,6 +686,9 @@ Scopes: recipes, shopping, users, account, shared, api, shell, infra, ui
 - CORS: only allowed origins (enforced at Gateway, not API)
 - Rate Limiting: 10 imports/minute/user
 - Secrets: Azure Key Vault only, NEVER in code
+  - All credentials flow through Aspire `AddParameter(..., secret: true)` — `PostgresPassword`, `KeycloakPassword`, `MessagingPassword`, `RedisPassword`, `YumneyApiClientSecret`, `OpenAiApiKey`.
+  - In run mode the AppHost provides a clearly-labeled dev default for the Keycloak client secret (matching `Realms/yumney-realm.json`); in publish mode the value is sourced from a Container App secret backed by Key Vault.
+  - `gitleaks` runs on every PR (`.github/workflows/secret-scan.yml`) to catch regressions.
 - No token in localStorage – HttpOnly Cookie
 - Angular Sanitization: never disable
 

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -19,6 +19,13 @@ var keycloakPassword = builder.AddParameter("KeycloakPassword", secret: true);
 var messagingPassword = builder.AddParameter("MessagingPassword", secret: true);
 var redisPassword = builder.AddParameter("RedisPassword", secret: true);
 
+// Run mode: default matches the literal in Realms/yumney-realm.json so the dev
+// stack works out of the box. Publish mode: no default — value must be supplied
+// via Container App secret backed by Key Vault.
+var yumneyApiClientSecret = isRunMode
+	? builder.AddParameter("YumneyApiClientSecret", "dev-only-keycloak-client-secret", secret: true)
+	: builder.AddParameter("YumneyApiClientSecret", secret: true);
+
 IResourceBuilder<IResourceWithConnectionString> recipesDb, shoppingDb, usersDb, mealplanDb, keycloakDb;
 
 if (options.DatabaseOnly)
@@ -114,6 +121,7 @@ if (!options.DatabaseOnly)
 	var usersApi = builder
 		.AddProject<Projects.Yumney_Users_Api>("users-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.WithEnvironment("Keycloak__ClientSecret", yumneyApiClientSecret)
 		.AsYumneyApi(usersDb, keycloak, redis, messaging, migrationRunner);
 	var mealplanApi = builder
 		.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")

--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -41,7 +41,7 @@
       "name": "Yumney API",
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
-      "secret": "yumney-api-secret",
+      "secret": "dev-only-keycloak-client-secret",
       "publicClient": false,
       "bearerOnly": false,
       "standardFlowEnabled": false,

--- a/src/Yumney.Users.Api/appsettings.Development.json
+++ b/src/Yumney.Users.Api/appsettings.Development.json
@@ -1,7 +1,4 @@
 {
-  "Keycloak": {
-    "ClientSecret": "yumney-api-secret"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/src/Yumney.Users.Api/appsettings.json
+++ b/src/Yumney.Users.Api/appsettings.json
@@ -1,8 +1,7 @@
 {
   "Keycloak": {
     "Realm": "yumney",
-    "ClientId": "yumney-api",
-    "ClientSecret": "yumney-api-secret"
+    "ClientId": "yumney-api"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
Closes #458 (CRITICAL — hardcoded Keycloak client secret in committed `appsettings`).

- `Yumney.Users.Api/appsettings.json` and `appsettings.Development.json` no longer contain `Keycloak:ClientSecret`. The value is now injected as `Keycloak__ClientSecret` env var by `Yumney.AppHost` via a secret parameter (`YumneyApiClientSecret`).
- **Run mode:** the parameter has a clearly-labeled dev default (`dev-only-keycloak-client-secret`) that matches the literal in `Realms/yumney-realm.json`. Local `aspire run` works out of the box.
- **Publish mode:** the parameter has no default — value must be supplied via Container App secret backed by Azure Key Vault.
- The dev realm-import literal is renamed from `yumney-api-secret` to `dev-only-keycloak-client-secret` so any old grep finds nothing and the value is self-documenting as non-production.
- `KeycloakOptions` already enforces `[Required(AllowEmptyStrings = false)]` with `ValidateOnStart`, so a missing secret fails fast at boot — no extra guard needed.
- Adds `.github/workflows/secret-scan.yml` running `gitleaks` on every PR/push to prevent regressions.

## Out-of-band actions still required
This PR removes the secret from new code; it does **not** invalidate the old one or scrub history.

- [ ] **Rotate** the `yumney-api` client secret in any deployed Keycloak realms (staging, production). The literal `yumney-api-secret` may still be valid in deployed environments bootstrapped from the old realm import.
- [ ] **Configure** `Parameters:YumneyApiClientSecret` in Azure for staging and production before the next deploy (ideally backed by Key Vault). Without it, `users-api` will fail validation at startup.
- [ ] **Decide** whether to scrub git history with `git filter-repo` + force-push. Destructive — not done here.

## Test plan
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format Yumney.slnx --verify-no-changes` — clean
- [x] `dotnet test tests/Yumney.Architecture.Tests` — 117/117 passed
- [x] `dotnet test tests/Yumney.Users.Application.Tests` — 35/35 passed
- [x] `dotnet test tests/Yumney.Users.Infrastructure.Tests` — 19/19 passed
- [x] `dotnet test tests/Yumney.Users.Api.Tests` — 24/24 passed
- [x] Confirmed `KeycloakAdminService` is the only consumer of `KeycloakOptions.ClientSecret`; other APIs do not need it.
- [x] Confirmed dev parameter default exactly matches the realm-import literal.
- [ ] Verify `aspire run` succeeds end-to-end and `users-api` can call Keycloak admin endpoints (manual smoke).