### PR TITLE
refactor(shopping): convert ShoppingList to event-sourced aggregate (#476)

### DIFF
--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
@@ -9,7 +9,7 @@ public static class ShoppingListMappingExtensions
 		public ShoppingListDetailDto ToDetailDto()
 		{
 			return new ShoppingListDetailDto(
-				shoppingList.Id.Value,
+				shoppingList.Identifier.Value,
 				shoppingList.Title.Value,
 				shoppingList.RecipeReference?.Value,
 				shoppingList.CreatedAt,

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsChecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsUnchecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemAdded(
+	ShoppingListItemIdentifier ItemId,
+	ItemName Name,
+	Quantity? Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemChecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemUnchecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record RecipeReferenceCleared : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ShoppingListCreated(
+	ShoppingListIdentifier Identifier,
+	ShoppingListTitle Title,
+	OwnerIdentifier Owner,
+	RecipeReference? RecipeReference,
+	DateTime CreatedAt) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
@@ -1,7 +1,0 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
-
-namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-
-public sealed record ShoppingListCreatedEvent(
-	ShoppingListIdentifier ShoppingListIdentifier,
-	ShoppingListTitle Title) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -4,7 +4,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
+public sealed class ShoppingList : EventSourcedAggregate<ShoppingListIdentifier>
 {
 	private readonly List<ShoppingListItem> items = [];
 
@@ -20,6 +20,13 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
 	private ShoppingList()
 	{
+		On<ShoppingListCreated>(OnCreated);
+		On<ListItemAdded>(OnListItemAdded);
+		On<ListItemChecked>(OnListItemChecked);
+		On<ListItemUnchecked>(OnListItemUnchecked);
+		On<AllItemsChecked>(_ => OnAllItemsChecked());
+		On<AllItemsUnchecked>(_ => OnAllItemsUnchecked());
+		On<RecipeReferenceCleared>(_ => OnRecipeReferenceCleared());
 	}
 
 	public static ShoppingList Create(
@@ -30,60 +37,113 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 	{
 		Ensure.That(items).IsNotEmpty();
 
-		var shoppingList = new ShoppingList
+		var list = new ShoppingList();
+		list.RaiseEvent(new ShoppingListCreated(
+			ShoppingListIdentifier.New(),
+			title,
+			owner,
+			recipeReference,
+			DateTime.UtcNow));
+
+		foreach (var item in items)
 		{
-			Id = ShoppingListIdentifier.New(),
-			Title = title,
-			Owner = owner,
-			RecipeReference = recipeReference,
-			CreatedAt = DateTime.UtcNow,
-		};
+			list.RaiseEvent(new ListItemAdded(item.Id, item.Name, item.Quantity));
+		}
 
-		shoppingList.items.AddRange(items);
+		return list;
+	}
 
-		shoppingList.AddDomainEvent(new ShoppingListCreatedEvent(shoppingList.Id, title));
-
-		return shoppingList;
+	public static ShoppingList FromEvents(
+		ShoppingListIdentifier identifier,
+		IEnumerable<IDomainEvent> events,
+		AggregateVersion? startVersion = null)
+	{
+		var list = new ShoppingList { Identifier = identifier };
+		list.LoadFromHistory(events, startVersion);
+		return list;
 	}
 
 	public ShoppingList CheckOffItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Check();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemChecked(itemId));
 		return this;
 	}
 
 	public ShoppingList UncheckItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Uncheck();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemUnchecked(itemId));
 		return this;
 	}
 
 	public ShoppingList CheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Check();
-		}
-
+		RaiseEvent(new AllItemsChecked());
 		return this;
 	}
 
 	public ShoppingList UncheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Uncheck();
