### PR TITLE
feat(recipes): what-can-i-cook recipe matching backend (US-342)

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -117,11 +117,6 @@ if (!options.DatabaseOnly)
 
 	var apiEnvironment = builder.Environment.EnvironmentName;
 
-	var recipesApi = builder
-		.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.AsYumneyApi(recipesDb, keycloak, redis, messaging, migrationRunner)
-		.WithLlmProvider(builder, options);
 	var usersApi = builder
 		.AddProject<Projects.Yumney_Users_Api>("users-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
@@ -132,6 +127,12 @@ if (!options.DatabaseOnly)
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.AsYumneyApi(shoppingDb, keycloak, redis, messaging, migrationRunner)
 		.WithReference(usersApi);
+	var recipesApi = builder
+		.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
+		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.AsYumneyApi(recipesDb, keycloak, redis, messaging, migrationRunner)
+		.WithLlmProvider(builder, options)
+		.WithReference(shoppingApi);
 	var mealplanApi = builder
 		.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -165,5 +165,19 @@ public static partial class RecipesEndpoints
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}
+
+		group.MapGet("/what-can-i-cook", WhatCanICook)
+			.WithName("WhatCanICook")
+			.WithTags("Recipes")
+			.Produces<IReadOnlyList<CookableRecipeDto>>();
+
+		static async Task<IResult> WhatCanICook(
+			IQueryHandler<GetCookableRecipesQuery, Result<IReadOnlyList<CookableRecipeDto>>> handler,
+			CancellationToken cancellationToken,
+			bool fullMatchOnly = false)
+		{
+			var result = await handler.HandleAsync(new GetCookableRecipesQuery(fullMatchOnly), cancellationToken);
+			return result.ToOk();
+		}
 	}
 }

--- a/src/Yumney.Recipes.Application/DTOs/CookableRecipeDto.cs
+++ b/src/Yumney.Recipes.Application/DTOs/CookableRecipeDto.cs
@@ -1,0 +1,17 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+/// <summary>
+/// One result row from "What Can I Cook?". Pairs a recipe summary with the
+/// match classification + the ingredients that are missing (empty for Full).
+/// </summary>
+public sealed record CookableRecipeDto(
+	Guid RecipeIdentifier,
+	string Title,
+	string? ImageUrl,
+	int? Servings,
+	int? PrepTimeMinutes,
+	int? CookTimeMinutes,
+	string? Difficulty,
+	int IngredientCount,
+	CookableRecipeMatchTier Tier,
+	IReadOnlyList<string> MissingIngredients);

--- a/src/Yumney.Recipes.Application/DTOs/CookableRecipeMatchTier.cs
+++ b/src/Yumney.Recipes.Application/DTOs/CookableRecipeMatchTier.cs
@@ -1,0 +1,13 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+/// <summary>
+/// Classification of a recipe against a user's at-home + staples balance.
+/// </summary>
+public enum CookableRecipeMatchTier
+{
+	/// <summary>All ingredients are available — recipe is ready to cook.</summary>
+	Full,
+
+	/// <summary>One or two ingredients are missing — close to ready.</summary>
+	Near,
+}

