### PR TITLE
feat(shopping): build read model + projection handler for ShoppingList (#478)

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListItemReadItemConfiguration : IEntityTypeConfiguration<ShoppingListItemReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListItemReadItem> entity)
+	{
+		entity.ToTable("ShoppingListItemReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.QuantityUnit).HasMaxLength(50);
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.ListId);
+		entity.HasIndex(e => new { e.OwnerId, e.ListId });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShoppingListSummaryReadItemConfiguration : IEntityTypeConfiguration<ShoppingListSummaryReadItem>
+{
+	public void Configure(EntityTypeBuilder<ShoppingListSummaryReadItem> entity)
+	{
+		entity.ToTable("ShoppingListSummaryReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.CreatedAt).IsRequired();
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.HasIndex(e => e.OwnerId);
+		entity.HasIndex(e => new { e.OwnerId, e.CreatedAt });
+		entity.HasIndex(e => new { e.OwnerId, e.Title });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AllItemsUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record AllItemsUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	AllItemsUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemAddedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemAddedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemAdded Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemCheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemCheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemChecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ListItemUncheckedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ListItemUncheckedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ListItemUnchecked Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/RecipeReferenceClearedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record RecipeReferenceClearedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	RecipeReferenceCleared Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListCreatedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1649
+public sealed record ShoppingListCreatedIntegrationEvent(
+	string OwnerId,
+	Guid AggregateId,
+	ShoppingListCreated Inner) : ShoppingListIntegrationEvent(OwnerId, AggregateId);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEvent.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Base record for all ShoppingList integration events. Carries the routing pair
+/// (OwnerId, AggregateId) that identifies the list stream the event came from.
+/// Concrete events stay as sealed records so the bus's name-based handler
+/// discovery still works.
+/// </summary>
+public abstract record ShoppingListIntegrationEvent(string OwnerId, Guid AggregateId) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428213905_AddShoppingListReadModel")]
+    partial class AddShoppingListReadModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260428213905_AddShoppingListReadModel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShoppingListReadModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShoppingListItemReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    QuantityAmount = table.Column<decimal>(type: "numeric", nullable: true),
+                    QuantityUnit = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    IsChecked = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListItemReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ShoppingListSummaryReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    RecipeIdentifier = table.Column<Guid>(type: "uuid", nullable: true),
+                    ItemCount = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShoppingListSummaryReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_ListId",
+                table: "ShoppingListItemReadItems",
+                column: "ListId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListItemReadItems_OwnerId_ListId",
+                table: "ShoppingListItemReadItems",
+                columns: new[] { "OwnerId", "ListId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId",
+                table: "ShoppingListSummaryReadItems",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_CreatedAt",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShoppingListSummaryReadItems_OwnerId_Title",
+                table: "ShoppingListSummaryReadItems",
+                columns: new[] { "OwnerId", "Title" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShoppingListItemReadItems");
+
+            migrationBuilder.DropTable(
+                name: "ShoppingListSummaryReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListItemReadItem.cs
@@ -1,0 +1,26 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one item within a ShoppingList. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListItemReadItem
+{
+	public Guid Id { get; set; }
+
+	public Guid ListId { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Name { get; set; } = default!;
+
+	public decimal? QuantityAmount { get; set; }
+
+	public string? QuantityUnit { get; set; }
+
+	public bool IsChecked { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -69,9 +69,12 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 				CreatedAt = DateTime.UtcNow,
 				LastUpdated = DateTime.UtcNow,
 			});
+
+			// Only increment when the item is newly inserted — otherwise replay/duplicate
+			// delivery would drift the count while the items table stays at 1 row.
+			await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		}
 
-		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
 		await context.SaveChangesAsync(cancellationToken);
 	}
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -1,0 +1,154 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Async projection handler — rebuilds the ShoppingList read model from
+/// integration events published by the event store. Idempotent upserts so
+/// replay produces the same final state.
+/// </summary>
+public sealed class ShoppingListProjection(ShoppingDbContext context)
+	: IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemAddedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>,
+	  IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>,
+	  IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>
+{
+	public async Task HandleAsync(ShoppingListCreatedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListSummaryReadItem>().Add(new ShoppingListSummaryReadItem
+			{
+				Id = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Title = inner.Title.Value,
+				RecipeIdentifier = inner.RecipeReference?.Value,
+				ItemCount = 0,
+				CreatedAt = inner.CreatedAt,
+				LastUpdated = inner.CreatedAt,
+			});
+		}
+		else
+		{
+			existing.OwnerId = @event.OwnerId;
+			existing.Title = inner.Title.Value;
+			existing.RecipeIdentifier = inner.RecipeReference?.Value;
+			existing.CreatedAt = inner.CreatedAt;
+			existing.LastUpdated = DateTime.UtcNow;
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemAddedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var existing = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == inner.ItemId.Value, cancellationToken);
+
+		if (existing is null)
+		{
+			context.Set<ShoppingListItemReadItem>().Add(new ShoppingListItemReadItem
+			{
+				Id = inner.ItemId.Value,
+				ListId = @event.AggregateId,
+				OwnerId = @event.OwnerId,
+				Name = inner.Name.Value,
+				QuantityAmount = inner.Quantity?.Amount.Value,
+				QuantityUnit = inner.Quantity?.Unit?.Value,
+				IsChecked = false,
+				CreatedAt = DateTime.UtcNow,
+				LastUpdated = DateTime.UtcNow,
+			});
+		}
+
+		await IncrementItemCountAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(ListItemUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetCheckedAsync(@event.Inner.ItemId.Value, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsCheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, true, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(AllItemsUncheckedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		await SetAllCheckedAsync(@event.AggregateId, false, cancellationToken);
+		await TouchSummaryAsync(@event.AggregateId, cancellationToken);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public async Task HandleAsync(RecipeReferenceClearedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+		if (summary is null) return;
+
+		summary.RecipeIdentifier = null;
+		summary.LastUpdated = DateTime.UtcNow;
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	private async Task SetCheckedAsync(Guid itemId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var item = await context.Set<ShoppingListItemReadItem>()
+			.FirstOrDefaultAsync(i => i.Id == itemId, cancellationToken);
+		if (item is null) return;
+		item.IsChecked = isChecked;
+		item.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task SetAllCheckedAsync(Guid listId, bool isChecked, CancellationToken cancellationToken)
+	{
+		var items = await context.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == listId)
+			.ToListAsync(cancellationToken);
+		foreach (var item in items)
+		{
+			item.IsChecked = isChecked;
+			item.LastUpdated = DateTime.UtcNow;
+		}
+	}
+
+	private async Task IncrementItemCountAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.ItemCount += 1;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+
+	private async Task TouchSummaryAsync(Guid listId, CancellationToken cancellationToken)
+	{
+		var summary = await context.Set<ShoppingListSummaryReadItem>()
+			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+		if (summary is null) return;
+		summary.LastUpdated = DateTime.UtcNow;
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSummaryReadItem.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Materialized read model for one ShoppingList aggregate. Populated by
+/// <see cref="ShoppingListProjection"/> from the list event stream.
+/// </summary>
+public sealed class ShoppingListSummaryReadItem
+{
+	public Guid Id { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string Title { get; set; } = default!;
+
+	public Guid? RecipeIdentifier { get; set; }
+
+	public int ItemCount { get; set; }
+
+	public DateTime CreatedAt { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
@@ -8,6 +8,10 @@ public sealed class ShoppingReadDbContext(DbContextOptions<ShoppingReadDbContext
 {
 	public DbSet<ShoppingListReadItem> ShoppingListReadItems => Set<ShoppingListReadItem>();
 
+	public DbSet<ShoppingListSummaryReadItem> ShoppingListSummaryReadItems => Set<ShoppingListSummaryReadItem>();
+
+	public DbSet<ShoppingListItemReadItem> ShoppingListItemReadItems => Set<ShoppingListItemReadItem>();
+
 	public DbSet<ShoppingList> ShoppingLists => Set<ShoppingList>();
 
 	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,13 +1,18 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
 public sealed class ShoppingUnitOfWork(
 	ShoppingDbContext context,
 	IShoppingListRepository shoppingLists,
-	IShoppingListEventStore listEventStore) : IShoppingUnitOfWork
+	IShoppingListEventStore listEventStore,
+	IEventBus eventBus) : IShoppingUnitOfWork
 {
 	public IShoppingListRepository ShoppingLists => shoppingLists;
 
@@ -17,6 +22,10 @@ public sealed class ShoppingUnitOfWork(
 			.Where(e => e.State != EntityState.Detached)
 			.Select(e => e.Entity)
 			.Where(l => l.UncommittedEvents.Count > 0)
+			.ToList();
+
+		var pendingPublishes = trackedLists
+			.Select(list => (list, events: list.UncommittedEvents.ToList()))
 			.ToList();
 
 		foreach (var list in trackedLists)
@@ -34,11 +43,38 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
-		foreach (var list in trackedLists)
+		foreach (var (list, events) in pendingPublishes)
 		{
+			foreach (var domainEvent in events)
+			{
+				var integrationEvent = MapToIntegrationEvent(list, domainEvent);
+				if (integrationEvent is not null)
+				{
+					await eventBus.PublishAsync(integrationEvent, cancellationToken);
+				}
+			}
+
 			list.MarkCommitted();
 		}
 
 		return result;
+	}
+
+	private static IIntegrationEvent? MapToIntegrationEvent(ShoppingList list, IDomainEvent domainEvent)
+	{
+		var ownerId = list.Owner.Value;
+		var aggregateId = list.Identifier.Value;
+
+		return domainEvent switch
+		{
+			ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
+			ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
+			ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
+			ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
+			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
+			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
+			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+			_ => null,
+		};
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -43,6 +43,15 @@ public sealed class ShoppingUnitOfWork(
 			throw new ConcurrencyConflictException(nameof(ShoppingList), trackedLists.FirstOrDefault()?.Identifier.Value ?? Guid.Empty, ex);
 		}
 
+		// Mark committed BEFORE publishing: events are already persisted to the store,
+		// so the aggregate is conceptually "clean". A publish failure (e.g. a projection
+		// handler throws) propagates to the caller, but the aggregate doesn't keep stale
+		// uncommitted events that would re-stage with conflicting versions on retry.
+		foreach (var (list, _) in pendingPublishes)
+		{
+			list.MarkCommitted();
+		}
+
 		foreach (var (list, events) in pendingPublishes)
 		{
 			foreach (var domainEvent in events)
@@ -53,8 +62,6 @@ public sealed class ShoppingUnitOfWork(
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
 				}
 			}
-
-			list.MarkCommitted();
 		}
 
 		return result;

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -50,6 +50,14 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingListProjectionHandler>();
+		services.AddScoped<ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemAddedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>, ShoppingListProjection>();
+		services.AddScoped<IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>, ShoppingListProjection>();
 		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
 		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();

--- a/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.Persistence;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingUnitOfWorkTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"uow-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => fixture.ResetShoppingListEventStoreAsync(owner);
+
+	[Fact]
+	public async Task SaveChangesAsync_PublishFails_StillMarksAggregateCommitted()
+	{
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+
+		var listEventStore = new EfCoreShoppingListEventStore(
+			writeContext,
+			NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+
+		var failingBus = Substitute.For<IEventBus>();
+		failingBus
+			.PublishAsync(Arg.Any<IIntegrationEvent>(), Arg.Any<CancellationToken>())
+			.ThrowsAsyncForAnyArgs(new InvalidOperationException("projection boom"));
+
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, failingBus);
+
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
+		await repo.AddAsync(list);
+
+		var act = () => uow.SaveChangesAsync();
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("projection boom");
+		list.UncommittedEvents.Should().BeEmpty(
+			"MarkCommitted must run before publish so a failing handler doesn't wedge the aggregate with stale events");
+
+		// Events must still have been persisted before the publish attempt.
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var stored = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == list.Identifier.Value)
+			.CountAsync();
+		stored.Should().Be(2);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using Xunit;
@@ -30,15 +31,10 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_InsertsSummaryRow()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -52,11 +48,13 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task ItemAdded_InsertsItemAndIncrementsCount()
 	{
 		await SeedCreatedAsync();
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
 
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(
+				ItemAddedEvent(itemId, "Flour"));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
@@ -71,14 +69,39 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task ItemAdded_DeliveredTwice_KeepsCountAtOne()
+	{
+		await SeedCreatedAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, "Flour"));
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == aggregateId).CountAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		items.Should().Be(1);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
 	public async Task ItemChecked_FlipsIsCheckedFlag()
 	{
 		await SeedCreatedAsync();
 		var itemId = await SeedItemAsync("Sugar");
-		var projection = await CreateProjectionAsync();
 
-		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
-			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new ListItemCheckedIntegrationEvent(
+				owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
@@ -89,20 +112,20 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task AllItemsChecked_FlipsEveryItemForList()
 	{
 		await SeedCreatedAsync();
-		var first = await SeedItemAsync("Sugar");
-		var second = await SeedItemAsync("Salt");
-		var projection = await CreateProjectionAsync();
+		await SeedItemAsync("Sugar");
+		await SeedItemAsync("Salt");
 
-		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
-			owner.Value, aggregateId, new AllItemsChecked()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new AllItemsCheckedIntegrationEvent(
+				owner.Value, aggregateId, new AllItemsChecked()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var items = await verify.Set<ShoppingListItemReadItem>()
 			.Where(i => i.ListId == aggregateId).ToListAsync();
 		items.Should().HaveCount(2);
 		items.Should().OnlyContain(i => i.IsChecked);
-		_ = first;
-		_ = second;
 	}
 
 	[Fact]
@@ -115,11 +138,18 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 			owner,
 			RecipeReference: RecipeReference.From(recipe),
 			CreatedAt: DateTime.UtcNow);
-		var projection = await CreateProjectionAsync();
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
 
-		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
-			owner.Value, aggregateId, new RecipeReferenceCleared()));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var projection = new ShoppingListProjection(ctx);
+			await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		}
+
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+				owner.Value, aggregateId, new RecipeReferenceCleared()));
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
@@ -129,46 +159,46 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task Created_TwiceForSameAggregate_IsIdempotent()
 	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
-			ShoppingListIdentifier.From(aggregateId),
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
+		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
 		rows.Should().Be(1);
 	}
 
-	private async Task<ShoppingListProjection> CreateProjectionAsync()
-	{
-		var ctx = await fixture.CreateShoppingDbContextAsync();
-		return new ShoppingListProjection(ctx);
-	}
-
-	private async Task SeedCreatedAsync()
-	{
-		var projection = await CreateProjectionAsync();
-		var inner = new ShoppingListCreated(
+	private ShoppingListCreatedIntegrationEvent CreatedEvent() =>
+		new(owner.Value, aggregateId, new ShoppingListCreated(
 			ShoppingListIdentifier.From(aggregateId),
 			ShoppingListTitle.From("Weekly Groceries"),
 			owner,
 			RecipeReference: null,
-			CreatedAt: DateTime.UtcNow);
-		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+			CreatedAt: DateTime.UtcNow));
+
+	private ListItemAddedIntegrationEvent ItemAddedEvent(ShoppingListItemIdentifier itemId, string name) =>
+		new(owner.Value, aggregateId, new ListItemAdded(
+			itemId,
+			ItemName.From(name),
+			Quantity.Of(Amount.From(500), Unit.Gram)));
+
+	private async Task SeedCreatedAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(CreatedEvent());
 	}
 
 	private async Task<Guid> SeedItemAsync(string name)
 	{
-		var projection = await CreateProjectionAsync();
 		var itemId = ShoppingListItemIdentifier.New();
-		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
-		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		await new ShoppingListProjection(ctx).HandleAsync(ItemAddedEvent(itemId, name));
 		return itemId.Value;
 	}
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"listproj-{Guid.NewGuid():N}");
+	private readonly Guid aggregateId = Guid.CreateVersion7();
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task Created_InsertsSummaryRow()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.Title.Should().Be("Weekly Groceries");
+		summary.OwnerId.Should().Be(owner.Value);
+		summary.ItemCount.Should().Be(0);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ItemAdded_InsertsItemAndIncrementsCount()
+	{
+		await SeedCreatedAsync();
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId.Value);
+		item.Name.Should().Be("Flour");
+		item.QuantityAmount.Should().Be(500);
+		item.QuantityUnit.Should().Be("g");
+		item.IsChecked.Should().BeFalse();
+		item.ListId.Should().Be(aggregateId);
+
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.ItemCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ItemChecked_FlipsIsCheckedFlag()
+	{
+		await SeedCreatedAsync();
+		var itemId = await SeedItemAsync("Sugar");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new ListItemCheckedIntegrationEvent(
+			owner.Value, aggregateId, new ListItemChecked(ShoppingListItemIdentifier.From(itemId))));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.Id == itemId);
+		item.IsChecked.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task AllItemsChecked_FlipsEveryItemForList()
+	{
+		await SeedCreatedAsync();
+		var first = await SeedItemAsync("Sugar");
+		var second = await SeedItemAsync("Salt");
+		var projection = await CreateProjectionAsync();
+
+		await projection.HandleAsync(new AllItemsCheckedIntegrationEvent(
+			owner.Value, aggregateId, new AllItemsChecked()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>()
+			.Where(i => i.ListId == aggregateId).ToListAsync();
+		items.Should().HaveCount(2);
+		items.Should().OnlyContain(i => i.IsChecked);
+		_ = first;
+		_ = second;
+	}
+
+	[Fact]
+	public async Task RecipeReferenceCleared_NullsRecipeIdentifierOnSummary()
+	{
+		var recipe = Guid.CreateVersion7();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Cake"),
+			owner,
+			RecipeReference: RecipeReference.From(recipe),
+			CreatedAt: DateTime.UtcNow);
+		var projection = await CreateProjectionAsync();
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await projection.HandleAsync(new RecipeReferenceClearedIntegrationEvent(
+			owner.Value, aggregateId, new RecipeReferenceCleared()));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
+		summary.RecipeIdentifier.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Created_TwiceForSameAggregate_IsIdempotent()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
+		rows.Should().Be(1);
+	}
+
+	private async Task<ShoppingListProjection> CreateProjectionAsync()
+	{
+		var ctx = await fixture.CreateShoppingDbContextAsync();
+		return new ShoppingListProjection(ctx);
+	}
+
+	private async Task SeedCreatedAsync()
+	{
+		var projection = await CreateProjectionAsync();
+		var inner = new ShoppingListCreated(
+			ShoppingListIdentifier.From(aggregateId),
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			RecipeReference: null,
+			CreatedAt: DateTime.UtcNow);
+		await projection.HandleAsync(new ShoppingListCreatedIntegrationEvent(owner.Value, aggregateId, inner));
+	}
+
+	private async Task<Guid> SeedItemAsync(string name)
+	{
+		var projection = await CreateProjectionAsync();
+		var itemId = ShoppingListItemIdentifier.New();
+		var inner = new ListItemAdded(itemId, ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram));
+		await projection.HandleAsync(new ListItemAddedIntegrationEvent(owner.Value, aggregateId, inner));
+		return itemId.Value;
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Shopping module ES migration. Closes #478. Recreated from #486 after its parent base branch was deleted post-merge.

- 7 integration events wrapping each list domain event with `(OwnerId, AggregateId)` routing.
- New read-model tables (migration `AddShoppingListReadModel`): `ShoppingListSummaryReadItems` and `ShoppingListItemReadItems`.
- `ShoppingListProjection` implements `IIntegrationEventHandler<>` for all 7 events. Idempotent upserts.
- `ShoppingUnitOfWork.SaveChangesAsync` now publishes integration events via `IEventBus` after a successful save, then `MarkCommitted` on each aggregate.
- Read path is unchanged — Phase 4 cuts queries over to these tables.
- Includes the Phase-3 follow-up `fix(shopping): projection idempotency + UoW commit ordering` (Items count drift + MarkCommitted ordering — see commit ea11e21e in branch history).

## How to Test

1. `dotnet build -p:TreatWarningsAsErrors=true` — clean.
2. `dotnet format --verify-no-changes` — clean.
3. Unit + arch suites pass locally.
4. Integration tests on CI.

## Checklist

- [x] Tests updated
- [x] All unit tests green
- [x] No new linter warnings
- [x] No secrets
- [ ] Integration tests run on CI