### PR TITLE
feat(infra): dashboard reset entry for ShoppingList projections (#481)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -82,6 +82,18 @@ if (!options.DatabaseOnly)
 			.WaitFor(mealplanDb)
 			.WithEnvironment("Persistence__ResetMealPlanOnly", "true")
 			.WithExplicitStart();
+
+		// Dashboard-only entry (run mode): truncates the ShoppingList projection
+		// tables and replays the event store into them. Events, metadata, and the
+		// legacy ShoppingLists table are untouched. Idempotent.
+		builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-shopping-projection-reset")
+			.WithReference(recipesDb)
+			.WithReference(shoppingDb)
+			.WithReference(usersDb)
+			.WithReference(mealplanDb)
+			.WaitFor(shoppingDb)
+			.WithEnvironment("Persistence__RebuildShoppingProjections", "true")
+			.WithExplicitStart();
 	}
 
 	// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)

--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
@@ -12,10 +13,14 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 /// Background worker that applies EF Core migrations for all modules on startup.
 /// Uses PostgreSQL advisory locks to prevent concurrent migration from multiple instances.
 ///
-/// When started with <c>Persistence:ResetMealPlanOnly=true</c> the worker only
-/// touches the MealPlan database, dropping and re-migrating it. This is the mode
-/// used by the dashboard "yumney-mealplan-reset" entry — convenient for wiping
-/// the event-sourced MealPlan store during local development.
+/// Dashboard-driven modes (set via configuration before start):
+/// <list type="bullet">
+///   <item><c>Persistence:ResetMealPlanOnly=true</c> — drops and re-migrates the
+///   MealPlan database only. Wipes the event-sourced MealPlan store.</item>
+///   <item><c>Persistence:RebuildShoppingProjections=true</c> — truncates the
+///   ShoppingList projection tables and replays the event store into them.
+///   Other Shopping data (events, metadata, legacy lists) is untouched.</item>
+/// </list>
 /// </summary>
 public sealed partial class MigrationWorker(
 	IServiceProvider serviceProvider,
@@ -27,7 +32,11 @@ public sealed partial class MigrationWorker(
 	{
 		try
 		{
-			if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
+			if (configuration.GetValue<bool>("Persistence:RebuildShoppingProjections"))
+			{
+				await RebuildShoppingProjectionsAsync(stoppingToken);
+			}
+			else if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
 			{
 				await ApplyMigrationsAsync<MealPlanDbContext>("MealPlan", stoppingToken, reset: true);
 			}
@@ -74,10 +83,21 @@ public sealed partial class MigrationWorker(
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{Module}: dropping database before migrating")]
 	private static partial void LogResettingDatabase(ILogger logger, string module);
 
+	[LoggerMessage(Level = LogLevel.Information, Message = "Shopping: rebuilt {Count} projection events")]
+	private static partial void LogShoppingProjectionsRebuilt(ILogger logger, int count);
+
 	private static int GenerateLockId(string moduleName)
 	{
 		var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"yumney-migration-{moduleName}"));
 		return BitConverter.ToInt32(hash, 0);
+	}
+
+	private async Task RebuildShoppingProjectionsAsync(CancellationToken cancellationToken)
+	{
+		await using var scope = serviceProvider.CreateAsyncScope();
+		var rebuilder = scope.ServiceProvider.GetRequiredService<IShoppingListProjectionRebuilder>();
+		var replayed = await rebuilder.RebuildAsync(cancellationToken);
+		LogShoppingProjectionsRebuilt(logger, replayed);
 	}
 
 	private async Task ApplyMigrationsAsync<TContext>(string moduleName, CancellationToken cancellationToken, bool reset = false)

--- a/src/Yumney.MigrationRunner/Program.cs
+++ b/src/Yumney.MigrationRunner/Program.cs
@@ -3,7 +3,9 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.MigrationRunner;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -29,6 +31,12 @@ builder.Services.AddDbContext<MealPlanDbContext>(options =>
 	options.UseNpgsql(
 		builder.Configuration.GetConnectionString("mealplandb"),
 		x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory")));
+
+// Minimal service registrations for the optional Shopping projection-rebuild path.
+// The dashboard reset entry sets Persistence:RebuildShoppingProjections=true to drive
+// MigrationWorker through this code path; the regular migration run never resolves them.
+builder.Services.AddScoped<ShoppingListProjection>();
+builder.Services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 
 builder.Services.AddHostedService<MigrationWorker>();
 

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRebuilder.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRebuilder.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Operational tool that truncates the ShoppingList projection tables and
+/// re-applies every event from the event store. Used by the dashboard reset
+/// entry to recover from projection drift, schema migrations, or projection
+/// handler bugs without losing the source-of-truth event stream.
+/// </summary>
+public interface IShoppingListProjectionRebuilder
+{
+	/// <summary>
+	/// Truncates the projection tables and replays the entire event history.
+	/// Idempotent — running twice yields the same final state because the
+	/// projection upserts.
+	/// </summary>
+	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+	/// <returns>The number of events replayed.</returns>
+	Task<int> RebuildAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -1,12 +1,7 @@
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
-using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
-using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
@@ -15,35 +10,6 @@ public sealed partial class EfCoreShoppingListEventStore(
 	ShoppingDbContext context,
 	ILogger<EfCoreShoppingListEventStore> logger) : IShoppingListEventStore
 {
-#pragma warning disable SA1311, SA1303, SA1204
-	private static readonly JsonSerializerOptions jsonOptions = new()
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-		Converters =
-		{
-			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
-			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
-			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
-			new ShoppingListIdentifierJsonConverter(),
-			new ShoppingListItemIdentifierJsonConverter(),
-			new RecipeReferenceJsonConverter(),
-			new AmountJsonConverter(),
-			new UnitJsonConverter(),
-		},
-	};
-
-	private static readonly Dictionary<string, Type> eventTypeMap = new()
-	{
-		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
-		[nameof(ListItemAdded)] = typeof(ListItemAdded),
-		[nameof(ListItemChecked)] = typeof(ListItemChecked),
-		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
-		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
-		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
-		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
-	};
-#pragma warning restore SA1311
-
 	public async Task<ShoppingList?> LoadAsync(
 		ShoppingListIdentifier identifier,
 		CancellationToken cancellationToken = default)
@@ -64,7 +30,10 @@ public sealed partial class EfCoreShoppingListEventStore(
 
 		if (storedEvents.Count == 0) return null;
 
-		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+		var events = storedEvents
+			.Select(s => ShoppingListEventSerializer.Deserialize(s.EventType, s.EventData))
+			.Where(e => e is not null)
+			.Cast<IDomainEvent>();
 
 		return ShoppingList.FromEvents(identifier, events);
 	}
@@ -98,20 +67,13 @@ public sealed partial class EfCoreShoppingListEventStore(
 				Id = Guid.CreateVersion7(),
 				AggregateId = aggregateId,
 				EventType = @event.GetType().Name,
-				EventData = JsonSerializer.Serialize(@event, @event.GetType(), jsonOptions),
+				EventData = ShoppingListEventSerializer.Serialize(@event),
 				Version = baseVersion + index + 1,
 				OccurredAt = @event.OccurredOn,
 			});
 		}
 
 		LogEventsStaged(aggregateId, uncommitted.Count, list.Version);
-	}
-
-	private static IDomainEvent? DeserializeEvent(ShoppingListStoredEvent stored)
-	{
-		if (!eventTypeMap.TryGetValue(stored.EventType, out var type)) return null;
-
-		return JsonSerializer.Deserialize(stored.EventData, type, jsonOptions) as IDomainEvent;
 	}
 
 	[LoggerMessage(Level = LogLevel.Debug, Message = "Staged {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventSerializer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventSerializer.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Converters;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Centralised JSON options + type map for ShoppingList event payloads. Shared
+/// between the event store (write/read) and the projection rebuilder so both
+/// agree on serialisation contract.
+/// </summary>
+internal static class ShoppingListEventSerializer
+{
+#pragma warning disable SA1311
+	public static JsonSerializerOptions Options { get; } = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters =
+		{
+			new StringValueObjectJsonConverter<OwnerIdentifier>(OwnerIdentifier.From),
+			new StringValueObjectJsonConverter<ShoppingListTitle>(ShoppingListTitle.From),
+			new StringValueObjectJsonConverter<ItemName>(ItemName.From),
+			new ShoppingListIdentifierJsonConverter(),
+			new ShoppingListItemIdentifierJsonConverter(),
+			new RecipeReferenceJsonConverter(),
+			new AmountJsonConverter(),
+			new UnitJsonConverter(),
+		},
+	};
+
+	private static readonly Dictionary<string, Type> eventTypeMap = new()
+	{
+		[nameof(ShoppingListCreated)] = typeof(ShoppingListCreated),
+		[nameof(ListItemAdded)] = typeof(ListItemAdded),
+		[nameof(ListItemChecked)] = typeof(ListItemChecked),
+		[nameof(ListItemUnchecked)] = typeof(ListItemUnchecked),
+		[nameof(AllItemsChecked)] = typeof(AllItemsChecked),
+		[nameof(AllItemsUnchecked)] = typeof(AllItemsUnchecked),
+		[nameof(RecipeReferenceCleared)] = typeof(RecipeReferenceCleared),
+	};
+
+#pragma warning restore SA1311
+
+	public static string Serialize(IDomainEvent @event) =>
+		JsonSerializer.Serialize(@event, @event.GetType(), Options);
+
+	public static IDomainEvent? Deserialize(string eventType, string eventData)
+	{
+		if (!eventTypeMap.TryGetValue(eventType, out var type)) return null;
+		return JsonSerializer.Deserialize(eventData, type, Options) as IDomainEvent;
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEventMapper.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListIntegrationEventMapper.cs
@@ -1,0 +1,26 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+/// <summary>
+/// Maps a ShoppingList domain event to its in-module integration-event wrapper.
+/// Shared by <see cref="EventStore.EfCoreShoppingListEventStore"/> /
+/// <see cref="ShoppingUnitOfWork"/> at publish time and by the projection
+/// rebuilder during replay.
+/// </summary>
+internal static class ShoppingListIntegrationEventMapper
+{
+	public static IIntegrationEvent? Map(string ownerId, Guid aggregateId, IDomainEvent domainEvent) => domainEvent switch
+	{
+		ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
+		ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
+		ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
+		ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
+		AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
+		AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
+		RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
+		_ => null,
+	};
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+#pragma warning disable SA1601
+public sealed partial class ShoppingListProjectionRebuilder(
+	ShoppingDbContext context,
+	ShoppingListProjection projection,
+	ILogger<ShoppingListProjectionRebuilder> logger) : IShoppingListProjectionRebuilder
+{
+	public async Task<int> RebuildAsync(CancellationToken cancellationToken = default)
+	{
+		LogStarting();
+
+		// Truncate projection tables in dependency-safe order. Items first since
+		// the summary row is the conceptual parent (no FK today, but kept for clarity).
+		await context.Database.ExecuteSqlRawAsync(
+			@"TRUNCATE TABLE ""ShoppingListItemReadItems"", ""ShoppingListSummaryReadItems"" RESTART IDENTITY",
+			cancellationToken);
+
+		var ownerByAggregate = await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.ToDictionaryAsync(m => m.AggregateId, m => m.OwnerId, cancellationToken);
+
+		var storedEvents = await context.Set<ShoppingListStoredEvent>()
+			.AsNoTracking()
+			.OrderBy(e => e.AggregateId)
+			.ThenBy(e => e.Version)
+			.ToListAsync(cancellationToken);
+
+		var replayed = 0;
+		var skippedUnknownType = 0;
+		var skippedMissingOwner = 0;
+
+		foreach (var stored in storedEvents)
+		{
+			if (!ownerByAggregate.TryGetValue(stored.AggregateId, out var ownerId))
+			{
+				skippedMissingOwner++;
+				continue;
+			}
+
+			var domainEvent = ShoppingListEventSerializer.Deserialize(stored.EventType, stored.EventData);
+			if (domainEvent is null)
+			{
+				skippedUnknownType++;
+				continue;
+			}
+
+			var integrationEvent = ShoppingListIntegrationEventMapper.Map(ownerId, stored.AggregateId, domainEvent);
+			if (integrationEvent is null)
+			{
+				skippedUnknownType++;
+				continue;
+			}
+
+			switch (integrationEvent)
+			{
+				case ShoppingListCreatedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemAddedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemCheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case ListItemUncheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case AllItemsCheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case AllItemsUncheckedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				case RecipeReferenceClearedIntegrationEvent e:
+					await projection.HandleAsync(e, cancellationToken);
+					break;
+				default:
+					skippedUnknownType++;
+					continue;
+			}
+
+			replayed++;
+		}
+
+		LogFinished(replayed, skippedUnknownType, skippedMissingOwner);
+		return replayed;
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList projection rebuild starting — truncating projection tables")]
+	private partial void LogStarting();
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList projection rebuild finished. Replayed={Replayed} SkippedUnknownType={SkippedUnknownType} SkippedMissingOwner={SkippedMissingOwner}")]
+	private partial void LogFinished(int replayed, int skippedUnknownType, int skippedMissingOwner);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUnitOfWork.cs
@@ -57,7 +57,8 @@ public sealed class ShoppingUnitOfWork(
 		{
 			foreach (var domainEvent in events)
 			{
-				var integrationEvent = MapToIntegrationEvent(list, domainEvent);
+				var integrationEvent = ShoppingListIntegrationEventMapper.Map(
+					list.Owner.Value, list.Identifier.Value, domainEvent);
 				if (integrationEvent is not null)
 				{
 					await eventBus.PublishAsync(integrationEvent, cancellationToken);
@@ -72,24 +73,6 @@ public sealed class ShoppingUnitOfWork(
 		}
 
 		return result;
-	}
-
-	private static IIntegrationEvent? MapToIntegrationEvent(ShoppingList list, IDomainEvent domainEvent)
-	{
-		var ownerId = list.Owner.Value;
-		var aggregateId = list.Identifier.Value;
-
-		return domainEvent switch
-		{
-			ShoppingListCreated created => new ShoppingListCreatedIntegrationEvent(ownerId, aggregateId, created),
-			ListItemAdded added => new ListItemAddedIntegrationEvent(ownerId, aggregateId, added),
-			ListItemChecked checked_ => new ListItemCheckedIntegrationEvent(ownerId, aggregateId, checked_),
-			ListItemUnchecked unchecked_ => new ListItemUncheckedIntegrationEvent(ownerId, aggregateId, unchecked_),
-			AllItemsChecked allChecked => new AllItemsCheckedIntegrationEvent(ownerId, aggregateId, allChecked),
-			AllItemsUnchecked allUnchecked => new AllItemsUncheckedIntegrationEvent(ownerId, aggregateId, allUnchecked),
-			RecipeReferenceCleared cleared => new RecipeReferenceClearedIntegrationEvent(ownerId, aggregateId, cleared),
-			_ => null,
-		};
 	}
 
 	private static IIntegrationEvent? MapToCrossModuleEvent(ShoppingList list, IDomainEvent domainEvent)

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingListWriter, ShoppingListWriter>();
 		services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
 		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
+		services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 		services.AddScoped<ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"rebuild-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await fixture.ResetShoppingListEventStoreAsync(owner);
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var lists = await ctx.ShoppingLists.Where(l => l.Owner == owner).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		ctx.RemoveRange(lists);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task RebuildAsync_WithSeededEvents_RestoresProjectionTables()
+	{
+		var listId = await SeedListAsync("Weekly Groceries", "Flour", "Sugar");
+		await CheckOffFirstItemAsync(listId);
+		await TruncateProjectionsForOwnerAsync();
+
+		var replayed = await RunRebuildAsync();
+
+		replayed.Should().BeGreaterThan(0);
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+		summary.Title.Should().Be("Weekly Groceries");
+		summary.ItemCount.Should().Be(2);
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).ToListAsync();
+		items.Should().HaveCount(2);
+		items.Count(i => i.IsChecked).Should().Be(1);
+	}
+
+	[Fact]
+	public async Task RebuildAsync_RunTwice_YieldsSameProjectionState()
+	{
+		var listId = await SeedListAsync("Pantry", "Salt", "Pepper", "Oil");
+		await TruncateProjectionsForOwnerAsync();
+
+		await RunRebuildAsync();
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var firstSummary = await ctx.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+			firstSummary.ItemCount.Should().Be(3);
+		}
+
+		await RunRebuildAsync();
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).CountAsync();
+		summary.ItemCount.Should().Be(3);
+		items.Should().Be(3);
+	}
+
+	private async Task<int> RunRebuildAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var projection = new ShoppingListProjection(ctx);
+		var rebuilder = new ShoppingListProjectionRebuilder(
+			ctx,
+			projection,
+			NullLogger<ShoppingListProjectionRebuilder>.Instance);
+		return await rebuilder.RebuildAsync();
+	}
+
+	private async Task TruncateProjectionsForOwnerAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		await ctx.SaveChangesAsync();
+	}
+
+	private async Task<ShoppingListIdentifier> SeedListAsync(string title, params string[] itemNames)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var items = itemNames
+			.Select(n => ShoppingListItem.Create(ItemName.From(n), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.ToList();
+		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
+		await legacy.AddAsync(list);
+		await uow.SaveChangesAsync();
+		return list.Identifier;
+	}
+
+	private async Task CheckOffFirstItemAsync(ShoppingListIdentifier listId)
+	{
+		await using var writeCtx = await fixture.CreateShoppingDbContextAsync();
+		await using var readCtx = await fixture.CreateShoppingReadDbContextAsync();
+		var legacy = new ShoppingListRepository(writeCtx, readCtx);
+		var listEventStore = new EfCoreShoppingListEventStore(writeCtx, NullLogger<EfCoreShoppingListEventStore>.Instance);
+		var bus = Substitute.For<IEventBus>();
+		var uow = new ShoppingUnitOfWork(writeCtx, legacy, listEventStore, bus);
+
+		var list = await legacy.GetByIdForUpdateAsync(listId);
+		list.CheckOffItem(list.Items[0].Id);
+		await uow.SaveChangesAsync();
+	}
+}


### PR DESCRIPTION
Phase 6 of the Shopping ES migration. Closes #481. Recreated from #489.

- New `IShoppingListProjectionRebuilder` + concrete impl. Truncates projection tables, replays event store, idempotent.
- 2 extracted helpers: `ShoppingListEventSerializer` and `ShoppingListIntegrationEventMapper`.
- `MigrationRunner` gets `Persistence:RebuildShoppingProjections` mode + `yumney-shopping-projection-reset` dashboard entry.