### PR TITLE
test(shopping): clear projection in cleanup + wait on EC reads

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -201,24 +201,35 @@ public sealed class AspireFixture : IAsyncLifetime
 
 	public async Task ResetShoppingListEventStoreAsync(ShoppingDomain.ShoppingList.OwnerIdentifier owner)
 	{
-		await using var context = await CreateShoppingDbContextAsync();
-		var aggregateIds = await context.Set<ShoppingListAggregateMetadata>()
+		await using var writeContext = await CreateShoppingDbContextAsync();
+		var aggregateIds = await writeContext.Set<ShoppingListAggregateMetadata>()
 			.Where(m => m.OwnerId == owner.Value)
 			.Select(m => m.AggregateId)
 			.ToListAsync();
 
-		if (aggregateIds.Count == 0) return;
+		if (aggregateIds.Count > 0)
+		{
+			await writeContext.Set<ShoppingListStoredEvent>()
+				.Where(e => aggregateIds.Contains(e.AggregateId))
+				.ExecuteDeleteAsync();
+			await writeContext.Set<ShoppingListAggregateMetadata>()
+				.Where(m => aggregateIds.Contains(m.AggregateId))
+				.ExecuteDeleteAsync();
+		}
 
-		var events = await context.Set<ShoppingListStoredEvent>()
-			.Where(e => aggregateIds.Contains(e.AggregateId))
-			.ToListAsync();
-		var metadata = await context.Set<ShoppingListAggregateMetadata>()
-			.Where(m => aggregateIds.Contains(m.AggregateId))
-			.ToListAsync();
-
-		context.RemoveRange(events);
-		context.RemoveRange(metadata);
-		await context.SaveChangesAsync();
+		// Read model lives in a separate set of tables — the event-store wipe
+		// above doesn't touch it. Without this, lists materialised by the
+		// projection handler in earlier tests stay visible to subsequent
+		// reads, surfacing as "expected 0 lists, found N" assertion failures
+		// in the integration test suite (the umbrella backend job that runs
+		// every Shopping integration class against one shared database).
+		await using var readContext = await CreateShoppingReadDbContextAsync();
+		await readContext.Set<ShoppingListItemReadItem>()
+			.Where(i => i.OwnerId == owner.Value)
+			.ExecuteDeleteAsync();
+		await readContext.Set<ShoppingListSummaryReadItem>()
+			.Where(s => s.OwnerId == owner.Value)
+			.ExecuteDeleteAsync();
 	}
 
 	public async Task ResetShoppingReadModelAsync(string ownerId)

--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+
+/// <summary>
+/// Polling-retry helper for assertions that must wait for an eventually-
+/// consistent read model to catch up.
+///
+/// The Shopping module publishes integration events through Wolverine/RabbitMQ;
+/// the projection handler that updates the read model runs on a worker, so a
+/// test that does write → immediate read can race the handler. Wrapping the
+/// read+assert block in <see cref="AssertAsync"/> makes the test honest about
+/// the async boundary without changing production code.
+/// </summary>
+public static class Eventually
+{
+	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
+
+	public static async Task AssertAsync(
+		Func<Task> assertion,
+		TimeSpan? timeout = null,
+		TimeSpan? pollInterval = null)
+	{
+		var deadline = DateTime.UtcNow + (timeout ?? DefaultTimeout);
+		var interval = pollInterval ?? DefaultPollInterval;
+		Exception? lastError = null;
+
+		while (true)
+		{
+			try
+			{
+				await assertion();
+				return;
+			}
+			catch (Exception ex) when (DateTime.UtcNow < deadline)
+			{
+				lastError = ex;
+				await Task.Delay(interval);
+			}
+			catch (Exception ex)
+			{
+				lastError = ex;
+				break;
+			}
+		}
+
+		throw lastError!;
+	}
+}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
@@ -40,10 +40,13 @@ public class CheckOffAllItemsContractTests(AspireFixture fixture) : IAsyncLifeti
 			new { isChecked = true });
 
 		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-		var detail = await GetListAsync(client, listId);
-		detail.GetProperty("items").EnumerateArray()
-			.Select(i => i.GetProperty("isChecked").GetBoolean())
-			.Should().AllBeEquivalentTo(true);
+		await Eventually.AssertAsync(async () =>
+		{
+			var detail = await GetListAsync(client, listId);
+			detail.GetProperty("items").EnumerateArray()
+				.Select(i => i.GetProperty("isChecked").GetBoolean())
+				.Should().AllBeEquivalentTo(true);
+		});
 	}
 
 	[Fact]
@@ -58,10 +61,13 @@ public class CheckOffAllItemsContractTests(AspireFixture fixture) : IAsyncLifeti
 			new { isChecked = false });
 
 		response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-		var detail = await GetListAsync(client, listId);
-		detail.GetProperty("items").EnumerateArray()
-			.Select(i => i.GetProperty("isChecked").GetBoolean())
-			.Should().AllBeEquivalentTo(false);
+		await Eventually.AssertAsync(async () =>
+		{
+			var detail = await GetListAsync(client, listId);
+			detail.GetProperty("items").EnumerateArray()
+				.Select(i => i.GetProperty("isChecked").GetBoolean())
+				.Should().AllBeEquivalentTo(false);
+		});
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
@@ -44,12 +44,14 @@ public class GetShoppingListsContractTests(AspireFixture fixture) : IAsyncLifeti
 		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
 		await CreateListAsync(client, "List A");
 
