### PR TITLE
feat(shopping): perishable freshness on the balance projection (US-341)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,5 +64,6 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Yumney.Shared/Common/Freshness.cs
+++ b/src/Yumney.Shared/Common/Freshness.cs
@@ -1,0 +1,20 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Freshness state for a stored ingredient (US-341). Computed from the
+/// item's category-based shelf life and how long ago it was last bought.
+/// </summary>
+public enum Freshness
+{
+	/// <summary>Category has no perishability tracking (pantry, household, …).</summary>
+	NotTracked,
+
+	/// <summary>Within the first half of the shelf life — green indicator.</summary>
+	Fresh,
+
+	/// <summary>Past half the shelf life but not yet expired — yellow indicator.</summary>
+	UseSoon,
+
+	/// <summary>At or past the expected shelf life — orange indicator.</summary>
+	CheckIt,
+}

--- a/src/Yumney.Shared/Common/ShelfLife.cs
+++ b/src/Yumney.Shared/Common/ShelfLife.cs
@@ -1,0 +1,42 @@
+namespace SmartSolutionsLab.Yumney.Shared.Common;
+
+/// <summary>
+/// Coarse shelf-life lookup keyed by <see cref="IngredientCategory"/> (US-341).
+/// The values are deliberately conservative — the goal is a "use soon" nudge,
+/// not a precise expiry date. Returning <c>null</c> means the category is not
+/// tracked for freshness (pantry, household, beverages, other).
+/// </summary>
+public static class ShelfLife
+{
+	public static int? DaysFor(IngredientCategory category)
+	{
+		var key = category?.Value ?? IngredientCategory.Other.Value;
+
+		return key switch
+		{
+			"meat-fish" => 2,
+			"bakery" => 3,
+			"produce" => 5,
+			"dairy" => 6,
+			"frozen" => 60,
+			_ => null,
+		};
+	}
+
+	/// <summary>
+	/// Returns the freshness state for an item bought <paramref name="daysSinceBought"/>
+	/// days ago. <c>null</c> <paramref name="daysSinceBought"/> (no purchase recorded)
+	/// always yields <see cref="Freshness.NotTracked"/>.
+	/// </summary>
+	/// <param name="category">Ingredient category — drives the shelf-life lookup.</param>
+	/// <param name="daysSinceBought">Days since the most recent purchase, or null if unknown.</param>
+	/// <returns>The corresponding <see cref="Freshness"/> classification.</returns>
+	public static Freshness Classify(IngredientCategory category, int? daysSinceBought)
+	{
+		var shelf = DaysFor(category);
+		if (shelf is null || daysSinceBought is null) return Freshness.NotTracked;
+		if (daysSinceBought.Value >= shelf.Value) return Freshness.CheckIt;
+		if (daysSinceBought.Value * 2 >= shelf.Value) return Freshness.UseSoon;
+		return Freshness.Fresh;
+	}
+}

--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceItemDto.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceItemDto.cs
@@ -1,13 +1,19 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
 namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
 /// <summary>
 /// One ingredient in the balance sheet ("what's at home right now").
 /// <see cref="Quantity"/> is null for staples that are tracked as
 /// "always available" rather than as a measurable amount.
+/// <see cref="Freshness"/> drives the visual nudge (US-341): staples and
+/// pantry items always come back as <see cref="Freshness.NotTracked"/>.
 /// </summary>
 public sealed record IngredientBalanceItemDto(
 	string ItemName,
 	decimal? Quantity,
 	string? Unit,
 	string Category,
-	IngredientBalanceSource Source);
+	IngredientBalanceSource Source,
+	Freshness Freshness = Freshness.NotTracked,
+	int? DaysSinceBought = null);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
@@ -18,6 +18,7 @@ internal sealed class IngredientBalanceReadItemConfiguration : IEntityTypeConfig
 		entity.Property(e => e.BoughtTotal).HasColumnType("numeric");
 		entity.Property(e => e.ConsumedTotal).HasColumnType("numeric");
 		entity.Property(e => e.RemovedTotal).HasColumnType("numeric");
