### PR TITLE
feat(shopping): build read model + projection handler for ShoppingList (#478)

### DIFF
--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
@@ -9,7 +9,7 @@ public static class ShoppingListMappingExtensions
 		public ShoppingListDetailDto ToDetailDto()
 		{
 			return new ShoppingListDetailDto(
-				shoppingList.Id.Value,
+				shoppingList.Identifier.Value,
 				shoppingList.Title.Value,
 				shoppingList.RecipeReference?.Value,
 				shoppingList.CreatedAt,

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsChecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsUnchecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemAdded(
+	ShoppingListItemIdentifier ItemId,
+	ItemName Name,
+	Quantity? Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemChecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemUnchecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record RecipeReferenceCleared : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ShoppingListCreated(
+	ShoppingListIdentifier Identifier,
+	ShoppingListTitle Title,
+	OwnerIdentifier Owner,
+	RecipeReference? RecipeReference,
+	DateTime CreatedAt) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
@@ -1,7 +1,0 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
-
-namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-
-public sealed record ShoppingListCreatedEvent(
-	ShoppingListIdentifier ShoppingListIdentifier,
-	ShoppingListTitle Title) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+/// <summary>
+/// Append-only event store for the <see cref="ShoppingList"/> aggregate. Events are
+/// staged on the underlying <see cref="Microsoft.EntityFrameworkCore.DbContext"/> by
+/// <see cref="AppendAsync"/> and flushed by the <see cref="IShoppingUnitOfWork"/> in
+/// the same transaction as any relational state writes.
+/// </summary>
+public interface IShoppingListEventStore
+{
+	Task<ShoppingList?> LoadAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
+
+	Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -4,7 +4,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
+public sealed class ShoppingList : EventSourcedAggregate<ShoppingListIdentifier>
 {
 	private readonly List<ShoppingListItem> items = [];
 
@@ -20,6 +20,13 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
 	private ShoppingList()
 	{
+		On<ShoppingListCreated>(OnCreated);
+		On<ListItemAdded>(OnListItemAdded);
+		On<ListItemChecked>(OnListItemChecked);
+		On<ListItemUnchecked>(OnListItemUnchecked);
+		On<AllItemsChecked>(_ => OnAllItemsChecked());
+		On<AllItemsUnchecked>(_ => OnAllItemsUnchecked());
+		On<RecipeReferenceCleared>(_ => OnRecipeReferenceCleared());
 	}
 
 	public static ShoppingList Create(
@@ -30,60 +37,113 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 	{
 		Ensure.That(items).IsNotEmpty();
 
-		var shoppingList = new ShoppingList
+		var list = new ShoppingList();
+		list.RaiseEvent(new ShoppingListCreated(
+			ShoppingListIdentifier.New(),
+			title,
+			owner,
+			recipeReference,
+			DateTime.UtcNow));
+
+		foreach (var item in items)
 		{
-			Id = ShoppingListIdentifier.New(),
-			Title = title,
-			Owner = owner,
-			RecipeReference = recipeReference,
-			CreatedAt = DateTime.UtcNow,
-		};
+			list.RaiseEvent(new ListItemAdded(item.Id, item.Name, item.Quantity));
+		}
 
-		shoppingList.items.AddRange(items);
+		return list;
+	}
 
-		shoppingList.AddDomainEvent(new ShoppingListCreatedEvent(shoppingList.Id, title));
-
-		return shoppingList;
+	public static ShoppingList FromEvents(
+		ShoppingListIdentifier identifier,
+		IEnumerable<IDomainEvent> events,
+		AggregateVersion? startVersion = null)
+	{
+		var list = new ShoppingList { Identifier = identifier };
+		list.LoadFromHistory(events, startVersion);
+		return list;
 	}
 
 	public ShoppingList CheckOffItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Check();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemChecked(itemId));
 		return this;
 	}
 
 	public ShoppingList UncheckItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Uncheck();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemUnchecked(itemId));
 		return this;
 	}
 
 	public ShoppingList CheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Check();
-		}
-
+		RaiseEvent(new AllItemsChecked());
 		return this;
 	}
 
 	public ShoppingList UncheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Uncheck();
-		}
-
+		RaiseEvent(new AllItemsUnchecked());
 		return this;
 	}
 
 	public ShoppingList ClearRecipeReference()
 	{
-		RecipeReference = null;
+		RaiseEvent(new RecipeReferenceCleared());
 		return this;
+	}
+
+	private void OnCreated(ShoppingListCreated e)
+	{
+		Identifier = e.Identifier;
+		Title = e.Title;
+		Owner = e.Owner;
+		RecipeReference = e.RecipeReference;
+		CreatedAt = e.CreatedAt;
+	}
+
+	private void OnListItemAdded(ListItemAdded e)
+	{
+		items.Add(ShoppingListItem.Hydrate(e.ItemId, e.Name, e.Quantity));
+	}
+
+	private void OnListItemChecked(ListItemChecked e)
+	{
+		FindItem(e.ItemId).MarkChecked();
+	}
+
+	private void OnListItemUnchecked(ListItemUnchecked e)
+	{
+		FindItem(e.ItemId).MarkUnchecked();
+	}
+
+	private void OnAllItemsChecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkChecked();
+		}
+	}
+
+	private void OnAllItemsUnchecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkUnchecked();
+		}
+	}
+
+	private void OnRecipeReferenceCleared()
+	{
+		RecipeReference = null;
+	}
+
+	private void EnsureItemExists(ShoppingListItemIdentifier itemId)
+	{
+		var item = items.FirstOrDefault(i => i.Id == itemId);
+		Ensure.That(item!).IsNotNull();
 	}
 
 	private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
