### PR TITLE
feat(infra): dashboard reset entry for shoppingdb (#481 follow-up)

### DIFF
--- a/src/Yumney.AppHost/DashboardResetEntries.cs
+++ b/src/Yumney.AppHost/DashboardResetEntries.cs
@@ -24,6 +24,10 @@ internal static class DashboardResetEntries
 		// Drops and re-migrates mealplandb — wipes the event-sourced MealPlan store.
 		Add(builder, "yumney-mealplan-reset", "Persistence__ResetMealPlanOnly", mealplanDb, allDbs);
 
+		// Drops and re-migrates shoppingdb — wipes events, metadata, projections,
+		// and legacy lists in one shot.
+		Add(builder, "yumney-shopping-reset", "Persistence__ResetShoppingOnly", shoppingDb, allDbs);
+
 		// Truncates the ShoppingList projection tables and replays the event store
 		// into them. Events, metadata, and the legacy ShoppingLists table are
 		// untouched. Idempotent.

--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -17,6 +17,9 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 /// <list type="bullet">
 ///   <item><c>Persistence:ResetMealPlanOnly=true</c> — drops and re-migrates the
 ///   MealPlan database only. Wipes the event-sourced MealPlan store.</item>
+///   <item><c>Persistence:ResetShoppingOnly=true</c> — drops and re-migrates the
+///   Shopping database only. Wipes events, metadata, projections, and legacy
+///   lists in one shot.</item>
 ///   <item><c>Persistence:RebuildShoppingProjections=true</c> — truncates the
 ///   ShoppingList projection tables and replays the event store into them.
 ///   Other Shopping data (events, metadata, legacy lists) is untouched.</item>
@@ -46,6 +49,10 @@ public sealed partial class MigrationWorker(
 			else if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
 			{
 				await ApplyMigrationsAsync<MealPlanDbContext>("MealPlan", stoppingToken, reset: true);
+			}
+			else if (configuration.GetValue<bool>("Persistence:ResetShoppingOnly"))
+			{
+				await ApplyMigrationsAsync<ShoppingDbContext>("Shopping", stoppingToken, reset: true);
 			}
 			else
 			{


### PR DESCRIPTION
Adds yumney-shopping-reset alongside yumney-mealplan-reset so devs can nuke shoppingdb in one click. Recreated from #492.