### PR TITLE
test(e2e): re-enable aria-command-name in a11y smoke (validates #443 slice 1)

### DIFF
--- a/client/apps/shell-e2e/src/a11y/a11y-smoke.spec.ts
+++ b/client/apps/shell-e2e/src/a11y/a11y-smoke.spec.ts
@@ -20,8 +20,9 @@ const SERIOUS_OR_CRITICAL = ['serious', 'critical'] as const;
 
 // Pre-existing serious violations on develop, tracked in #443. Disabled
 // here so this smoke can land green and surface NEW regressions on top
-// of the known-bad baseline. Remove once #443 ships.
-const DISABLED_RULES_PENDING_443 = ['color-contrast', 'aria-command-name'];
+// of the known-bad baseline. aria-command-name was fixed in #454 (slice 1);
+// color-contrast remains pending. Remove the last entry once that lands.
+const DISABLED_RULES_PENDING_443 = ['color-contrast'];
 
 async function runAxe(page: import('@playwright/test').Page): Promise<void> {
   const results = await new AxeBuilder({ page })


### PR DESCRIPTION
## Summary

PR #454 added \`aria-label\` to the seven \`role=\"button\"\` empty meal slots — the only sample axe surfaced for \`aria-command-name\` in run 25033833453. Drop the rule from \`DISABLED_RULES_PENDING_443\` so the smoke fails on any new violation.

If CI is green, slice 1 of #443 is fully verified and only color-contrast remains. If CI fails, the axe payload will name the unhandled violator and slice 1 picks up another component.

\`color-contrast\` stays disabled pending slice 2 (the \`.cta-button\` / \`--yn-primary\` work documented on #443).

## Test plan

- [ ] CI green — proves \`aria-command-name\` is fully clean across the five tested pages
- [ ] If green, this acts as the regression gate going forward