### PR TITLE
refactor(shopping): repoint list queries to projection read model (#479)

### DIFF
--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
@@ -1,0 +1,38 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Read-side query repository backed by the ShoppingList projection tables
+/// (<c>ShoppingListSummaryReadItems</c>, <c>ShoppingListItemReadItems</c>).
+/// Phase 4 cuts the list-detail / list-collection queries over from the
+/// relational write tables to this repository.
+/// </summary>
+public interface IShoppingListProjectionRepository
+{
+	Task<(IReadOnlyList<ShoppingListSummary> Items, ItemCount TotalCount)> GetByOwnerAsync(
+		OwnerIdentifier owner,
+		PagingOptions paging,
+		SortingOptions<ShoppingListSortField> sorting,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Loads the projection-shaped detail for one list. Throws
+	/// <see cref="EntityNotFoundException"/> if no projection row exists.
+	/// </summary>
+	/// <param name="identifier">The list identifier.</param>
+	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+	/// <returns>The owner-tagged DTO for the list.</returns>
+	Task<ShoppingListProjectedDetail> GetByIdAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Projection-shaped result of <see cref="IShoppingListProjectionRepository.GetByIdAsync"/>.
+/// Carries the owner separately so the query handler can apply access control
+/// without rebuilding the aggregate.
+/// </summary>
+public sealed record ShoppingListProjectedDetail(string OwnerId, ShoppingListDetailDto Dto);

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
 public sealed class GetShoppingListByIdQueryHandler(
 	IShoppingListRepository shoppingLists,
+	IShoppingListProjectionRepository projection,
+	ShoppingOptions options,
 	ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListByIdQuery, Result<ShoppingListDetailDto>>
 {
@@ -16,12 +19,16 @@ public sealed class GetShoppingListByIdQueryHandler(
 	{
 		var identifier = query.Identifier;
 
+		if (options.UseProjectionReadModel)
+		{
+			var detail = await projection.GetByIdAsync(identifier, cancellationToken);
+			if (detail.OwnerId != currentUser.UserId) return GetShoppingListByIdErrors.AccessDenied;
+			return detail.Dto;
+		}
+
 		var shoppingList = await shoppingLists.GetByIdAsync(identifier, cancellationToken);
-
 		var owner = currentUser.AsOwner();
-
 		if (shoppingList.Owner != owner) return GetShoppingListByIdErrors.AccessDenied;
-
 		return shoppingList.ToDetailDto();
 	}
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
 public sealed class GetShoppingListsQueryHandler(
 	IShoppingListRepository shoppingLists,
+	IShoppingListProjectionRepository projection,
+	ShoppingOptions options,
 	ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListsQuery, Result<PagedResult<ShoppingListSummaryDto>>>
 {
@@ -17,7 +20,9 @@ public sealed class GetShoppingListsQueryHandler(
 		var (paging, sorting) = query;
 		var owner = currentUser.AsOwner();
 
-		var (items, totalCount) = await shoppingLists.GetByOwnerAsync(owner, paging, sorting, cancellationToken);
+		var (items, totalCount) = options.UseProjectionReadModel
+			? await projection.GetByOwnerAsync(owner, paging, sorting, cancellationToken)
+			: await shoppingLists.GetByOwnerAsync(owner, paging, sorting, cancellationToken);
 
 		var shoppingListSummaryDtos = items.Select(l => l.ToSummaryDto()).ToList();
 

--- a/src/Yumney.Shopping.Application/ShoppingOptions.cs
+++ b/src/Yumney.Shopping.Application/ShoppingOptions.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application;
+
+/// <summary>
+/// Runtime toggles for the Shopping module. Bound from configuration section
+/// <c>Shopping</c>.
+/// </summary>
+public sealed class ShoppingOptions
+{
+	public const string SectionName = "Shopping";
+
+	/// <summary>
+	/// Gets or sets a value indicating whether <c>GetShoppingLists</c> and
+	/// <c>GetShoppingListById</c> read from the projection tables populated by
+	/// the event stream. When <c>false</c>, queries fall back to the relational
+	/// write tables — the legacy path. Used as an emergency rollback during the
+	/// Phase 4 cutover. Defaults to <c>true</c>.
+	/// </summary>
+	public bool UseProjectionReadModel { get; set; } = true;
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext context)
+	: IShoppingListProjectionRepository
+{
+	public async Task<(IReadOnlyList<ShoppingListSummary> Items, ItemCount TotalCount)> GetByOwnerAsync(
+		OwnerIdentifier owner,
+		PagingOptions paging,
+		SortingOptions<ShoppingListSortField> sorting,
+		CancellationToken cancellationToken = default)
+	{
+		var query = context.ShoppingListSummaryReadItems.Where(s => s.OwnerId == owner.Value);
+
+		query = ApplySorting(query, sorting);
+
+		var totalCount = await query.CountAsync(cancellationToken);
+		var items = await query
+			.Skip(paging.Skip)
+			.Take(paging.PageSize.Value)
+			.Select(s => new ShoppingListSummary(
+				ShoppingListIdentifier.From(s.Id),
+				ShoppingListTitle.From(s.Title),
+				ItemCount.From(s.ItemCount),
+				s.CreatedAt))
+			.ToListAsync(cancellationToken);
+
+		return (items, ItemCount.From(totalCount));
+	}
+
+	public async Task<ShoppingListProjectedDetail> GetByIdAsync(
+		ShoppingListIdentifier identifier,
+		CancellationToken cancellationToken = default)
+	{
+		var summary = await context.ShoppingListSummaryReadItems
+			.FirstOrDefaultAsync(s => s.Id == identifier.Value, cancellationToken)
+			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
+
+		var items = await context.ShoppingListItemReadItems
+			.Where(i => i.ListId == identifier.Value)
+			.OrderBy(i => i.CreatedAt)
+			.Select(i => new ShoppingListItemDto(i.Id, i.Name, i.QuantityAmount, i.QuantityUnit, i.IsChecked))
+			.ToListAsync(cancellationToken);
+
+		var dto = new ShoppingListDetailDto(
+			summary.Id,
+			summary.Title,
+			summary.RecipeIdentifier,
+			summary.CreatedAt,
+			items);
+
+		return new ShoppingListProjectedDetail(summary.OwnerId, dto);
+	}
+
+	private static IQueryable<ShoppingListSummaryReadItem> ApplySorting(
+		IQueryable<ShoppingListSummaryReadItem> query,
+		SortingOptions<ShoppingListSortField> sorting)
+	{
+		return (sorting.SortBy, sorting.Direction) switch
+		{
+			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(s => s.Title),
+			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(s => s.Title),
+			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(s => s.CreatedAt),
+			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(s => s.CreatedAt),
+			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
+		};
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application;
 using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
@@ -21,6 +22,15 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 {
 	public static IServiceCollection AddShoppingInfrastructure(this IServiceCollection services, IConfiguration configuration)
 	{
+		services.AddSingleton(_ =>
+		{
+			var section = configuration.GetSection(ShoppingOptions.SectionName);
+			return new ShoppingOptions
+			{
+				UseProjectionReadModel = bool.TryParse(section["UseProjectionReadModel"], out var v) ? v : true,
+			};
+		});
+
 		var connectionString = configuration.GetConnectionString("shoppingdb");
 		Action<NpgsqlDbContextOptionsBuilder> contextOptions = builder => builder
 			.MigrationsHistoryTable("__ShoppingMigrationsHistory")
@@ -44,6 +54,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();
 		services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
+		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
 		services.AddScoped<ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListReadParityTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListReadParityTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+/// <summary>
+/// Phase 4 acceptance: the projection path returns equivalent data to the
+/// legacy relational path for the same input. Both paths are populated by a
+/// single UoW.SaveChanges (dual-write from Phase 2 + projection from Phase 3).
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class ShoppingListReadParityTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly PagingOptions DefaultPaging = PagingOptions.Of(Page.From(1), PageSize.From(20));
+	private static readonly SortingOptions<ShoppingListSortField> ByDateDesc = new(ShoppingListSortField.Date, SortDirection.Descending);
+
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"parity-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await fixture.ResetShoppingListEventStoreAsync(owner);
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var lists = await ctx.ShoppingLists.Where(l => l.Owner == owner).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		ctx.RemoveRange(lists);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task GetById_LegacyAndProjection_ReturnEquivalentData()
+	{
+		var listId = await SeedListAsync("Weekly Groceries", "Flour", "Sugar");
+
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+
+		var legacyResult = await legacy.GetByIdAsync(listId);
+		var projectionResult = await projection.GetByIdAsync(listId);
+
+		projectionResult.OwnerId.Should().Be(legacyResult.Owner.Value);
+		projectionResult.Dto.Identifier.Should().Be(legacyResult.Identifier.Value);
+		projectionResult.Dto.Title.Should().Be(legacyResult.Title.Value);
+		projectionResult.Dto.RecipeReference.Should().Be(legacyResult.RecipeReference?.Value);
+		projectionResult.Dto.Items.Select(i => i.Name).Should().BeEquivalentTo(legacyResult.Items.Select(i => i.Name.Value));
+		projectionResult.Dto.Items.Select(i => i.IsChecked).Should().BeEquivalentTo(legacyResult.Items.Select(i => i.IsChecked));
+	}
+
+	[Fact]
+	public async Task GetByOwner_LegacyAndProjection_ReturnEquivalentSummaries()
+	{
+		await SeedListAsync("List A", "Flour");
+		await SeedListAsync("List B", "Salt", "Pepper");
+
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+
+		var (legacyItems, legacyTotal) = await legacy.GetByOwnerAsync(owner, DefaultPaging, ByDateDesc);
+		var (projectionItems, projectionTotal) = await projection.GetByOwnerAsync(owner, DefaultPaging, ByDateDesc);
+
+		projectionTotal.Value.Should().Be(legacyTotal.Value);
+		projectionItems.Select(s => s.Title.Value).Should().BeEquivalentTo(legacyItems.Select(s => s.Title.Value));
+		projectionItems.Select(s => s.ItemCount.Value).Should().BeEquivalentTo(legacyItems.Select(s => s.ItemCount.Value));
+	}
+
+	[Fact]
+	public async Task GetById_AfterCheckOff_ProjectionReflectsCheckedState()
+	{
+		var listId = await SeedListAsync("Groceries", "Bread");
+		await CheckOffFirstItemAsync(listId);
+
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var projection = new EfCoreShoppingListProjectionRepository(readCtx);
+		var detail = await projection.GetByIdAsync(listId);
+
+		detail.Dto.Items.Should().ContainSingle().Which.IsChecked.Should().BeTrue();
+	}
+
+	private async Task<ShoppingListIdentifier> SeedListAsync(string title, params string[] itemNames)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = await CreateProjectingBusAsync();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var items = itemNames
+			.Select(n => ShoppingListItem.Create(ItemName.From(n), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.ToList();
+		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
+		await legacy.AddAsync(list);
+		await uow.SaveChangesAsync();
+
+		return list.Identifier;
+	}
+
+	private async Task CheckOffFirstItemAsync(ShoppingListIdentifier listId)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = await CreateProjectingBusAsync();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var list = await legacy.GetByIdForUpdateAsync(listId);
+		list.CheckOffItem(list.Items[0].Id);
+		await uow.SaveChangesAsync();
+	}
+
+	/// <summary>
+	/// Wires a tiny in-place IEventBus that hands integration events directly to a
+	/// fresh ShoppingListProjection backed by its own DbContext — keeps these tests
+	/// self-contained without spinning up the full DI graph.
+	/// </summary>
+	private async Task<IEventBus> CreateProjectingBusAsync()
+	{
+		var bus = Substitute.For<IEventBus>();
+		bus.PublishAsync(Arg.Any<IIntegrationEvent>(), Arg.Any<CancellationToken>())
+			.Returns(async ci =>
+			{
+				var integrationEvent = ci.Arg<IIntegrationEvent>();
+				var ct = ci.Arg<CancellationToken>();
+				await using var ctx = await fixture.CreateShoppingDbContextAsync();
+				var projection = new ShoppingListProjection(ctx);
+				switch (integrationEvent)
+				{
+					case ShoppingListCreatedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemAddedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemCheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case ListItemUncheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case AllItemsCheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case AllItemsUncheckedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+					case RecipeReferenceClearedIntegrationEvent e: await projection.HandleAsync(e, ct); break;
+				}
+			});
+		await Task.CompletedTask;
+		return bus;
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListByIdQueryHandlerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -11,13 +13,15 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
 public class GetShoppingListByIdQueryHandlerTests
 {
 	private readonly IShoppingListRepository shoppingLists = Substitute.For<IShoppingListRepository>();
+	private readonly IShoppingListProjectionRepository projection = Substitute.For<IShoppingListProjectionRepository>();
+	private readonly ShoppingOptions options = new() { UseProjectionReadModel = false };
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
 	private readonly GetShoppingListByIdQueryHandler handler;
 
 	public GetShoppingListByIdQueryHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
-		handler = new GetShoppingListByIdQueryHandler(shoppingLists, currentUser);
+		handler = new GetShoppingListByIdQueryHandler(shoppingLists, projection, options, currentUser);
 	}
 
 	[Fact]
@@ -60,6 +64,42 @@ public class GetShoppingListByIdQueryHandlerTests
 		var query = new GetShoppingListByIdQuery(shoppingList.Identifier);
 
 		var result = await handler.HandleAsync(query);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(GetShoppingListByIdErrors.AccessDenied);
+	}
+
+	[Fact]
+	public async Task HandleAsync_WhenProjectionFlagIsOn_QueriesProjectionRepository()
+	{
+		options.UseProjectionReadModel = true;
+		var listId = ShoppingListIdentifier.New();
+		var dto = new ShoppingListDetailDto(
+			listId.Value,
+			"Projected",
+			RecipeReference: null,
+			DateTime.UtcNow,
+			Items: []);
+		projection.GetByIdAsync(listId, Arg.Any<CancellationToken>())
+			.Returns(new ShoppingListProjectedDetail("user-123", dto));
+
+		var result = await handler.HandleAsync(new GetShoppingListByIdQuery(listId));
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Title.Should().Be("Projected");
+		await shoppingLists.DidNotReceiveWithAnyArgs().GetByIdAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProjectionDifferentOwner_ReturnsAccessDenied()
+	{
+		options.UseProjectionReadModel = true;
+		var listId = ShoppingListIdentifier.New();
+		var dto = new ShoppingListDetailDto(listId.Value, "T", null, DateTime.UtcNow, []);
+		projection.GetByIdAsync(listId, Arg.Any<CancellationToken>())
+			.Returns(new ShoppingListProjectedDetail("other-user", dto));
+
+		var result = await handler.HandleAsync(new GetShoppingListByIdQuery(listId));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(GetShoppingListByIdErrors.AccessDenied);

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetShoppingListsQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -11,13 +12,15 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
 public class GetShoppingListsQueryHandlerTests
 {
 	private readonly IShoppingListRepository shoppingLists = Substitute.For<IShoppingListRepository>();
+	private readonly IShoppingListProjectionRepository projection = Substitute.For<IShoppingListProjectionRepository>();
+	private readonly ShoppingOptions options = new() { UseProjectionReadModel = false };
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
 	private readonly GetShoppingListsQueryHandler handler;
 
 	public GetShoppingListsQueryHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
-		handler = new GetShoppingListsQueryHandler(shoppingLists, currentUser);
+		handler = new GetShoppingListsQueryHandler(shoppingLists, projection, options, currentUser);
 	}
 
 	[Fact]
@@ -98,6 +101,29 @@ public class GetShoppingListsQueryHandlerTests
 			Arg.Is<SortingOptions<ShoppingListSortField>>(s =>
 				s.SortBy == ShoppingListSortField.Title && s.Direction == SortDirection.Ascending),
 			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_WhenProjectionFlagIsOn_QueriesProjectionRepository()
+	{
+		options.UseProjectionReadModel = true;
+		List<ShoppingListSummary> summaries =
+		[
+			new(ShoppingListIdentifier.New(), ShoppingListTitle.From("Projected"), ItemCount.From(3), DateTime.UtcNow)
+		];
+		projection.GetByOwnerAsync(
+			Arg.Any<OwnerIdentifier>(),
+			Arg.Any<PagingOptions>(),
+			Arg.Any<SortingOptions<ShoppingListSortField>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(((IReadOnlyList<ShoppingListSummary>)summaries, ItemCount.From(1)));
+
+		var query = CreateQuery(1, 20, ShoppingListSortField.Date, SortDirection.Descending);
+		var result = await handler.HandleAsync(query);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Items.Should().ContainSingle().Which.Title.Should().Be("Projected");
+		await shoppingLists.DidNotReceiveWithAnyArgs().GetByOwnerAsync(default!, default!, default!);
 	}
 
 	[Fact]


### PR DESCRIPTION
Phase 4 of the Shopping ES migration. Closes #479. Recreated from #487 after parent base branch was deleted.

- New `IShoppingListProjectionRepository` querying the projection tables.
- `GetShoppingListsQueryHandler` and `GetShoppingListByIdQueryHandler` branch on `ShoppingOptions.UseProjectionReadModel` (default `true`); legacy fallback retained.
- `ShoppingOptions` flag bound from `Shopping:UseProjectionReadModel`.
- Projection-vs-legacy parity tests + handler unit tests for both branches.

Stack continues: #495 (final cleanup) drops the flag entirely once the projection has proven stable in production.