-		}
-
+		RaiseEvent(new AllItemsUnchecked());
 		return this;
 	}
 
 	public ShoppingList ClearRecipeReference()
 	{
-		RecipeReference = null;
+		RaiseEvent(new RecipeReferenceCleared());
 		return this;
+	}
+
+	private void OnCreated(ShoppingListCreated e)
+	{
+		Identifier = e.Identifier;
+		Title = e.Title;
+		Owner = e.Owner;
+		RecipeReference = e.RecipeReference;
+		CreatedAt = e.CreatedAt;
+	}
+
+	private void OnListItemAdded(ListItemAdded e)
+	{
+		items.Add(ShoppingListItem.Hydrate(e.ItemId, e.Name, e.Quantity));
+	}
+
+	private void OnListItemChecked(ListItemChecked e)
+	{
+		FindItem(e.ItemId).MarkChecked();
+	}
+
+	private void OnListItemUnchecked(ListItemUnchecked e)
+	{
+		FindItem(e.ItemId).MarkUnchecked();
+	}
+
+	private void OnAllItemsChecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkChecked();
+		}
+	}
+
+	private void OnAllItemsUnchecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkUnchecked();
+		}
+	}
+
+	private void OnRecipeReferenceCleared()
+	{
+		RecipeReference = null;
+	}
+
+	private void EnsureItemExists(ShoppingListItemIdentifier itemId)
+	{
+		var item = items.FirstOrDefault(i => i.Id == itemId);
+		Ensure.That(item!).IsNotNull();
 	}
 
 	private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
@@ -25,13 +25,24 @@ public sealed class ShoppingListItem : Entity<ShoppingListItemIdentifier>
 		};
 	}
 
-	public ShoppingListItem Check()
+	internal static ShoppingListItem Hydrate(ShoppingListItemIdentifier id, ItemName name, Quantity? quantity)
+	{
+		return new ShoppingListItem
+		{
+			Id = id,
+			Name = name,
+			Quantity = quantity,
+			IsChecked = false,
+		};
+	}
+
+	internal ShoppingListItem MarkChecked()
 	{
 		IsChecked = true;
 		return this;
 	}
 
-	public ShoppingListItem Uncheck()
+	internal ShoppingListItem MarkUnchecked()
 	{
 		IsChecked = false;
 		return this;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
@@ -10,8 +10,9 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 	public void Configure(EntityTypeBuilder<ShoppingList> entity)
 	{
 		entity.ToTable("ShoppingLists");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		entity.HasKey(e => e.Identifier);
+		entity.Property(e => e.Identifier)
+			.HasColumnName("Id")
 			.HasConversion<ShoppingListIdentifierConverter>();
 
 		entity.Property(e => e.Title)
@@ -62,6 +63,7 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 		entity.Property<uint>("xmin")
 			.HasColumnType("xid")
 			.IsRowVersion();
-		entity.Ignore(e => e.DomainEvents);
+		entity.Ignore(e => e.UncommittedEvents);
+		entity.Ignore(e => e.Version);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
@@ -19,7 +19,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -29,7 +29,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await shoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -47,7 +47,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 		var items = await query
 			.Skip(paging.Skip)
 			.Take(paging.PageSize.Value)
-			.Select(l => new ShoppingListSummary(l.Id, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
+			.Select(l => new ShoppingListSummary(l.Identifier, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
 			.ToListAsync(cancellationToken);
 
 		return (items, ItemCount.From(totalCount));

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -44,7 +44,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 			var userId = await fixture.GetTestUserIdAsync();
 			var owner = OwnerIdentifier.From(userId);
 			await using var ctx = await fixture.CreateShoppingDbContextAsync();
-			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(listId) && l.Owner == owner);
+			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(listId) && l.Owner == owner);
 			return list.RecipeReference is null;
 		});
 	}
@@ -65,7 +65,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		await Task.Delay(2000);
 
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(linkedToB));
+		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(linkedToB));
 		list.RecipeReference.Should().NotBeNull();
 	}
 

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
@@ -41,7 +41,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved.Should().NotBeNull();
 		saved!.Title.Should().Be(ShoppingListTitle.From("Weekly Groceries"));
@@ -65,7 +65,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved!.RecipeReference.Should().NotBeNull();
 	}
@@ -79,7 +79,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		loaded.Title.Should().Be(ShoppingListTitle.From("Party Supplies"));
 		loaded.Items.Should().NotBeEmpty();
@@ -106,7 +106,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 
 		writeContext.Entry(loaded).State.Should().Be(EntityState.Unchanged);
 	}
@@ -122,7 +122,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using (var readDbContext = await fixture.CreateShoppingReadDbContextAsync())
 		{
 			var shoppingLists = new ShoppingListRepository(writeContext, readDbContext);
-			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 			loaded.CheckOffItem(itemId);
 			await writeContext.SaveChangesAsync();
 		}
@@ -130,7 +130,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext2 = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists2 = new ShoppingListRepository(writeContext2, readContext);
-		var reloaded = await shoppingLists2.GetByIdAsync(list.Id);
+		var reloaded = await shoppingLists2.GetByIdAsync(list.Identifier);
 
 		reloaded.Items.First(i => i.Id == itemId).IsChecked.Should().BeTrue();
 	}