+		entity.Property(e => e.LastBoughtAt);
 		entity.Property(e => e.LastUpdated).IsRequired();
 
 		entity.Ignore(e => e.AtHome);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260430080828_AddLastBoughtAtToIngredientBalance.Designer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260430080828_AddLastBoughtAtToIngredientBalance.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ShoppingDbContext))]
-    partial class ShoppingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430080828_AddLastBoughtAtToIngredientBalance")]
+    partial class AddLastBoughtAtToIngredientBalance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260430080828_AddLastBoughtAtToIngredientBalance.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Migrations/20260430080828_AddLastBoughtAtToIngredientBalance.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLastBoughtAtToIngredientBalance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastBoughtAt",
+                table: "IngredientBalanceReadItems",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastBoughtAt",
+                table: "IngredientBalanceReadItems");
+        }
+    }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
@@ -23,11 +23,16 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 	public Task HandleAsync(ShoppingItemBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
+		var now = DateTime.UtcNow;
 		return UpsertAsync(
 			@event.OwnerId,
 			inner.ItemName,
 			inner.Quantity.Unit?.Value,
-			row => row.BoughtTotal += inner.Quantity.Amount,
+			row =>
+			{
+				row.BoughtTotal += inner.Quantity.Amount;
+				row.LastBoughtAt = now;
+			},
 			cancellationToken);
 	}
 
@@ -67,11 +72,16 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 	public Task HandleAsync(ShoppingItemAddedAsAtHomeIntegrationEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
+		var now = DateTime.UtcNow;
 		return UpsertAsync(
 			@event.OwnerId,
 			inner.ItemName,
 			inner.Quantity.Unit?.Value,
-			row => row.BoughtTotal += inner.Quantity.Amount,
+			row =>
+			{
+				row.BoughtTotal += inner.Quantity.Amount;
+				row.LastBoughtAt = now;
+			},
 			cancellationToken);
 	}
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
@@ -13,7 +13,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel
 /// Powers the <see cref="GetIngredientBalanceQuery"/> ("what's at home right now")
 /// and is the data source for the "What Can I Cook?" feature (US-342).
 /// </summary>
-public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context)
+public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context, TimeProvider timeProvider)
 	: IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>,
 	  IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>,
 	  IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>,
