### PR TITLE
feat(shopping): publish ShoppingList integration events for cross-module consumers (#480)

### DIFF
--- a/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
+++ b/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
@@ -10,11 +10,21 @@ public sealed partial class InProcessEventBus(IServiceProvider serviceProvider, 
 	public async Task PublishAsync<TEvent>(TEvent integrationEvent, CancellationToken cancellationToken = default)
 		where TEvent : IIntegrationEvent
 	{
-		var handlers = serviceProvider.GetServices<IIntegrationEventHandler<TEvent>>();
-		var eventName = typeof(TEvent).Name;
+		// Resolve handlers by the runtime concrete type, not the compile-time
+		// generic argument. Without this, callers that publish via an
+		// `IIntegrationEvent` static type (e.g. from a `... switch { ... }`
+		// mapping that returns the marker interface) would inadvertently bind
+		// TEvent to the interface and miss every concrete-type subscriber.
+		var eventType = integrationEvent.GetType();
+		var handlerInterface = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
+		var handleMethod = handlerInterface.GetMethod(nameof(IIntegrationEventHandler<TEvent>.HandleAsync))!;
+		var handlers = serviceProvider.GetServices(handlerInterface);
+		var eventName = eventType.Name;
 
 		foreach (var handler in handlers)
 		{
+			if (handler is null) continue;
+
 			var handlerName = handler.GetType().Name;
 			using var activity = EventsDiagnostics.ActivitySource.StartActivity($"integration_event.{eventName}.{handlerName}");
 			activity?.SetTag("event.name", eventName);
@@ -25,15 +35,28 @@ public sealed partial class InProcessEventBus(IServiceProvider serviceProvider, 
 
 			try
 			{
-				await handler.HandleAsync(integrationEvent, cancellationToken);
+				await (Task)handleMethod.Invoke(handler, [integrationEvent, cancellationToken])!;
 				var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
 				activity?.SetTag("event.result", "success");
 				activity?.SetStatus(ActivityStatusCode.Ok);
 				LogHandlerCompleted(eventName, handlerName, elapsed);
 			}
+			catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is OperationCanceledException && cancellationToken.IsCancellationRequested)
+			{
+				throw tie.InnerException;
+			}
 			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 			{
 				throw;
+			}
+			catch (System.Reflection.TargetInvocationException tie)
+			{
+				var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+				activity?.SetTag("event.result", "error");
+				activity?.SetStatus(ActivityStatusCode.Error, tie.InnerException?.Message ?? tie.Message);
+
+				// Isolate handlers — one failing subscriber must not block the others.
+				LogHandlerFailed(tie.InnerException ?? tie, eventName, handlerName, elapsed);
 			}
 			catch (Exception ex)
 			{

--- a/src/Yumney.Shared.Events/CrossModule/ShoppingListCreatedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/ShoppingListCreatedCrossModuleIntegrationEvent.cs
@@ -1,0 +1,13 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Shopping module when a new <c>ShoppingList</c> aggregate
+/// is created. Carries primitive types only so cross-module subscribers
+/// (Recipes, MealPlan) can react without taking a Shopping.Domain dependency.
+/// </summary>
+public sealed record ShoppingListCreatedCrossModuleIntegrationEvent(
+	string OwnerId,
+	Guid ListIdentifier,
+	string Title,
+	Guid? RecipeIdentifier,
+	DateTime CreatedAt) : IntegrationEvent;

--- a/src/Yumney.Shared.Events/CrossModule/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Shopping module when a list's recipe-reference link is
+/// cleared (for instance, in response to <see cref="RecipeDeletedIntegrationEvent"/>).
+/// Lets cross-module subscribers reconcile any state that depended on the
+/// recipe→list pairing.
+/// </summary>
+public sealed record ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent(
+	string OwnerId,
+	Guid ListIdentifier) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
@@ -61,6 +62,12 @@ public sealed class ShoppingUnitOfWork(
 				{
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
 				}
+
+				var crossModuleEvent = MapToCrossModuleEvent(list, domainEvent);
+				if (crossModuleEvent is not null)
+				{
+					await eventBus.PublishAsync(crossModuleEvent, cancellationToken);
+				}
 			}
 		}
 
@@ -81,6 +88,26 @@ public sealed class ShoppingUnitOfWork(
 			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
 			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
 			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+			_ => null,
+		};
+	}
+
+	private static IIntegrationEvent? MapToCrossModuleEvent(ShoppingList list, IDomainEvent domainEvent)
+	{
+		var ownerId = list.Owner.Value;
+		var aggregateId = list.Identifier.Value;
+
+		return domainEvent switch
+		{
+			ShoppingListCreated created => new ShoppingListCreatedCrossModuleIntegrationEvent(
+				ownerId,
+				aggregateId,
+				created.Title.Value,
+				created.RecipeReference?.Value,
+				created.CreatedAt),
+			RecipeReferenceCleared => new ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent(
+				ownerId,
+				aggregateId),
 			_ => null,
 		};
 	}

--- a/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Persistence/ShoppingUnitOfWorkTests.cs
@@ -5,7 +5,9 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using Xunit;
@@ -57,5 +59,72 @@ public class ShoppingUnitOfWorkTests(AspireFixture fixture) : IAsyncLifetime
 			.Where(e => e.AggregateId == list.Identifier.Value)
 			.CountAsync();
 		stored.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task SaveChangesAsync_NewList_PublishesCrossModuleCreatedEvent()
+	{
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+
+		var listEventStore = new EfCoreShoppingListEventStore(
+			writeContext,
+			NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+		var bus = Substitute.For<IEventBus>();
+
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, bus);
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly Groceries"),
+			owner,
+			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
+		await repo.AddAsync(list);
+
+		await uow.SaveChangesAsync();
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingListCreatedCrossModuleIntegrationEvent>(e =>
+				e.OwnerId == owner.Value
+				&& e.ListIdentifier == list.Identifier.Value
+				&& e.Title == "Weekly Groceries"
+				&& e.RecipeIdentifier == null),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SaveChangesAsync_ClearRecipeReference_PublishesCrossModuleClearedEvent()
+	{
+		ShoppingList list;
+		await using (var seedContext = await fixture.CreateShoppingDbContextAsync())
+		await using (var seedRead = await fixture.CreateShoppingReadDbContextAsync())
+		{
+			var seedStore = new EfCoreShoppingListEventStore(seedContext, NullLogger<EfCoreShoppingListEventStore>.Instance);
+			var seedRepo = new ShoppingListRepository(seedContext, seedRead);
+			var seedUow = new ShoppingUnitOfWork(seedContext, seedRepo, seedStore, Substitute.For<IEventBus>());
+			list = ShoppingList.Create(
+				ShoppingListTitle.From("Cake"),
+				owner,
+				[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
+				RecipeReference.New());
+			await seedRepo.AddAsync(list);
+			await seedUow.SaveChangesAsync();
+		}
+
+		await using var writeContext = await fixture.CreateShoppingDbContextAsync();
+		await using var readContext = await fixture.CreateShoppingReadDbContextAsync();
+		var listEventStore = new EfCoreShoppingListEventStore(writeContext, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var repo = new ShoppingListRepository(writeContext, readContext);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeContext, repo, listEventStore, bus);
+
+		var loaded = await repo.GetByIdForUpdateAsync(list.Identifier);
+		loaded.ClearRecipeReference();
+		await uow.SaveChangesAsync();
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent>(e =>
+				e.OwnerId == owner.Value
+				&& e.ListIdentifier == list.Identifier.Value),
+			Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Yumney.Shared.Events.Tests/InProcessEventBusTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/InProcessEventBusTests.cs
@@ -48,6 +48,24 @@ public class InProcessEventBusTests
 	}
 
 	[Fact]
+	public async Task PublishAsync_ViaInterfaceStaticType_StillReachesConcreteHandler()
+	{
+		// Regression: callers commonly map domain events to integration events with a
+		// `IIntegrationEvent? = switch { ... }` expression — the variable's static type
+		// is the marker interface, so naive generic-parameter dispatch would bind
+		// TEvent to IIntegrationEvent and miss every concrete-type subscriber. The bus
+		// must resolve handlers by the event's runtime type to avoid silently dropping
+		// every integration event published this way.
+		var handler = new TestIntegrationEventHandler();
+		var eventBus = CreateEventBus(services => services.AddSingleton<IIntegrationEventHandler<TestIntegrationEvent>>(handler));
+		IIntegrationEvent integrationEvent = new TestIntegrationEvent();
+
+		await eventBus.PublishAsync(integrationEvent);
+
+		handler.HandledEvents.Should().ContainSingle().Which.Should().Be(integrationEvent);
+	}
+
+	[Fact]
 	public async Task PublishAsync_WithNoHandler_CompletesWithoutError()
 	{
 		// Arrange


### PR DESCRIPTION
Phase 5 of the Shopping ES migration. Closes #480. Recreated from #488.

- 2 new cross-module integration events in `Yumney.Shared.Events.CrossModule`: `ShoppingListCreatedCrossModuleIntegrationEvent`, `ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent`.
- `ShoppingUnitOfWork.SaveChangesAsync` publishes both in-module and cross-module variants.
- **Critical bus dispatch fix**: `InProcessEventBus.PublishAsync` now resolves handlers by runtime type, not the compile-time `TEvent` parameter. Without this, callers using `IIntegrationEvent? = switch { ... }` mappings (Shopping AND MealPlan event stores) silently dropped every published event. Includes a regression test.