--- a/src/Yumney.Recipes.Application/Queries/GetCookableRecipesQuery.cs
+++ b/src/Yumney.Recipes.Application/Queries/GetCookableRecipesQuery.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Queries;
+
+/// <summary>
+/// "What Can I Cook?" — returns recipes the user can prepare right now,
+/// optionally including near-matches (one or two missing ingredients).
+/// Powered by the shared <see cref="IIngredientBalanceProvider"/> which
+/// merges at-home ledger items with the user's staples list.
+/// </summary>
+public sealed record GetCookableRecipesQuery(bool FullMatchOnly = false)
+	: IQuery<Result<IReadOnlyList<CookableRecipeDto>>>;

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
@@ -1,0 +1,63 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Queries.Handlers;
+
+public sealed class GetCookableRecipesQueryHandler(
+	IRecipeRepository recipes,
+	IIngredientBalanceProvider balanceProvider,
+	ICurrentUser currentUser)
+	: IQueryHandler<GetCookableRecipesQuery, Result<IReadOnlyList<CookableRecipeDto>>>
+{
+#pragma warning disable SA1303
+	private const int maxMissingForNearMatch = 2;
+#pragma warning restore SA1303
+
+	public async Task<Result<IReadOnlyList<CookableRecipeDto>>> HandleAsync(GetCookableRecipesQuery query, CancellationToken cancellationToken = default)
+	{
+		var owner = currentUser.AsOwner();
+
+		var recipesTask = recipes.GetAllByOwnerWithIngredientsAsync(owner, cancellationToken);
+		var availableTask = balanceProvider.GetAvailableIngredientNamesAsync(currentUser.UserId, cancellationToken);
+		await Task.WhenAll(recipesTask, availableTask);
+
+		var available = availableTask.Result;
+		var matches = new List<CookableRecipeDto>();
+
+		foreach (var recipe in recipesTask.Result)
+		{
+			var missing = recipe.Ingredients
+				.Where(i => !available.Contains(i.Name.Value.Trim()))
+				.Select(i => i.Name.Value)
+				.ToList();
+
+			var tier = missing.Count == 0
+				? CookableRecipeMatchTier.Full
+				: CookableRecipeMatchTier.Near;
+
+			if (tier == CookableRecipeMatchTier.Near && missing.Count > maxMissingForNearMatch) continue;
+			if (query.FullMatchOnly && tier != CookableRecipeMatchTier.Full) continue;
+
+			matches.Add(new CookableRecipeDto(
+				RecipeIdentifier: recipe.Id.Value,
+				Title: recipe.Title.Value,
+				ImageUrl: recipe.ImageUrl?.Value,
+				Servings: recipe.Servings?.Value,
+				PrepTimeMinutes: recipe.Timing?.Preparation?.Value,
+				CookTimeMinutes: recipe.Timing?.Cooking?.Value,
+				Difficulty: recipe.Difficulty?.Value,
+				IngredientCount: recipe.Ingredients.Count,
+				Tier: tier,
+				MissingIngredients: missing));
+		}
+
+		IReadOnlyList<CookableRecipeDto> ranked = [.. matches
+			.OrderBy(m => m.Tier == CookableRecipeMatchTier.Full ? 0 : 1)
+			.ThenBy(m => m.MissingIngredients.Count)
+			.ThenBy(m => m.Title, StringComparer.OrdinalIgnoreCase)];
+
+		return Result<IReadOnlyList<CookableRecipeDto>>.Success(ranked);
+	}
+}

--- a/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/IRecipeRepository.cs
@@ -22,5 +22,12 @@ public interface IRecipeRepository
 		RecipeFilter? filter = null,
 		CancellationToken cancellationToken = default);
 
+	// Bulk fetch with ingredients eagerly loaded. Used by the recipe-matching
+	// engine ("What Can I Cook?"). Untracked. Keep in mind this loads the full
+	// recipe set for the owner — caller is responsible for any ranking + cap.
+	Task<IReadOnlyList<Recipe>> GetAllByOwnerWithIngredientsAsync(
+		OwnerIdentifier owner,
+		CancellationToken cancellationToken = default);
+
 	void Remove(Recipe recipe);
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -46,6 +46,18 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 		context.Recipes.Remove(recipe);
 	}
 
