### PR TITLE
fix(shell): drop shopping-api NGSW data group (closes #432)

### DIFF
--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -71,12 +71,11 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     await expect(cards.or(empty).first()).toBeVisible({ timeout: TIMEOUTS.default });
   });
 
-  // The next three tests are fixme'd pending #432: in CI the just-created
-  // list (test 5) doesn't show up at /shopping/lists for reasons we
-  // haven't pinned down — backend contract tests pass, frontend has no
-  // in-memory cache layer, NGSW freshness timeout bump didn't help. Needs
-  // trace artifacts to root-cause.
-  test.fixme('should check off an item with strikethrough', async ({ authenticatedPage }) => {
+  // Re-enabled — #432 fix dropped the shopping-api data group from
+  // ngsw-config.json. The NGSW freshness fallback was serving stale
+  // empty cached responses under CI load, which made just-created lists
+  // appear missing. Shopping data is too volatile to cache anyway.
+  test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
@@ -91,7 +90,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     await expect(detailPage.checkedItems.first()).toBeVisible();
   });
 
-  test.fixme('should check all items and reset', async ({ authenticatedPage }) => {
+  test('should check all items and reset', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();
@@ -112,7 +111,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     }
   });
 
-  test.fixme('should show progress counter', async ({ authenticatedPage }) => {
+  test('should show progress counter', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
     const firstCard = authenticatedPage.locator('.list-card').first();
     await firstCard.click();

--- a/client/apps/shell/ngsw-config.json
+++ b/client/apps/shell/ngsw-config.json
@@ -43,16 +43,6 @@
       }
     },
     {
-      "name": "shopping-api",
-      "urls": ["/api/v1/shopping-lists", "/api/v1/shopping-lists/*"],
-      "cacheConfig": {
-        "maxSize": 50,
-        "maxAge": "1d",
-        "strategy": "freshness",
-        "timeout": "3s"
-      }
-    },
-    {
       "name": "i18n",
       "urls": ["/assets/i18n/*"],
       "cacheConfig": {


### PR DESCRIPTION
## Summary

NGSW's freshness strategy was caching \`/api/v1/shopping-lists*\` with a 3 s network timeout, then falling back to stale empty bodies under CI load. That made:

- \`/shopping/lists\` (list-of-lists) miss freshly created lists in subsequent tests — **three tests in \`shopping-list.spec.ts\` fixme'd**
- \`/shopping\` (merged view) miss freshly added items — **\`merged-list.spec.ts\` flake** captured in the trace from run 25040801807

## Why not just bump the timeout?

#433 already tried 3 s → 15 s and was closed as not-helping. Likely cause: SW state on per-test fresh Playwright contexts (installing / activating) wasn't fully ready when requests fired, so the freshness path falls through regardless of timeout.

## Why drop the cache entirely?

- Backend has no read-write split, no projection lag (event publication is synchronous within the request — verified by walking \`AddManualItemCommandHandler\` → \`InProcessEventBus.PublishAsync\` → \`ShoppingListProjectionHandler\`).
- The cache fallback is the only remaining explanation for stale-empty responses.
- **Shopping data is too volatile to serve from cache**: a stale shopping list is worse than no list, since the user can't actually shop offline anyway (add/remove still need the network).
- Recipes-api keeps its cache because recipe content is mostly read-only post-import — different volatility profile.

## Changes

- Remove the \`shopping-api\` data group from \`ngsw-config.json\`
- Re-enable three \`shopping-list.spec.ts\` tests that were tracking #432 (check off, check all, progress counter)

## Test plan

- [ ] CI green — proves the un-fixme'd tests now pass with NGSW out of the way
- [ ] If green, **closes #432**