### PR TITLE
feat(infra): backfill events for legacy ShoppingLists rows (#482)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -94,6 +94,18 @@ if (!options.DatabaseOnly)
 			.WaitFor(shoppingDb)
 			.WithEnvironment("Persistence__RebuildShoppingProjections", "true")
 			.WithExplicitStart();
+
+		// Dashboard-only entry (run mode): synthesises events for any legacy
+		// ShoppingLists rows that don't yet have an entry in the event store.
+		// One-off operation; idempotent for already-backfilled lists.
+		builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-shopping-event-backfill")
+			.WithReference(recipesDb)
+			.WithReference(shoppingDb)
+			.WithReference(usersDb)
+			.WithReference(mealplanDb)
+			.WaitFor(shoppingDb)
+			.WithEnvironment("Persistence__BackfillShoppingEvents", "true")
+			.WithExplicitStart();
 	}
 
 	// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)

--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -20,6 +20,9 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 ///   <item><c>Persistence:RebuildShoppingProjections=true</c> — truncates the
 ///   ShoppingList projection tables and replays the event store into them.
 ///   Other Shopping data (events, metadata, legacy lists) is untouched.</item>
+///   <item><c>Persistence:BackfillShoppingEvents=true</c> — synthesises events
+///   for legacy <c>ShoppingLists</c> rows that don't yet have an event-store
+///   entry. One-off; idempotent for already-backfilled lists.</item>
 /// </list>
 /// </summary>
 public sealed partial class MigrationWorker(
@@ -32,7 +35,11 @@ public sealed partial class MigrationWorker(
 	{
 		try
 		{
-			if (configuration.GetValue<bool>("Persistence:RebuildShoppingProjections"))
+			if (configuration.GetValue<bool>("Persistence:BackfillShoppingEvents"))
+			{
+				await BackfillShoppingEventsAsync(stoppingToken);
+			}
+			else if (configuration.GetValue<bool>("Persistence:RebuildShoppingProjections"))
 			{
 				await RebuildShoppingProjectionsAsync(stoppingToken);
 			}
@@ -86,6 +93,9 @@ public sealed partial class MigrationWorker(
 	[LoggerMessage(Level = LogLevel.Information, Message = "Shopping: rebuilt {Count} projection events")]
 	private static partial void LogShoppingProjectionsRebuilt(ILogger logger, int count);
 
+	[LoggerMessage(Level = LogLevel.Information, Message = "Shopping: backfilled events for {Count} legacy list(s)")]
+	private static partial void LogShoppingEventsBackfilled(ILogger logger, int count);
+
 	private static int GenerateLockId(string moduleName)
 	{
 		var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"yumney-migration-{moduleName}"));
@@ -98,6 +108,14 @@ public sealed partial class MigrationWorker(
 		var rebuilder = scope.ServiceProvider.GetRequiredService<IShoppingListProjectionRebuilder>();
 		var replayed = await rebuilder.RebuildAsync(cancellationToken);
 		LogShoppingProjectionsRebuilt(logger, replayed);
+	}
+
+	private async Task BackfillShoppingEventsAsync(CancellationToken cancellationToken)
+	{
+		await using var scope = serviceProvider.CreateAsyncScope();
+		var backfill = scope.ServiceProvider.GetRequiredService<IShoppingListBackfillService>();
+		var count = await backfill.BackfillAsync(cancellationToken);
+		LogShoppingEventsBackfilled(logger, count);
 	}
 
 	private async Task ApplyMigrationsAsync<TContext>(string moduleName, CancellationToken cancellationToken, bool reset = false)

--- a/src/Yumney.MigrationRunner/Program.cs
+++ b/src/Yumney.MigrationRunner/Program.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
@@ -37,6 +38,7 @@ builder.Services.AddDbContext<MealPlanDbContext>(options =>
 // MigrationWorker through this code path; the regular migration run never resolves them.
 builder.Services.AddScoped<ShoppingListProjection>();
 builder.Services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
+builder.Services.AddScoped<IShoppingListBackfillService, ShoppingListBackfillService>();
 
 builder.Services.AddHostedService<MigrationWorker>();
 

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListBackfillService.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListBackfillService.cs
@@ -1,0 +1,20 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// One-off operational tool: walks the legacy <c>ShoppingLists</c> table and
+/// emits synthetic events for every row that doesn't yet have a corresponding
+/// entry in the event store. Lets the event-sourced read path catch up to
+/// data that pre-dates Phase 2.
+/// </summary>
+public interface IShoppingListBackfillService
+{
+	/// <summary>
+	/// Synthesises and persists events for legacy lists that aren't yet in the
+	/// event store. Idempotent — a list with an existing
+	/// <see cref="SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore.ShoppingListAggregateMetadata"/>
+	/// row is skipped.
+	/// </summary>
+	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+	/// <returns>Number of legacy lists that were backfilled this run.</returns>
+	Task<int> BackfillAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListBackfillService.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListBackfillService.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+#pragma warning disable SA1601
+public sealed partial class ShoppingListBackfillService(
+	ShoppingDbContext context,
+	ILogger<ShoppingListBackfillService> logger) : IShoppingListBackfillService
+{
+	public async Task<int> BackfillAsync(CancellationToken cancellationToken = default)
+	{
+		LogStarting();
+
+		var existingAggregateIds = (await context.Set<ShoppingListAggregateMetadata>()
+			.AsNoTracking()
+			.Select(m => m.AggregateId)
+			.ToListAsync(cancellationToken))
+			.ToHashSet();
+
+		var legacy = await context.ShoppingLists
+			.AsNoTracking()
+			.Include(l => l.Items)
+			.ToListAsync(cancellationToken);
+
+		var backfilled = 0;
+		var skipped = 0;
+
+		foreach (var list in legacy)
+		{
+			if (existingAggregateIds.Contains(list.Identifier.Value))
+			{
+				skipped++;
+				continue;
+			}
+
+			AppendSyntheticEvents(list);
+			backfilled++;
+		}
+
+		if (backfilled == 0)
+		{
+			LogFinished(backfilled, skipped);
+			return 0;
+		}
+
+		await context.SaveChangesAsync(cancellationToken);
+		LogFinished(backfilled, skipped);
+		return backfilled;
+	}
+
+	private void AppendSyntheticEvents(ShoppingList list)
+	{
+		var aggregateId = list.Identifier.Value;
+		var occurredAt = list.CreatedAt;
+		var version = 0;
+
+		context.Set<ShoppingListAggregateMetadata>().Add(new ShoppingListAggregateMetadata
+		{
+			AggregateId = aggregateId,
+			OwnerId = list.Owner.Value,
+		});
+
+		AppendStoredEvent(
+			aggregateId,
+			++version,
+			occurredAt,
+			new ShoppingListCreated(list.Identifier, list.Title, list.Owner, list.RecipeReference, list.CreatedAt));
+
+		foreach (var item in list.Items)
+		{
+			AppendStoredEvent(
+				aggregateId,
+				++version,
+				occurredAt,
+				new ListItemAdded(item.Id, item.Name, item.Quantity));
+		}
+
+		// Items in a "checked" state get a synthetic ListItemChecked emitted after their
+		// ListItemAdded so replay reconstructs the same flag. Without an audit trail of
+		// when the user actually checked the item we keep the OccurredAt aligned with
+		// the list's CreatedAt — the column is best-effort for legacy rows.
+		foreach (var item in list.Items.Where(i => i.IsChecked))
+		{
+			AppendStoredEvent(
+				aggregateId,
+				++version,
+				occurredAt,
+				new ListItemChecked(item.Id));
+		}
+	}
+
+	private void AppendStoredEvent(Guid aggregateId, int version, DateTime occurredAt, IDomainEvent @event)
+	{
+		context.Set<ShoppingListStoredEvent>().Add(new ShoppingListStoredEvent
+		{
+			Id = Guid.CreateVersion7(),
+			AggregateId = aggregateId,
+			EventType = @event.GetType().Name,
+			EventData = ShoppingListEventSerializer.Serialize(@event),
+			Version = version,
+			OccurredAt = occurredAt,
+		});
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList backfill starting")]
+	private partial void LogStarting();
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "ShoppingList backfill finished. Backfilled={Backfilled} Skipped={Skipped}")]
+	private partial void LogFinished(int backfilled, int skipped);
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingListReadModelRepository, ShoppingListReadModelRepository>();
 		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
 		services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
+		services.AddScoped<IShoppingListBackfillService, ShoppingListBackfillService>();
 		services.AddScoped<ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingListProjectionHandler>();
 		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingListProjectionHandler>();

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/ShoppingListBackfillServiceTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/ShoppingListBackfillServiceTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.EventStore;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingListBackfillServiceTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"backfill-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public async Task DisposeAsync()
+	{
+		await fixture.ResetShoppingListEventStoreAsync(owner);
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var lists = await ctx.ShoppingLists.Where(l => l.Owner == owner).ToListAsync();
+		ctx.RemoveRange(summaries);
+		ctx.RemoveRange(items);
+		ctx.RemoveRange(lists);
+		await ctx.SaveChangesAsync();
+	}
+
+	[Fact]
+	public async Task BackfillAsync_LegacyListWithoutEvents_EmitsCreatedAndItemAddedEvents()
+	{
+		var listId = await SeedLegacyOnlyAsync("Pantry", checkedItem: false);
+
+		var count = await RunBackfillAsync();
+
+		count.Should().Be(1);
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var events = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == listId.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+		events.Should().HaveCount(2);
+		events[0].EventType.Should().Be(nameof(SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events.ShoppingListCreated));
+		events[0].Version.Should().Be(1);
+		events[1].EventType.Should().Be(nameof(SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events.ListItemAdded));
+		events[1].Version.Should().Be(2);
+
+		var metadata = await verify.Set<ShoppingListAggregateMetadata>()
+			.SingleAsync(m => m.AggregateId == listId.Value);
+		metadata.OwnerId.Should().Be(owner.Value);
+	}
+
+	[Fact]
+	public async Task BackfillAsync_LegacyListWithCheckedItem_EmitsListItemCheckedAfterAdd()
+	{
+		var listId = await SeedLegacyOnlyAsync("Pantry", checkedItem: true);
+
+		await RunBackfillAsync();
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var events = await verify.Set<ShoppingListStoredEvent>()
+			.Where(e => e.AggregateId == listId.Value)
+			.OrderBy(e => e.Version)
+			.ToListAsync();
+		events.Should().HaveCount(3);
+		events[2].EventType.Should().Be(nameof(SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events.ListItemChecked));
+	}
+
+	[Fact]
+	public async Task BackfillAsync_RunTwice_SkipsAlreadyBackfilledLists()
+	{
+		await SeedLegacyOnlyAsync("Pantry", checkedItem: false);
+
+		var firstRun = await RunBackfillAsync();
+		var secondRun = await RunBackfillAsync();
+
+		firstRun.Should().Be(1);
+		secondRun.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task BackfillAsync_FollowedByProjectionRebuild_PopulatesProjectionTables()
+	{
+		var listId = await SeedLegacyOnlyAsync("Pantry", checkedItem: true);
+
+		await RunBackfillAsync();
+
+		// Run the projection rebuilder against the backfilled events.
+		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
+		{
+			var projection = new ShoppingListProjection(ctx);
+			var rebuilder = new ShoppingListProjectionRebuilder(
+				ctx,
+				projection,
+				NullLogger<ShoppingListProjectionRebuilder>.Instance);
+			await rebuilder.RebuildAsync();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
+		summary.Title.Should().Be("Pantry");
+		summary.ItemCount.Should().Be(1);
+		var item = await verify.Set<ShoppingListItemReadItem>().SingleAsync(i => i.ListId == listId.Value);
+		item.IsChecked.Should().BeTrue();
+	}
+
+	private async Task<int> RunBackfillAsync()
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+		var service = new ShoppingListBackfillService(ctx, NullLogger<ShoppingListBackfillService>.Instance);
+		return await service.BackfillAsync();
+	}
+
+	/// <summary>
+	/// Inserts a list directly into the legacy ShoppingLists table, bypassing
+	/// the event-sourced path so the test mirrors a row that pre-dates Phase 2.
+	/// EF tracks aggregate state via the ChangeTracker without involving the
+	/// UoW's event-publishing logic.
+	/// </summary>
+	private async Task<ShoppingListIdentifier> SeedLegacyOnlyAsync(string title, bool checkedItem)
+	{
+		await using var ctx = await fixture.CreateShoppingDbContextAsync();
+
+		// We can't construct the aggregate via Create() without raising events,
+		// so build it through reflection-friendly state directly. Easiest path:
+		// instantiate via Create() then DETACH from any change tracker and
+		// re-add as Added without keeping uncommitted events on the heap.
+		var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From(title),
+			owner,
+			[item]);
+
+		if (checkedItem)
+		{
+			list.CheckOffItem(item.Id);
+		}
+
+		// Drop any uncommitted events so the dual-write path is bypassed —
+		// the row only ends up in the legacy table.
+		list.MarkCommitted();
+		ctx.ShoppingLists.Add(list);
+		await ctx.SaveChangesAsync();
+		return list.Identifier;
+	}
+}


### PR DESCRIPTION
Phase 7 of the Shopping ES migration (backfill half). Closes #482 backfill scope. Recreated from #490.

- `IShoppingListBackfillService` + impl synthesises events for legacy rows that don't yet have an event-store entry.
- `MigrationRunner` mode `Persistence:BackfillShoppingEvents` + dashboard entry.
- Idempotent — second run is a no-op for already-backfilled lists.

Note: the legacy table drop (the other half of #482) is part of #495.