+	public async Task<IReadOnlyList<Recipe>> GetAllByOwnerWithIngredientsAsync(
+		OwnerIdentifier owner,
+		CancellationToken cancellationToken = default)
+	{
+		return await recipes
+			.AsNoTracking()
+			.Where(r => r.Owner == owner)
+			.Include(r => r.Ingredients)
+			.AsSplitQuery()
+			.ToListAsync(cancellationToken);
+	}
+
 	public async Task<(IReadOnlyList<Recipe> Items, ItemCount TotalCount)> GetByOwnerAsync(
 		OwnerIdentifier owner,
 		PagingOptions paging,

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -25,6 +25,10 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipeFavoriteRepository, RecipeFavoriteRepository>();
 		services.AddScoped<IRecipesUnitOfWork, RecipesUnitOfWork>();
 		services.AddScoped<IRecipeIngredientProvider, RecipeIngredientProvider>();
+		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
+		services.AddTransient<AuthTokenDelegatingHandler>();
+		services.AddHttpClient("shopping-api", client => client.BaseAddress = new Uri("http://shopping-api"))
+			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
 		return services;

--- a/src/Yumney.Recipes.Infrastructure/Services/AuthTokenDelegatingHandler.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/AuthTokenDelegatingHandler.cs
@@ -1,0 +1,19 @@
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+
+public sealed class AuthTokenDelegatingHandler(IHttpContextAccessor httpContextAccessor) : DelegatingHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var authHeader = httpContextAccessor.HttpContext?.Request.Headers.Authorization.ToString();
+		if (authHeader.HasValue())
+		{
+			request.Headers.Authorization = AuthenticationHeaderValue.Parse(authHeader!);
+		}
+
+		return base.SendAsync(request, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/Services/HttpIngredientBalanceProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/HttpIngredientBalanceProvider.cs
@@ -1,0 +1,33 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+
+/// <summary>
+/// HTTP-backed <see cref="IIngredientBalanceProvider"/> for callers in the
+/// Recipes module. Calls the Shopping API balance endpoint and projects the
+/// returned items to a lowercased name set used for case-insensitive matching.
+/// </summary>
+public sealed class HttpIngredientBalanceProvider(IHttpClientFactory httpClientFactory) : IIngredientBalanceProvider
+{
+	public async Task<IReadOnlySet<string>> GetAvailableIngredientNamesAsync(string ownerId, CancellationToken cancellationToken = default)
+	{
+		var client = httpClientFactory.CreateClient("shopping-api");
+		var dto = await client.GetFromJsonAsync<BalanceDto>("/api/v1/shopping-lists/balance", cancellationToken);
+
+		if (dto?.Items is null)
+		{
+			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		}
+
+		return dto.Items
+			.Select(i => i.ItemName.Trim())
+			.Where(n => n.Length > 0)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+#pragma warning disable SA1313, SA1402, SA1649
+	private sealed record BalanceDto(IReadOnlyList<BalanceItemDto> Items);
+
+	private sealed record BalanceItemDto(string ItemName);
+}

--- a/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
+++ b/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Yumney.Recipes.Application\Yumney.Recipes.Application.csproj" />
     <ProjectReference Include="..\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
@@ -8,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>

--- a/src/Yumney.Shared/Common/IIngredientBalanceProvider.cs
+++ b/src/Yumney.Shared/Common/IIngredientBalanceProvider.cs
@@ -1,0 +1,14 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Cross-module read access to a user's "available ingredients" set —
+/// the union of at-home ledger items (Bought − Consumed − Removed &gt; 0)
+/// and staples. Returned names are lowercased / trimmed to match
+/// case-insensitively against recipe ingredient names.
+/// Implementations: Shopping module (in-process) and a HTTP client for
+/// callers in other modules (e.g., Recipes' "What Can I Cook?" matcher).
+/// </summary>
+public interface IIngredientBalanceProvider
+{
+	Task<IReadOnlySet<string>> GetAvailableIngredientNamesAsync(string ownerId, CancellationToken cancellationToken = default);
+}

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
@@ -65,7 +65,7 @@ public class WhatCanICookContractTests(AspireFixture fixture) : IAsyncLifetime
 	[Fact]
 	public async Task WhatCanICook_Unauthenticated_Returns401()
 	{
-		using var client = fixture.RecipesApi;
+		var client = fixture.RecipesApi;
 
 		var response = await client.GetAsync(Endpoint);
 

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
+
+/// <summary>
+/// Contract tests for GET /api/v1/recipes/what-can-i-cook — exercises the
+/// cross-module HTTP path Recipes → Shopping `/balance` end-to-end.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class WhatCanICookContractTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private const string Endpoint = "/api/v1/recipes/what-can-i-cook";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public Task InitializeAsync() => CleanupAsync();
+
+	public Task DisposeAsync() => CleanupAsync();
+
+	[Fact]
+	public async Task WhatCanICook_NoRecipes_ReturnsEmptyArray()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetArrayLength().Should().Be(0);
+	}
+
+	[Fact]
+	public async Task WhatCanICook_RecipesButNoBalance_ReturnsRecipesAsNearMatchOrExcluded()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+
+		// Lasagne has 10 ingredients — none in balance, so excluded (>2 missing).
+		// TomatoSoup is a smaller recipe (4 ingredients) — also excluded.
+		await fixture.SeedRecipesAsync(RecipeFactory.Lasagne(userId), RecipeFactory.TomatoSoup(userId));
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetArrayLength().Should().Be(0);
+	}
+
+	[Fact]
+	public async Task WhatCanICook_FullMatchOnly_FlagAcceptedWithoutError()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.GetAsync($"{Endpoint}?fullMatchOnly=true");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task WhatCanICook_Unauthenticated_Returns401()
+	{
+		using var client = fixture.RecipesApi;
+
+		var response = await client.GetAsync(Endpoint);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	private async Task CleanupAsync()
+	{
+		var userId = await fixture.GetTestUserIdAsync();
+		var owner = OwnerIdentifier.From(userId);
+		await AspireFixture.CleanupAsync(
+			fixture.CreateRecipesDbContextAsync,
+			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+	}
+}

--- a/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
@@ -114,6 +114,56 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task GetAllByOwnerWithIngredientsAsync_ReturnsRecipesWithIngredientsLoaded()
+	{
+		var lasagne = RecipeFactory.Lasagne(owner.Value);
+		var soup = RecipeFactory.TomatoSoup(owner.Value);
+		await fixture.SeedRecipesAsync(lasagne, soup);
+
+		await using var readContext = await fixture.CreateRecipesDbContextAsync();
+		var recipes = new RecipeRepository(readContext);
+		var loaded = await recipes.GetAllByOwnerWithIngredientsAsync(owner);
+
+		loaded.Should().HaveCount(2);
+		loaded.Should().AllSatisfy(r => r.Ingredients.Should().NotBeEmpty());
+	}
+
+	[Fact]
+	public async Task GetAllByOwnerWithIngredientsAsync_OtherOwnersRecipes_NotIncluded()
+	{
+		var mine = RecipeFactory.Lasagne(owner.Value);
+		var otherOwner = OwnerIdentifier.From($"other-{Guid.NewGuid():N}");
+		var theirs = RecipeFactory.TomatoSoup(otherOwner.Value);
+		try
+		{
+			await fixture.SeedRecipesAsync(mine, theirs);
+
+			await using var readContext = await fixture.CreateRecipesDbContextAsync();
+			var recipes = new RecipeRepository(readContext);
+			var loaded = await recipes.GetAllByOwnerWithIngredientsAsync(owner);
+
+			loaded.Should().ContainSingle().Which.Id.Should().Be(mine.Id);
+		}
+		finally
+		{
+			await AspireFixture.CleanupAsync(
+				fixture.CreateRecipesDbContextAsync,
+				ctx => ctx.Recipes.Where(r => r.Owner == otherOwner));
+		}
+	}
+
+	[Fact]
+	public async Task GetAllByOwnerWithIngredientsAsync_NoRecipes_ReturnsEmpty()
+	{
+		await using var context = await fixture.CreateRecipesDbContextAsync();
+		var recipes = new RecipeRepository(context);
+
+		var loaded = await recipes.GetAllByOwnerWithIngredientsAsync(owner);
+
+		loaded.Should().BeEmpty();
+	}
+
+	[Fact]
 	public async Task GetByOwnerAsync_RecipeWithTags_LoadsTagsForListItems()
 	{
 		var recipe = RecipeFactory.Lasagne(owner.Value);

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
+using SmartSolutionsLab.Yumney.Recipes.Application.Queries.Handlers;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Queries;
+
+public class GetCookableRecipesQueryHandlerTests
+{
+	private const string OwnerId = "user-123";
+
+	private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
+	private readonly IIngredientBalanceProvider balanceProvider = Substitute.For<IIngredientBalanceProvider>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly GetCookableRecipesQueryHandler handler;
+
+	public GetCookableRecipesQueryHandlerTests()
+	{
+		currentUser.UserId.Returns(OwnerId);
+		handler = new GetCookableRecipesQueryHandler(recipes, balanceProvider, currentUser);
+	}
+
+	[Fact]
+	public async Task HandleAsync_NoRecipes_ReturnsEmptyList()
+	{
+		ConfigureBalance("salt", "pepper");
+		ConfigureRecipes();
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_AllIngredientsAvailable_ReturnsFullMatch()
+	{
+		ConfigureBalance("flour", "eggs", "milk");
+		ConfigureRecipes(MakeRecipe("Pancakes", "Flour", "Eggs", "Milk"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		var match = result.Value.Should().ContainSingle().Subject;
+		match.Title.Should().Be("Pancakes");
+		match.Tier.Should().Be(CookableRecipeMatchTier.Full);
+		match.MissingIngredients.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_OneIngredientMissing_ReturnsNearMatchWithMissingItem()
+	{
+		ConfigureBalance("flour", "eggs");
+		ConfigureRecipes(MakeRecipe("Pancakes", "Flour", "Eggs", "Milk"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		var match = result.Value.Should().ContainSingle().Subject;
+		match.Tier.Should().Be(CookableRecipeMatchTier.Near);
+		match.MissingIngredients.Should().BeEquivalentTo(["Milk"]);
+	}
+
+	[Fact]
+	public async Task HandleAsync_MoreThanTwoMissing_RecipeIsExcluded()
+	{
+		ConfigureBalance("flour");
+		ConfigureRecipes(MakeRecipe("Carbonara", "Pasta", "Egg", "Pancetta", "Cheese"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_FullMatchOnly_HidesNearMatches()
+	{
+		ConfigureBalance("flour", "eggs");
+		ConfigureRecipes(
+			MakeRecipe("Pancakes", "Flour", "Eggs", "Milk"),
+			MakeRecipe("Crepes", "Flour", "Eggs"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery(FullMatchOnly: true));
+
+		result.Value.Should().ContainSingle().Which.Title.Should().Be("Crepes");
+	}
+
+	[Fact]
+	public async Task HandleAsync_StaplesCountAsAvailable()
+	{
+		ConfigureBalance("salt", "pepper", "tomato");
+		ConfigureRecipes(MakeRecipe("Tomato Salt", "Tomato", "Salt", "Pepper"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Should().ContainSingle().Which.Tier.Should().Be(CookableRecipeMatchTier.Full);
+	}
+
+	[Fact]
+	public async Task HandleAsync_MatchingIsCaseInsensitive()
+	{
+		ConfigureBalance("FLOUR", "EGGS");
+		ConfigureRecipes(MakeRecipe("Crepes", "flour", "eggs"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Should().ContainSingle().Which.Tier.Should().Be(CookableRecipeMatchTier.Full);
+	}
+
+	[Fact]
+	public async Task HandleAsync_RanksFullMatchesBeforeNear()
+	{
+		ConfigureBalance("flour", "eggs");
+		ConfigureRecipes(
+			MakeRecipe("Pancakes", "Flour", "Eggs", "Milk"),
+			MakeRecipe("Crepes", "Flour", "Eggs"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("Crepes", "Pancakes");
+	}
+
+	[Fact]
+	public async Task HandleAsync_WithinSameTier_FewerMissingFirst()
+	{
+		ConfigureBalance("flour");
+		ConfigureRecipes(
+			MakeRecipe("RecipeA", "Flour", "Eggs", "Milk"),
+			MakeRecipe("RecipeB", "Flour", "Sugar"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("RecipeB", "RecipeA");
+	}
+
+	[Fact]
+	public async Task HandleAsync_TiesBrokenAlphabetically()
+	{
+		ConfigureBalance("flour", "eggs", "milk");
+		ConfigureRecipes(
+			MakeRecipe("Zuppa", "Flour", "Eggs", "Milk"),
+			MakeRecipe("Apple Pie", "Flour", "Eggs", "Milk"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("Apple Pie", "Zuppa");
+	}
+
+	[Fact]
+	public async Task HandleAsync_BalanceProviderQueriedWithCurrentUser()
+	{
+		ConfigureBalance();
+		ConfigureRecipes();
+
+		await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		await balanceProvider.Received(1).GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>());
+	}
+
+	private static Recipe MakeRecipe(string title, params string[] ingredientNames)
+	{
+		return Recipe.Create(
+			RecipeTitle.From(title),
+			OwnerIdentifier.From(OwnerId),
+			ingredientNames.Select(n => Ingredient.Create(IngredientName.From(n), null)).ToList(),
+			[Step.Create(StepNumber.From(1), StepDescription.From("Cook"))]);
+	}
+
+	private void ConfigureRecipes(params Recipe[] recipeList)
+	{
+		recipes.GetAllByOwnerWithIngredientsAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns(recipeList);
+	}
+
+	private void ConfigureBalance(params string[] availableNames)
+	{
+		balanceProvider.GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>())
+			.Returns((IReadOnlySet<string>)availableNames.ToHashSet(StringComparer.OrdinalIgnoreCase));
+	}
+}


### PR DESCRIPTION
## Summary
- New `GET /api/v1/recipes/what-can-i-cook?fullMatchOnly=false` returns recipes the user can prepare right now. Each result is `{ recipe info, tier (Full/Near), missingIngredients[] }`.
- Ranking: Tier (Full first) → missing-count asc → title asc. Near-matches are capped at two missing ingredients.
- Matching pulls the user's at-home + staples set via the new shared `IIngredientBalanceProvider`. The Recipes module gets an HTTP-backed implementation that calls Shopping's `/balance` endpoint (mirrors the `HttpStaplesProvider` used in MealPlan).
- New `IRecipeRepository.GetAllByOwnerWithIngredientsAsync` — bulk, untracked, ingredients eager-loaded with `AsSplitQuery`.

## Closes
Closes #183 (US-342).

## Scope cuts (called out so reviewers don't expect them)
- **Match key:** ingredient name only, case-insensitive. No unit/quantity comparison, no synonym resolution. Recipe says `flour`, balance says `Flour` → match. Recipe says `200 g flour`, balance has `1 kg flour` → match (quantity ignored). Refining this is its own story.
- **Ranking:** perishable-first ranking is deferred (depends on US-341 freshness data, not built). User-rating ranking is deferred (depends on US-120, not built). Once those land, the third tie-breaker can extend.
- **Frontend:** separate PR. The endpoint is shaped to feed glassmorphism cards directly (returns enough display data to render without follow-up calls).

## Test plan
- [x] Build green with `TreatWarningsAsErrors=true`
- [x] `dotnet format --verify-no-changes` clean
- [x] `GetCookableRecipesQueryHandlerTests` — 11 tests covering AC TC-342-01..06:
  - empty recipes / empty balance
  - all available → Full match
  - one missing → Near match with the missing item listed
  - >2 missing → recipe excluded
  - `fullMatchOnly=true` hides Near matches
  - staples count as available
  - case-insensitive matching
  - tier ordering (Full before Near)
  - within-tier ordering (fewer missing first)
  - within-tier ties broken alphabetically
  - balance provider queried with current user id
- [x] All Recipes test suites green (153 application, 233 domain, 161 api, 81 infra) + Architecture tests (117) — 745 total
- [ ] Manual smoke once merged: hit `/api/v1/recipes/what-can-i-cook` after seeding a recipe + buying its ingredients via the Shopping API.

## Follow-ups
- Frontend (separate PR, will likely be one US — entry point in nav + dashboard tile + result page).
- Synonym/unit-aware matching when usage shows it's needed.
- Rebuild ranking once perishable + rating data exists.