### PR TITLE
feat(shopping): persist ShoppingList events via EfCoreShoppingListEventStore (#477)

### DIFF
--- a/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+/// <summary>
+/// Append-only event store for the <see cref="ShoppingList"/> aggregate. Events are
+/// staged on the underlying <see cref="Microsoft.EntityFrameworkCore.DbContext"/> by
+/// <see cref="AppendAsync"/> and flushed by the <see cref="IShoppingUnitOfWork"/> in
+/// the same transaction as any relational state writes.
+/// </summary>
+public interface IShoppingListEventStore
+{
+	Task<ShoppingList?> LoadAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
+
+	Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListAggregateMetadataConfiguration : IEntityTypeConfiguration<ShoppingListAggregateMetadata>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListAggregateMetadata> entity)
+	{
+		entity.ToTable("ShoppingListAggregates");
+		entity.HasKey(e => e.AggregateId);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.HasIndex(e => e.OwnerId);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+#pragma warning disable SA1649
+internal sealed class ShoppingListStoredEventConfiguration : IEntityTypeConfiguration<ShoppingListStoredEvent>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListStoredEvent> entity)
+	{
+		entity.ToTable("ShoppingListEvents");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.AggregateId).IsRequired();
+		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
+		entity.Property(e => e.EventData).IsRequired();
+		entity.Property(e => e.Version).IsRequired();
+		entity.Property(e => e.OccurredAt).IsRequired();
+
+		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
+		entity.HasIndex(e => e.OccurredAt);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class RecipeReferenceJsonConverter : JsonConverter<RecipeReference>
+{
+	public override RecipeReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		RecipeReference.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, RecipeReference value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListIdentifierJsonConverter : JsonConverter<ShoppingListIdentifier>
+{
+	public override ShoppingListIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListItemIdentifierJsonConverter : JsonConverter<ShoppingListItemIdentifier>
+{
+	public override ShoppingListItemIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListItemIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListItemIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1601
+public sealed partial class EfCoreShoppingListEventStore(
+	ShoppingDbContext context,
+	ILogger<EfCoreShoppingListEventStore> logger) : IShoppingListEventStore
+{
+#pragma warning disable SA1311, SA1303, SA1204
+	private static readonly JsonSerializerOptions jsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters =
+		{
+			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
+			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
+			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
+			new ShoppingListIdentifierJsonConverter(),
+			new ShoppingListItemIdentifierJsonConverter(),
+			new RecipeReferenceJsonConverter(),
+			new AmountJsonConverter(),
+			new UnitJsonConverter(),
+		},
+	};
+
+	private static readonly Dictionary<string, Type> eventTypeMap = new()
+	{
+		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
+		[nameof(ListItemAdded)] = typeof(ListItemAdded),
+		[nameof(ListItemChecked)] = typeof(ListItemChecked),
+		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
+		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
+		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
+		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
+	};
+#pragma warning restore SA1311
+
+	public async Task<ShoppingList?> LoadAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default)
+	{
+		var aggregateId = identifier.Value;
+
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (metadata is null) return null;
+
+		var storedEvents = await context.Set<ShoppingListStoredEvent>()
+			.AsNoTracking()
+			.Where(e => e.AggregateId == aggregateId)
+			.OrderBy(e => e.Version)
+			.ToListAsync(cancellationToken);
+
+		if (storedEvents.Count == 0) return null;
+
+		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+
+		return ShoppingList.FromEvents(identifier, events);
+	}
+
+	public async Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default)
+	{
+		var uncommitted = list.UncommittedEvents.ToList();
+		if (uncommitted.Count == 0) return;
+
+		var aggregateId = list.Identifier.Value;
+
+		var existingMetadata = await context.Set<ShoppingListAggregateMetadata>()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (existingMetadata is null)
+		{
+			context.Set<ShoppingListAggregateMetadata>().Add(new ShoppingListAggregateMetadata
+			{
+				AggregateId = aggregateId,
+				OwnerId = list.Owner.Value,
+			});
+		}
+
+		var baseVersion = list.Version - uncommitted.Count;
+
+		for (var index = 0; index < uncommitted.Count; index++)
+		{
+			var @event = uncommitted[index];
+			context.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = aggregateId,
+				EventType = @event.GetType().Name,
+				EventData = JsonSerializer.Serialize(@event, @event.GetType(), jsonOptions),
+				Version = baseVersion + index + 1,
+				OccurredAt = @event.OccurredOn,
+			});
+		}
+
+		LogEventsStaged(aggregateId, uncommitted.Count, list.Version);
+	}
+
+	private static IDomainEvent? DeserializeEvent(ShoppingListStoredEvent stored)
+	{
+		if (!eventTypeMap.TryGetValue(stored.EventType, out var type)) return null;
+
+		return JsonSerializer.Deserialize(stored.EventData, type, jsonOptions) as IDomainEvent;
+	}
+
+	[LoggerMessage(Level = LogLevel.Debug, Message = "Staged {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]
+	private partial void LogEventsStaged(Guid aggregateId, int count, int version);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Tracks identity and ownership for one <see cref="SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList"/>
+/// aggregate. Multiple rows per owner (one per list).
+/// </summary>
+public sealed class ShoppingListAggregateMetadata
+{
+	public Guid AggregateId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Persisted event row for the ShoppingList aggregate stream. Mirrors the shape of
+/// <see cref="SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.StoredEvent"/>
+/// but maps to its own table so the ShoppingList stream stays separate from the
+/// ShoppingLedger stream.
+/// </summary>
+public sealed class ShoppingListStoredEvent
+{
+	public Guid Id { get; set; }
+
+	public Guid AggregateId { get; set; }
+
+	public string EventType { get; set; } = default!;
+
+	public string EventData { get; set; } = default!;
+
+	public int Version { get; set; }
+
+	public DateTime OccurredAt { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428212832_AddShoppingListEventStore")]
+    partial class AddShoppingListEventStore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListEventStore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListAggregates",
+                columns: table => new
+                {
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListAggregates", x => x.AggregateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EventData = table.Column<string>(type: "text", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListAggregates_OwnerId",
+                table: "ShoppingListAggregates",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_AggregateId_Version",
+                table: "ShoppingListEvents",
+                columns: new[] { "AggregateId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_OccurredAt",
+                table: "ShoppingListEvents",
+                column: "OccurredAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListAggregates");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListEvents");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
@@ -17,6 +17,10 @@ public sealed class ShoppingDbContext(DbContextOptions<ShoppingDbContext> option
 
 	public DbSet<AggregateMetadata> ShoppingAggregates => Set<AggregateMetadata>();
 
+	public DbSet<ShoppingListStoredEvent> ShoppingListEvents => Set<ShoppingListStoredEvent>();
+
+	public DbSet<ShoppingListAggregateMetadata> ShoppingListAggregates => Set<ShoppingListAggregateMetadata>();
+
 	public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,11 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
-public sealed class ShoppingUnitOfWork(ShoppingDbContext context, IShoppingListRepository shoppingLists) : IShoppingUnitOfWork
+public sealed class ShoppingUnitOfWork(
+	ShoppingDbContext context,
+	IShoppingListRepository shoppingLists,
+	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
-	public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-		=> context.SaveChangesAsync(cancellationToken);
+	public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		var trackedLists = context.ChangeTracker.Entries<ShoppingList>()
+			.Where(e => e.State != EntityState.Detached)
+			.Select(e => e.Entity)
+			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		foreach (var list in trackedLists)
+		{
+			await listEventStore.AppendAsync(list, cancellationToken);
+		}
+
+		int result;
+		try
+		{
+			result = await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+		{
+			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
+		}
+
+		foreach (var list in trackedLists)
+		{
+			list.MarkCommitted();
+		}
+
+		return result;
+	}
 }

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		});
 
 		services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+		services.AddScoped<IShoppingListEventStore, EfCoreShoppingListEventStore>();
 		services.AddScoped<IShoppingUnitOfWork, ShoppingUnitOfWork>();
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -203,6 +203,28 @@ public sealed class AspireFixture : IAsyncLifetime
 		await context.SaveChangesAsync();
 	}
 
+	public async Task ResetShoppingListEventStoreAsync(ShoppingDomain.ShoppingList.OwnerIdentifier owner)
+	{
+		await using var context = await CreateShoppingDbContextAsync();
+		var aggregateIds = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => m.OwnerId == owner.Value)
+			.Select(m => m.AggregateId)
+			.ToListAsync();
+
+		if (aggregateIds.Count == 0) return;
+
+		var events = await context.Set<ShoppingListStoredEvent>()
+			.Where(e => aggregateIds.Contains(e.AggregateId))
+			.ToListAsync();
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => aggregateIds.Contains(m.AggregateId))
+			.ToListAsync();
+
+		context.RemoveRange(events);
+		context.RemoveRange(metadata);
+		await context.SaveChangesAsync();
+	}
+
 	public async Task ResetShoppingReadModelAsync(string ownerId)
 	{
 		await using var context = await CreateShoppingDbContextAsync();

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.EventStore;
+
+[Collection(AspireCollection.Name)]
+public class EfCoreShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listevtstore-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task LoadAsync_NoEventsForIdentifier_ReturnsNull()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+
+		var loaded = await store.LoadAsync(ShoppingListIdentifier.New());
+
+		loaded.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task AppendAsync_NewList_StagesEventsAndMetadata()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var list = CreateList();
+
+		await store.AppendAsync(list);
+		await context.SaveChangesAsync();
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+		var metadata = await verify.Set<ShoppingListAggregateMetadata>()
+			.SingleAsync(m => m.AggregateId == list.Identifier.Value);
+
+		stored.Should().HaveCount(2);
+		stored[0].EventType.Should().Be(nameof(ShoppingListCreated));
+		stored[0].Version.Should().Be(1);
+		stored[1].EventType.Should().Be(nameof(ListItemAdded));
+		stored[1].Version.Should().Be(2);
+		metadata.OwnerId.Should().Be(owner.Value);
+	}
+
+	[Fact]
+	public async Task AppendAsync_OnlyAfterMarkCommitted_DoesNotDoubleStage()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+
+		stored.Should().HaveCount(3);
+		stored[2].EventType.Should().Be(nameof(ListItemChecked));
+		stored[2].Version.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task LoadAsync_ReplaysEventsToSameState()
+	{
+		var original = CreateList();
+		original.CheckOffItem(original.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(original);
+			await context.SaveChangesAsync();
+		}
+
+		await using var loadContext = await fixture.CreateShoppingDbContextAsync();
+		var loadStore = CreateStore(loadContext);
+		var loaded = await loadStore.LoadAsync(original.Identifier);
+
+		loaded.Should().NotBeNull();
+		loaded!.Identifier.Should().Be(original.Identifier);
+		loaded.Title.Should().Be(original.Title);
+		loaded.Owner.Should().Be(original.Owner);
+		loaded.Items.Should().HaveCount(1);
+		loaded.Items[0].IsChecked.Should().BeTrue();
+		loaded.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public async Task AppendAsync_ConflictingVersion_ThrowsOnSave()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		// Simulate a competing write at version 2 by manually inserting a row with the
+		// same (AggregateId, Version) as the next staged event would use.
+		await using (var conflictContext = await fixture.CreateShoppingDbContextAsync())
+		{
+			conflictContext.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = list.Identifier.Value,
+				EventType = nameof(ListItemChecked),
+				EventData = "{}",
+				Version = list.Version + 1,
+				OccurredAt = DateTime.UtcNow,
+			});
+			await conflictContext.SaveChangesAsync();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using var context2 = await fixture.CreateShoppingDbContextAsync();
+		var store2 = CreateStore(context2);
+		await store2.AppendAsync(list);
+
+		var act = () => context2.SaveChangesAsync();
+		var ex = await act.Should().ThrowAsync<DbUpdateException>();
+		ex.Which.IsUniqueViolation().Should().BeTrue();
+	}
+
+	private static EfCoreShoppingListEventStore CreateStore(ShoppingDbContext context) =>
+		new(context, NullLogger<EfCoreShoppingListEventStore>.Instance);
+
+	private ShoppingList CreateList()
+	{
+		var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+		return ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[item]);
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Shopping module ES migration. Closes #477. Stacked on #484 (Phase 1).

- New `IShoppingListEventStore` interface in Domain.
- `EfCoreShoppingListEventStore` (Infrastructure): JSON-serialized events, VO converters, optimistic concurrency via unique `(AggregateId, Version)` index. Mirrors the MealPlan event store pattern; uses staged-append semantics so the UoW owns the transaction.
- New tables / migration `AddShoppingListEventStore`: `ShoppingListEvents` and `ShoppingListAggregates` (separate POCOs from the existing ShoppingLedger stream).
- `ShoppingUnitOfWork.SaveChangesAsync` scans the ChangeTracker for tracked `ShoppingList` aggregates with uncommitted events, stages them via the event store, then SaveChanges atomically. `DbUpdateException.IsUniqueViolation()` translates to `ConcurrencyConflictException`.
- Integration tests: null-on-empty load, append staging, replay parity, no-double-stage after `MarkCommitted`, concurrency conflict.

Read path is unchanged. The relational `ShoppingLists`/`ShoppingListItems` tables continue to be the read source until #478/#479 cut over to projections.

## How to Test

1. `dotnet build -p:TreatWarningsAsErrors=true` — clean (verified).
2. `dotnet format --verify-no-changes` — clean (verified).
3. `dotnet test tests/Yumney.Shopping.Domain.Tests` — 174 ✅
4. `dotnet test tests/Yumney.Shopping.Application.Tests` — 113 ✅
5. `dotnet test tests/Yumney.Shopping.Infrastructure.Tests` — 8 ✅
6. `dotnet test tests/Yumney.Architecture.Tests` — 117 ✅
7. Integration tests (`Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs`) require a live Aspire stack — run on CI.
8. Smoke check the migration: `aspire run` → check `mealplan-reset` analog or apply manually → verify `ShoppingListEvents` and `ShoppingListAggregates` tables exist with the unique index.

## Notes

- This PR is **stacked on #484** (Phase 1). After #484 merges to develop, GitHub will offer to retarget the base.
- No feature flag added: the dual-write is unconditional. If a runtime issue ever required disabling event appends, it's a single DI line to remove (`AddScoped<IShoppingListEventStore, ...>`).
- Acceptance criteria from #477 covered: migrations ✅, `EfCoreShoppingListEventStore` appends + loads + concurrency ✅, dual-write tests ✅, no read-path changes ✅. Toggle config skipped — see note above.

## Checklist

- [x] Code follows naming conventions
- [x] New/updated tests written
- [x] All tests green (locally verified — domain, application, infrastructure, architecture)
- [x] No new linter warnings
- [x] No `any` in TypeScript code (no FE changes)
- [x] No secrets in code
- [ ] Integration tests run against live Aspire stack (CI)