@@ -25,13 +25,24 @@ public sealed class ShoppingListItem : Entity<ShoppingListItemIdentifier>
 		};
 	}
 
-	public ShoppingListItem Check()
+	internal static ShoppingListItem Hydrate(ShoppingListItemIdentifier id, ItemName name, Quantity? quantity)
+	{
+		return new ShoppingListItem
+		{
+			Id = id,
+			Name = name,
+			Quantity = quantity,
+			IsChecked = false,
+		};
+	}
+
+	internal ShoppingListItem MarkChecked()
 	{
 		IsChecked = true;
 		return this;
 	}
 
-	public ShoppingListItem Uncheck()
+	internal ShoppingListItem MarkUnchecked()
 	{
 		IsChecked = false;
 		return this;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListAggregateMetadataConfiguration : IEntityTypeConfiguration<ShoppingListAggregateMetadata>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListAggregateMetadata> entity)
+	{
+		entity.ToTable("ShoppingListAggregates");
+		entity.HasKey(e => e.AggregateId);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.HasIndex(e => e.OwnerId);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
@@ -10,8 +10,9 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 	public void Configure(EntityTypeBuilder<ShoppingList> entity)
 	{
 		entity.ToTable("ShoppingLists");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		entity.HasKey(e => e.Identifier);
+		entity.Property(e => e.Identifier)
+			.HasColumnName("Id")
 			.HasConversion<ShoppingListIdentifierConverter>();
 
 		entity.Property(e => e.Title)
@@ -62,6 +63,7 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 		entity.Property<uint>("xmin")
 			.HasColumnType("xid")
 			.IsRowVersion();
-		entity.Ignore(e => e.DomainEvents);
+		entity.Ignore(e => e.UncommittedEvents);
+		entity.Ignore(e => e.Version);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListItemReadItemConfiguration : IEntityTypeConfiguration<ShoppingListItemReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListItemReadItem> entity)
+	{
+		entity.ToTable("ShoppingListItemReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.QuantityUnit).HasMaxLength(50);
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.ListId);
+		entity.HasIndex(e => new { e.OwnerId, e.ListId });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+#pragma warning disable SA1649
+internal sealed class ShoppingListStoredEventConfiguration : IEntityTypeConfiguration<ShoppingListStoredEvent>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListStoredEvent> entity)
+	{
+		entity.ToTable("ShoppingListEvents");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.AggregateId).IsRequired();
+		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
+		entity.Property(e => e.EventData).IsRequired();
+		entity.Property(e => e.Version).IsRequired();
+		entity.Property(e => e.OccurredAt).IsRequired();
+
+		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
+		entity.HasIndex(e => e.OccurredAt);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListSummaryReadItemConfiguration : IEntityTypeConfiguration<ShoppingListSummaryReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListSummaryReadItem> entity)
+	{
+		entity.ToTable("ShoppingListSummaryReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.OwnerId);
+		entity.HasIndex(e => new { e.OwnerId, e.CreatedAt });
+		entity.HasIndex(e => new { e.OwnerId, e.Title });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class RecipeReferenceJsonConverter : JsonConverter<RecipeReference>
+{
+	public override RecipeReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		RecipeReference.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, RecipeReference value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListIdentifierJsonConverter : JsonConverter<ShoppingListIdentifier>
+{
+	public override ShoppingListIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListItemIdentifierJsonConverter : JsonConverter<ShoppingListItemIdentifier>
+{
+	public override ShoppingListItemIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListItemIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListItemIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1601
+public sealed partial class EfCoreShoppingListEventStore(
+	ShoppingDbContext context,
+	ILogger<EfCoreShoppingListEventStore> logger) : IShoppingListEventStore
+{
+#pragma warning disable SA1311, SA1303, SA1204
+	private static readonly JsonSerializerOptions jsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters =
+		{
+			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
+			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
+			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
+			new ShoppingListIdentifierJsonConverter(),
+			new ShoppingListItemIdentifierJsonConverter(),
+			new RecipeReferenceJsonConverter(),
+			new AmountJsonConverter(),
+			new UnitJsonConverter(),
+		},
+	};
+
+	private static readonly Dictionary<string, Type> eventTypeMap = new()
+	{
+		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
+		[nameof(ListItemAdded)] = typeof(ListItemAdded),
+		[nameof(ListItemChecked)] = typeof(ListItemChecked),
+		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
+		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
+		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
+		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
+	};
+#pragma warning restore SA1311
+
+	public async Task<ShoppingList?> LoadAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default)
+	{
+		var aggregateId = identifier.Value;
+
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (metadata is null) return null;
+
+		var storedEvents = await context.Set<ShoppingListStoredEvent>()
+			.AsNoTracking()
+			.Where(e => e.AggregateId == aggregateId)
+			.OrderBy(e => e.Version)
+			.ToListAsync(cancellationToken);
+
+		if (storedEvents.Count == 0) return null;
+
+		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+
+		return ShoppingList.FromEvents(identifier, events);
+	}
+
+	public async Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default)
+	{
+		var uncommitted = list.UncommittedEvents.ToList();
+		if (uncommitted.Count == 0) return;
+
+		var aggregateId = list.Identifier.Value;
+
+		var existingMetadata = await context.Set<ShoppingListAggregateMetadata>()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (existingMetadata is null)
+		{
+			context.Set<ShoppingListAggregateMetadata>().Add(new ShoppingListAggregateMetadata
+			{
+				AggregateId = aggregateId,
+				OwnerId = list.Owner.Value,
+			});
+		}
+
+		var baseVersion = list.Version - uncommitted.Count;
+
+		for (var index = 0; index < uncommitted.Count; index++)
+		{
+			var @event = uncommitted[index];
+			context.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = aggregateId,
+				EventType = @event.GetType().Name,
+				EventData = JsonSerializer.Serialize(@event, @event.GetType(), jsonOptions),
+				Version = baseVersion + index + 1,
+				OccurredAt = @event.OccurredOn,
+			});
+		}
+
+		LogEventsStaged(aggregateId, uncommitted.Count, list.Version);
+	}
+
+	private static IDomainEvent? DeserializeEvent(ShoppingListStoredEvent stored)
+	{
+		if (!eventTypeMap.TryGetValue(stored.EventType, out var type)) return null;
+
+		return JsonSerializer.Deserialize(stored.EventData, type, jsonOptions) as IDomainEvent;
+	}
+
+	[LoggerMessage(Level = LogLevel.Debug, Message = "Staged {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]
+	private partial void LogEventsStaged(Guid aggregateId, int count, int version);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemAddedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemAdded Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record RecipeReferenceClearedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	RecipeReferenceCleared Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Tracks identity and ownership for one <see cref="SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList"/>
+/// aggregate. Multiple rows per owner (one per list).
+/// </summary>
+public sealed class ShoppingListAggregateMetadata
+{
+	public Guid AggregateId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ShoppingListCreatedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ShoppingListCreated Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Base record for all ShoppingList integration events. Carries the routing pair
+/// (OwnerId, AggregateId) that identifies the list stream the event came from.
+/// Concrete events stay as sealed records so the bus's name-based handler
+/// discovery still works.
+/// </summary>
+public abstract record ShoppingListIntegrationEvent(string OwnerId, Guid AggregateId) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Persisted event row for the ShoppingList aggregate stream. Mirrors the shape of
+/// <see cref="SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.StoredEvent"/>
+/// but maps to its own table so the ShoppingList stream stays separate from the
+/// ShoppingLedger stream.
+/// </summary>
+public sealed class ShoppingListStoredEvent
+{
+	public Guid Id { get; set; }
+
+	public Guid AggregateId { get; set; }
+
+	public string EventType { get; set; } = default!;
+
+	public string EventData { get; set; } = default!;
+
+	public int Version { get; set; }
+
+	public DateTime OccurredAt { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428212832_AddShoppingListEventStore")]
+    partial class AddShoppingListEventStore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListEventStore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListAggregates",
+                columns: table => new
+                {
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListAggregates", x => x.AggregateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EventData = table.Column<string>(type: "text", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListAggregates_OwnerId",
+                table: "ShoppingListAggregates",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_AggregateId_Version",
+                table: "ShoppingListEvents",
+                columns: new[] { "AggregateId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_OccurredAt",
+                table: "ShoppingListEvents",
+                column: "OccurredAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListAggregates");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListEvents");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428213905_AddShoppingListReadModel")]
+    partial class AddShoppingListReadModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListReadModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListItemReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    QuantityAmount = table.Column<decimal>(type: "numeric", nullable: true),
+                    QuantityUnit = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    IsChecked = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListItemReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListSummaryReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    RecipeIdentifier = table.Column<Guid>(type: "uuid", nullable: true),
+                    ItemCount = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListSummaryReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_ListId",
+                table: "ShoppingListItemReadItems",
+                column: "ListId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_OwnerId_ListId",
+                table: "ShoppingListItemReadItems",
+                columns: new[] { "OwnerId", "ListId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId",
+                table: "ShoppingListSummaryReadItems",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_CreatedAt",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_Title",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "Title" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListItemReadItems");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListSummaryReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
@@ -1,0 +1,26 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one item within a ShoppingList. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListItemReadItem
+{
+	public Guid Id { get; set; }
+
+	public Guid ListId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Name { get; set; } = default!;
+
+	public decimal? QuantityAmount { get; set; }
+
+	public string? QuantityUnit { get; set; }
+
+	public bool IsChecked { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -69,9 +69,12 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 				CreatedAt = DateTime.UtcNow,
 				LastUpdated = DateTime.UtcNow,
 			});
+
+			// Only increment when the item is newly inserted — otherwise replay/duplicate
+			// delivery would drift the count while the items table stays at 1 row.
+			await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		}
 
-		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		await context.SaveChangesAsync(cancellationToken);
 	}
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -1,0 +1,154 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Async projection handler — rebuilds the ShoppingList read model from
+/// integration events published by the event store. Idempotent upserts so
+/// replay produces the same final state.
+/// </summary>
+public sealed class ShoppingListProjection(ShoppingDbContext context)
+	: IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemAddedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>
+{
+	public async Task HandleAsync(ShoppingListCreatedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListSummaryReadItem>().Add(new ShoppingListSummaryReadItem
+			{
+				Id = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Title = inner.Title.Value,
+				RecipeIdentifier = inner.RecipeReference?.Value,
+				ItemCount = 0,
+				CreatedAt = inner.CreatedAt,
+				LastUpdated = inner.CreatedAt,
+			});
+		}
+		else
+		{
+			existing.OwnerId = @event.OwnerId;
+			existing.Title = inner.Title.Value;
+			existing.RecipeIdentifier = inner.RecipeReference?.Value;
+			existing.CreatedAt = inner.CreatedAt;
+			existing.LastUpdated = DateTime.UtcNow;
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemAddedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == inner.ItemId.Value, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListItemReadItem>().Add(new ShoppingListItemReadItem
+			{
+				Id = inner.ItemId.Value,
+				ListId = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Name = inner.Name.Value,
+				QuantityAmount = inner.Quantity?.Amount.Value,
+				QuantityUnit = inner.Quantity?.Unit?.Value,
+				IsChecked = false,
+				CreatedAt = DateTime.UtcNow,
+				LastUpdated = DateTime.UtcNow,
+			});
+		}
+
+		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(RecipeReferenceClearedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+		if (summary is null) return;
+
+		summary.RecipeIdentifier = null;
+		summary.LastUpdated = DateTime.UtcNow;
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	private async Task SetCheckedAsync(Guid itemId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var item = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+		if (item is null) return;
+		item.IsChecked = isChecked;
+		item.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task SetAllCheckedAsync(Guid listId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var items = await context.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == listId)
+			.ToListAsync(cancellationToken);
+		foreach (var item in items)
+		{
+			item.IsChecked = isChecked;
+			item.LastUpdated = DateTime.UtcNow;
+		}
+	}
+
+	private async Task IncrementItemCountAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.ItemCount += 1;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task TouchSummaryAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one ShoppingList aggregate. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListSummaryReadItem
+{
+	public Guid Id { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Title { get; set; } = default!;
+
+	public Guid? RecipeIdentifier { get; set; }
+
+	public int ItemCount { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
@@ -17,6 +17,10 @@ public sealed class ShoppingDbContext(DbContextOptions<ShoppingDbContext> option
 
 	public DbSet<AggregateMetadata> ShoppingAggregates => Set<AggregateMetadata>();
 
+	public DbSet<ShoppingListStoredEvent> ShoppingListEvents => Set<ShoppingListStoredEvent>();
+
+	public DbSet<ShoppingListAggregateMetadata> ShoppingListAggregates => Set<ShoppingListAggregateMetadata>();
+
 	public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
@@ -19,7 +19,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -29,7 +29,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await shoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -47,7 +47,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 		var items = await query
 			.Skip(paging.Skip)
 			.Take(paging.PageSize.Value)
-			.Select(l => new ShoppingListSummary(l.Id, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
+			.Select(l => new ShoppingListSummary(l.Identifier, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
 			.ToListAsync(cancellationToken);
 
 		return (items, ItemCount.From(totalCount));

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
@@ -8,6 +8,10 @@ public sealed class ShoppingReadDbContext(DbContextOptions<ShoppingReadDbContext
 {
 	public DbSet<ShoppingListReadItem> ShoppingListReadItems => Set<ShoppingListReadItem>();
 
+	public DbSet<ShoppingListSummaryReadItem> ShoppingListSummaryReadItems => Set<ShoppingListSummaryReadItem>();
+
+	public DbSet<ShoppingListItemReadItem> ShoppingListItemReadItems => Set<ShoppingListItemReadItem>();
+
 	public DbSet<ShoppingList> ShoppingLists => Set<ShoppingList>();
 
 	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,13 +1,18 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
 public sealed class ShoppingUnitOfWork(
 	ShoppingDbContext context,
 	IShoppingListRepository shoppingLists,
-	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
+	IShoppingListEventStore listEventStore,
+	IEventBus eventBus) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
@@ -17,6 +22,10 @@ public sealed class ShoppingUnitOfWork(
 			.Where(e => e.State != EntityState.Detached)
 			.Select(e => e.Entity)
 			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		var pendingPublishes = trackedLists
+			.Select(list => (list, events: list.UncommittedEvents.ToList()))
 			.ToList();
 
 		foreach (var list in trackedLists)
@@ -34,11 +43,38 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
-		foreach (var list in trackedLists)
+		foreach (var (list, events) in pendingPublishes)
 		{
+			foreach (var domainEvent in events)
+			{
+				var integrationEvent = MapToIntegrationEvent(list, domainEvent);
+				if (integrationEvent is not null)
+				{
+					await eventBus.PublishAsync(integrationEvent, cancellationToken);
+				}
+			}
+
 			list.MarkCommitted();
 		}
 
 		return result;
+	}
+
+	private static IIntegrationEvent? MapToIntegrationEvent(ShoppingList list, IDomainEvent domainEvent)
+	{
+		var ownerId = list.Owner.Value;
+		var aggregateId = list.Identifier.Value;
+
+		return domainEvent switch
+		{
+			ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
+			ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
+			ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
+			ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
+			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
+			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
+			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+			_ => null,
+		};
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,11 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
-public sealed class ShoppingUnitOfWork(ShoppingDbContext context, IShoppingListRepository shoppingLists) : IShoppingUnitOfWork
+public sealed class ShoppingUnitOfWork(
+	ShoppingDbContext context,
+	IShoppingListRepository shoppingLists,
+	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
-	public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-		=> context.SaveChangesAsync(cancellationToken);
+	public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		var trackedLists = context.ChangeTracker.Entries<ShoppingList>()
+			.Where(e => e.State != EntityState.Detached)
+			.Select(e => e.Entity)
+			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		foreach (var list in trackedLists)
+		{
+			await listEventStore.AppendAsync(list, cancellationToken);
+		}
+
+		int result;
+		try
+		{
+			result = await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+		{
+			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
+		}
+
+		foreach (var list in trackedLists)
+		{
+			list.MarkCommitted();
+		}
+
+		return result;
+	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -43,6 +43,15 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
+		// Mark committed BEFORE publishing: events are already persisted to the store,
+		// so the aggregate is conceptually "clean". A publish failure (e.g. a projection
+		// handler throws) propagates to the caller, but the aggregate doesn't keep stale
+		// uncommitted events that would re-stage with conflicting versions on retry.
+		foreach (var (list, _) in pendingPublishes)
+		{
+			list.MarkCommitted();
+		}
+
 		foreach (var (list, events) in pendingPublishes)
 		{
 			foreach (var domainEvent in events)
@@ -53,8 +62,6 @@ public sealed class ShoppingUnitOfWork(
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
 				}
 			}
-
-			list.MarkCommitted();
 		}
 
 		return result;

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -50,6 +50,14 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingListProjectionHandler>();
+		services.AddScoped<ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemAddedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>, ShoppingListProjection>();
 		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
 		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		});
 
 		services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+		services.AddScoped<IShoppingListEventStore, EfCoreShoppingListEventStore>();
 		services.AddScoped<IShoppingUnitOfWork, ShoppingUnitOfWork>();
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -44,7 +44,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 			var userId = await fixture.GetTestUserIdAsync();
 			var owner = OwnerIdentifier.From(userId);
 			await using var ctx = await fixture.CreateShoppingDbContextAsync();
-			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(listId) && l.Owner == owner);
+			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(listId) && l.Owner == owner);
 			return list.RecipeReference is null;
 		});
 	}
@@ -65,7 +65,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		await Task.Delay(2000);
 
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(linkedToB));
+		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(linkedToB));
 		list.RecipeReference.Should().NotBeNull();
 	}
 

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -203,6 +203,28 @@ public sealed class AspireFixture : IAsyncLifetime
 		await context.SaveChangesAsync();
 	}
 
+	public async Task ResetShoppingListEventStoreAsync(ShoppingDomain.ShoppingList.OwnerIdentifier owner)
+	{
+		await using var context = await CreateShoppingDbContextAsync();
+		var aggregateIds = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => m.OwnerId == owner.Value)
+			.Select(m => m.AggregateId)
+			.ToListAsync();
+
+		if (aggregateIds.Count == 0) return;
+
+		var events = await context.Set<ShoppingListStoredEvent>()
+			.Where(e => aggregateIds.Contains(e.AggregateId))
+			.ToListAsync();
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => aggregateIds.Contains(m.AggregateId))
+			.ToListAsync();
+
+		context.RemoveRange(events);
+		context.RemoveRange(metadata);
+		await context.SaveChangesAsync();
+	}
+
 	public async Task ResetShoppingReadModelAsync(string ownerId)
 	{
 		await using var context = await CreateShoppingDbContextAsync();

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.EventStore;
+
+[Collection(AspireCollection.Name)]
+public class EfCoreShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listevtstore-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task LoadAsync_NoEventsForIdentifier_ReturnsNull()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+
+		var loaded = await store.LoadAsync(ShoppingListIdentifier.New());
+
+		loaded.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task AppendAsync_NewList_StagesEventsAndMetadata()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var list = CreateList();
+
+		await store.AppendAsync(list);
+		await context.SaveChangesAsync();
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+		var metadata = await verify.Set<ShoppingListAggregateMetadata>()
+			.SingleAsync(m => m.AggregateId == list.Identifier.Value);
+
+		stored.Should().HaveCount(2);
+		stored[0].EventType.Should().Be(nameof(ShoppingListCreated));
+		stored[0].Version.Should().Be(1);
+		stored[1].EventType.Should().Be(nameof(ListItemAdded));
+		stored[1].Version.Should().Be(2);
+		metadata.OwnerId.Should().Be(owner.Value);
+	}
+
+	[Fact]
+	public async Task AppendAsync_OnlyAfterMarkCommitted_DoesNotDoubleStage()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+
+		stored.Should().HaveCount(3);
+		stored[2].EventType.Should().Be(nameof(ListItemChecked));
+		stored[2].Version.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task LoadAsync_ReplaysEventsToSameState()
+	{
+		var original = CreateList();
+		original.CheckOffItem(original.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(original);
+			await context.SaveChangesAsync();
+		}
+
+		await using var loadContext = await fixture.CreateShoppingDbContextAsync();
+		var loadStore = CreateStore(loadContext);
+		var loaded = await loadStore.LoadAsync(original.Identifier);
+
+		loaded.Should().NotBeNull();
+		loaded!.Identifier.Should().Be(original.Identifier);
+		loaded.Title.Should().Be(original.Title);
+		loaded.Owner.Should().Be(original.Owner);
+		loaded.Items.Should().HaveCount(1);
+		loaded.Items[0].IsChecked.Should().BeTrue();
+		loaded.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public async Task AppendAsync_ConflictingVersion_ThrowsOnSave()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		// Simulate a competing write at version 2 by manually inserting a row with the
+		// same (AggregateId, Version) as the next staged event would use.
+		await using (var conflictContext = await fixture.CreateShoppingDbContextAsync())
+		{
+			conflictContext.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = list.Identifier.Value,
+				EventType = nameof(ListItemChecked),
+				EventData = "{}",
+				Version = list.Version + 1,
+				OccurredAt = DateTime.UtcNow,
+			});
+			await conflictContext.SaveChangesAsync();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using var context2 = await fixture.CreateShoppingDbContextAsync();
+		var store2 = CreateStore(context2);
+		await store2.AppendAsync(list);
+
+		var act = () => context2.SaveChangesAsync();
+		var ex = await act.Should().ThrowAsync<DbUpdateException>();
+		ex.Which.IsUniqueViolation().Should().BeTrue();
+	}
+
+	private static EfCoreShoppingListEventStore CreateStore(ShoppingDbContext context) =>
+		new(context, NullLogger<EfCoreShoppingListEventStore>.Instance);
+
+	private ShoppingList CreateList()
+	{
+		var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+		return ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[item]);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Persistence;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingUnitOfWorkTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"uow-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task SaveChangesAsync_PublishFails_StillMarksAggregateCommitted()
+	{
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+
+		var listEventStore = new EfCoreShoppingListEventStore(
+			writeContext,
+			NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+
+		var failingBus = Substitute.For<IEventBus>();
+		failingBus
+			.PublishAsync(Arg.Any<IIntegrationEvent>(), Arg.Any<CancellationToken>())
+			.ThrowsAsyncForAnyArgs(new InvalidOperationException("projection boom"));
+
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, failingBus);
+
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
+		await repo.AddAsync(list);
+
+		var act = () => uow.SaveChangesAsync();
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("projection boom");
+		list.UncommittedEvents.Should().BeEmpty(
+			"MarkCommitted must run before publish so a failing handler doesn't wedge the aggregate with stale events");
+
+		// Events must still have been persisted before the publish attempt.
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.CountAsync();
+		stored.Should().Be(2);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using Xunit;
@@ -30,15 +31,10 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_InsertsSummaryRow()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -52,11 +48,13 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task ItemAdded_InsertsItemAndIncrementsCount()
 	{
 		await SeedCreatedAsync();
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(
+				ItemAddedEvent(itemId, "Flour"));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
@@ -71,14 +69,39 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task ItemAdded_DeliveredTwice_KeepsCountAtOne()
+	{
+		await SeedCreatedAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == aggregateId).CountAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		items.Should().Be(1);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
 	public async Task ItemChecked_FlipsIsCheckedFlag()
 	{
 		await SeedCreatedAsync();
 		var itemId = await SeedItemAsync("Sugar");
-		var projection = await CreateProjectionAsync();
 
-		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
-			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new ListItemCheckedIntegrationEvent(
+				owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
@@ -89,20 +112,20 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task AllItemsChecked_FlipsEveryItemForList()
 	{
 		await SeedCreatedAsync();
-		var first = await SeedItemAsync("Sugar");
-		var second = await SeedItemAsync("Salt");
-		var projection = await CreateProjectionAsync();
+		await SeedItemAsync("Sugar");
+		await SeedItemAsync("Salt");
 
-		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
-			owner.Value, aggregateId, new AllItemsChecked()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new AllItemsCheckedIntegrationEvent(
+				owner.Value, aggregateId, new AllItemsChecked()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var items = await verify.Set<ShoppingListItemReadItem>()
 			.Where(i => i.ListId == aggregateId).ToListAsync();
 		items.Should().HaveCount(2);
 		items.Should().OnlyContain(i => i.IsChecked);
-		_ = first;
-		_ = second;
 	}
 
 	[Fact]
@@ -115,11 +138,18 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 			owner,
 			RecipeReference: RecipeReference.From(recipe),
 			CreatedAt: DateTime.UtcNow);
-		var projection = await CreateProjectionAsync();
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
 
-		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
-			owner.Value, aggregateId, new RecipeReferenceCleared()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var projection = new ShoppingListProjection(ctx);
+			await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+				owner.Value, aggregateId, new RecipeReferenceCleared()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -129,46 +159,46 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_TwiceForSameAggregate_IsIdempotent()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
 		rows.Should().Be(1);
 	}
 
-	private async Task<ShoppingListProjection> CreateProjectionAsync()
-	{
-		var ctx = await fixture.CreateShoppingDbContextAsync();
-		return new ShoppingListProjection(ctx);
-	}
-
-	private async Task SeedCreatedAsync()
-	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
+	private ShoppingListCreatedIntegrationEvent CreatedEvent() =>
+		new(owner.Value, aggregateId, new ShoppingListCreated(
 			ShoppingListIdentifier.From(aggregateId),
 			ShoppingListTitle.From("Weekly Groceries"),
 			owner,
 			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+			CreatedAt: DateTime.UtcNow));
+
+	private ListItemAddedIntegrationEvent ItemAddedEvent(ShoppingListItemIdentifier itemId, string name) =>
+		new(owner.Value, aggregateId, new ListItemAdded(
+			itemId,
+			ItemName.From(name),
+			Quantity.Of(Amount.From(500), Unit.Gram)));
+
+	private async Task SeedCreatedAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
 	}
 
 	private async Task<Guid> SeedItemAsync(string name)
 	{
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, name));
 		return itemId.Value;
 	}
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listproj-{Guid.NewGuid():N}");
+	private readonly Guid aggregateId = Guid.CreateVersion7();
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task Created_InsertsSummaryRow()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.Title.Should().Be("Weekly Groceries");
+		summary.OwnerId.Should().Be(owner.Value);
+		summary.ItemCount.Should().Be(0);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ItemAdded_InsertsItemAndIncrementsCount()
+	{
+		await SeedCreatedAsync();
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
+		item.Name.Should().Be("Flour");
+		item.QuantityAmount.Should().Be(500);
+		item.QuantityUnit.Should().Be("g");
+		item.IsChecked.Should().BeFalse();
+		item.ListId.Should().Be(aggregateId);
+
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ItemChecked_FlipsIsCheckedFlag()
+	{
+		await SeedCreatedAsync();
+		var itemId = await SeedItemAsync("Sugar");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
+			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
+		item.IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task AllItemsChecked_FlipsEveryItemForList()
+	{
+		await SeedCreatedAsync();
+		var first = await SeedItemAsync("Sugar");
+		var second = await SeedItemAsync("Salt");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
+			owner.Value, aggregateId, new AllItemsChecked()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == aggregateId).ToListAsync();
+		items.Should().HaveCount(2);
+		items.Should().OnlyContain(i => i.IsChecked);
+		_ = first;
+		_ = second;
+	}
+
+	[Fact]
+	public async Task RecipeReferenceCleared_NullsRecipeIdentifierOnSummary()
+	{
+		var recipe = Guid.CreateVersion7();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Cake"),
+			owner,
+			RecipeReference: RecipeReference.From(recipe),
+			CreatedAt: DateTime.UtcNow);
+		var projection = await CreateProjectionAsync();
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+			owner.Value, aggregateId, new RecipeReferenceCleared()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Created_TwiceForSameAggregate_IsIdempotent()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
+		rows.Should().Be(1);
+	}
+
+	private async Task<ShoppingListProjection> CreateProjectionAsync()
+	{
+		var ctx = await fixture.CreateShoppingDbContextAsync();
+		return new ShoppingListProjection(ctx);
+	}
+
+	private async Task SeedCreatedAsync()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+	}
+
+	private async Task<Guid> SeedItemAsync(string name)
+	{
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		return itemId.Value;
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
@@ -41,7 +41,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved.Should().NotBeNull();
 		saved!.Title.Should().Be(ShoppingListTitle.From("Weekly Groceries"));
@@ -65,7 +65,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved!.RecipeReference.Should().NotBeNull();
 	}
@@ -79,7 +79,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		loaded.Title.Should().Be(ShoppingListTitle.From("Party Supplies"));
 		loaded.Items.Should().NotBeEmpty();
@@ -106,7 +106,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 
 		writeContext.Entry(loaded).State.Should().Be(EntityState.Unchanged);
 	}
@@ -122,7 +122,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using (var readDbContext = await fixture.CreateShoppingReadDbContextAsync())
 		{
 			var shoppingLists = new ShoppingListRepository(writeContext, readDbContext);
-			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 			loaded.CheckOffItem(itemId);
 			await writeContext.SaveChangesAsync();
 		}
@@ -130,7 +130,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext2 = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists2 = new ShoppingListRepository(writeContext2, readContext);
-		var reloaded = await shoppingLists2.GetByIdAsync(list.Id);
+		var reloaded = await shoppingLists2.GetByIdAsync(list.Identifier);
 
 		reloaded.Items.First(i => i.Id == itemId).IsChecked.Should().BeTrue();
 	}
@@ -251,7 +251,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		readContext.Entry(loaded).State.Should().Be(EntityState.Detached);
 	}

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_UncheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItems("other-user");
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_AllItemsChecked()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -89,8 +89,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
 		list.CheckAllItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidUncheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("other-user", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -88,8 +88,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_CallsCheckOffItem()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
 		list.CheckOffItem(itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -57,7 +57,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -72,7 +72,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 		var cts = new CancellationTokenSource();
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		await handler.HandleAsync(query, cts.Token);
 

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
@@ -50,27 +50,6 @@ public class ShoppingListItemTests
 		item.IsChecked.Should().BeFalse();
 	}
 
-	[Fact]
-	public void Check_SetsIsCheckedToTrue()
-	{
-		var item = CreateFlourItem();
-
-		item.Check();
-
-		item.IsChecked.Should().BeTrue();
-	}
-
-	[Fact]
-	public void Uncheck_SetsIsCheckedToFalse()
-	{
-		var item = CreateFlourItem();
-		item.Check();
-
-		item.Uncheck();
-
-		item.IsChecked.Should().BeFalse();
-	}
-
 	private static ShoppingListItem CreateFlourItem() =>
 		ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
@@ -9,11 +10,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
 public class ShoppingListTests
 {
 	[Fact]
-	public void Create_ValidInput_CreatesShoppingListWithId()
+	public void Create_ValidInput_CreatesShoppingListWithIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		shoppingList.Id.Should().NotBeNull();
+		shoppingList.Identifier.Should().NotBeNull();
 	}
 
 	[Fact]
@@ -93,29 +94,41 @@ public class ShoppingListTests
 
 		var shoppingList = CreateValidShoppingList(title: title);
 
-		shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>()
+		shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle()
 			.Which.Title.Should().Be(title);
 	}
 
 	[Fact]