@@ -251,7 +251,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		readContext.Entry(loaded).State.Should().Be(EntityState.Detached);
 	}

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_UncheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItems("other-user");
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_AllItemsChecked()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -89,8 +89,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
 		list.CheckAllItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidUncheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("other-user", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -88,8 +88,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_CallsCheckOffItem()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
 		list.CheckOffItem(itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -57,7 +57,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -72,7 +72,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 		var cts = new CancellationTokenSource();
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		await handler.HandleAsync(query, cts.Token);
 

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
@@ -50,27 +50,6 @@ public class ShoppingListItemTests
 		item.IsChecked.Should().BeFalse();
 	}
 
-	[Fact]
-	public void Check_SetsIsCheckedToTrue()
-	{
-		var item = CreateFlourItem();
-
-		item.Check();
-
-		item.IsChecked.Should().BeTrue();
-	}
-
-	[Fact]
-	public void Uncheck_SetsIsCheckedToFalse()
-	{
-		var item = CreateFlourItem();
-		item.Check();
-
-		item.Uncheck();
-
-		item.IsChecked.Should().BeFalse();
-	}
-
 	private static ShoppingListItem CreateFlourItem() =>
 		ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
@@ -9,11 +10,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
 public class ShoppingListTests
 {
 	[Fact]
-	public void Create_ValidInput_CreatesShoppingListWithId()
+	public void Create_ValidInput_CreatesShoppingListWithIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		shoppingList.Id.Should().NotBeNull();
+		shoppingList.Identifier.Should().NotBeNull();
 	}
 
 	[Fact]
@@ -93,29 +94,41 @@ public class ShoppingListTests
 
 		var shoppingList = CreateValidShoppingList(title: title);
 
-		shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>()
+		shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle()
 			.Which.Title.Should().Be(title);
 	}
 
 	[Fact]
-	public void Create_ShoppingListCreatedEvent_ContainsShoppingListId()
+	public void Create_ShoppingListCreatedEvent_ContainsShoppingListIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		var domainEvent = shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>().Subject;
+		var domainEvent = shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle().Subject;
 
-		domainEvent.ShoppingListIdentifier.Should().Be(shoppingList.Id);
+		domainEvent.Identifier.Should().Be(shoppingList.Identifier);
 	}
 
 	[Fact]
-	public void Create_GeneratesUniqueIds()
+	public void Create_RaisesListItemAddedEventPerItem()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncommittedEvents.OfType<ListItemAdded>().Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void Create_GeneratesUniqueIdentifiers()
 	{
 		var list1 = CreateValidShoppingList();
 		var list2 = CreateValidShoppingList();
 
-		list1.Id.Should().NotBe(list2.Id);
+		list1.Identifier.Should().NotBe(list2.Identifier);
 	}
 
 	[Fact]
@@ -130,6 +143,21 @@ public class ShoppingListTests
 		shoppingList.CheckOffItem(items[0].Id);
 
 		shoppingList.Items[0].IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CheckOffItem_RaisesListItemCheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemChecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
 	}
 
 	[Fact]
@@ -148,6 +176,21 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckItem_RaisesListItemUncheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncheckItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemUnchecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
+	}
+
+	[Fact]
 	public void CheckAllItems_ChecksAllItems()
 	{
 		List<ShoppingListItem> items =
@@ -160,6 +203,16 @@ public class ShoppingListTests
 		shoppingList.CheckAllItems();
 
 		shoppingList.Items.Should().OnlyContain(i => i.IsChecked);
+	}
+
+	[Fact]
+	public void CheckAllItems_RaisesAllItemsCheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.CheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsChecked>().Should().ContainSingle();
 	}
 
 	[Fact]