-		var response = await client.GetAsync(Endpoint);
-
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-		body.GetProperty("totalCount").GetInt32().Should().Be(1);
-		body.GetProperty("items")[0].GetProperty("title").GetString().Should().Be("List A");
+		await Eventually.AssertAsync(async () =>
+		{
+			var response = await client.GetAsync(Endpoint);
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			body.GetProperty("totalCount").GetInt32().Should().Be(1);
+			body.GetProperty("items")[0].GetProperty("title").GetString().Should().Be("List A");
+		});
 	}
 
 	[Fact]
@@ -60,12 +62,14 @@ public class GetShoppingListsContractTests(AspireFixture fixture) : IAsyncLifeti
 		await CreateListAsync(client, "Two");
 		await CreateListAsync(client, "Three");
 
-		var response = await client.GetAsync($"{Endpoint}?page=1&pageSize=2");
-
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-		body.GetProperty("items").GetArrayLength().Should().Be(2);
-		body.GetProperty("totalCount").GetInt32().Should().Be(3);
+		await Eventually.AssertAsync(async () =>
+		{
+			var response = await client.GetAsync($"{Endpoint}?page=1&pageSize=2");
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			body.GetProperty("items").GetArrayLength().Should().Be(2);
+			body.GetProperty("totalCount").GetInt32().Should().Be(3);
+		});
 	}
 
 	[Fact]
@@ -76,13 +80,15 @@ public class GetShoppingListsContractTests(AspireFixture fixture) : IAsyncLifeti
 		await CreateListAsync(client, "Alpha");
 		await CreateListAsync(client, "Bravo");
 
-		var response = await client.GetAsync($"{Endpoint}?sortBy=Title&sortDirection=Ascending");
-
-		response.StatusCode.Should().Be(HttpStatusCode.OK);
-		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-		var titles = body.GetProperty("items").EnumerateArray()
-			.Select(i => i.GetProperty("title").GetString()).ToList();
-		titles.Should().Equal("Alpha", "Bravo", "Charlie");
+		await Eventually.AssertAsync(async () =>
+		{
+			var response = await client.GetAsync($"{Endpoint}?sortBy=Title&sortDirection=Ascending");
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			var titles = body.GetProperty("items").EnumerateArray()
+				.Select(i => i.GetProperty("title").GetString()).ToList();
+			titles.Should().Equal("Alpha", "Bravo", "Charlie");
+		});
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ShoppingListCreateFlowTests.cs
@@ -38,14 +38,16 @@ public class ShoppingListCreateFlowTests(AspireFixture fixture)
 		var identifier = created.GetProperty("identifier").GetGuid();
 		identifier.Should().NotBeEmpty();
 
-		// Retrieve
-		var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{identifier}");
-
-		getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-		var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-
-		detail.GetProperty("title").GetString().Should().Be("Integration Test List");
-		detail.GetProperty("items").GetArrayLength().Should().Be(3);
+		// Retrieve via the read model — projection handler runs asynchronously
+		// on the Wolverine worker, so the GET races the handler.
+		await Eventually.AssertAsync(async () =>
+		{
+			var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{identifier}");
+			getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+			var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			detail.GetProperty("title").GetString().Should().Be("Integration Test List");
+			detail.GetProperty("items").GetArrayLength().Should().Be(3);
+		});
 	}
 
 	[Fact]
@@ -94,11 +96,12 @@ public class ShoppingListCreateFlowTests(AspireFixture fixture)
 
 		checkResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-		// Retrieve and verify
-		var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{listId}");
-		var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-
-		detail.GetProperty("items")[0].GetProperty("isChecked").GetBoolean().Should().BeTrue();
+		await Eventually.AssertAsync(async () =>
+		{
+			var getResponse = await client.GetAsync($"/api/v1/shopping-lists/{listId}");
+			var detail = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+			detail.GetProperty("items")[0].GetProperty("isChecked").GetBoolean().Should().BeTrue();
+		});
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary
Two related fixes that make the umbrella **Backend (Build + Test)** job actually green for Shopping.

### 1. Cleanup also clears the projection
\`ResetShoppingListEventStoreAsync\` previously wiped only the event-store side. After the Shopping ES migration, reads come from \`ShoppingListSummaryReadItems\` + \`ShoppingListItemReadItems\` — populated by the projection handler. Those tables weren't cleaned, so lists materialised in one test class stayed visible to the next as ghost rows ("expected 0, found 7").

### 2. Tests wait for the projection to catch up
Wolverine publishes integration events to RabbitMQ; the projection handler runs on a worker. Tests that did write → immediate read raced the handler. Adds \`Eventually.AssertAsync\` (5s timeout, 100ms poll), wraps the read+assert blocks in the affected tests:
- \`ShoppingListCreateFlowTests.CreateAndRetrieve_*\`
- \`ShoppingListCreateFlowTests.CreateAndCheckOff_*\`
- \`CheckOffAllItemsContractTests.CheckOffAll_*\` (both)
- \`GetShoppingListsContractTests.GetShoppingLists_AfterCreate_*\`
- \`GetShoppingListsContractTests.GetShoppingLists_Pagination_*\`
- \`GetShoppingListsContractTests.GetShoppingLists_SortByTitleAscending_*\`

## Why fix #1 alone wasn't enough
Cleanup eliminated the state-leak class of failures (\"expected N, found M\") but unmasked the eventual-consistency class (\"expected 1, found 0\" / \"isChecked True, found False\"). Both classes share a root cause: the post-migration write/read split that the test infrastructure didn't account for.

## Verification
- Local: \`dotnet test tests/Yumney.Integration.Tests\` — **183 passed, 0 failed, 1 skipped**.
- \`dotnet build -p:TreatWarningsAsErrors=true\` clean, \`dotnet format --verify-no-changes\` clean.

## Test plan
- [x] Local full integration suite passes.
- [ ] CI: umbrella Backend (Build + Test) Shopping tests pass.
- [ ] CI: per-module split jobs stay green.