-	public void Create_ShoppingListCreatedEvent_ContainsShoppingListId()
+	public void Create_ShoppingListCreatedEvent_ContainsShoppingListIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		var domainEvent = shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>().Subject;
+		var domainEvent = shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle().Subject;
 
-		domainEvent.ShoppingListIdentifier.Should().Be(shoppingList.Id);
+		domainEvent.Identifier.Should().Be(shoppingList.Identifier);
 	}
 
 	[Fact]
-	public void Create_GeneratesUniqueIds()
+	public void Create_RaisesListItemAddedEventPerItem()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncommittedEvents.OfType<ListItemAdded>().Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void Create_GeneratesUniqueIdentifiers()
 	{
 		var list1 = CreateValidShoppingList();
 		var list2 = CreateValidShoppingList();
 
-		list1.Id.Should().NotBe(list2.Id);
+		list1.Identifier.Should().NotBe(list2.Identifier);
 	}
 
 	[Fact]
@@ -130,6 +143,21 @@ public class ShoppingListTests
 		shoppingList.CheckOffItem(items[0].Id);
 
 		shoppingList.Items[0].IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CheckOffItem_RaisesListItemCheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemChecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
 	}
 
 	[Fact]
@@ -148,6 +176,21 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckItem_RaisesListItemUncheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncheckItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemUnchecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
+	}
+
+	[Fact]
 	public void CheckAllItems_ChecksAllItems()
 	{
 		List<ShoppingListItem> items =
@@ -160,6 +203,16 @@ public class ShoppingListTests
 		shoppingList.CheckAllItems();
 
 		shoppingList.Items.Should().OnlyContain(i => i.IsChecked);
+	}
+
+	[Fact]
+	public void CheckAllItems_RaisesAllItemsCheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.CheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsChecked>().Should().ContainSingle();
 	}
 
 	[Fact]
