### PR TITLE
feat(infra): dashboard reset entry for ShoppingList projections (#481)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -82,6 +82,18 @@ if (!options.DatabaseOnly)
 			.WaitFor(mealplanDb)
 			.WithEnvironment("Persistence__ResetMealPlanOnly", "true")
 			.WithExplicitStart();
+
+		// Dashboard-only entry (run mode): truncates the ShoppingList projection
+		// tables and replays the event store into them. Events, metadata, and the
+		// legacy ShoppingLists table are untouched. Idempotent.
+		builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-shopping-projection-reset")
+			.WithReference(recipesDb)
+			.WithReference(shoppingDb)
+			.WithReference(usersDb)
+			.WithReference(mealplanDb)
+			.WaitFor(shoppingDb)
+			.WithEnvironment("Persistence__RebuildShoppingProjections", "true")
+			.WithExplicitStart();
 	}
 
 	// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)

--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
@@ -12,10 +13,14 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 /// Background worker that applies EF Core migrations for all modules on startup.
 /// Uses PostgreSQL advisory locks to prevent concurrent migration from multiple instances.
 ///
-/// When started with <c>Persistence:ResetMealPlanOnly=true</c> the worker only
-/// touches the MealPlan database, dropping and re-migrating it. This is the mode
-/// used by the dashboard "yumney-mealplan-reset" entry — convenient for wiping
-/// the event-sourced MealPlan store during local development.
+/// Dashboard-driven modes (set via configuration before start):
+/// <list type="bullet">
+///   <item><c>Persistence:ResetMealPlanOnly=true</c> — drops and re-migrates the
+///   MealPlan database only. Wipes the event-sourced MealPlan store.</item>
+///   <item><c>Persistence:RebuildShoppingProjections=true</c> — truncates the
+///   ShoppingList projection tables and replays the event store into them.
+///   Other Shopping data (events, metadata, legacy lists) is untouched.</item>
+/// </list>
 /// </summary>
 public sealed partial class MigrationWorker(
 	IServiceProvider serviceProvider,
@@ -27,7 +32,11 @@ public sealed partial class MigrationWorker(
 	{
 		try
 		{
-			if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
+			if (configuration.GetValue<bool>("Persistence:RebuildShoppingProjections"))
+			{
+				await RebuildShoppingProjectionsAsync(stoppingToken);
+			}
+			else if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
 			{
 				await ApplyMigrationsAsync<MealPlanDbContext>("MealPlan", stoppingToken, reset: true);
 			}
@@ -74,10 +83,21 @@ public sealed partial class MigrationWorker(
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{Module}: dropping database before migrating")]
 	private static partial void LogResettingDatabase(ILogger logger, string module);
 
+	[LoggerMessage(Level = LogLevel.Information, Message = "Shopping: rebuilt {Count} projection events")]
+	private static partial void LogShoppingProjectionsRebuilt(ILogger logger, int count);
+
 	private static int GenerateLockId(string moduleName)
 	{
 		var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"yumney-migration-{moduleName}"));
 		return BitConverter.ToInt32(hash, 0);
+	}
+
+	private async Task RebuildShoppingProjectionsAsync(CancellationToken cancellationToken)
+	{
+		await using var scope = serviceProvider.CreateAsyncScope();
+		var rebuilder = scope.ServiceProvider.GetRequiredService<IShoppingListProjectionRebuilder>();
+		var replayed = await rebuilder.RebuildAsync(cancellationToken);
+		LogShoppingProjectionsRebuilt(logger, replayed);
 	}
 
 	private async Task ApplyMigrationsAsync<TContext>(string moduleName, CancellationToken cancellationToken, bool reset = false)

--- a/src/Yumney.MigrationRunner/Program.cs
+++ b/src/Yumney.MigrationRunner/Program.cs
@@ -3,7 +3,9 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.MigrationRunner;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -29,6 +31,12 @@ builder.Services.AddDbContext<MealPlanDbContext>(options =>
 	options.UseNpgsql(
 		builder.Configuration.GetConnectionString("mealplandb"),
 		x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory")));
+
+// Minimal service registrations for the optional Shopping projection-rebuild path.
+// The dashboard reset entry sets Persistence:RebuildShoppingProjections=true to drive
+// MigrationWorker through this code path; the regular migration run never resolves them.
+builder.Services.AddScoped<ShoppingListProjection>();
+builder.Services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 
 builder.Services.AddHostedService<MigrationWorker>();
 

--- a/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
+++ b/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
@@ -10,11 +10,21 @@ public sealed partial class InProcessEventBus(IServiceProvider serviceProvider, 
 	public async Task PublishAsync<TEvent>(TEvent integrationEvent, CancellationToken cancellationToken = default)
 		where TEvent : IIntegrationEvent
 	{
-		var handlers = serviceProvider.GetServices<IIntegrationEventHandler<TEvent>>();
-		var eventName = typeof(TEvent).Name;
+		// Resolve handlers by the runtime concrete type, not the compile-time
+		// generic argument. Without this, callers that publish via an
+		// `IIntegrationEvent` static type (e.g. from a `... switch { ... }`
+		// mapping that returns the marker interface) would inadvertently bind
+		// TEvent to the interface and miss every concrete-type subscriber.
+		var eventType = integrationEvent.GetType();
+		var handlerInterface = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
+		var handleMethod = handlerInterface.GetMethod(nameof(IIntegrationEventHandler<TEvent>.HandleAsync))!;
+		var handlers = serviceProvider.GetServices(handlerInterface);
+		var eventName = eventType.Name;
 
 		foreach (var handler in handlers)
 		{
+			if (handler is null) continue;
+
 			var handlerName = handler.GetType().Name;
 			using var activity = EventsDiagnostics.ActivitySource.StartActivity($"integration_event.{eventName}.{handlerName}");
 			activity?.SetTag("event.name", eventName);
@@ -25,15 +35,28 @@ public sealed partial class InProcessEventBus(IServiceProvider serviceProvider, 
 
 			try
 			{
-				await handler.HandleAsync(integrationEvent, cancellationToken);
+				await (Task)handleMethod.Invoke(handler, [integrationEvent, cancellationToken])!;
 				var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
 				activity?.SetTag("event.result", "success");
 				activity?.SetStatus(ActivityStatusCode.Ok);
 				LogHandlerCompleted(eventName, handlerName, elapsed);
 			}
+			catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is OperationCanceledException && cancellationToken.IsCancellationRequested)
+			{
+				throw tie.InnerException;
+			}
 			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 			{
 				throw;
+			}
+			catch (System.Reflection.TargetInvocationException tie)
+			{
+				var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+				activity?.SetTag("event.result", "error");
+				activity?.SetStatus(ActivityStatusCode.Error, tie.InnerException?.Message ?? tie.Message);
+
+				// Isolate handlers — one failing subscriber must not block the others.
+				LogHandlerFailed(tie.InnerException ?? tie, eventName, handlerName, elapsed);
 			}
 			catch (Exception ex)
 			{

--- a/src/Yumney.Shared.Events/CrossModule/ShoppingListCreatedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/ShoppingListCreatedCrossModuleIntegrationEvent.cs
@@ -1,0 +1,13 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Shopping module when a new <c>ShoppingList</c> aggregate
+/// is created. Carries primitive types only so cross-module subscribers
+/// (Recipes, MealPlan) can react without taking a Shopping.Domain dependency.
+/// </summary>
+public sealed record ShoppingListCreatedCrossModuleIntegrationEvent(
+	string OwnerId,
+	Guid ListIdentifier,
+	string Title,
+	Guid? RecipeIdentifier,
+	DateTime CreatedAt) : IntegrationEvent;

--- a/src/Yumney.Shared.Events/CrossModule/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Shopping module when a list's recipe-reference link is
+/// cleared (for instance, in response to <see cref="RecipeDeletedIntegrationEvent"/>).
+/// Lets cross-module subscribers reconcile any state that depended on the
+/// recipe→list pairing.
+/// </summary>
+public sealed record ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent(
+	string OwnerId,
+	Guid ListIdentifier) : IntegrationEvent;

--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
@@ -9,7 +9,7 @@ public static class ShoppingListMappingExtensions
 		public ShoppingListDetailDto ToDetailDto()
 		{
 			return new ShoppingListDetailDto(
-				shoppingList.Id.Value,
+				shoppingList.Identifier.Value,
 				shoppingList.Title.Value,
 				shoppingList.RecipeReference?.Value,
 				shoppingList.CreatedAt,

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRebuilder.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRebuilder.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Operational tool that truncates the ShoppingList projection tables and
+/// re-applies every event from the event store. Used by the dashboard reset
+/// entry to recover from projection drift, schema migrations, or projection
+/// handler bugs without losing the source-of-truth event stream.
+/// </summary>
+public interface IShoppingListProjectionRebuilder
+{
+	/// <summary>
+	/// Truncates the projection tables and replays the entire event history.
+	/// Idempotent — running twice yields the same final state because the
+	/// projection upserts.
+	/// </summary>
+	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+	/// <returns>The number of events replayed.</returns>
+	Task<int> RebuildAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
@@ -1,0 +1,38 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Read-side query repository backed by the ShoppingList projection tables
+/// (<c>ShoppingListSummaryReadItems</c>, <c>ShoppingListItemReadItems</c>).
+/// Phase 4 cuts the list-detail / list-collection queries over from the
+/// relational write tables to this repository.
+/// </summary>
+public interface IShoppingListProjectionRepository
+{
+	Task<(IReadOnlyList<ShoppingListSummary> Items, ItemCount TotalCount)> GetByOwnerAsync(
+		OwnerIdentifier owner,
+		PagingOptions paging,
+		SortingOptions<ShoppingListSortField> sorting,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Loads the projection-shaped detail for one list. Throws
+	/// <see cref="EntityNotFoundException"/> if no projection row exists.
+	/// </summary>
+	/// <param name="identifier">The list identifier.</param>
+	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+	/// <returns>The owner-tagged DTO for the list.</returns>
+	Task<ShoppingListProjectedDetail> GetByIdAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Projection-shaped result of <see cref="IShoppingListProjectionRepository.GetByIdAsync"/>.
+/// Carries the owner separately so the query handler can apply access control
+/// without rebuilding the aggregate.
+/// </summary>
+public sealed record ShoppingListProjectedDetail(string OwnerId, ShoppingListDetailDto Dto);

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
 public sealed class GetShoppingListByIdQueryHandler(
 	IShoppingListRepository shoppingLists,
+	IShoppingListProjectionRepository projection,
+	ShoppingOptions options,
 	ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListByIdQuery, Result<ShoppingListDetailDto>>
 {
@@ -16,12 +19,16 @@ public sealed class GetShoppingListByIdQueryHandler(
 	{
 		var identifier = query.Identifier;
 
+		if (options.UseProjectionReadModel)
+		{
+			var detail = await projection.GetByIdAsync(identifier, cancellationToken);
+			if (detail.OwnerId != currentUser.UserId) return GetShoppingListByIdErrors.AccessDenied;
+			return detail.Dto;
+		}
+
 		var shoppingList = await shoppingLists.GetByIdAsync(identifier, cancellationToken);
-
 		var owner = currentUser.AsOwner();
-
 		if (shoppingList.Owner != owner) return GetShoppingListByIdErrors.AccessDenied;
-
 		return shoppingList.ToDetailDto();
 	}
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
 public sealed class GetShoppingListsQueryHandler(
 	IShoppingListRepository shoppingLists,
+	IShoppingListProjectionRepository projection,
+	ShoppingOptions options,
 	ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListsQuery, Result<PagedResult<ShoppingListSummaryDto>>>
 {
@@ -17,7 +20,9 @@ public sealed class GetShoppingListsQueryHandler(
 		var (paging, sorting) = query;
 		var owner = currentUser.AsOwner();
 
-		var (items, totalCount) = await shoppingLists.GetByOwnerAsync(owner, paging, sorting, cancellationToken);
+		var (items, totalCount) = options.UseProjectionReadModel
+			? await projection.GetByOwnerAsync(owner, paging, sorting, cancellationToken)
+			: await shoppingLists.GetByOwnerAsync(owner, paging, sorting, cancellationToken);
 
 		var shoppingListSummaryDtos = items.Select(l => l.ToSummaryDto()).ToList();
 

--- a/src/Yumney.Shopping.Application/ShoppingOptions.cs
+++ b/src/Yumney.Shopping.Application/ShoppingOptions.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application;
+
+/// <summary>
+/// Runtime toggles for the Shopping module. Bound from configuration section
+/// <c>Shopping</c>.
+/// </summary>
+public sealed class ShoppingOptions
+{
+	public const string SectionName = "Shopping";
+
+	/// <summary>
+	/// Gets or sets a value indicating whether <c>GetShoppingLists</c> and
+	/// <c>GetShoppingListById</c> read from the projection tables populated by
+	/// the event stream. When <c>false</c>, queries fall back to the relational
+	/// write tables — the legacy path. Used as an emergency rollback during the
+	/// Phase 4 cutover. Defaults to <c>true</c>.
+	/// </summary>
+	public bool UseProjectionReadModel { get; set; } = true;
+}

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsChecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/AllItemsUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record AllItemsUnchecked : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemAdded.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemAdded(
+	ShoppingListItemIdentifier ItemId,
+	ItemName Name,
+	Quantity? Quantity) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemChecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemChecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ListItemUnchecked.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ListItemUnchecked(ShoppingListItemIdentifier ItemId) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/RecipeReferenceCleared.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record RecipeReferenceCleared : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreated.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+public sealed record ShoppingListCreated(
+	ShoppingListIdentifier Identifier,
+	ShoppingListTitle Title,
+	OwnerIdentifier Owner,
+	RecipeReference? RecipeReference,
+	DateTime CreatedAt) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Events/ShoppingListCreatedEvent.cs
@@ -1,7 +1,0 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
-
-namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-
-public sealed record ShoppingListCreatedEvent(
-	ShoppingListIdentifier ShoppingListIdentifier,
-	ShoppingListTitle Title) : DomainEvent;

--- a/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/IShoppingListEventStore.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+/// <summary>
+/// Append-only event store for the <see cref="ShoppingList"/> aggregate. Events are
+/// staged on the underlying <see cref="Microsoft.EntityFrameworkCore.DbContext"/> by
+/// <see cref="AppendAsync"/> and flushed by the <see cref="IShoppingUnitOfWork"/> in
+/// the same transaction as any relational state writes.
+/// </summary>
+public interface IShoppingListEventStore
+{
+	Task<ShoppingList?> LoadAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
+
+	Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -4,7 +4,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
+public sealed class ShoppingList : EventSourcedAggregate<ShoppingListIdentifier>
 {
 	private readonly List<ShoppingListItem> items = [];
 
@@ -20,6 +20,13 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 
 	private ShoppingList()
 	{
+		On<ShoppingListCreated>(OnCreated);
+		On<ListItemAdded>(OnListItemAdded);
+		On<ListItemChecked>(OnListItemChecked);
+		On<ListItemUnchecked>(OnListItemUnchecked);
+		On<AllItemsChecked>(_ => OnAllItemsChecked());
+		On<AllItemsUnchecked>(_ => OnAllItemsUnchecked());
+		On<RecipeReferenceCleared>(_ => OnRecipeReferenceCleared());
 	}
 
 	public static ShoppingList Create(
@@ -30,60 +37,113 @@ public sealed class ShoppingList : AggregateRoot<ShoppingListIdentifier>
 	{
 		Ensure.That(items).IsNotEmpty();
 
-		var shoppingList = new ShoppingList
+		var list = new ShoppingList();
+		list.RaiseEvent(new ShoppingListCreated(
+			ShoppingListIdentifier.New(),
+			title,
+			owner,
+			recipeReference,
+			DateTime.UtcNow));
+
+		foreach (var item in items)
 		{
-			Id = ShoppingListIdentifier.New(),
-			Title = title,
-			Owner = owner,
-			RecipeReference = recipeReference,
-			CreatedAt = DateTime.UtcNow,
-		};
+			list.RaiseEvent(new ListItemAdded(item.Id, item.Name, item.Quantity));
+		}
 
-		shoppingList.items.AddRange(items);
+		return list;
+	}
 
-		shoppingList.AddDomainEvent(new ShoppingListCreatedEvent(shoppingList.Id, title));
-
-		return shoppingList;
+	public static ShoppingList FromEvents(
+		ShoppingListIdentifier identifier,
+		IEnumerable<IDomainEvent> events,
+		AggregateVersion? startVersion = null)
+	{
+		var list = new ShoppingList { Identifier = identifier };
+		list.LoadFromHistory(events, startVersion);
+		return list;
 	}
 
 	public ShoppingList CheckOffItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Check();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemChecked(itemId));
 		return this;
 	}
 
 	public ShoppingList UncheckItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = FindItem(itemId);
-		item.Uncheck();
+		EnsureItemExists(itemId);
+		RaiseEvent(new ListItemUnchecked(itemId));
 		return this;
 	}
 
 	public ShoppingList CheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Check();
-		}
-
+		RaiseEvent(new AllItemsChecked());
 		return this;
 	}
 
 	public ShoppingList UncheckAllItems()
 	{
-		foreach (var item in items)
-		{
-			item.Uncheck();
-		}
-
+		RaiseEvent(new AllItemsUnchecked());
 		return this;
 	}
 
 	public ShoppingList ClearRecipeReference()
 	{
-		RecipeReference = null;
+		RaiseEvent(new RecipeReferenceCleared());
 		return this;
+	}
+
+	private void OnCreated(ShoppingListCreated e)
+	{
+		Identifier = e.Identifier;
+		Title = e.Title;
+		Owner = e.Owner;
+		RecipeReference = e.RecipeReference;
+		CreatedAt = e.CreatedAt;
+	}
+
+	private void OnListItemAdded(ListItemAdded e)
+	{
+		items.Add(ShoppingListItem.Hydrate(e.ItemId, e.Name, e.Quantity));
+	}
+
+	private void OnListItemChecked(ListItemChecked e)
+	{
+		FindItem(e.ItemId).MarkChecked();
+	}
+
+	private void OnListItemUnchecked(ListItemUnchecked e)
+	{
+		FindItem(e.ItemId).MarkUnchecked();
+	}
+
+	private void OnAllItemsChecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkChecked();
+		}
+	}
+
+	private void OnAllItemsUnchecked()
+	{
+		foreach (var item in items)
+		{
+			item.MarkUnchecked();
+		}
+	}
+
+	private void OnRecipeReferenceCleared()
+	{
+		RecipeReference = null;
+	}
+
+	private void EnsureItemExists(ShoppingListItemIdentifier itemId)
+	{
+		var item = items.FirstOrDefault(i => i.Id == itemId);
+		Ensure.That(item!).IsNotNull();
 	}
 
 	private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItem.cs
@@ -25,13 +25,24 @@ public sealed class ShoppingListItem : Entity<ShoppingListItemIdentifier>
 		};
 	}
 
-	public ShoppingListItem Check()
+	internal static ShoppingListItem Hydrate(ShoppingListItemIdentifier id, ItemName name, Quantity? quantity)
+	{
+		return new ShoppingListItem
+		{
+			Id = id,
+			Name = name,
+			Quantity = quantity,
+			IsChecked = false,
+		};
+	}
+
+	internal ShoppingListItem MarkChecked()
 	{
 		IsChecked = true;
 		return this;
 	}
 
-	public ShoppingListItem Uncheck()
+	internal ShoppingListItem MarkUnchecked()
 	{
 		IsChecked = false;
 		return this;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListAggregateMetadataConfiguration : IEntityTypeConfiguration<ShoppingListAggregateMetadata>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListAggregateMetadata> entity)
+	{
+		entity.ToTable("ShoppingListAggregates");
+		entity.HasKey(e => e.AggregateId);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.HasIndex(e => e.OwnerId);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListConfiguration.cs
@@ -10,8 +10,9 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 	public void Configure(EntityTypeBuilder<ShoppingList> entity)
 	{
 		entity.ToTable("ShoppingLists");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		entity.HasKey(e => e.Identifier);
+		entity.Property(e => e.Identifier)
+			.HasColumnName("Id")
 			.HasConversion<ShoppingListIdentifierConverter>();
 
 		entity.Property(e => e.Title)
@@ -62,6 +63,7 @@ internal sealed class ShoppingListConfiguration : IEntityTypeConfiguration<Shopp
 		entity.Property<uint>("xmin")
 			.HasColumnType("xid")
 			.IsRowVersion();
-		entity.Ignore(e => e.DomainEvents);
+		entity.Ignore(e => e.UncommittedEvents);
+		entity.Ignore(e => e.Version);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListItemReadItemConfiguration : IEntityTypeConfiguration<ShoppingListItemReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListItemReadItem> entity)
+	{
+		entity.ToTable("ShoppingListItemReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.QuantityUnit).HasMaxLength(50);
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.ListId);
+		entity.HasIndex(e => new { e.OwnerId, e.ListId });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+#pragma warning disable SA1649
+internal sealed class ShoppingListStoredEventConfiguration : IEntityTypeConfiguration<ShoppingListStoredEvent>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListStoredEvent> entity)
+	{
+		entity.ToTable("ShoppingListEvents");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.AggregateId).IsRequired();
+		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
+		entity.Property(e => e.EventData).IsRequired();
+		entity.Property(e => e.Version).IsRequired();
+		entity.Property(e => e.OccurredAt).IsRequired();
+
+		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
+		entity.HasIndex(e => e.OccurredAt);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListSummaryReadItemConfiguration : IEntityTypeConfiguration<ShoppingListSummaryReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListSummaryReadItem> entity)
+	{
+		entity.ToTable("ShoppingListSummaryReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.OwnerId);
+		entity.HasIndex(e => new { e.OwnerId, e.CreatedAt });
+		entity.HasIndex(e => new { e.OwnerId, e.Title });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/RecipeReferenceJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class RecipeReferenceJsonConverter : JsonConverter<RecipeReference>
+{
+	public override RecipeReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		RecipeReference.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, RecipeReference value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListIdentifierJsonConverter : JsonConverter<ShoppingListIdentifier>
+{
+	public override ShoppingListIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Converters/ShoppingListItemIdentifierJsonConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+internal sealed class ShoppingListItemIdentifierJsonConverter : JsonConverter<ShoppingListItemIdentifier>
+{
+	public override ShoppingListItemIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		ShoppingListItemIdentifier.From(reader.GetGuid());
+
+	public override void Write(Utf8JsonWriter writer, ShoppingListItemIdentifier value, JsonSerializerOptions options) =>
+		writer.WriteStringValue(value.Value);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -1,12 +1,7 @@
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
-using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
-using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
@@ -15,35 +10,6 @@ public sealed partial class EfCoreShoppingListEventStore(
 	ShoppingDbContext context,
 	ILogger<EfCoreShoppingListEventStore> logger) : IShoppingListEventStore
 {
-#pragma warning disable SA1311, SA1303, SA1204
-	private static readonly JsonSerializerOptions jsonOptions = new()
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-		Converters =
-		{
-			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
-			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
-			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
-			new ShoppingListIdentifierJsonConverter(),
-			new ShoppingListItemIdentifierJsonConverter(),
-			new RecipeReferenceJsonConverter(),
-			new AmountJsonConverter(),
-			new UnitJsonConverter(),
-		},
-	};
-
-	private static readonly Dictionary<string, Type> eventTypeMap = new()
-	{
-		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
-		[nameof(ListItemAdded)] = typeof(ListItemAdded),
-		[nameof(ListItemChecked)] = typeof(ListItemChecked),
-		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
-		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
-		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
-		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
-	};
-#pragma warning restore SA1311
-
 	public async Task<ShoppingList?> LoadAsync(
 		ShoppingListIdentifier identifier,
 		CancellationToken cancellationToken = default)
@@ -64,7 +30,10 @@ public sealed partial class EfCoreShoppingListEventStore(
 
 		if (storedEvents.Count == 0) return null;
 
-		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+		var events = storedEvents
+			.Select(s => ShoppingListEventSerializer.Deserialize(s.EventType, s.EventData))
+			.Where(e => e is not null)
+			.Cast<IDomainEvent>();
 
 		return ShoppingList.FromEvents(identifier, events);
 	}
@@ -98,20 +67,13 @@ public sealed partial class EfCoreShoppingListEventStore(
 				Id = Guid.CreateVersion7(),
 				AggregateId = aggregateId,
 				EventType = @event.GetType().Name,
-				EventData = JsonSerializer.Serialize(@event, @event.GetType(), jsonOptions),
+				EventData = ShoppingListEventSerializer.Serialize(@event),
 				Version = baseVersion + index + 1,
 				OccurredAt = @event.OccurredOn,
 			});
 		}
 
 		LogEventsStaged(aggregateId, uncommitted.Count, list.Version);
-	}
-
-	private static IDomainEvent? DeserializeEvent(ShoppingListStoredEvent stored)
-	{
-		if (!eventTypeMap.TryGetValue(stored.EventType, out var type)) return null;
-
-		return JsonSerializer.Deserialize(stored.EventData, type, jsonOptions) as IDomainEvent;
 	}
 
 	[LoggerMessage(Level = LogLevel.Debug, Message = "Staged {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1601
+public sealed partial class EfCoreShoppingListEventStore(
+	ShoppingDbContext context,
+	ILogger<EfCoreShoppingListEventStore> logger) : IShoppingListEventStore
+{
+#pragma warning disable SA1311, SA1303, SA1204
+	private static readonly JsonSerializerOptions jsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters =
+		{
+			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
+			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
+			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
+			new ShoppingListIdentifierJsonConverter(),
+			new ShoppingListItemIdentifierJsonConverter(),
+			new RecipeReferenceJsonConverter(),
+			new AmountJsonConverter(),
+			new UnitJsonConverter(),
+		},
+	};
+
+	private static readonly Dictionary<string, Type> eventTypeMap = new()
+	{
+		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
+		[nameof(ListItemAdded)] = typeof(ListItemAdded),
+		[nameof(ListItemChecked)] = typeof(ListItemChecked),
+		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
+		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
+		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
+		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
+	};
+#pragma warning restore SA1311
+
+	public async Task<ShoppingList?> LoadAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default)
+	{
+		var aggregateId = identifier.Value;
+
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (metadata is null) return null;
+
+		var storedEvents = await context.Set<ShoppingListStoredEvent>()
+			.AsNoTracking()
+			.Where(e => e.AggregateId == aggregateId)
+			.OrderBy(e => e.Version)
+			.ToListAsync(cancellationToken);
+
+		if (storedEvents.Count == 0) return null;
+
+		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+
+		return ShoppingList.FromEvents(identifier, events);
+	}
+
+	public async Task AppendAsync(ShoppingList list, CancellationToken cancellationToken = default)
+	{
+		var uncommitted = list.UncommittedEvents.ToList();
+		if (uncommitted.Count == 0) return;
+
+		var aggregateId = list.Identifier.Value;
+
+		var existingMetadata = await context.Set<ShoppingListAggregateMetadata>()
+			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+
+		if (existingMetadata is null)
+		{
+			context.Set<ShoppingListAggregateMetadata>().Add(new ShoppingListAggregateMetadata
+			{
+				AggregateId = aggregateId,
+				OwnerId = list.Owner.Value,
+			});
+		}
+
+		var baseVersion = list.Version - uncommitted.Count;
+
+		for (var index = 0; index < uncommitted.Count; index++)
+		{
+			var @event = uncommitted[index];
+			context.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = aggregateId,
+				EventType = @event.GetType().Name,
+				EventData = JsonSerializer.Serialize(@event, @event.GetType(), jsonOptions),
+				Version = baseVersion + index + 1,
+				OccurredAt = @event.OccurredOn,
+			});
+		}
+
+		LogEventsStaged(aggregateId, uncommitted.Count, list.Version);
+	}
+
+	private static IDomainEvent? DeserializeEvent(ShoppingListStoredEvent stored)
+	{
+		if (!eventTypeMap.TryGetValue(stored.EventType, out var type)) return null;
+
+		return JsonSerializer.Deserialize(stored.EventData, type, jsonOptions) as IDomainEvent;
+	}
+
+	[LoggerMessage(Level = LogLevel.Debug, Message = "Staged {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]
+	private partial void LogEventsStaged(Guid aggregateId, int count, int version);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemAddedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemAdded Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record RecipeReferenceClearedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	RecipeReferenceCleared Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Tracks identity and ownership for one <see cref="SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList"/>
+/// aggregate. Multiple rows per owner (one per list).
+/// </summary>
+public sealed class ShoppingListAggregateMetadata
+{
+	public Guid AggregateId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ShoppingListCreatedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ShoppingListCreated Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventSerializer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventSerializer.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Centralised JSON options + type map for ShoppingList event payloads. Shared
+/// between the event store (write/read) and the projection rebuilder so both
+/// agree on serialisation contract.
+/// </summary>
+internal static class ShoppingListEventSerializer
+{
+#pragma warning disable SA1311
+	public static JsonSerializerOptions Options { get; } = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters =
+		{
+			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
+			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
+			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
+			new ShoppingListIdentifierJsonConverter(),
+			new ShoppingListItemIdentifierJsonConverter(),
+			new RecipeReferenceJsonConverter(),
+			new AmountJsonConverter(),
+			new UnitJsonConverter(),
+		},
+	};
+
+	private static readonly Dictionary<string, Type> eventTypeMap = new()
+	{
+		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
+		[nameof(ListItemAdded)] = typeof(ListItemAdded),
+		[nameof(ListItemChecked)] = typeof(ListItemChecked),
+		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
+		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
+		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
+		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
+	};
+
+#pragma warning restore SA1311
+
+	public static string Serialize(IDomainEvent @event) =>
+		JsonSerializer.Serialize(@event, @event.GetType(), Options);
+
+	public static IDomainEvent? Deserialize(string eventType, string eventData)
+	{
+		if (!eventTypeMap.TryGetValue(eventType, out var type)) return null;
+		return JsonSerializer.Deserialize(eventData, type, Options) as IDomainEvent;
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Base record for all ShoppingList integration events. Carries the routing pair
+/// (OwnerId, AggregateId) that identifies the list stream the event came from.
+/// Concrete events stay as sealed records so the bus's name-based handler
+/// discovery still works.
+/// </summary>
+public abstract record ShoppingListIntegrationEvent(string OwnerId, Guid AggregateId) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEventMapper.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEventMapper.cs
@@ -1,0 +1,26 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Maps a ShoppingList domain event to its in-module integration-event wrapper.
+/// Shared by <see cref="EventStore.EfCoreShoppingListEventStore"/> /
+/// <see cref="ShoppingUnitOfWork"/> at publish time and by the projection
+/// rebuilder during replay.
+/// </summary>
+internal static class ShoppingListIntegrationEventMapper
+{
+	public static IIntegrationEvent? Map(string ownerId, Guid aggregateId, IDomainEvent domainEvent) => domainEvent switch
+	{
+		ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
+		ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
+		ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
+		ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
+		AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
+		AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
+		RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+		_ => null,
+	};
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListStoredEvent.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Persisted event row for the ShoppingList aggregate stream. Mirrors the shape of
+/// <see cref="SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.StoredEvent"/>
+/// but maps to its own table so the ShoppingList stream stays separate from the
+/// ShoppingLedger stream.
+/// </summary>
+public sealed class ShoppingListStoredEvent
+{
+	public Guid Id { get; set; }
+
+	public Guid AggregateId { get; set; }
+
+	public string EventType { get; set; } = default!;
+
+	public string EventData { get; set; } = default!;
+
+	public int Version { get; set; }
+
+	public DateTime OccurredAt { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428212832_AddShoppingListEventStore")]
+    partial class AddShoppingListEventStore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428212832_AddShoppingListEventStore.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListEventStore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListAggregates",
+                columns: table => new
+                {
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListAggregates", x => x.AggregateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AggregateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    EventData = table.Column<string>(type: "text", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListAggregates_OwnerId",
+                table: "ShoppingListAggregates",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_AggregateId_Version",
+                table: "ShoppingListEvents",
+                columns: new[] { "AggregateId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListEvents_OccurredAt",
+                table: "ShoppingListEvents",
+                column: "OccurredAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListAggregates");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListEvents");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428213905_AddShoppingListReadModel")]
+    partial class AddShoppingListReadModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListReadModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListItemReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    QuantityAmount = table.Column<decimal>(type: "numeric", nullable: true),
+                    QuantityUnit = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    IsChecked = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListItemReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListSummaryReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    RecipeIdentifier = table.Column<Guid>(type: "uuid", nullable: true),
+                    ItemCount = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListSummaryReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_ListId",
+                table: "ShoppingListItemReadItems",
+                column: "ListId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_OwnerId_ListId",
+                table: "ShoppingListItemReadItems",
+                columns: new[] { "OwnerId", "ListId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId",
+                table: "ShoppingListSummaryReadItems",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_CreatedAt",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_Title",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "Title" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListItemReadItems");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListSummaryReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext context)
+	: IShoppingListProjectionRepository
+{
+	public async Task<(IReadOnlyList<ShoppingListSummary> Items, ItemCount TotalCount)> GetByOwnerAsync(
+		OwnerIdentifier owner,
+		PagingOptions paging,
+		SortingOptions<ShoppingListSortField> sorting,
+		CancellationToken cancellationToken = default)
+	{
+		var query = context.ShoppingListSummaryReadItems.Where(s => s.OwnerId == owner.Value);
+
+		query = ApplySorting(query, sorting);
+
+		var totalCount = await query.CountAsync(cancellationToken);
+		var items = await query
+			.Skip(paging.Skip)
+			.Take(paging.PageSize.Value)
+			.Select(s => new ShoppingListSummary(
+				ShoppingListIdentifier.From(s.Id),
+				ShoppingListTitle.From(s.Title),
+				ItemCount.From(s.ItemCount),
+				s.CreatedAt))
+			.ToListAsync(cancellationToken);
+
+		return (items, ItemCount.From(totalCount));
+	}
+
+	public async Task<ShoppingListProjectedDetail> GetByIdAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default)
+	{
+		var summary = await context.ShoppingListSummaryReadItems
+			.FirstOrDefaultAsync(s => s.Id == identifier.Value, cancellationToken)
+			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
+
+		var items = await context.ShoppingListItemReadItems
+			.Where(i => i.ListId == identifier.Value)
+			.OrderBy(i => i.CreatedAt)
+			.Select(i => new ShoppingListItemDto(i.Id, i.Name, i.QuantityAmount, i.QuantityUnit, i.IsChecked))
+			.ToListAsync(cancellationToken);
+
+		var dto = new ShoppingListDetailDto(
+			summary.Id,
+			summary.Title,
+			summary.RecipeIdentifier,
+			summary.CreatedAt,
+			items);
+
+		return new ShoppingListProjectedDetail(summary.OwnerId, dto);
+	}
+
+	private static IQueryable<ShoppingListSummaryReadItem> ApplySorting(
+		IQueryable<ShoppingListSummaryReadItem> query,
+		SortingOptions<ShoppingListSortField> sorting)
+	{
+		return (sorting.SortBy, sorting.Direction) switch
+		{
+			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(s => s.Title),
+			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(s => s.Title),
+			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(s => s.CreatedAt),
+			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(s => s.CreatedAt),
+			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
+		};
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
@@ -1,0 +1,26 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one item within a ShoppingList. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListItemReadItem
+{
+	public Guid Id { get; set; }
+
+	public Guid ListId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Name { get; set; } = default!;
+
+	public decimal? QuantityAmount { get; set; }
+
+	public string? QuantityUnit { get; set; }
+
+	public bool IsChecked { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -69,9 +69,12 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 				CreatedAt = DateTime.UtcNow,
 				LastUpdated = DateTime.UtcNow,
 			});
+
+			// Only increment when the item is newly inserted — otherwise replay/duplicate
+			// delivery would drift the count while the items table stays at 1 row.
+			await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		}
 
-		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		await context.SaveChangesAsync(cancellationToken);
 	}
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -1,0 +1,154 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Async projection handler — rebuilds the ShoppingList read model from
+/// integration events published by the event store. Idempotent upserts so
+/// replay produces the same final state.
+/// </summary>
+public sealed class ShoppingListProjection(ShoppingDbContext context)
+	: IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemAddedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>
+{
+	public async Task HandleAsync(ShoppingListCreatedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListSummaryReadItem>().Add(new ShoppingListSummaryReadItem
+			{
+				Id = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Title = inner.Title.Value,
+				RecipeIdentifier = inner.RecipeReference?.Value,
+				ItemCount = 0,
+				CreatedAt = inner.CreatedAt,
+				LastUpdated = inner.CreatedAt,
+			});
+		}
+		else
+		{
+			existing.OwnerId = @event.OwnerId;
+			existing.Title = inner.Title.Value;
+			existing.RecipeIdentifier = inner.RecipeReference?.Value;
+			existing.CreatedAt = inner.CreatedAt;
+			existing.LastUpdated = DateTime.UtcNow;
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemAddedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == inner.ItemId.Value, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListItemReadItem>().Add(new ShoppingListItemReadItem
+			{
+				Id = inner.ItemId.Value,
+				ListId = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Name = inner.Name.Value,
+				QuantityAmount = inner.Quantity?.Amount.Value,
+				QuantityUnit = inner.Quantity?.Unit?.Value,
+				IsChecked = false,
+				CreatedAt = DateTime.UtcNow,
+				LastUpdated = DateTime.UtcNow,
+			});
+		}
+
+		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(RecipeReferenceClearedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+		if (summary is null) return;
+
+		summary.RecipeIdentifier = null;
+		summary.LastUpdated = DateTime.UtcNow;
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	private async Task SetCheckedAsync(Guid itemId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var item = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+		if (item is null) return;
+		item.IsChecked = isChecked;
+		item.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task SetAllCheckedAsync(Guid listId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var items = await context.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == listId)
+			.ToListAsync(cancellationToken);
+		foreach (var item in items)
+		{
+			item.IsChecked = isChecked;
+			item.LastUpdated = DateTime.UtcNow;
+		}
+	}
+
+	private async Task IncrementItemCountAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.ItemCount += 1;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task TouchSummaryAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+#pragma warning disable SA1601
+public sealed partial class ShoppingListProjectionRebuilder(
+	ShoppingDbContext context,
+	ShoppingListProjection projection,
+	ILogger<ShoppingListProjectionRebuilder> logger) : IShoppingListProjectionRebuilder
+{
+	public async Task<int> RebuildAsync(CancellationToken cancellationToken = default)
+	{
+		LogStarting();
+
+		// Truncate projection tables in dependency-safe order. Items first since
+		// the summary row is the conceptual parent (no FK today, but kept for clarity).
+		await context.Database.ExecuteSqlRawAsync(
+			@"TRUNCATE TABLE ""ShoppingListItemReadItems"", ""ShoppingListSummaryReadItems"" RESTART IDENTITY",
+			cancellationToken);
+
+		var ownerByAggregate = await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.ToDictionaryAsync(m => m.AggregateId, m => m.OwnerId, cancellationToken);
+
+		var storedEvents = await context.Set<ShoppingListStoredEvent>()
+			.AsNoTracking()
+			.OrderBy(e => e.AggregateId)
+			.ThenBy(e => e.Version)
+			.ToListAsync(cancellationToken);
+
+		var replayed = 0;
+		var skippedUnknownType = 0;
+		var skippedMissingOwner = 0;
+
+		foreach (var stored in storedEvents)
+		{
+			if (!ownerByAggregate.TryGetValue(stored.AggregateId, out var ownerId))
+			{
+				skippedMissingOwner++;
+				continue;
+			}
+
+			var domainEvent = ShoppingListEventSerializer.Deserialize(stored.EventType, stored.EventData);
+			if (domainEvent is null)
+			{
+				skippedUnknownType++;
+				continue;
+			}
+
+			var integrationEvent = ShoppingListIntegrationEventMapper.Map(ownerId, stored.AggregateId, domainEvent);
+			if (integrationEvent is null)
+			{
+				skippedUnknownType++;
+				continue;
+			}
+
+			switch (integrationEvent)
+			{
+				case ShoppingListCreatedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemAddedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemCheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemUncheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case AllItemsCheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case AllItemsUncheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case RecipeReferenceClearedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				default:
+					skippedUnknownType++;
+					continue;
+			}
+
+			replayed++;
+		}
+
+		LogFinished(replayed, skippedUnknownType, skippedMissingOwner);
+		return replayed;
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList projection rebuild starting — truncating projection tables")]
+	private partial void LogStarting();
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList projection rebuild finished. Replayed={Replayed} SkippedUnknownType={SkippedUnknownType} SkippedMissingOwner={SkippedMissingOwner}")]
+	private partial void LogFinished(int replayed, int skippedUnknownType, int skippedMissingOwner);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one ShoppingList aggregate. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListSummaryReadItem
+{
+	public Guid Id { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Title { get; set; } = default!;
+
+	public Guid? RecipeIdentifier { get; set; }
+
+	public int ItemCount { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDbContext.cs
@@ -17,6 +17,10 @@ public sealed class ShoppingDbContext(DbContextOptions<ShoppingDbContext> option
 
 	public DbSet<AggregateMetadata> ShoppingAggregates => Set<AggregateMetadata>();
 
+	public DbSet<ShoppingListStoredEvent> ShoppingListEvents => Set<ShoppingListStoredEvent>();
+
+	public DbSet<ShoppingListAggregateMetadata> ShoppingListAggregates => Set<ShoppingListAggregateMetadata>();
+
 	public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingListRepository.cs
@@ -19,7 +19,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -29,7 +29,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 	{
 		return await shoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(l => l.Identifier == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 	}
 
@@ -47,7 +47,7 @@ public sealed class ShoppingListRepository(ShoppingDbContext writeContext, Shopp
 		var items = await query
 			.Skip(paging.Skip)
 			.Take(paging.PageSize.Value)
-			.Select(l => new ShoppingListSummary(l.Id, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
+			.Select(l => new ShoppingListSummary(l.Identifier, l.Title, ItemCount.From(l.Items.Count), l.CreatedAt))
 			.ToListAsync(cancellationToken);
 
 		return (items, ItemCount.From(totalCount));

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
@@ -8,6 +8,10 @@ public sealed class ShoppingReadDbContext(DbContextOptions<ShoppingReadDbContext
 {
 	public DbSet<ShoppingListReadItem> ShoppingListReadItems => Set<ShoppingListReadItem>();
 
+	public DbSet<ShoppingListSummaryReadItem> ShoppingListSummaryReadItems => Set<ShoppingListSummaryReadItem>();
+
+	public DbSet<ShoppingListItemReadItem> ShoppingListItemReadItems => Set<ShoppingListItemReadItem>();
+
 	public DbSet<ShoppingList> ShoppingLists => Set<ShoppingList>();
 
 	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,13 +1,18 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
 public sealed class ShoppingUnitOfWork(
 	ShoppingDbContext context,
 	IShoppingListRepository shoppingLists,
-	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
+	IShoppingListEventStore listEventStore,
+	IEventBus eventBus) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
@@ -17,6 +22,10 @@ public sealed class ShoppingUnitOfWork(
 			.Where(e => e.State != EntityState.Detached)
 			.Select(e => e.Entity)
 			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		var pendingPublishes = trackedLists
+			.Select(list => (list, events: list.UncommittedEvents.ToList()))
 			.ToList();
 
 		foreach (var list in trackedLists)
@@ -34,11 +43,38 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
-		foreach (var list in trackedLists)
+		foreach (var (list, events) in pendingPublishes)
 		{
+			foreach (var domainEvent in events)
+			{
+				var integrationEvent = MapToIntegrationEvent(list, domainEvent);
+				if (integrationEvent is not null)
+				{
+					await eventBus.PublishAsync(integrationEvent, cancellationToken);
+				}
+			}
+
 			list.MarkCommitted();
 		}
 
 		return result;
+	}
+
+	private static IIntegrationEvent? MapToIntegrationEvent(ShoppingList list, IDomainEvent domainEvent)
+	{
+		var ownerId = list.Owner.Value;
+		var aggregateId = list.Identifier.Value;
+
+		return domainEvent switch
+		{
+			ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
+			ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
+			ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
+			ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
+			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
+			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
+			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+			_ => null,
+		};
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,11 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
-public sealed class ShoppingUnitOfWork(ShoppingDbContext context, IShoppingListRepository shoppingLists) : IShoppingUnitOfWork
+public sealed class ShoppingUnitOfWork(
+	ShoppingDbContext context,
+	IShoppingListRepository shoppingLists,
+	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
-	public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-		=> context.SaveChangesAsync(cancellationToken);
+	public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		var trackedLists = context.ChangeTracker.Entries<ShoppingList>()
+			.Where(e => e.State != EntityState.Detached)
+			.Select(e => e.Entity)
+			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		foreach (var list in trackedLists)
+		{
+			await listEventStore.AppendAsync(list, cancellationToken);
+		}
+
+		int result;
+		try
+		{
+			result = await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+		{
+			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
+		}
+
+		foreach (var list in trackedLists)
+		{
+			list.MarkCommitted();
+		}
+
+		return result;
+	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -43,6 +43,15 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
+		// Mark committed BEFORE publishing: events are already persisted to the store,
+		// so the aggregate is conceptually "clean". A publish failure (e.g. a projection
+		// handler throws) propagates to the caller, but the aggregate doesn't keep stale
+		// uncommitted events that would re-stage with conflicting versions on retry.
+		foreach (var (list, _) in pendingPublishes)
+		{
+			list.MarkCommitted();
+		}
+
 		foreach (var (list, events) in pendingPublishes)
 		{
 			foreach (var domainEvent in events)
@@ -53,8 +62,6 @@ public sealed class ShoppingUnitOfWork(
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
 				}
 			}
-
-			list.MarkCommitted();
 		}
 
 		return result;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
@@ -61,6 +62,12 @@ public sealed class ShoppingUnitOfWork(
 				{
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
 				}
+
+				var crossModuleEvent = MapToCrossModuleEvent(list, domainEvent);
+				if (crossModuleEvent is not null)
+				{
+					await eventBus.PublishAsync(crossModuleEvent, cancellationToken);
+				}
 			}
 		}
 
@@ -81,6 +88,26 @@ public sealed class ShoppingUnitOfWork(
 			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
 			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
 			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+			_ => null,
+		};
+	}
+
+	private static IIntegrationEvent? MapToCrossModuleEvent(ShoppingList list, IDomainEvent domainEvent)
+	{
+		var ownerId = list.Owner.Value;
+		var aggregateId = list.Identifier.Value;
+
+		return domainEvent switch
+		{
+			ShoppingListCreated created => new ShoppingListCreatedCrossModuleIntegrationEvent(
+				ownerId,
+				aggregateId,
+				created.Title.Value,
+				created.RecipeReference?.Value,
+				created.CreatedAt),
+			RecipeReferenceCleared => new ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent(
+				ownerId,
+				aggregateId),
 			_ => null,
 		};
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -57,7 +57,8 @@ public sealed class ShoppingUnitOfWork(
 		{
 			foreach (var domainEvent in events)
 			{
-				var integrationEvent = MapToIntegrationEvent(list, domainEvent);
+				var integrationEvent = ShoppingListIntegrationEventMapper.Map(
+					list.Owner.Value, list.Identifier.Value, domainEvent);
 				if (integrationEvent is not null)
 				{
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
@@ -72,24 +73,6 @@ public sealed class ShoppingUnitOfWork(
 		}
 
 		return result;
-	}
-
-	private static IIntegrationEvent? MapToIntegrationEvent(ShoppingList list, IDomainEvent domainEvent)
-	{
-		var ownerId = list.Owner.Value;
-		var aggregateId = list.Identifier.Value;
-
-		return domainEvent switch
-		{
-			ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
-			ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
-			ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
-			ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
-			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
-			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
-			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
-			_ => null,
-		};
 	}
 
 	private static IIntegrationEvent? MapToCrossModuleEvent(ShoppingList list, IDomainEvent domainEvent)

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -50,6 +50,14 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingListProjectionHandler>();
+		services.AddScoped<ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemAddedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>, ShoppingListProjection>();
 		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
 		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		});
 
 		services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+		services.AddScoped<IShoppingListEventStore, EfCoreShoppingListEventStore>();
 		services.AddScoped<IShoppingUnitOfWork, ShoppingUnitOfWork>();
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();
 		services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
 		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
+		services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 		services.AddScoped<ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application;
 using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
@@ -21,6 +22,15 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 {
 	public static IServiceCollection AddShoppingInfrastructure(this IServiceCollection services, IConfiguration configuration)
 	{
+		services.AddSingleton(_ =>
+		{
+			var section = configuration.GetSection(ShoppingOptions.SectionName);
+			return new ShoppingOptions
+			{
+				UseProjectionReadModel = bool.TryParse(section["UseProjectionReadModel"], out var v) ? v : true,
+			};
+		});
+
 		var connectionString = configuration.GetConnectionString("shoppingdb");
 		Action<NpgsqlDbContextOptionsBuilder> contextOptions = builder => builder
 			.MigrationsHistoryTable("__ShoppingMigrationsHistory")
@@ -44,6 +54,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();
 		services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
+		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
 		services.AddScoped<ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -44,7 +44,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 			var userId = await fixture.GetTestUserIdAsync();
 			var owner = OwnerIdentifier.From(userId);
 			await using var ctx = await fixture.CreateShoppingDbContextAsync();
-			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(listId) && l.Owner == owner);
+			var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(listId) && l.Owner == owner);
 			return list.RecipeReference is null;
 		});
 	}
@@ -65,7 +65,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		await Task.Delay(2000);
 
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Id == ShoppingListIdentifier.From(linkedToB));
+		var list = await ctx.ShoppingLists.AsNoTracking().SingleAsync(l => l.Identifier == ShoppingListIdentifier.From(linkedToB));
 		list.RecipeReference.Should().NotBeNull();
 	}
 

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -203,6 +203,28 @@ public sealed class AspireFixture : IAsyncLifetime
 		await context.SaveChangesAsync();
 	}
 
+	public async Task ResetShoppingListEventStoreAsync(ShoppingDomain.ShoppingList.OwnerIdentifier owner)
+	{
+		await using var context = await CreateShoppingDbContextAsync();
+		var aggregateIds = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => m.OwnerId == owner.Value)
+			.Select(m => m.AggregateId)
+			.ToListAsync();
+
+		if (aggregateIds.Count == 0) return;
+
+		var events = await context.Set<ShoppingListStoredEvent>()
+			.Where(e => aggregateIds.Contains(e.AggregateId))
+			.ToListAsync();
+		var metadata = await context.Set<ShoppingListAggregateMetadata>()
+			.Where(m => aggregateIds.Contains(m.AggregateId))
+			.ToListAsync();
+
+		context.RemoveRange(events);
+		context.RemoveRange(metadata);
+		await context.SaveChangesAsync();
+	}
+
 	public async Task ResetShoppingReadModelAsync(string ownerId)
 	{
 		await using var context = await CreateShoppingDbContextAsync();

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.EventStore;
+
+[Collection(AspireCollection.Name)]
+public class EfCoreShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listevtstore-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task LoadAsync_NoEventsForIdentifier_ReturnsNull()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+
+		var loaded = await store.LoadAsync(ShoppingListIdentifier.New());
+
+		loaded.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task AppendAsync_NewList_StagesEventsAndMetadata()
+	{
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var store = CreateStore(context);
+		var list = CreateList();
+
+		await store.AppendAsync(list);
+		await context.SaveChangesAsync();
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+		var metadata = await verify.Set<ShoppingListAggregateMetadata>()
+			.SingleAsync(m => m.AggregateId == list.Identifier.Value);
+
+		stored.Should().HaveCount(2);
+		stored[0].EventType.Should().Be(nameof(ShoppingListCreated));
+		stored[0].Version.Should().Be(1);
+		stored[1].EventType.Should().Be(nameof(ListItemAdded));
+		stored[1].Version.Should().Be(2);
+		metadata.OwnerId.Should().Be(owner.Value);
+	}
+
+	[Fact]
+	public async Task AppendAsync_OnlyAfterMarkCommitted_DoesNotDoubleStage()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+
+		stored.Should().HaveCount(3);
+		stored[2].EventType.Should().Be(nameof(ListItemChecked));
+		stored[2].Version.Should().Be(3);
+	}
+
+	[Fact]
+	public async Task LoadAsync_ReplaysEventsToSameState()
+	{
+		var original = CreateList();
+		original.CheckOffItem(original.Items[0].Id);
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(original);
+			await context.SaveChangesAsync();
+		}
+
+		await using var loadContext = await fixture.CreateShoppingDbContextAsync();
+		var loadStore = CreateStore(loadContext);
+		var loaded = await loadStore.LoadAsync(original.Identifier);
+
+		loaded.Should().NotBeNull();
+		loaded!.Identifier.Should().Be(original.Identifier);
+		loaded.Title.Should().Be(original.Title);
+		loaded.Owner.Should().Be(original.Owner);
+		loaded.Items.Should().HaveCount(1);
+		loaded.Items[0].IsChecked.Should().BeTrue();
+		loaded.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public async Task AppendAsync_ConflictingVersion_ThrowsOnSave()
+	{
+		var list = CreateList();
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = CreateStore(context);
+			await store.AppendAsync(list);
+			await context.SaveChangesAsync();
+			list.MarkCommitted();
+		}
+
+		// Simulate a competing write at version 2 by manually inserting a row with the
+		// same (AggregateId, Version) as the next staged event would use.
+		await using (var conflictContext = await fixture.CreateShoppingDbContextAsync())
+		{
+			conflictContext.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+			{
+				Id = Guid.CreateVersion7(),
+				AggregateId = list.Identifier.Value,
+				EventType = nameof(ListItemChecked),
+				EventData = "{}",
+				Version = list.Version + 1,
+				OccurredAt = DateTime.UtcNow,
+			});
+			await conflictContext.SaveChangesAsync();
+		}
+
+		list.CheckOffItem(list.Items[0].Id);
+
+		await using var context2 = await fixture.CreateShoppingDbContextAsync();
+		var store2 = CreateStore(context2);
+		await store2.AppendAsync(list);
+
+		var act = () => context2.SaveChangesAsync();
+		var ex = await act.Should().ThrowAsync<DbUpdateException>();
+		ex.Which.IsUniqueViolation().Should().BeTrue();
+	}
+
+	private static EfCoreShoppingListEventStore CreateStore(ShoppingDbContext context) =>
+		new(context, NullLogger<EfCoreShoppingListEventStore>.Instance);
+
+	private ShoppingList CreateList()
+	{
+		var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+		return ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[item]);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Persistence;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingUnitOfWorkTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"uow-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task SaveChangesAsync_PublishFails_StillMarksAggregateCommitted()
+	{
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+
+		var listEventStore = new EfCoreShoppingListEventStore(
+			writeContext,
+			NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+
+		var failingBus = Substitute.For<IEventBus>();
+		failingBus
+			.PublishAsync(Arg.Any<IIntegrationEvent>(), Arg.Any<CancellationToken>())
+			.ThrowsAsyncForAnyArgs(new InvalidOperationException("projection boom"));
+
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, failingBus);
+
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
+		await repo.AddAsync(list);
+
+		var act = () => uow.SaveChangesAsync();
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("projection boom");
+		list.UncommittedEvents.Should().BeEmpty(
+			"MarkCommitted must run before publish so a failing handler doesn't wedge the aggregate with stale events");
+
+		// Events must still have been persisted before the publish attempt.
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.CountAsync();
+		stored.Should().Be(2);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
@@ -5,7 +5,9 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using Xunit;
@@ -57,5 +59,72 @@ public class ShoppingUnitOfWorkTests(AspireFixture fixture) : IAsyncLifetime
 			.Where(e => e.AggregateId == list.Identifier.Value)
 			.CountAsync();
 		stored.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task SaveChangesAsync_NewList_PublishesCrossModuleCreatedEvent()
+	{
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+
+		var listEventStore = new EfCoreShoppingListEventStore(
+			writeContext,
+			NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+		var bus = Substitute.For<IEventBus>();
+
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, bus);
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
+		await repo.AddAsync(list);
+
+		await uow.SaveChangesAsync();
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingListCreatedCrossModuleIntegrationEvent>(e =>
+				e.OwnerId == owner.Value
+				&& e.ListIdentifier == list.Identifier.Value
+				&& e.Title == "Weekly Groceries"
+				&& e.RecipeIdentifier == null),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SaveChangesAsync_ClearRecipeReference_PublishesCrossModuleClearedEvent()
+	{
+		ShoppingList list;
+		await using (var seedContext = await fixture.CreateShoppingDbContextAsync())
+		await using (var seedRead = await fixture.CreateShoppingReadDbContextAsync())
+		{
+			var seedStore = new EfCoreShoppingListEventStore(seedContext, NullLogger<EfCoreShoppingListEventStore>.Instance);
+			var seedRepo = new ShoppingListRepository(seedContext, seedRead);
+			var seedUow = new ShoppingUnitOfWork(seedContext, seedRepo, seedStore, Substitute.For<IEventBus>());
+			list = ShoppingList.Create(
+				ShoppingListTitle.From("Cake"),
+				owner,
+				[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
+				RecipeReference.New());
+			await seedRepo.AddAsync(list);
+			await seedUow.SaveChangesAsync();
+		}
+
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+		var listEventStore = new EfCoreShoppingListEventStore(writeContext, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, bus);
+
+		var loaded = await repo.GetByIdForUpdateAsync(list.Identifier);
+		loaded.ClearRecipeReference();
+		await uow.SaveChangesAsync();
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent>(e =>
+				e.OwnerId == owner.Value
+				&& e.ListIdentifier == list.Identifier.Value),
+			Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"rebuild-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await fixture.ResetShoppingListEventStoreAsync(owner);
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var lists = await ctx.ShoppingLists.Where(l => l.Owner == owner).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		ctx.RemoveRange(lists);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task RebuildAsync_WithSeededEvents_RestoresProjectionTables()
+	{
+		var listId = await SeedListAsync("Weekly Groceries", "Flour", "Sugar");
+		await CheckOffFirstItemAsync(listId);
+		await TruncateProjectionsForOwnerAsync();
+
+		var replayed = await RunRebuildAsync();
+
+		replayed.Should().BeGreaterThan(0);
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+		summary.Title.Should().Be("Weekly Groceries");
+		summary.ItemCount.Should().Be(2);
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).ToListAsync();
+		items.Should().HaveCount(2);
+		items.Count(i => i.IsChecked).Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RebuildAsync_RunTwice_YieldsSameProjectionState()
+	{
+		var listId = await SeedListAsync("Pantry", "Salt", "Pepper", "Oil");
+		await TruncateProjectionsForOwnerAsync();
+
+		await RunRebuildAsync();
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var firstSummary = await ctx.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+			firstSummary.ItemCount.Should().Be(3);
+		}
+
+		await RunRebuildAsync();
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).CountAsync();
+		summary.ItemCount.Should().Be(3);
+		items.Should().Be(3);
+	}
+
+	private async Task<int> RunRebuildAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var projection = new ShoppingListProjection(ctx);
+		var rebuilder = new ShoppingListProjectionRebuilder(
+			ctx,
+			projection,
+			NullLogger<ShoppingListProjectionRebuilder>.Instance);
+		return await rebuilder.RebuildAsync();
+	}
+
+	private async Task TruncateProjectionsForOwnerAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		await ctx.SaveChangesAsync();
+	}
+
+	private async Task<ShoppingListIdentifier> SeedListAsync(string title, params string[] itemNames)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var items = itemNames
+			.Select(n => ShoppingListItem.Create(ItemName.From(n), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.ToList();
+		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
+		await legacy.AddAsync(list);
+		await uow.SaveChangesAsync();
+		return list.Identifier;
+	}
+
+	private async Task CheckOffFirstItemAsync(ShoppingListIdentifier listId)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var list = await legacy.GetByIdForUpdateAsync(listId);
+		list.CheckOffItem(list.Items[0].Id);
+		await uow.SaveChangesAsync();
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using Xunit;
@@ -30,15 +31,10 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_InsertsSummaryRow()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -52,11 +48,13 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task ItemAdded_InsertsItemAndIncrementsCount()
 	{
 		await SeedCreatedAsync();
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(
+				ItemAddedEvent(itemId, "Flour"));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
@@ -71,14 +69,39 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task ItemAdded_DeliveredTwice_KeepsCountAtOne()
+	{
+		await SeedCreatedAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == aggregateId).CountAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		items.Should().Be(1);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
 	public async Task ItemChecked_FlipsIsCheckedFlag()
 	{
 		await SeedCreatedAsync();
 		var itemId = await SeedItemAsync("Sugar");
-		var projection = await CreateProjectionAsync();
 
-		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
-			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new ListItemCheckedIntegrationEvent(
+				owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
@@ -89,20 +112,20 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task AllItemsChecked_FlipsEveryItemForList()
 	{
 		await SeedCreatedAsync();
-		var first = await SeedItemAsync("Sugar");
-		var second = await SeedItemAsync("Salt");
-		var projection = await CreateProjectionAsync();
+		await SeedItemAsync("Sugar");
+		await SeedItemAsync("Salt");
 
-		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
-			owner.Value, aggregateId, new AllItemsChecked()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new AllItemsCheckedIntegrationEvent(
+				owner.Value, aggregateId, new AllItemsChecked()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var items = await verify.Set<ShoppingListItemReadItem>()
 			.Where(i => i.ListId == aggregateId).ToListAsync();
 		items.Should().HaveCount(2);
 		items.Should().OnlyContain(i => i.IsChecked);
-		_ = first;
-		_ = second;
 	}
 
 	[Fact]
@@ -115,11 +138,18 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 			owner,
 			RecipeReference: RecipeReference.From(recipe),
 			CreatedAt: DateTime.UtcNow);
-		var projection = await CreateProjectionAsync();
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
 
-		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
-			owner.Value, aggregateId, new RecipeReferenceCleared()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var projection = new ShoppingListProjection(ctx);
+			await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+				owner.Value, aggregateId, new RecipeReferenceCleared()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -129,46 +159,46 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_TwiceForSameAggregate_IsIdempotent()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
 		rows.Should().Be(1);
 	}
 
-	private async Task<ShoppingListProjection> CreateProjectionAsync()
-	{
-		var ctx = await fixture.CreateShoppingDbContextAsync();
-		return new ShoppingListProjection(ctx);
-	}
-
-	private async Task SeedCreatedAsync()
-	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
+	private ShoppingListCreatedIntegrationEvent CreatedEvent() =>
+		new(owner.Value, aggregateId, new ShoppingListCreated(
 			ShoppingListIdentifier.From(aggregateId),
 			ShoppingListTitle.From("Weekly Groceries"),
 			owner,
 			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+			CreatedAt: DateTime.UtcNow));
+
+	private ListItemAddedIntegrationEvent ItemAddedEvent(ShoppingListItemIdentifier itemId, string name) =>
+		new(owner.Value, aggregateId, new ListItemAdded(
+			itemId,
+			ItemName.From(name),
+			Quantity.Of(Amount.From(500), Unit.Gram)));
+
+	private async Task SeedCreatedAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
 	}
 
 	private async Task<Guid> SeedItemAsync(string name)
 	{
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, name));
 		return itemId.Value;
 	}
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listproj-{Guid.NewGuid():N}");
+	private readonly Guid aggregateId = Guid.CreateVersion7();
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task Created_InsertsSummaryRow()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.Title.Should().Be("Weekly Groceries");
+		summary.OwnerId.Should().Be(owner.Value);
+		summary.ItemCount.Should().Be(0);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ItemAdded_InsertsItemAndIncrementsCount()
+	{
+		await SeedCreatedAsync();
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
+		item.Name.Should().Be("Flour");
+		item.QuantityAmount.Should().Be(500);
+		item.QuantityUnit.Should().Be("g");
+		item.IsChecked.Should().BeFalse();
+		item.ListId.Should().Be(aggregateId);
+
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ItemChecked_FlipsIsCheckedFlag()
+	{
+		await SeedCreatedAsync();
+		var itemId = await SeedItemAsync("Sugar");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
+			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
+		item.IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task AllItemsChecked_FlipsEveryItemForList()
+	{
+		await SeedCreatedAsync();
+		var first = await SeedItemAsync("Sugar");
+		var second = await SeedItemAsync("Salt");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
+			owner.Value, aggregateId, new AllItemsChecked()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == aggregateId).ToListAsync();
+		items.Should().HaveCount(2);
+		items.Should().OnlyContain(i => i.IsChecked);
+		_ = first;
+		_ = second;
+	}
+
+	[Fact]
+	public async Task RecipeReferenceCleared_NullsRecipeIdentifierOnSummary()
+	{
+		var recipe = Guid.CreateVersion7();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Cake"),
+			owner,
+			RecipeReference: RecipeReference.From(recipe),
+			CreatedAt: DateTime.UtcNow);
+		var projection = await CreateProjectionAsync();
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+			owner.Value, aggregateId, new RecipeReferenceCleared()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Created_TwiceForSameAggregate_IsIdempotent()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
+		rows.Should().Be(1);
+	}
+
+	private async Task<ShoppingListProjection> CreateProjectionAsync()
+	{
+		var ctx = await fixture.CreateShoppingDbContextAsync();
+		return new ShoppingListProjection(ctx);
+	}
+
+	private async Task SeedCreatedAsync()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+	}
+
+	private async Task<Guid> SeedItemAsync(string name)
+	{
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		return itemId.Value;
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListReadParityTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListReadParityTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+/// <summary>
+/// Phase 4 acceptance: the projection path returns equivalent data to the
+/// legacy relational path for the same input. Both paths are populated by a
+/// single UoW.SaveChanges (dual-write from Phase 2 + projection from Phase 3).
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class ShoppingListReadParityTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly PagingOptions DefaultPaging = PagingOptions.Of(Page.From(1), PageSize.From(20));
+	private static readonly SortingOptions<ShoppingListSortField> ByDateDesc = new(ShoppingListSortField.Date, SortDirection.Descending);
+
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"parity-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await fixture.ResetShoppingListEventStoreAsync(owner);
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var lists = await ctx.ShoppingLists.Where(l => l.Owner == owner).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		ctx.RemoveRange(lists);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task GetById_LegacyAndProjection_ReturnEquivalentData()
+	{
+		var listId = await SeedListAsync("Weekly Groceries", "Flour", "Sugar");
+
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+
+		var legacyResult = await legacy.GetByIdAsync(listId);
+		var projectionResult = await projection.GetByIdAsync(listId);
+
+		projectionResult.OwnerId.Should().Be(legacyResult.Owner.Value);
+		projectionResult.Dto.Identifier.Should().Be(legacyResult.Identifier.Value);
+		projectionResult.Dto.Title.Should().Be(legacyResult.Title.Value);
+		projectionResult.Dto.RecipeReference.Should().Be(legacyResult.RecipeReference?.Value);
+		projectionResult.Dto.Items.Select(i => i.Name).Should().BeEquivalentTo(legacyResult.Items.Select(i => i.Name.Value));
+		projectionResult.Dto.Items.Select(i => i.IsChecked).Should().BeEquivalentTo(legacyResult.Items.Select(i => i.IsChecked));
+	}
+
+	[Fact]
+	public async Task GetByOwner_LegacyAndProjection_ReturnEquivalentSummaries()
+	{
+		await SeedListAsync("List A", "Flour");
+		await SeedListAsync("List B", "Salt", "Pepper");
+
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+
+		var (legacyItems, legacyTotal) = await legacy.GetByOwnerAsync(owner, DefaultPaging, ByDateDesc);
+		var (projectionItems, projectionTotal) = await projection.GetByOwnerAsync(owner, DefaultPaging, ByDateDesc);
+
+		projectionTotal.Value.Should().Be(legacyTotal.Value);
+		projectionItems.Select(s => s.Title.Value).Should().BeEquivalentTo(legacyItems.Select(s => s.Title.Value));
+		projectionItems.Select(s => s.ItemCount.Value).Should().BeEquivalentTo(legacyItems.Select(s => s.ItemCount.Value));
+	}
+
+	[Fact]
+	public async Task GetById_AfterCheckOff_ProjectionReflectsCheckedState()
+	{
+		var listId = await SeedListAsync("Groceries", "Bread");
+		await CheckOffFirstItemAsync(listId);
+
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+		var detail = await projection.GetByIdAsync(listId);
+
+		detail.Dto.Items.Should().ContainSingle().Which.IsChecked.Should().BeTrue();
+	}
+
+	private async Task<ShoppingListIdentifier> SeedListAsync(string title, params string[] itemNames)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = await CreateProjectingBusAsync();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var items = itemNames
+			.Select(n => ShoppingListItem.Create(ItemName.From(n), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.ToList();
+		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
+		await legacy.AddAsync(list);
+		await uow.SaveChangesAsync();
+
+		return list.Identifier;
+	}
+
+	private async Task CheckOffFirstItemAsync(ShoppingListIdentifier listId)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = await CreateProjectingBusAsync();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var list = await legacy.GetByIdForUpdateAsync(listId);
+		list.CheckOffItem(list.Items[0].Id);
+		await uow.SaveChangesAsync();
+	}
+
+	/// <summary>
+	/// Wires a tiny in-place IEventBus that hands integration events directly to a
+	/// fresh ShoppingListProjection backed by its own DbContext — keeps these tests
+	/// self-contained without spinning up the full DI graph.
+	/// </summary>
+	private async Task<IEventBus> CreateProjectingBusAsync()
+	{
+		var bus = Substitute.For<IEventBus>();
+		bus.PublishAsync(Arg.Any<IIntegrationEvent>(), Arg.Any<CancellationToken>())
+			.Returns(async ci =>
+			{
+				var integrationEvent = ci.Arg<IIntegrationEvent>();
+				var ct = ci.Arg<CancellationToken>();
+				await using var ctx = await fixture.CreateShoppingDbContextAsync();
+				var projection = new ShoppingListProjection(ctx);
+				switch (integrationEvent)
+				{
+					case ShoppingListCreatedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemAddedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemCheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemUncheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case AllItemsCheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case AllItemsUncheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case RecipeReferenceClearedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+				}
+			});
+		await Task.CompletedTask;
+		return bus;
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListPersistenceTests.cs
@@ -41,7 +41,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
 			.Include(l => l.Items)
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved.Should().NotBeNull();
 		saved!.Title.Should().Be(ShoppingListTitle.From("Weekly Groceries"));
@@ -65,7 +65,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 
 		await using var readContext = await fixture.CreateShoppingDbContextAsync();
 		var saved = await readContext.ShoppingLists
-			.FirstOrDefaultAsync(l => l.Id == list.Id);
+			.FirstOrDefaultAsync(l => l.Identifier == list.Identifier);
 
 		saved!.RecipeReference.Should().NotBeNull();
 	}
@@ -79,7 +79,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		loaded.Title.Should().Be(ShoppingListTitle.From("Party Supplies"));
 		loaded.Items.Should().NotBeEmpty();
@@ -106,7 +106,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 
 		writeContext.Entry(loaded).State.Should().Be(EntityState.Unchanged);
 	}
@@ -122,7 +122,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using (var readDbContext = await fixture.CreateShoppingReadDbContextAsync())
 		{
 			var shoppingLists = new ShoppingListRepository(writeContext, readDbContext);
-			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Id);
+			var loaded = await shoppingLists.GetByIdForUpdateAsync(list.Identifier);
 			loaded.CheckOffItem(itemId);
 			await writeContext.SaveChangesAsync();
 		}
@@ -130,7 +130,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext2 = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists2 = new ShoppingListRepository(writeContext2, readContext);
-		var reloaded = await shoppingLists2.GetByIdAsync(list.Id);
+		var reloaded = await shoppingLists2.GetByIdAsync(list.Identifier);
 
 		reloaded.Items.First(i => i.Id == itemId).IsChecked.Should().BeTrue();
 	}
@@ -251,7 +251,7 @@ public class ShoppingListPersistenceTests(AspireFixture fixture) : IAsyncLifetim
 		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
 		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
 		var shoppingLists = new ShoppingListRepository(writeContext, readContext);
-		var loaded = await shoppingLists.GetByIdAsync(list.Id);
+		var loaded = await shoppingLists.GetByIdAsync(list.Identifier);
 
 		readContext.Entry(loaded).State.Should().Be(EntityState.Detached);
 	}

--- a/tests/Yumney.Shared.Events.Tests/InProcessEventBusTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/InProcessEventBusTests.cs
@@ -48,6 +48,24 @@ public class InProcessEventBusTests
 	}
 
 	[Fact]
+	public async Task PublishAsync_ViaInterfaceStaticType_StillReachesConcreteHandler()
+	{
+		// Regression: callers commonly map domain events to integration events with a
+		// `IIntegrationEvent? = switch { ... }` expression — the variable's static type
+		// is the marker interface, so naive generic-parameter dispatch would bind
+		// TEvent to IIntegrationEvent and miss every concrete-type subscriber. The bus
+		// must resolve handlers by the event's runtime type to avoid silently dropping
+		// every integration event published this way.
+		var handler = new TestIntegrationEventHandler();
+		var eventBus = CreateEventBus(services => services.AddSingleton<IIntegrationEventHandler<TestIntegrationEvent>>(handler));
+		IIntegrationEvent integrationEvent = new TestIntegrationEvent();
+
+		await eventBus.PublishAsync(integrationEvent);
+
+		handler.HandledEvents.Should().ContainSingle().Which.Should().Be(integrationEvent);
+	}
+
+	[Fact]
 	public async Task PublishAsync_WithNoHandler_CompletesWithoutError()
 	{
 		// Arrange

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffAllItemsCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_UncheckAllValid_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItems("other-user");
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_AllItemsChecked()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -89,8 +89,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
 		list.CheckAllItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, false);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffAllItemsCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffAllItemsCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItems();
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffAllItemsCommand(list.Id, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffAllItemsCommand(list.Identifier, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CheckOffItemCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -38,8 +38,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidUncheckCommand_ReturnsSuccess()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		var result = await handler.HandleAsync(command);
 
@@ -63,8 +63,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("other-user", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		var result = await handler.HandleAsync(command);
 
@@ -76,8 +76,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_ValidCommand_CallsSaveChanges()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -88,8 +88,8 @@ public class CheckOffItemCommandHandlerTests
 	public async Task HandleAsync_CheckTrue_CallsCheckOffItem()
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command);
 
@@ -101,8 +101,8 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
 		list.CheckOffItem(itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, false);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, false);
 
 		await handler.HandleAsync(command);
 
@@ -114,12 +114,12 @@ public class CheckOffItemCommandHandlerTests
 	{
 		var cts = new CancellationTokenSource();
 		var list = ShoppingListTestData.CreateListWithItem("user-123", out var itemId);
-		shoppingLists.GetByIdForUpdateAsync(list.Id, Arg.Any<CancellationToken>()).Returns(list);
-		var command = new CheckOffItemCommand(list.Id, itemId, true);
+		shoppingLists.GetByIdForUpdateAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+		var command = new CheckOffItemCommand(list.Identifier, itemId, true);
 
 		await handler.HandleAsync(command, cts.Token);
 
-		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Id, cts.Token);
+		await shoppingLists.Received(1).GetByIdForUpdateAsync(list.Identifier, cts.Token);
 		await unitOfWork.Received(1).SaveChangesAsync(cts.Token);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -11,13 +13,15 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
 public class GetShoppingListByIdQueryHandlerTests
 {
 	private readonly IShoppingListRepository shoppingLists = Substitute.For<IShoppingListRepository>();
+	private readonly IShoppingListProjectionRepository projection = Substitute.For<IShoppingListProjectionRepository>();
+	private readonly ShoppingOptions options = new() { UseProjectionReadModel = false };
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
 	private readonly GetShoppingListByIdQueryHandler handler;
 
 	public GetShoppingListByIdQueryHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
-		handler = new GetShoppingListByIdQueryHandler(shoppingLists, currentUser);
+		handler = new GetShoppingListByIdQueryHandler(shoppingLists, projection, options, currentUser);
 	}
 
 	[Fact]
@@ -60,6 +64,42 @@ public class GetShoppingListByIdQueryHandlerTests
 		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(GetShoppingListByIdErrors.AccessDenied);
+	}
+
+	[Fact]
+	public async Task HandleAsync_WhenProjectionFlagIsOn_QueriesProjectionRepository()
+	{
+		options.UseProjectionReadModel = true;
+		var listId = ShoppingListIdentifier.New();
+		var dto = new ShoppingListDetailDto(
+			listId.Value,
+			"Projected",
+			RecipeReference: null,
+			DateTime.UtcNow,
+			Items: []);
+		projection.GetByIdAsync(listId, Arg.Any<CancellationToken>())
+			.Returns(new ShoppingListProjectedDetail("user-123", dto));
+
+		var result = await handler.HandleAsync(new GetShoppingListByIdQuery(listId));
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Title.Should().Be("Projected");
+		await shoppingLists.DidNotReceiveWithAnyArgs().GetByIdAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProjectionDifferentOwner_ReturnsAccessDenied()
+	{
+		options.UseProjectionReadModel = true;
+		var listId = ShoppingListIdentifier.New();
+		var dto = new ShoppingListDetailDto(listId.Value, "T", null, DateTime.UtcNow, []);
+		projection.GetByIdAsync(listId, Arg.Any<CancellationToken>())
+			.Returns(new ShoppingListProjectedDetail("other-user", dto));
+
+		var result = await handler.HandleAsync(new GetShoppingListByIdQuery(listId));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(GetShoppingListByIdErrors.AccessDenied);

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -57,7 +57,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
 
@@ -72,7 +72,7 @@ public class GetShoppingListByIdQueryHandlerTests
 		shoppingLists.GetByIdAsync(Arg.Any<ShoppingListIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(shoppingList);
 		var cts = new CancellationTokenSource();
-		var query = new GetShoppingListByIdQuery(shoppingList.Id);
+		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		await handler.HandleAsync(query, cts.Token);
 

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -11,13 +12,15 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
 public class GetShoppingListsQueryHandlerTests
 {
 	private readonly IShoppingListRepository shoppingLists = Substitute.For<IShoppingListRepository>();
+	private readonly IShoppingListProjectionRepository projection = Substitute.For<IShoppingListProjectionRepository>();
+	private readonly ShoppingOptions options = new() { UseProjectionReadModel = false };
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
 	private readonly GetShoppingListsQueryHandler handler;
 
 	public GetShoppingListsQueryHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
-		handler = new GetShoppingListsQueryHandler(shoppingLists, currentUser);
+		handler = new GetShoppingListsQueryHandler(shoppingLists, projection, options, currentUser);
 	}
 
 	[Fact]
@@ -98,6 +101,29 @@ public class GetShoppingListsQueryHandlerTests
 			Arg.Is<SortingOptions<ShoppingListSortField>>(s =>
 				s.SortBy == ShoppingListSortField.Title && s.Direction == SortDirection.Ascending),
 			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_WhenProjectionFlagIsOn_QueriesProjectionRepository()
+	{
+		options.UseProjectionReadModel = true;
+		List<ShoppingListSummary> summaries =
+		[
+			new(ShoppingListIdentifier.New(), ShoppingListTitle.From("Projected"), ItemCount.From(3), DateTime.UtcNow)
+		];
+		projection.GetByOwnerAsync(
+			Arg.Any<OwnerIdentifier>(),
+			Arg.Any<PagingOptions>(),
+			Arg.Any<SortingOptions<ShoppingListSortField>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(((IReadOnlyList<ShoppingListSummary>)summaries, ItemCount.From(1)));
+
+		var query = CreateQuery(1, 20, ShoppingListSortField.Date, SortDirection.Descending);
+		var result = await handler.HandleAsync(query);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Items.Should().ContainSingle().Which.Title.Should().Be("Projected");
+		await shoppingLists.DidNotReceiveWithAnyArgs().GetByOwnerAsync(default!, default!, default!);
 	}
 
 	[Fact]

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListItemTests.cs
@@ -50,27 +50,6 @@ public class ShoppingListItemTests
 		item.IsChecked.Should().BeFalse();
 	}
 
-	[Fact]
-	public void Check_SetsIsCheckedToTrue()
-	{
-		var item = CreateFlourItem();
-
-		item.Check();
-
-		item.IsChecked.Should().BeTrue();
-	}
-
-	[Fact]
-	public void Uncheck_SetsIsCheckedToFalse()
-	{
-		var item = CreateFlourItem();
-		item.Check();
-
-		item.Uncheck();
-
-		item.IsChecked.Should().BeFalse();
-	}
-
 	private static ShoppingListItem CreateFlourItem() =>
 		ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 }

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
@@ -9,11 +10,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
 public class ShoppingListTests
 {
 	[Fact]
-	public void Create_ValidInput_CreatesShoppingListWithId()
+	public void Create_ValidInput_CreatesShoppingListWithIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		shoppingList.Id.Should().NotBeNull();
+		shoppingList.Identifier.Should().NotBeNull();
 	}
 
 	[Fact]
@@ -93,29 +94,41 @@ public class ShoppingListTests
 
 		var shoppingList = CreateValidShoppingList(title: title);
 
-		shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>()
+		shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle()
 			.Which.Title.Should().Be(title);
 	}
 
 	[Fact]
-	public void Create_ShoppingListCreatedEvent_ContainsShoppingListId()
+	public void Create_ShoppingListCreatedEvent_ContainsShoppingListIdentifier()
 	{
 		var shoppingList = CreateValidShoppingList();
 
-		var domainEvent = shoppingList.DomainEvents.Should().ContainSingle()
-			.Which.Should().BeOfType<ShoppingListCreatedEvent>().Subject;
+		var domainEvent = shoppingList.UncommittedEvents.OfType<ShoppingListCreated>().Should().ContainSingle().Subject;
 
-		domainEvent.ShoppingListIdentifier.Should().Be(shoppingList.Id);
+		domainEvent.Identifier.Should().Be(shoppingList.Identifier);
 	}
 
 	[Fact]
-	public void Create_GeneratesUniqueIds()
+	public void Create_RaisesListItemAddedEventPerItem()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncommittedEvents.OfType<ListItemAdded>().Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void Create_GeneratesUniqueIdentifiers()
 	{
 		var list1 = CreateValidShoppingList();
 		var list2 = CreateValidShoppingList();
 
-		list1.Id.Should().NotBe(list2.Id);
+		list1.Identifier.Should().NotBe(list2.Identifier);
 	}
 
 	[Fact]
@@ -130,6 +143,21 @@ public class ShoppingListTests
 		shoppingList.CheckOffItem(items[0].Id);
 
 		shoppingList.Items[0].IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CheckOffItem_RaisesListItemCheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemChecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
 	}
 
 	[Fact]
@@ -148,6 +176,21 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckItem_RaisesListItemUncheckedEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+
+		shoppingList.UncheckItem(items[0].Id);
+
+		shoppingList.UncommittedEvents.OfType<ListItemUnchecked>().Should().ContainSingle()
+			.Which.ItemId.Should().Be(items[0].Id);
+	}
+
+	[Fact]
 	public void CheckAllItems_ChecksAllItems()
 	{
 		List<ShoppingListItem> items =
@@ -160,6 +203,16 @@ public class ShoppingListTests
 		shoppingList.CheckAllItems();
 
 		shoppingList.Items.Should().OnlyContain(i => i.IsChecked);
+	}
+
+	[Fact]
+	public void CheckAllItems_RaisesAllItemsCheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.CheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsChecked>().Should().ContainSingle();
 	}
 
 	[Fact]
@@ -179,6 +232,36 @@ public class ShoppingListTests
 	}
 
 	[Fact]
+	public void UncheckAllItems_RaisesAllItemsUncheckedEvent()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.UncheckAllItems();
+
+		shoppingList.UncommittedEvents.OfType<AllItemsUnchecked>().Should().ContainSingle();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_ClearsTheReference()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public void ClearRecipeReference_RaisesRecipeReferenceClearedEvent()
+	{
+		var shoppingList = CreateValidShoppingList(recipeReference: RecipeReference.New());
+
+		shoppingList.ClearRecipeReference();
+
+		shoppingList.UncommittedEvents.OfType<RecipeReferenceCleared>().Should().ContainSingle();
+	}
+
+	[Fact]
 	public void CheckOffItem_InvalidItemId_Throws()
 	{
 		var shoppingList = CreateValidShoppingList();
@@ -186,6 +269,57 @@ public class ShoppingListTests
 		var act = () => shoppingList.CheckOffItem(ShoppingListItemIdentifier.New());
 
 		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Version_IncrementsOnEachEvent()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))
+		];
+		var shoppingList = CreateValidShoppingList(items: items);
+		var versionAfterCreate = shoppingList.Version;
+
+		shoppingList.CheckOffItem(items[0].Id);
+
+		shoppingList.Version.Should().Be(versionAfterCreate.Increment());
+	}
+
+	[Fact]
+	public void FromEvents_ReplaysToSameState()
+	{
+		List<ShoppingListItem> items =
+		[
+			ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
+			ShoppingListItem.Create(ItemName.From("Sugar"), Quantity.Of(Amount.From(200), Unit.Gram))
+		];
+		var original = CreateValidShoppingList(items: items, recipeReference: RecipeReference.New());
+		original.CheckOffItem(items[0].Id);
+		original.ClearRecipeReference();
+		var capturedEvents = original.UncommittedEvents.ToList();
+
+		var replayed = Domain.ShoppingList.ShoppingList.FromEvents(original.Identifier, capturedEvents);
+
+		replayed.Identifier.Should().Be(original.Identifier);
+		replayed.Title.Should().Be(original.Title);
+		replayed.Owner.Should().Be(original.Owner);
+		replayed.CreatedAt.Should().Be(original.CreatedAt);
+		replayed.RecipeReference.Should().BeNull();
+		replayed.Items.Should().HaveCount(2);
+		replayed.Items.Single(i => i.Id == items[0].Id).IsChecked.Should().BeTrue();
+		replayed.Items.Single(i => i.Id == items[1].Id).IsChecked.Should().BeFalse();
+		replayed.Version.Should().Be(original.Version);
+	}
+
+	[Fact]
+	public void MarkCommitted_ClearsUncommittedEvents()
+	{
+		var shoppingList = CreateValidShoppingList();
+
+		shoppingList.MarkCommitted();
+
+		shoppingList.UncommittedEvents.Should().BeEmpty();
 	}
 
 	private static Domain.ShoppingList.ShoppingList CreateValidShoppingList(


### PR DESCRIPTION
## Summary

Phase 6 (operational) of the Shopping module ES migration. Closes #481. **Stacked on #488** → #487 → #486 → #485 → #484.

Mirrors the existing MealPlan dashboard reset (`yumney-mealplan-reset`) but with **projection-rebuild semantics**, not a database drop — events stay intact.

- `IShoppingListProjectionRebuilder` (Application) + `ShoppingListProjectionRebuilder` (Infrastructure). Truncates `ShoppingListSummaryReadItems` + `ShoppingListItemReadItems`, then replays every `ShoppingListStoredEvent` through `ShoppingListProjection`. Idempotent (projection upserts guarantee identical final state across runs).
- Two extracted helpers used by both the event store and the rebuilder: `ShoppingListEventSerializer` (JsonSerializerOptions + type map) and `ShoppingListIntegrationEventMapper` (domain → in-module integration event). No behavioural change to the existing event store / UoW publish — same code, single home.
- `MigrationRunner` gets a third mode behind `Persistence:RebuildShoppingProjections=true`. The dashboard entry `yumney-shopping-projection-reset` sets the flag and uses `WithExplicitStart()` so it sits idle until the dev clicks **Start**.
- Resource only registered for local Aspire runs (`isRunMode`) — no production exposure. Other module DBs and other Shopping data (events, metadata, legacy `ShoppingLists`) are untouched.

## How to Test

1. `dotnet build -p:TreatWarningsAsErrors=true` — clean.
2. `dotnet format --verify-no-changes` — clean.
3. Unit + arch suites: 174 / 116 / 8 / 117 / 13 ✅ (no changes).
4. Integration tests (`Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs`) — rebuild restores summary/items/checked-state; rebuild-twice yields identical state. CI runs them.
5. Manual: `aspire run` → dashboard → click **Start** on `yumney-shopping-projection-reset` → check structured logs for *"ShoppingList projection rebuild starting"* and *"...finished. Replayed=N"* → verify projection rows match event history.

## Notes

- Acceptance criteria from #481: dashboard entry visible in dev ✅, rebuild from events ✅, idempotent ✅, disabled in production ✅.
- Out of scope: rebuild for the existing ledger projection (`ShoppingListReadItems`). That projection is owned by the older `ShoppingListProjectionHandler` and pre-dates this migration; would be a separate operational PR.

## Checklist

- [x] Code follows naming conventions
- [x] New/updated tests written
- [x] All tests green (locally — domain, application, infrastructure, architecture, shared events)
- [x] No new linter warnings
- [x] No `any` in TypeScript code (no FE changes)
- [x] No secrets in code
- [ ] Integration tests run against live Aspire stack (CI)