@@ -23,7 +23,7 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 	public Task HandleAsync(ShoppingItemBoughtIntegrationEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var now = DateTime.UtcNow;
+		var now = timeProvider.GetUtcNow().UtcDateTime;
 		return UpsertAsync(
 			@event.OwnerId,
 			inner.ItemName,
@@ -72,7 +72,7 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 	public Task HandleAsync(ShoppingItemAddedAsAtHomeIntegrationEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var now = DateTime.UtcNow;
+		var now = timeProvider.GetUtcNow().UtcDateTime;
 		return UpsertAsync(
 			@event.OwnerId,
 			inner.ItemName,
@@ -116,7 +116,7 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 		}
 
 		mutate(row);
-		row.LastUpdated = DateTime.UtcNow;
+		row.LastUpdated = timeProvider.GetUtcNow().UtcDateTime;
 		await context.SaveChangesAsync(cancellationToken);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadItem.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadItem.cs
@@ -31,6 +31,12 @@ public sealed class IngredientBalanceReadItem
 
 	public decimal RemovedTotal { get; set; }
 
+	/// <summary>
+	/// Gets or sets the most recent Bought / AddedAsAtHome timestamp,
+	/// used to compute freshness (US-341). Null until the first purchase.
+	/// </summary>
+	public DateTime? LastBoughtAt { get; set; }
+
 	public DateTime LastUpdated { get; set; }
 
 	/// <summary>

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
@@ -1,10 +1,11 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
-public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext context) : IIngredientBalanceReadModelRepository
+public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext context, TimeProvider timeProvider) : IIngredientBalanceReadModelRepository
 {
 	public async Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(string ownerId, CancellationToken cancellationToken = default)
 	{
@@ -12,14 +13,27 @@ public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext c
 			.Where(r => r.OwnerId == ownerId)
 			.ToListAsync(cancellationToken);
 
+		var now = timeProvider.GetUtcNow().UtcDateTime;
+
 		return rows
 			.Where(r => r.AtHome > 0)
-			.Select(r => new IngredientBalanceItemDto(
-				ItemName: r.ItemName,
-				Quantity: r.AtHome,
-				Unit: r.Unit,
-				Category: r.Category,
-				Source: IngredientBalanceSource.AtHome))
+			.Select(r =>
+			{
+				var category = IngredientCategory.From(r.Category);
+				var daysSinceBought = r.LastBoughtAt is null
+					? (int?)null
+					: Math.Max(0, (int)(now - r.LastBoughtAt.Value).TotalDays);
+				var freshness = ShelfLife.Classify(category, daysSinceBought);
+
+				return new IngredientBalanceItemDto(
+					ItemName: r.ItemName,
+					Quantity: r.AtHome,
+					Unit: r.Unit,
+					Category: r.Category,
+					Source: IngredientBalanceSource.AtHome,
+					Freshness: freshness,
+					DaysSinceBought: daysSinceBought);
+			})
 			.ToList();
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
@@ -70,6 +71,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"))
 			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
+		services.TryAddSingleton(TimeProvider.System);
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
 		return services;

--- a/tests/Yumney.Shared.Tests/Common/ShelfLifeTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/ShelfLifeTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class ShelfLifeTests
+{
+	[Theory]
+	[InlineData("meat-fish", 2)]
+	[InlineData("dairy", 6)]
+	[InlineData("produce", 5)]
+	[InlineData("bakery", 3)]
+	[InlineData("frozen", 60)]
+	public void DaysFor_PerishableCategory_ReturnsExpected(string category, int expected)
+	{
+		ShelfLife.DaysFor(IngredientCategory.From(category)).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData("pantry")]
+	[InlineData("household")]
+	[InlineData("beverages")]
+	[InlineData("other")]
+	public void DaysFor_NonTrackedCategory_ReturnsNull(string category)
+	{
+		ShelfLife.DaysFor(IngredientCategory.From(category)).Should().BeNull();
+	}
+
+	[Fact]
+	public void Classify_NullDaysSinceBought_AlwaysNotTracked()
+	{
+		ShelfLife.Classify(IngredientCategory.MeatFish, null).Should().Be(Freshness.NotTracked);
+	}
+
+	[Fact]
+	public void Classify_NonTrackedCategory_ReturnsNotTrackedRegardlessOfAge()
+	{
+		ShelfLife.Classify(IngredientCategory.Pantry, 30).Should().Be(Freshness.NotTracked);
+	}
+
+	[Theory]
+	[InlineData(0, Freshness.Fresh)] // 0 days < 1 (= 50% of 2)
+	[InlineData(1, Freshness.UseSoon)] // 1 day = 50% of 2
+	[InlineData(2, Freshness.CheckIt)] // expired
+	[InlineData(5, Freshness.CheckIt)]
+	public void Classify_MeatFish_TwoDayShelfLife(int daysSinceBought, Freshness expected)
+	{
+		ShelfLife.Classify(IngredientCategory.MeatFish, daysSinceBought).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(0, Freshness.Fresh)]
+	[InlineData(2, Freshness.Fresh)] // 2*2 = 4 < 6 → Fresh
+	[InlineData(3, Freshness.UseSoon)] // 3*2 = 6 >= 6 → UseSoon
+	[InlineData(5, Freshness.UseSoon)]
+	[InlineData(6, Freshness.CheckIt)]
+	public void Classify_Dairy_SixDayShelfLife(int daysSinceBought, Freshness expected)
+	{
+		ShelfLife.Classify(IngredientCategory.Dairy, daysSinceBought).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(29, Freshness.Fresh)] // 29*2 = 58 < 60
+	[InlineData(30, Freshness.UseSoon)] // 30*2 = 60 >= 60
+	[InlineData(60, Freshness.CheckIt)]
+	public void Classify_Frozen_SixtyDayShelfLife(int daysSinceBought, Freshness expected)
+	{
+		ShelfLife.Classify(IngredientCategory.Frozen, daysSinceBought).Should().Be(expected);
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
@@ -15,11 +17,13 @@ public class IngredientBalanceProjectionHandlerTests
 {
 	private const string OwnerId = "user-1";
 
+	private readonly TimeProvider timeProvider = TimeProvider.System;
+
 	[Fact]
 	public async Task Bought_NewItem_CreatesRowWithBoughtTotal()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var domainEvent = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l")));
 
 		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, domainEvent));
@@ -33,25 +37,24 @@ public class IngredientBalanceProjectionHandlerTests
 	}
 
 	[Fact]
-	public async Task Bought_SetsLastBoughtAt()
+	public async Task Bought_SetsLastBoughtAtToProviderTime()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
-		var before = DateTime.UtcNow;
+		var fakeTime = new FakeTimeProvider(DateTimeOffset.Parse("2026-04-30T10:00:00Z", CultureInfo.InvariantCulture));
+		var handler = new IngredientBalanceProjectionHandler(context, fakeTime);
 		var domainEvent = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")));
 
 		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, domainEvent));
-		var after = DateTime.UtcNow;
 
 		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
-		row.LastBoughtAt.Should().NotBeNull().And.BeOnOrAfter(before).And.BeOnOrBefore(after);
+		row.LastBoughtAt.Should().Be(fakeTime.GetUtcNow().UtcDateTime);
 	}
 
 	[Fact]
 	public async Task AddedAsAtHome_SetsLastBoughtAt()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var before = DateTime.UtcNow;
 		var domainEvent = new ShoppingItemAddedAsAtHome(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g")));
 
@@ -66,7 +69,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task Consumed_DoesNotChangeLastBoughtAt()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(
 			OwnerId, new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l")))));
 		var firstBoughtAt = (await context.Set<IngredientBalanceReadItem>().SingleAsync()).LastBoughtAt;
@@ -82,7 +85,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task Consumed_AfterBought_DecrementsAtHome()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var bought = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(5), Unit.From("l")));
 		var consumed = new ShoppingItemConsumed(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), ItemSource.From("meal-plan"));
 
