### PR TITLE
fix(gateway): scope DangerousAcceptAnyServerCertificate to Development (#459)

### DIFF
--- a/src/Yumney.Gateway/Program.cs
+++ b/src/Yumney.Gateway/Program.cs
@@ -6,6 +6,24 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+// Refuse to boot if any YARP cluster disables TLS validation outside Development.
+// This catches both stale config files and accidental overrides from environment
+// variables. The flag is legitimate only against the Aspire dev Keycloak which
+// uses an ASP.NET self-signed cert; production must use proper CAs.
+if (!builder.Environment.IsDevelopment())
+{
+	foreach (var cluster in builder.Configuration.GetSection("ReverseProxy:Clusters").GetChildren())
+	{
+		if (cluster.GetValue<bool>("HttpClient:DangerousAcceptAnyServerCertificate"))
+		{
+			throw new InvalidOperationException(
+				$"Cluster '{cluster.Key}' has DangerousAcceptAnyServerCertificate=true in environment "
+				+ $"'{builder.Environment.EnvironmentName}'. This flag is only allowed in Development. "
+				+ "Move it to appsettings.Development.json or remove the override.");
+		}
+	}
+}
+
 builder.Services.AddResponseCompression(options =>
 {
 	options.EnableForHttps = true;

--- a/src/Yumney.Gateway/appsettings.Development.json
+++ b/src/Yumney.Gateway/appsettings.Development.json
@@ -3,5 +3,14 @@
     "LogLevel": {
       "Default": "Debug"
     }
+  },
+  "ReverseProxy": {
+    "Clusters": {
+      "keycloak": {
+        "HttpClient": {
+          "DangerousAcceptAnyServerCertificate": true
+        }
+      }
+    }
   }
 }

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -93,9 +93,6 @@
         }
       },
       "keycloak": {
-        "HttpClient": {
-          "DangerousAcceptAnyServerCertificate": true
-        },
         "Destinations": {
           "primary": {
             "Address": "https+http://keycloak"


### PR DESCRIPTION
## Summary
Closes #459 (CRITICAL — TLS validation disabled in YARP cluster).

The keycloak YARP cluster previously had `HttpClient.DangerousAcceptAnyServerCertificate=true` in `appsettings.json`, which is loaded in every environment and silently disables TLS validation on the Gateway → Keycloak hop in production. The flag is only legitimate against the Aspire dev Keycloak, which presents an ASP.NET self-signed cert.

- Removed the flag from `src/Yumney.Gateway/appsettings.json`.
- Added it to `src/Yumney.Gateway/appsettings.Development.json` so `aspire run` still works.
- Added a startup guard in `Gateway/Program.cs` that throws `InvalidOperationException` if any cluster has `DangerousAcceptAnyServerCertificate=true` outside the `Development` environment. Catches both stale config files and accidental env-var overrides; fail-fast prevents shipping a TLS-bypassed gateway.

## Test plan
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format Yumney.slnx --verify-no-changes` — clean
- [x] `dotnet test tests/Yumney.Architecture.Tests` — 117/117 passed
- [ ] Manual smoke: `aspire run` succeeds and Keycloak is reachable through the gateway in Development.
- [ ] Manual smoke: setting `ASPNETCORE_ENVIRONMENT=Production` with the dev appsettings layered in fails fast at boot with the expected message.