@@ -179,6 +232,36 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckAllItems_RaisesAllItemsUncheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.UncheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsUnchecked>().Should().ContainSingle();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_ClearsTheReference()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_RaisesRecipeReferenceClearedEvent()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.UncommittedEvents.OfType<RecipeReferenceCleared>().Should().ContainSingle();
+	}
+
+	[Fact]
 	public void CheckOffItem_InvalidItemId_Throws()
 	{
 		var shoppingList = CreateValidShoppingList();
@@ -186,6 +269,57 @@ public class ShoppingListTests
 		var act = () => shoppingList.CheckOffItem(ShoppingListItemIdentifier.New());
 
 		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Version_IncrementsOnEachEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+		var versionAfterCreate = shoppingList.Version;
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.Version.Should().Be(versionAfterCreate.Increment());
+	}
+
+	[Fact]
+	public void FromEvents_ReplaysToSameState()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+		var original = CreateValidShoppingList(items: items, recipeReference: RecipeReference.New());
+		original.CheckOffItem(items[0].Id);
+		original.ClearRecipeReference();
+		var capturedEvents = original.UncommittedEvents.ToList();
+
+		var replayed = Domain.ShoppingList.ShoppingList.FromEvents(original.Identifier, capturedEvents);
+
+		replayed.Identifier.Should().Be(original.Identifier);
+		replayed.Title.Should().Be(original.Title);
+		replayed.Owner.Should().Be(original.Owner);
+		replayed.CreatedAt.Should().Be(original.CreatedAt);
+		replayed.RecipeReference.Should().BeNull();
+		replayed.Items.Should().HaveCount(2);
+		replayed.Items.Single(i => i.Id == items[0].Id).IsChecked.Should().BeTrue();
+		replayed.Items.Single(i => i.Id == items[1].Id).IsChecked.Should().BeFalse();
+		replayed.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public void MarkCommitted_ClearsUncommittedEvents()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.MarkCommitted();
+
+		shoppingList.UncommittedEvents.Should().BeEmpty();
 	}
 
 	private static Domain.ShoppingList.ShoppingList CreateValidShoppingList(


### PR DESCRIPTION
## Summary

Phase 3 of the Shopping module ES migration. Closes #478. **Stacked on #485** (Phase 2), which is stacked on #484 (Phase 1).

- 7 integration events wrapping each list domain event with `(OwnerId, AggregateId)` routing.
- New read-model tables (migration `AddShoppingListReadModel`): `ShoppingListSummaryReadItems` and `ShoppingListItemReadItems`.
- `ShoppingListProjection` implements `IIntegrationEventHandler<>` for all 7 events. Idempotent upserts: Created upserts summary; ItemAdded inserts if absent + increments `ItemCount`; checked/unchecked flips flags; RecipeReferenceCleared nulls the pointer.
- `ShoppingUnitOfWork.SaveChangesAsync` now captures uncommitted events before save, persists, **then** publishes integration events via `IEventBus`, then `MarkCommitted` on each aggregate. Mapping is a `switch` expression in the UoW.
- Read path is unchanged. The new tables shadow the existing relational `ShoppingLists` until Phase 4 (#479) cuts the queries over.

## How to Test

1. `dotnet build -p:TreatWarningsAsErrors=true` — clean.
2. `dotnet format --verify-no-changes` — clean.
3. `dotnet test tests/Yumney.Shopping.Domain.Tests` — 174 ✅
4. `dotnet test tests/Yumney.Shopping.Application.Tests` — 113 ✅
5. `dotnet test tests/Yumney.Shopping.Infrastructure.Tests` — 8 ✅
6. `dotnet test tests/Yumney.Architecture.Tests` — 117 ✅
7. Integration tests (`Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs`) require live Aspire — CI runs them.

## Notes

- **Stacked**: After #484 → #485 → #478 merge in order, GitHub will retarget bases automatically.
- **No outbox** for the publish step. If `eventBus.PublishAsync` fails after `SaveChangesAsync` succeeded, the projection lags. This matches the MealPlan event store pattern; an outbox upgrade is out of scope for Phase 3.
- Acceptance criteria from #478: new projection tables ✅, idempotent projection ✅, integration tests ✅, old read path remains default ✅.

## Checklist

- [x] Code follows naming conventions
- [x] New/updated tests written
- [x] All tests green (locally — domain, application, infrastructure, architecture)
- [x] No new linter warnings
- [x] No `any` in TypeScript code (no FE changes)
- [x] No secrets in code
- [ ] Integration tests run against live Aspire stack (CI)