@@ -99,7 +102,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task Removed_AfterBought_DecrementsAtHome()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var bought = new ShoppingItemBought(ItemName.From("Eggs"), Quantity.Of(Amount.From(12), null));
 		var removed = new ShoppingItemRemoved(ItemName.From("Eggs"), Quantity.Of(Amount.From(2), null), null);
 
@@ -114,7 +117,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task UndoBought_DecrementsBoughtTotal()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var bought = new ShoppingItemBought(ItemName.From("Bread"), Quantity.Of(Amount.From(3), null));
 		var undo = new ShoppingItemUndoBought(ItemName.From("Bread"), Quantity.Of(Amount.From(1), null));
 
@@ -130,7 +133,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task AddedAsAtHome_IncrementsBoughtTotal()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var atHome = new ShoppingItemAddedAsAtHome(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g")));
 
 		await handler.HandleAsync(new ShoppingItemAddedAsAtHomeIntegrationEvent(OwnerId, atHome));
@@ -144,7 +147,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task UndoBought_NeverNegative()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var undo = new ShoppingItemUndoBought(ItemName.From("Milk"), Quantity.Of(Amount.From(10), Unit.From("l")));
 
 		await handler.HandleAsync(new ShoppingItemUndoBoughtIntegrationEvent(OwnerId, undo));
@@ -158,7 +161,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task ConsumedExceedsBought_AtHomeClampedToZero()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var bought = new ShoppingItemBought(ItemName.From("Apple"), Quantity.Of(Amount.From(2), null));
 		var consumed = new ShoppingItemConsumed(ItemName.From("Apple"), Quantity.Of(Amount.From(5), null), ItemSource.From("meal-plan"));
 
@@ -173,7 +176,7 @@ public class IngredientBalanceProjectionHandlerTests
 	public async Task SameNameDifferentUnits_KeepsRowsSeparate()
 	{
 		await using var context = CreateContext();
-		var handler = new IngredientBalanceProjectionHandler(context);
+		var handler = new IngredientBalanceProjectionHandler(context, timeProvider);
 		var litres = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")));
 		var millis = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(500), Unit.From("ml")));
 

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceProjectionHandlerTests.cs
@@ -33,6 +33,52 @@ public class IngredientBalanceProjectionHandlerTests
 	}
 
 	[Fact]