@@ -179,6 +232,36 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckAllItems_RaisesAllItemsUncheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.UncheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsUnchecked>().Should().ContainSingle();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_ClearsTheReference()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_RaisesRecipeReferenceClearedEvent()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.UncommittedEvents.OfType<RecipeReferenceCleared>().Should().ContainSingle();
+	}
+
+	[Fact]
 	public void CheckOffItem_InvalidItemId_Throws()
 	{
 		var shoppingList = CreateValidShoppingList();
@@ -186,6 +269,57 @@ public class ShoppingListTests
 		var act = () => shoppingList.CheckOffItem(ShoppingListItemIdentifier.New());
 
 		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Version_IncrementsOnEachEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+		var versionAfterCreate = shoppingList.Version;
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.Version.Should().Be(versionAfterCreate.Increment());
+	}
+
+	[Fact]
+	public void FromEvents_ReplaysToSameState()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+		var original = CreateValidShoppingList(items: items, recipeReference: RecipeReference.New());
+		original.CheckOffItem(items[0].Id);
+		original.ClearRecipeReference();
+		var capturedEvents = original.UncommittedEvents.ToList();
+
+		var replayed = Domain.ShoppingList.ShoppingList.FromEvents(original.Identifier, capturedEvents);
+
+		replayed.Identifier.Should().Be(original.Identifier);
+		replayed.Title.Should().Be(original.Title);
+		replayed.Owner.Should().Be(original.Owner);
+		replayed.CreatedAt.Should().Be(original.CreatedAt);
+		replayed.RecipeReference.Should().BeNull();
+		replayed.Items.Should().HaveCount(2);
+		replayed.Items.Single(i => i.Id == items[0].Id).IsChecked.Should().BeTrue();
+		replayed.Items.Single(i => i.Id == items[1].Id).IsChecked.Should().BeFalse();
+		replayed.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public void MarkCommitted_ClearsUncommittedEvents()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.MarkCommitted();
+
+		shoppingList.UncommittedEvents.Should().BeEmpty();
 	}
 
 	private static Domain.ShoppingList.ShoppingList CreateValidShoppingList(


### PR DESCRIPTION
## Summary

Phase 1 of the Shopping module migration to the event-sourced architecture already used by MealPlan. Closes #476.

- `ShoppingList` now inherits `EventSourcedAggregate<ShoppingListIdentifier>` from `Yumney.Shared`. Every state change goes through `RaiseEvent` + `On<T>` handlers; added a `FromEvents` factory for replay.
- 6 new sealed-record events: `ListItemAdded`, `ListItemChecked`, `ListItemUnchecked`, `AllItemsChecked`, `AllItemsUnchecked`, `RecipeReferenceCleared`. Renamed `ShoppingListCreatedEvent` → `ShoppingListCreated` and expanded its payload (`Owner`, `RecipeReference`, `CreatedAt`) so replay can fully reconstruct top-level state.
- `ShoppingListItem.Check()` / `Uncheck()` → `internal MarkChecked()` / `MarkUnchecked()`. Added `internal Hydrate()` factory so `OnListItemAdded` rebuilds items with their original ids during replay.
- EF mapping: `Identifier` keyed via `HasColumnName("Id")` to keep the existing DB column — **no migration needed**. Ignores `UncommittedEvents` and `Version`.
- Persistence path is otherwise unchanged. The event store + projection layer arrive in #477 / #478.

## Out of scope (later phases)

- New `EfCoreShoppingListEventStore` and event tables — #477 (Phase 2)
- Read model + projection handler — #478 (Phase 3)
- Query cutover — #479 (Phase 4)
- Integration event publication — #480 (Phase 5)
- New aggregate methods (`AddItem`, `RemoveItem`, `Delete`) and their events

## How to Test

1. `dotnet build -p:TreatWarningsAsErrors=true` — clean (verified).
2. `dotnet format --verify-no-changes` — clean (verified).
3. `dotnet test tests/Yumney.Shopping.Domain.Tests` — 174 ✅
4. `dotnet test tests/Yumney.Shopping.Application.Tests` — 113 ✅
5. `dotnet test tests/Yumney.Architecture.Tests` — 117 ✅
6. Integration tests (`tests/Yumney.Integration.Tests`) need a live Aspire DB — not run locally; the schema is unchanged so the EF mapping should round-trip via the renamed `Identifier` property mapped to the existing `Id` column.

## Notes

- This PR is **stacked on #475** (the MealPlan refactor + shared event-sourcing primitives). Once #475 merges to `main`, GitHub will offer to retarget the base; the diff against `main` will then be Phase 1 only.

## Checklist

- [x] Code follows naming conventions
- [x] New/updated tests written
- [x] All tests green (locally verified — domain, application, architecture)
- [x] No new linter warnings
- [x] No `any` in TypeScript code (no FE changes)
- [x] No secrets in code
- [ ] Integration tests run against live Aspire stack