### PR TITLE
feat(shopping): ingredient balance sheet read model + query (US-340)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -122,15 +122,16 @@ if (!options.DatabaseOnly)
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.AsYumneyApi(recipesDb, keycloak, redis, messaging, migrationRunner)
 		.WithLlmProvider(builder, options);
-	var shoppingApi = builder
-		.AddProject<Projects.Yumney_Shopping_Api>("shopping-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.AsYumneyApi(shoppingDb, keycloak, redis, messaging, migrationRunner);
 	var usersApi = builder
 		.AddProject<Projects.Yumney_Users_Api>("users-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.WithEnvironment("Keycloak__ClientSecret", yumneyApiClientSecret)
 		.AsYumneyApi(usersDb, keycloak, redis, messaging, migrationRunner);
+	var shoppingApi = builder
+		.AddProject<Projects.Yumney_Shopping_Api>("shopping-api")
+		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.AsYumneyApi(shoppingDb, keycloak, redis, messaging, migrationRunner)
+		.WithReference(usersApi);
 	var mealplanApi = builder
 		.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -207,6 +207,19 @@ public static class ShoppingEndpoints
 			return result.ToNoContent();
 		}
 
+		group.MapGet("/balance", GetBalance)
+			.WithName("GetIngredientBalance")
+			.WithTags("Shopping")
+			.Produces<IngredientBalanceDto>();
+
+		static async Task<IResult> GetBalance(
+			IQueryHandler<GetIngredientBalanceQuery, Result<IngredientBalanceDto>> handler,
+			CancellationToken cancellationToken)
+		{
+			var result = await handler.HandleAsync(new GetIngredientBalanceQuery(), cancellationToken);
+			return result.ToOk();
+		}
+
 		group.MapGet("/export", Export)
 			.WithName("ExportShoppingList")
 			.WithTags("Shopping")

--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public sealed record IngredientBalanceDto(IReadOnlyList<IngredientBalanceItemDto> Items);

--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceItemDto.cs
@@ -1,0 +1,13 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+/// <summary>
+/// One ingredient in the balance sheet ("what's at home right now").
+/// <see cref="Quantity"/> is null for staples that are tracked as
+/// "always available" rather than as a measurable amount.
+/// </summary>
+public sealed record IngredientBalanceItemDto(
+	string ItemName,
+	decimal? Quantity,
+	string? Unit,
+	string Category,
+	IngredientBalanceSource Source);

--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceSource.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceSource.cs
@@ -1,0 +1,15 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+/// <summary>
+/// Origin of a balance sheet entry. Tracks whether an item is at home
+/// because it was bought (or marked as already-at-home) or because it
+/// is on the user's staples list.
+/// </summary>
+public enum IngredientBalanceSource
+{
+	/// <summary>Item is at home because of bought / added-as-at-home ledger events.</summary>
+	AtHome,
+
+	/// <summary>Item is always considered available because it is on the user's staples list.</summary>
+	Staple,
+}

--- a/src/Yumney.Shopping.Application/Interfaces/IIngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IIngredientBalanceReadModelRepository.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Read access to the ingredient balance projection. Returns ledger-derived
+/// at-home rows (Bought − Consumed − Removed) only; the query handler combines
+/// these with the user's staples to produce the full balance sheet.
+/// </summary>
+public interface IIngredientBalanceReadModelRepository
+{
+	Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(string ownerId, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Application/Queries/GetIngredientBalanceQuery.cs
+++ b/src/Yumney.Shopping.Application/Queries/GetIngredientBalanceQuery.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries;
+
+/// <summary>
+/// Returns the current ingredient balance ("what's at home right now") for
+/// the calling user. Combines ledger-derived at-home items (Bought − Consumed
+/// − Removed) with the user's staples list. Powers the "What Can I Cook?"
+/// feature (US-342) and any UI that needs an inventory view.
+/// </summary>
+public sealed record GetIngredientBalanceQuery : IQuery<Result<IngredientBalanceDto>>;

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -1,0 +1,49 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+
+public sealed class GetIngredientBalanceQueryHandler(
+	IIngredientBalanceReadModelRepository readModel,
+	IStaplesProvider staplesProvider,
+	ICurrentUser currentUser) : IQueryHandler<GetIngredientBalanceQuery, Result<IngredientBalanceDto>>
+{
+	public async Task<Result<IngredientBalanceDto>> HandleAsync(GetIngredientBalanceQuery query, CancellationToken cancellationToken = default)
+	{
+		var ownerId = currentUser.UserId;
+
+		var atHomeTask = readModel.GetAtHomeItemsAsync(ownerId, cancellationToken);
+		var staplesTask = staplesProvider.GetStapleNamesAsync(ownerId, cancellationToken);
+		await Task.WhenAll(atHomeTask, staplesTask);
+
+		var atHomeItems = atHomeTask.Result;
+		var staples = staplesTask.Result;
+
+		var atHomeNames = atHomeItems
+			.Select(i => i.ItemName)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		List<IngredientBalanceItemDto> items = [.. atHomeItems];
+
+		foreach (var staple in staples.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+		{
+			if (atHomeNames.Contains(staple)) continue;
+
+			var category = IngredientCategoryResolver.Resolve(staple) ?? IngredientCategory.Other;
+			items.Add(new IngredientBalanceItemDto(
+				ItemName: staple,
+				Quantity: null,
+				Unit: null,
+				Category: category.Value,
+				Source: IngredientBalanceSource.Staple));
+		}
+
+		List<IngredientBalanceItemDto> sorted = [.. items
+			.OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
+			.ThenBy(i => i.ItemName, StringComparer.OrdinalIgnoreCase)];
+
+		return new IngredientBalanceDto(sorted);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
+
+internal sealed class IngredientBalanceReadItemConfiguration : IEntityTypeConfiguration<IngredientBalanceReadItem>
+{
+	public void Configure(EntityTypeBuilder<IngredientBalanceReadItem> entity)
+	{
+		entity.ToTable("IngredientBalanceReadItems");
+		entity.HasKey(e => e.Id);
+		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
+		entity.Property(e => e.ItemName).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.NameKey).HasMaxLength(200).IsRequired();
+		entity.Property(e => e.Unit).HasMaxLength(20);
+		entity.Property(e => e.Category).HasMaxLength(30).IsRequired();
+		entity.Property(e => e.BoughtTotal).HasColumnType("numeric");
+		entity.Property(e => e.ConsumedTotal).HasColumnType("numeric");
+		entity.Property(e => e.RemovedTotal).HasColumnType("numeric");
+		entity.Property(e => e.LastUpdated).IsRequired();
+
+		entity.Ignore(e => e.AtHome);
+
+		entity.HasIndex(e => e.OwnerId);
+		entity.HasIndex(e => new { e.OwnerId, e.NameKey, e.Unit });
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
@@ -131,6 +131,10 @@ public sealed partial class EfCoreShoppingEventStore(
 				await eventBus.PublishAsync(new ShoppingItemRemovedIntegrationEvent(ownerId, removed), cancellationToken);
 			else if (@event is ShoppingItemQuantityAdjusted adjusted)
 				await eventBus.PublishAsync(new ShoppingItemQuantityAdjustedIntegrationEvent(ownerId, adjusted), cancellationToken);
+			else if (@event is ShoppingItemAddedAsAtHome atHome)
+				await eventBus.PublishAsync(new ShoppingItemAddedAsAtHomeIntegrationEvent(ownerId, atHome), cancellationToken);
+			else if (@event is ShoppingItemUndoBought undo)
+				await eventBus.PublishAsync(new ShoppingItemUndoBoughtIntegrationEvent(ownerId, undo), cancellationToken);
 		}
 	}
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingItemAddedAsAtHomeIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingItemAddedAsAtHomeIntegrationEvent.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+public sealed record ShoppingItemAddedAsAtHomeIntegrationEvent(string OwnerId, ShoppingItemAddedAsAtHome Inner) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingItemUndoBoughtIntegrationEvent.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingItemUndoBoughtIntegrationEvent.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+public sealed record ShoppingItemUndoBoughtIntegrationEvent(string OwnerId, ShoppingItemUndoBought Inner) : IntegrationEvent;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260429203904_AddIngredientBalanceReadModel.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260429203904_AddIngredientBalanceReadModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429203904_AddIngredientBalanceReadModel")]
+    partial class AddIngredientBalanceReadModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260429203904_AddIngredientBalanceReadModel.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260429203904_AddIngredientBalanceReadModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIngredientBalanceReadModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "IngredientBalanceReadItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    ItemName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    NameKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Unit = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    Category = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    BoughtTotal = table.Column<decimal>(type: "numeric", nullable: false),
+                    ConsumedTotal = table.Column<decimal>(type: "numeric", nullable: false),
+                    RemovedTotal = table.Column<decimal>(type: "numeric", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IngredientBalanceReadItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IngredientBalanceReadItems_OwnerId",
+                table: "IngredientBalanceReadItems",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IngredientBalanceReadItems_OwnerId_NameKey_Unit",
+                table: "IngredientBalanceReadItems",
+                columns: new[] { "OwnerId", "NameKey", "Unit" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IngredientBalanceReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Async projection handler that maintains per-ingredient at-home balance rows
+/// in <see cref="IngredientBalanceReadItem"/>. Subscribes to ledger integration
+/// events that affect the Bought / Consumed / Removed totals.
+///
+/// Powers the <see cref="GetIngredientBalanceQuery"/> ("what's at home right now")
+/// and is the data source for the "What Can I Cook?" feature (US-342).
+/// </summary>
+public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context)
+	: IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>,
+	  IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>,
+	  IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>,
+	  IIntegrationEventHandler<ShoppingItemUndoBoughtIntegrationEvent>,
+	  IIntegrationEventHandler<ShoppingItemAddedAsAtHomeIntegrationEvent>
+{
+	public Task HandleAsync(ShoppingItemBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		return UpsertAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			row => row.BoughtTotal += inner.Quantity.Amount,
+			cancellationToken);
+	}
+
+	public Task HandleAsync(ShoppingItemConsumedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		return UpsertAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			row => row.ConsumedTotal += inner.Quantity.Amount,
+			cancellationToken);
+	}
+
+	public Task HandleAsync(ShoppingItemRemovedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		return UpsertAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			row => row.RemovedTotal += inner.Quantity.Amount,
+			cancellationToken);
+	}
+
+	public Task HandleAsync(ShoppingItemUndoBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		return UpsertAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			row => row.BoughtTotal = Math.Max(0, row.BoughtTotal - inner.Quantity.Amount),
+			cancellationToken);
+	}
+
+	public Task HandleAsync(ShoppingItemAddedAsAtHomeIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		return UpsertAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			row => row.BoughtTotal += inner.Quantity.Amount,
+			cancellationToken);
+	}
+
+	private async Task UpsertAsync(
+		string ownerId,
+		string itemName,
+		string? unit,
+		Action<IngredientBalanceReadItem> mutate,
+		CancellationToken cancellationToken)
+	{
+		var nameKey = itemName.ToLowerInvariant();
+		var row = await context.Set<IngredientBalanceReadItem>()
+			.FirstOrDefaultAsync(
+				r => r.OwnerId == ownerId
+					&& r.NameKey == nameKey
+					&& r.Unit == unit,
+				cancellationToken);
+
+		if (row is null)
+		{
+			var category = IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other;
+			row = new IngredientBalanceReadItem
+			{
+				Id = Guid.CreateVersion7(),
+				OwnerId = ownerId,
+				ItemName = itemName,
+				NameKey = nameKey,
+				Unit = unit,
+				Category = category.Value,
+			};
+			context.Set<IngredientBalanceReadItem>().Add(row);
+		}
+
+		mutate(row);
+		row.LastUpdated = DateTime.UtcNow;
+		await context.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadItem.cs
@@ -1,0 +1,40 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Per-ingredient at-home balance derived from ledger events.
+/// One row per (OwnerId, ItemName, Unit). Maintained asynchronously
+/// by <see cref="IngredientBalanceProjectionHandler"/>.
+/// </summary>
+public sealed class IngredientBalanceReadItem
+{
+	public Guid Id { get; set; }
+
+	public string OwnerId { get; set; } = default!;
+
+	public string ItemName { get; set; } = default!;
+
+	/// <summary>
+	/// Gets or sets the lowercased <see cref="ItemName"/> used for case-insensitive lookup.
+	/// Maintained by the projection so SQL stays simple and provider-portable.
+	/// </summary>
+	public string NameKey { get; set; } = default!;
+
+	public string? Unit { get; set; }
+
+	public string Category { get; set; } = IngredientCategory.Other.Value;
+
+	public decimal BoughtTotal { get; set; }
+
+	public decimal ConsumedTotal { get; set; }
+
+	public decimal RemovedTotal { get; set; }
+
+	public DateTime LastUpdated { get; set; }
+
+	/// <summary>
+	/// Gets the current at-home balance: never negative.
+	/// </summary>
+	public decimal AtHome => Math.Max(0, BoughtTotal - ConsumedTotal - RemovedTotal);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext context) : IIngredientBalanceReadModelRepository
+{
+	public async Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(string ownerId, CancellationToken cancellationToken = default)
+	{
+		var rows = await context.IngredientBalanceReadItems
+			.Where(r => r.OwnerId == ownerId)
+			.ToListAsync(cancellationToken);
+
+		return rows
+			.Where(r => r.AtHome > 0)
+			.Select(r => new IngredientBalanceItemDto(
+				ItemName: r.ItemName,
+				Quantity: r.AtHome,
+				Unit: r.Unit,
+				Category: r.Category,
+				Source: IngredientBalanceSource.AtHome))
+			.ToList();
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDbContext.cs
@@ -11,6 +11,8 @@ public sealed class ShoppingReadDbContext(DbContextOptions<ShoppingReadDbContext
 
 	public DbSet<ShoppingListItemReadItem> ShoppingListItemReadItems => Set<ShoppingListItemReadItem>();
 
+	public DbSet<IngredientBalanceReadItem> IngredientBalanceReadItems => Set<IngredientBalanceReadItem>();
+
 	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 	{
 		optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);

--- a/src/Yumney.Shopping.Infrastructure/Services/AuthTokenDelegatingHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Services/AuthTokenDelegatingHandler.cs
@@ -1,0 +1,19 @@
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+
+public sealed class AuthTokenDelegatingHandler(IHttpContextAccessor httpContextAccessor) : DelegatingHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var authHeader = httpContextAccessor.HttpContext?.Request.Headers.Authorization.ToString();
+		if (authHeader.HasValue())
+		{
+			request.Headers.Authorization = AuthenticationHeaderValue.Parse(authHeader!);
+		}
+
+		return base.SendAsync(request, cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Services/HttpStaplesProvider.cs
+++ b/src/Yumney.Shopping.Infrastructure/Services/HttpStaplesProvider.cs
@@ -1,0 +1,16 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+
+public sealed class HttpStaplesProvider(IHttpClientFactory httpClientFactory) : IStaplesProvider
+{
+	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(string ownerId, CancellationToken cancellationToken = default)
+	{
+		var client = httpClientFactory.CreateClient("users-api");
+		var url = "/api/v1/users/staples";
+		List<string> staples = await client.GetFromJsonAsync<List<string>>(url, cancellationToken) ?? [];
+
+		return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -58,6 +58,17 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>, ShoppingListProjection>();
 		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
 		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
+		services.AddScoped<IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingItemUndoBoughtIntegrationEvent>, IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedAsAtHomeIntegrationEvent>, IngredientBalanceProjectionHandler>();
+		services.AddScoped<IIngredientBalanceReadModelRepository, IngredientBalanceReadModelRepository>();
+		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
+		services.AddTransient<AuthTokenDelegatingHandler>();
+		services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"))
+			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 

--- a/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
+++ b/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
@@ -8,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
@@ -295,6 +295,48 @@ public class EfCoreShoppingEventStoreTests(AspireFixture fixture) : IAsyncLifeti
 	}
 
 	[Fact]
+	public async Task SaveAsync_UndoBought_PublishesUndoBoughtIntegrationEvent()
+	{
+		var milk = ItemName.From("Milk");
+		var litre = Unit.From("l");
+		var oneLitre = Quantity.Of(Amount.From(1), litre);
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var bus = Substitute.For<IEventBus>();
+		var store = CreateStore(context, bus);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddItem(milk, oneLitre, Source)
+			.MarkBought(milk, oneLitre)
+			.UndoBought(milk, oneLitre);
+
+		await store.SaveAsync(ledger);
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingItemUndoBoughtIntegrationEvent>(e => e.OwnerId == owner.Value),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SaveAsync_AddedAsAtHome_PublishesAddedAsAtHomeIntegrationEvent()
+	{
+		var butter = ItemName.From("Butter");
+		var grams = Unit.From("g");
+
+		await using var context = await fixture.CreateShoppingDbContextAsync();
+		var bus = Substitute.For<IEventBus>();
+		var store = CreateStore(context, bus);
+		var ledger = ShoppingLedger.Create(owner)
+			.AddAsAtHome(butter, Quantity.Of(Amount.From(250), grams));
+
+		await store.SaveAsync(ledger);
+
+		await bus.Received(1).PublishAsync(
+			Arg.Is<ShoppingItemAddedAsAtHomeIntegrationEvent>(e =>
+				e.OwnerId == owner.Value && e.Inner.ItemName.Value == "Butter"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
 	public async Task SaveAsync_CancelledToken_ThrowsOperationCanceled()
 	{
 		using var cts = new CancellationTokenSource();

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
+using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
+
+public class GetIngredientBalanceQueryHandlerTests
+{
+	private readonly IIngredientBalanceReadModelRepository readModel = Substitute.For<IIngredientBalanceReadModelRepository>();
+	private readonly IStaplesProvider staplesProvider = Substitute.For<IStaplesProvider>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly GetIngredientBalanceQueryHandler handler;
+
+	public GetIngredientBalanceQueryHandlerTests()
+	{
+		currentUser.UserId.Returns("user-123");
+		handler = new GetIngredientBalanceQueryHandler(readModel, staplesProvider, currentUser);
+	}
+
+	[Fact]
+	public async Task HandleAsync_NoAtHomeNoStaples_ReturnsEmptyList()
+	{
+		ConfigureRepositories(atHome: [], staples: []);
+
+		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Items.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_AtHomeItem_ReturnsAsAtHomeSource()
+	{
+		var atHome = new IngredientBalanceItemDto("Milk", 4m, "L", "dairy", IngredientBalanceSource.AtHome);
+		ConfigureRepositories(atHome: [atHome], staples: []);
+
+		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		result.Value.Items.Should().ContainSingle()
+			.Which.Should().BeEquivalentTo(atHome);
+	}
+
+	[Fact]
+	public async Task HandleAsync_StapleNotInAtHome_AppearsAsStaple()
+	{
+		ConfigureRepositories(atHome: [], staples: ["salt", "pepper"]);
+
+		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		result.Value.Items.Should().HaveCount(2);
+		result.Value.Items.Should().AllSatisfy(i =>
+		{
+			i.Source.Should().Be(IngredientBalanceSource.Staple);
+			i.Quantity.Should().BeNull();
+			i.Unit.Should().BeNull();
+		});
+		result.Value.Items.Select(i => i.ItemName).Should().BeEquivalentTo(["salt", "pepper"]);
+	}
+
+	[Fact]
+	public async Task HandleAsync_StapleAlreadyAtHome_DoesNotDuplicate()
+	{
+		var atHome = new IngredientBalanceItemDto("Butter", 250m, "g", "dairy", IngredientBalanceSource.AtHome);
+		ConfigureRepositories(atHome: [atHome], staples: ["butter", "salt"]);
+
+		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		result.Value.Items.Should().HaveCount(2);
+		result.Value.Items.Where(i => string.Equals(i.ItemName, "Butter", StringComparison.OrdinalIgnoreCase))
+			.Should().ContainSingle()
+			.Which.Source.Should().Be(IngredientBalanceSource.AtHome);
+	}
+
+	[Fact]
+	public async Task HandleAsync_FetchesByCurrentUser()
+	{
+		ConfigureRepositories(atHome: [], staples: []);
+
+		await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		await readModel.Received(1).GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>());
+		await staplesProvider.Received(1).GetStapleNamesAsync("user-123", Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_OrdersByCategoryThenName()
+	{
+		var atHome = new[]
+		{
+			new IngredientBalanceItemDto("Yogurt", 500m, "g", IngredientCategory.Dairy.Value, IngredientBalanceSource.AtHome),
+			new IngredientBalanceItemDto("Tomato", 3m, null, IngredientCategory.Produce.Value, IngredientBalanceSource.AtHome),
+			new IngredientBalanceItemDto("Apple", 6m, null, IngredientCategory.Produce.Value, IngredientBalanceSource.AtHome),
+		};
+		ConfigureRepositories(atHome: atHome, staples: []);
+
+		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
+
+		var names = result.Value.Items.Select(i => i.ItemName).ToList();
+		names.Should().Equal("Apple", "Tomato", "Yogurt");
+	}
+
+	private void ConfigureRepositories(IReadOnlyList<IngredientBalanceItemDto> atHome, IReadOnlyCollection<string> staples)
+	{
+		readModel.GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>()).Returns(atHome);
+		staplesProvider.GetStapleNamesAsync("user-123", Arg.Any<CancellationToken>())
+			.Returns(staples.ToHashSet(StringComparer.OrdinalIgnoreCase));
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Persistence.ReadModel;
+
+public class IngredientBalanceProjectionHandlerTests
+{
+	private const string OwnerId = "user-1";
+
+	[Fact]
+	public async Task Bought_NewItem_CreatesRowWithBoughtTotal()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var domainEvent = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l")));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, domainEvent));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.OwnerId.Should().Be(OwnerId);
+		row.ItemName.Should().Be("Milk");
+		row.Unit.Should().Be("l");
+		row.BoughtTotal.Should().Be(2);
+		row.AtHome.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task Consumed_AfterBought_DecrementsAtHome()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var bought = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(5), Unit.From("l")));
+		var consumed = new ShoppingItemConsumed(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), ItemSource.From("meal-plan"));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, bought));
+		await handler.HandleAsync(new ShoppingItemConsumedIntegrationEvent(OwnerId, consumed));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.BoughtTotal.Should().Be(5);
+		row.ConsumedTotal.Should().Be(1);
+		row.AtHome.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task Removed_AfterBought_DecrementsAtHome()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var bought = new ShoppingItemBought(ItemName.From("Eggs"), Quantity.Of(Amount.From(12), null));
+		var removed = new ShoppingItemRemoved(ItemName.From("Eggs"), Quantity.Of(Amount.From(2), null), null);
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, bought));
+		await handler.HandleAsync(new ShoppingItemRemovedIntegrationEvent(OwnerId, removed));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.AtHome.Should().Be(10);
+	}
+
+	[Fact]
+	public async Task UndoBought_DecrementsBoughtTotal()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var bought = new ShoppingItemBought(ItemName.From("Bread"), Quantity.Of(Amount.From(3), null));
+		var undo = new ShoppingItemUndoBought(ItemName.From("Bread"), Quantity.Of(Amount.From(1), null));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, bought));
+		await handler.HandleAsync(new ShoppingItemUndoBoughtIntegrationEvent(OwnerId, undo));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.BoughtTotal.Should().Be(2);
+		row.AtHome.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task AddedAsAtHome_IncrementsBoughtTotal()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var atHome = new ShoppingItemAddedAsAtHome(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g")));
+
+		await handler.HandleAsync(new ShoppingItemAddedAsAtHomeIntegrationEvent(OwnerId, atHome));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.BoughtTotal.Should().Be(250);
+		row.AtHome.Should().Be(250);
+	}
+
+	[Fact]
+	public async Task UndoBought_NeverNegative()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var undo = new ShoppingItemUndoBought(ItemName.From("Milk"), Quantity.Of(Amount.From(10), Unit.From("l")));
+
+		await handler.HandleAsync(new ShoppingItemUndoBoughtIntegrationEvent(OwnerId, undo));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.BoughtTotal.Should().Be(0);
+		row.AtHome.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task ConsumedExceedsBought_AtHomeClampedToZero()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var bought = new ShoppingItemBought(ItemName.From("Apple"), Quantity.Of(Amount.From(2), null));
+		var consumed = new ShoppingItemConsumed(ItemName.From("Apple"), Quantity.Of(Amount.From(5), null), ItemSource.From("meal-plan"));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, bought));
+		await handler.HandleAsync(new ShoppingItemConsumedIntegrationEvent(OwnerId, consumed));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.AtHome.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task SameNameDifferentUnits_KeepsRowsSeparate()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var litres = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")));
+		var millis = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(500), Unit.From("ml")));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, litres));
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, millis));
+
+		var rows = await context.Set<IngredientBalanceReadItem>().ToListAsync();
+		rows.Should().HaveCount(2);
+	}
+
+	private static ShoppingDbContext CreateContext()
+	{
+		var options = new DbContextOptionsBuilder<ShoppingDbContext>()
+			.UseInMemoryDatabase($"projection-{Guid.NewGuid()}")
+			.Options;
+		return new ShoppingDbContext(options);
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Persistence.ReadModel;
+
+public class IngredientBalanceReadModelRepositoryTests
+{
+	private const string OwnerId = "user-1";
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_NoRows_ReturnsEmpty()
+	{
+		await using var context = CreateContext();
+		var repo = new IngredientBalanceReadModelRepository(context);
+
+		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+
+		items.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_OnlyZeroBalanceRow_ExcludesIt()
+	{
+		await using var context = CreateContext();
+		context.Set<IngredientBalanceReadItem>().Add(new IngredientBalanceReadItem
+		{
+			Id = Guid.NewGuid(),
+			OwnerId = OwnerId,
+			ItemName = "Milk",
+			NameKey = "milk",
+			Unit = "l",
+			Category = IngredientCategory.Dairy.Value,
+			BoughtTotal = 2,
+			ConsumedTotal = 2,
+			RemovedTotal = 0,
+		});
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context);
+		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+
+		items.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_PositiveBalance_ReturnsAtHomeAmount()
+	{
+		await using var context = CreateContext();
+		context.Set<IngredientBalanceReadItem>().Add(new IngredientBalanceReadItem
+		{
+			Id = Guid.NewGuid(),
+			OwnerId = OwnerId,
+			ItemName = "Milk",
+			NameKey = "milk",
+			Unit = "l",
+			Category = IngredientCategory.Dairy.Value,
+			BoughtTotal = 5,
+			ConsumedTotal = 1,
+			RemovedTotal = 0,
+		});
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context);
+		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+
+		items.Should().ContainSingle()
+			.Which.Should().BeEquivalentTo(new IngredientBalanceItemDto(
+				ItemName: "Milk",
+				Quantity: 4m,
+				Unit: "l",
+				Category: IngredientCategory.Dairy.Value,
+				Source: IngredientBalanceSource.AtHome));
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_FiltersByOwner()
+	{
+		await using var context = CreateContext();
+		context.Set<IngredientBalanceReadItem>().AddRange(
+			new IngredientBalanceReadItem
+			{
+				Id = Guid.NewGuid(),
+				OwnerId = OwnerId,
+				ItemName = "Milk",
+				NameKey = "milk",
+				Unit = "l",
+				Category = IngredientCategory.Dairy.Value,
+				BoughtTotal = 2,
+			},
+			new IngredientBalanceReadItem
+			{
+				Id = Guid.NewGuid(),
+				OwnerId = "other-user",
+				ItemName = "Bread",
+				NameKey = "bread",
+				Unit = null,
+				Category = IngredientCategory.Bakery.Value,
+				BoughtTotal = 1,
+			});
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context);
+		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+
+		items.Should().ContainSingle().Which.ItemName.Should().Be("Milk");
+	}
+
+	private static ShoppingReadDbContext CreateContext()
+	{
+		var options = new DbContextOptionsBuilder<ShoppingReadDbContext>()
+			.UseInMemoryDatabase($"ingredient-balance-{Guid.NewGuid()}")
+			.Options;
+		return new ShoppingReadDbContext(options);
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- New per-ingredient at-home balance projection (`IngredientBalanceReadItem`) updated from ledger integration events: Bought − Consumed − Removed (clamped at 0). Wires the two integration events (`AddedAsAtHome`, `UndoBought`) that the event store had not yet been publishing.
- New query `GetIngredientBalanceQuery` + endpoint `GET /api/v1/shopping-lists/balance` returns the user's current inventory: at-home items from the projection plus staples (always-available, no quantity), sorted by category then name.
- Shopping now consumes Users via `IStaplesProvider` over HTTP, mirroring the MealPlan setup. AppHost now wires `usersApi` as a reference of `shoppingApi`.

## Implementation notes
- The `ShoppingLedger` aggregate already tracks per-item `AtHome = max(0, Bought − Consumed − Removed)`. This PR projects those numbers into a flat read row so it can be queried without rehydrating the aggregate, and serves as the data source for "What Can I Cook?" (US-342).
- Read row keeps a `NameKey` (lowercased name) column so the projection upsert uses a plain equality predicate — no `EF.Functions.ILike`, which keeps the query provider-portable and easy to test against the in-memory provider.
- A new EF migration `AddIngredientBalanceReadModel` adds the `IngredientBalanceReadItems` table.

## Closes
Closes #181 (US-340).

## Test plan
- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Shopping unit + Architecture suites green (446 tests)
- [x] New tests:
  - `GetIngredientBalanceQueryHandlerTests` (6) — at-home + staple merging, dedup, ordering, owner scoping
  - `IngredientBalanceProjectionHandlerTests` (8) — Bought/Consumed/Removed/UndoBought/AddedAsAtHome flows, clamp-to-zero, separate rows per unit
  - `IngredientBalanceReadModelRepositoryTests` (4) — owner scoping, zero-balance hidden, mapping
- [ ] Manual smoke against `aspire run` once merged: hit `GET /api/v1/shopping-lists/balance`, confirm staples show up + bought items show up + cooked meal decrements.

## Follow-ups
- Light duplication of `AuthTokenDelegatingHandler` + `HttpStaplesProvider` between Shopping/MealPlan; can be folded into `Yumney.Shared.Web` later (out of scope here).
- Frontend consumer + UI for the balance sheet land in subsequent stories (US-342 What-Can-I-Cook).