+	public async Task Bought_SetsLastBoughtAt()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var before = DateTime.UtcNow;
+		var domainEvent = new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")));
+
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(OwnerId, domainEvent));
+		var after = DateTime.UtcNow;
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.LastBoughtAt.Should().NotBeNull().And.BeOnOrAfter(before).And.BeOnOrBefore(after);
+	}
+
+	[Fact]
+	public async Task AddedAsAtHome_SetsLastBoughtAt()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		var before = DateTime.UtcNow;
+		var domainEvent = new ShoppingItemAddedAsAtHome(ItemName.From("Butter"), Quantity.Of(Amount.From(250), Unit.From("g")));
+
+		await handler.HandleAsync(new ShoppingItemAddedAsAtHomeIntegrationEvent(OwnerId, domainEvent));
+		var after = DateTime.UtcNow;
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.LastBoughtAt.Should().NotBeNull().And.BeOnOrAfter(before).And.BeOnOrBefore(after);
+	}
+
+	[Fact]
+	public async Task Consumed_DoesNotChangeLastBoughtAt()
+	{
+		await using var context = CreateContext();
+		var handler = new IngredientBalanceProjectionHandler(context);
+		await handler.HandleAsync(new ShoppingItemBoughtIntegrationEvent(
+			OwnerId, new ShoppingItemBought(ItemName.From("Milk"), Quantity.Of(Amount.From(2), Unit.From("l")))));
+		var firstBoughtAt = (await context.Set<IngredientBalanceReadItem>().SingleAsync()).LastBoughtAt;
+
+		await handler.HandleAsync(new ShoppingItemConsumedIntegrationEvent(
+			OwnerId, new ShoppingItemConsumed(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.From("l")), ItemSource.From("meal-plan"))));
+
+		var row = await context.Set<IngredientBalanceReadItem>().SingleAsync();
+		row.LastBoughtAt.Should().Be(firstBoughtAt);
+	}
+
+	[Fact]
 	public async Task Consumed_AfterBought_DecrementsAtHome()
 	{
 		await using var context = CreateContext();

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -12,11 +14,13 @@ public class IngredientBalanceReadModelRepositoryTests
 {
 	private const string OwnerId = "user-1";
 
+	private readonly FakeTimeProvider timeProvider = new(DateTimeOffset.Parse("2026-04-30T12:00:00Z", CultureInfo.InvariantCulture));
+
 	[Fact]
 	public async Task GetAtHomeItemsAsync_NoRows_ReturnsEmpty()
 	{
 		await using var context = CreateContext();
-		var repo = new IngredientBalanceReadModelRepository(context);
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
 
 		var items = await repo.GetAtHomeItemsAsync(OwnerId);
 
@@ -41,7 +45,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		});
 		await context.SaveChangesAsync();
 
-		var repo = new IngredientBalanceReadModelRepository(context);
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
 		var items = await repo.GetAtHomeItemsAsync(OwnerId);
 
 		items.Should().BeEmpty();
@@ -62,19 +66,18 @@ public class IngredientBalanceReadModelRepositoryTests
 			BoughtTotal = 5,
 			ConsumedTotal = 1,
 			RemovedTotal = 0,
+			LastBoughtAt = timeProvider.GetUtcNow().UtcDateTime,
 		});
 		await context.SaveChangesAsync();
 
-		var repo = new IngredientBalanceReadModelRepository(context);
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
 		var items = await repo.GetAtHomeItemsAsync(OwnerId);
 
-		items.Should().ContainSingle()
-			.Which.Should().BeEquivalentTo(new IngredientBalanceItemDto(
-				ItemName: "Milk",
-				Quantity: 4m,
-				Unit: "l",
-				Category: IngredientCategory.Dairy.Value,
-				Source: IngredientBalanceSource.AtHome));
+		var item = items.Should().ContainSingle().Subject;
+		item.ItemName.Should().Be("Milk");
+		item.Quantity.Should().Be(4m);
+		item.Unit.Should().Be("l");
+		item.Source.Should().Be(IngredientBalanceSource.AtHome);
 	}
 
 	[Fact]
@@ -104,11 +107,95 @@ public class IngredientBalanceReadModelRepositoryTests
 			});
 		await context.SaveChangesAsync();
 
-		var repo = new IngredientBalanceReadModelRepository(context);
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
 		var items = await repo.GetAtHomeItemsAsync(OwnerId);
 
 		items.Should().ContainSingle().Which.ItemName.Should().Be("Milk");
 	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_NoLastBoughtAt_FreshnessIsNotTracked()
+	{
+		await using var context = CreateContext();
+		context.Set<IngredientBalanceReadItem>().Add(MakeRow(IngredientCategory.MeatFish, lastBoughtAt: null));
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
+		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+
+		item.Freshness.Should().Be(Freshness.NotTracked);
+		item.DaysSinceBought.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_PantryItem_AlwaysNotTracked()
+	{
+		await using var context = CreateContext();
+		var twentyDaysAgo = timeProvider.GetUtcNow().UtcDateTime.AddDays(-20);
+		context.Set<IngredientBalanceReadItem>().Add(MakeRow(IngredientCategory.Pantry, lastBoughtAt: twentyDaysAgo));
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
+		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+
+		item.Freshness.Should().Be(Freshness.NotTracked);
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_FreshMeatBoughtToday_IsFresh()
+	{
+		await using var context = CreateContext();
+		context.Set<IngredientBalanceReadItem>().Add(MakeRow(IngredientCategory.MeatFish, lastBoughtAt: timeProvider.GetUtcNow().UtcDateTime));
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
+		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+
+		item.Freshness.Should().Be(Freshness.Fresh);
+		item.DaysSinceBought.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_MeatBoughtOneDayAgo_IsUseSoon()
+	{
+		await using var context = CreateContext();
+		var oneDayAgo = timeProvider.GetUtcNow().UtcDateTime.AddDays(-1);
+		context.Set<IngredientBalanceReadItem>().Add(MakeRow(IngredientCategory.MeatFish, lastBoughtAt: oneDayAgo));
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
+		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+
+		item.Freshness.Should().Be(Freshness.UseSoon);
+		item.DaysSinceBought.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task GetAtHomeItemsAsync_MeatBoughtThreeDaysAgo_IsCheckIt()
+	{
+		await using var context = CreateContext();
+		var threeDaysAgo = timeProvider.GetUtcNow().UtcDateTime.AddDays(-3);
+		context.Set<IngredientBalanceReadItem>().Add(MakeRow(IngredientCategory.MeatFish, lastBoughtAt: threeDaysAgo));
+		await context.SaveChangesAsync();
+
+		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
+		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+
+		item.Freshness.Should().Be(Freshness.CheckIt);
+		item.DaysSinceBought.Should().Be(3);
+	}
+
+	private static IngredientBalanceReadItem MakeRow(IngredientCategory category, DateTime? lastBoughtAt) => new()
+	{
+		Id = Guid.NewGuid(),
+		OwnerId = OwnerId,
+		ItemName = "Item",
+		NameKey = "item",
+		Unit = null,
+		Category = category.Value,
+		BoughtTotal = 1,
+		LastBoughtAt = lastBoughtAt,
+	};
 
 	private static ShoppingReadDbContext CreateContext()
 	{

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Yumney.Shopping.Infrastructure.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Each at-home item in the `/api/v1/shopping-lists/balance` response now carries a `Freshness` classification (Fresh / UseSoon / CheckIt / NotTracked) and `DaysSinceBought`. The UI uses this to drive the green/yellow/orange nudge from US-341 — no API surface other than two new fields on `IngredientBalanceItemDto`.
- Shelf life is per category, intentionally coarse: `meat-fish: 2`, `bakery: 3`, `produce: 5`, `dairy: 6`, `frozen: 60` days. `pantry` / `household` / `beverages` / `other` → `NotTracked`. Threshold: `Fresh` < 50% of shelf life, `UseSoon` ≥ 50%, `CheckIt` ≥ 100%.
- New `LastBoughtAt` column on `IngredientBalanceReadItem` (nullable). The projection handler maintains it on `Bought` + `AddedAsAtHome` events. `Consumed` / `Removed` / `UndoBought` deliberately don't touch it — partial consumption shouldn't reset the freshness clock for the rest of the stock.

## Closes
Closes #182 (US-341).

## Architecture decisions
- **Compute freshness at query time, not in the projection.** A row's freshness changes daily even if no events fire. Storing a snapshot in the projection would go stale. The repository takes a `TimeProvider` (registered as `TimeProvider.System`) and runs `ShelfLife.Classify` on read.
- **Coarse category mapping vs. per-ingredient shelf life.** AC mentions "leafy greens 2-3 days" vs "hardy veg 1 week" — those distinctions need either an LLM call per ingredient or a curated lookup. For v1 we use the existing `IngredientCategory`. Refinement is a follow-up.

## Scope cuts
- **"I froze it" override** — new command + event (resets the freshness clock). Separate story; not blocking the must-have AC.
- **US-342 perishable-first ranking integration** — was already deferred from US-342. The data is now exposed via `IIngredientBalanceProvider`'s underlying DTO; the matching engine just hasn't been updated yet to use it. Easy follow-up.
- **Frontend indicators** — separate PR.
- **Per-ingredient shelf life refinement** — follow-up if/when the coarse mapping isn't accurate enough.

## Test plan
- [x] Build green with `TreatWarningsAsErrors=true`
- [x] `dotnet format --verify-no-changes` clean
- [x] **New tests:** `ShelfLifeTests` (23 cases) — every category mapped + every threshold edge across meat-fish / dairy / frozen.
- [x] **New tests:** `IngredientBalanceProjectionHandlerTests` — `Bought` and `AddedAsAtHome` set `LastBoughtAt`; `Consumed` does not change it (3 added).
- [x] **New tests:** `IngredientBalanceReadModelRepositoryTests` — null `LastBoughtAt` → `NotTracked`; pantry always `NotTracked`; meat-fish at 0 / 1 / 3 days → `Fresh` / `UseSoon` / `CheckIt`. Uses `FakeTimeProvider` for deterministic age (4 added).
- [x] Affected suites green: 242 Shared, 119 Shopping.Application, 28 Shopping.Infrastructure (was 20, +8 new), 173 Shopping.Domain, 17 Shopping.Api, 117 Architecture — 696 total.
- [ ] Manual smoke once merged: hit `/api/v1/shopping-lists/balance` with a recently-bought meat item; confirm `freshness` field renders.