### PR TITLE
feat(recipes): perishable-first ranking in /what-can-i-cook (US-342 follow-up)

### DIFF
--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
@@ -20,18 +20,28 @@ public sealed class GetCookableRecipesQueryHandler(
 		var owner = currentUser.AsOwner();
 
 		var recipesTask = recipes.GetAllByOwnerWithIngredientsAsync(owner, cancellationToken);
-		var availableTask = balanceProvider.GetAvailableIngredientNamesAsync(currentUser.UserId, cancellationToken);
+		var availableTask = balanceProvider.GetAvailableIngredientsAsync(currentUser.UserId, cancellationToken);
 		await Task.WhenAll(recipesTask, availableTask);
 
 		var available = availableTask.Result;
-		var matches = new List<CookableRecipeDto>();
+		var matches = new List<RankedMatch>();
 
 		foreach (var recipe in recipesTask.Result)
 		{
-			var missing = recipe.Ingredients
-				.Where(i => !available.Contains(i.Name.Value.Trim()))
-				.Select(i => i.Name.Value)
-				.ToList();
+			var missing = new List<string>();
+			var urgentCount = 0;
+
+			foreach (var ingredient in recipe.Ingredients)
+			{
+				var name = ingredient.Name.Value.Trim();
+				if (!available.TryGetValue(name, out var freshness))
+				{
+					missing.Add(ingredient.Name.Value);
+					continue;
+				}
+
+				if (freshness is Freshness.UseSoon or Freshness.CheckIt) urgentCount++;
+			}
 
 			var tier = missing.Count == 0
 				? CookableRecipeMatchTier.Full
@@ -40,24 +50,30 @@ public sealed class GetCookableRecipesQueryHandler(
 			if (tier == CookableRecipeMatchTier.Near && missing.Count > maxMissingForNearMatch) continue;
 			if (query.FullMatchOnly && tier != CookableRecipeMatchTier.Full) continue;
 
-			matches.Add(new CookableRecipeDto(
-				RecipeIdentifier: recipe.Id.Value,
-				Title: recipe.Title.Value,
-				ImageUrl: recipe.ImageUrl?.Value,
-				Servings: recipe.Servings?.Value,
-				PrepTimeMinutes: recipe.Timing?.Preparation?.Value,
-				CookTimeMinutes: recipe.Timing?.Cooking?.Value,
-				Difficulty: recipe.Difficulty?.Value,
-				IngredientCount: recipe.Ingredients.Count,
-				Tier: tier,
-				MissingIngredients: missing));
+			matches.Add(new RankedMatch(
+				new CookableRecipeDto(
+					RecipeIdentifier: recipe.Id.Value,
+					Title: recipe.Title.Value,
+					ImageUrl: recipe.ImageUrl?.Value,
+					Servings: recipe.Servings?.Value,
+					PrepTimeMinutes: recipe.Timing?.Preparation?.Value,
+					CookTimeMinutes: recipe.Timing?.Cooking?.Value,
+					Difficulty: recipe.Difficulty?.Value,
+					IngredientCount: recipe.Ingredients.Count,
+					Tier: tier,
+					MissingIngredients: missing),
+				urgentCount));
 		}
 
 		IReadOnlyList<CookableRecipeDto> ranked = [.. matches
-			.OrderBy(m => m.Tier == CookableRecipeMatchTier.Full ? 0 : 1)
-			.ThenBy(m => m.MissingIngredients.Count)
-			.ThenBy(m => m.Title, StringComparer.OrdinalIgnoreCase)];
+			.OrderBy(m => m.Dto.Tier == CookableRecipeMatchTier.Full ? 0 : 1)
+			.ThenByDescending(m => m.UrgentIngredientCount)
+			.ThenBy(m => m.Dto.MissingIngredients.Count)
+			.ThenBy(m => m.Dto.Title, StringComparer.OrdinalIgnoreCase)
+			.Select(m => m.Dto)];
 
 		return Result<IReadOnlyList<CookableRecipeDto>>.Success(ranked);
 	}
+
+	private sealed record RankedMatch(CookableRecipeDto Dto, int UrgentIngredientCount);
 }

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
@@ -22,7 +22,7 @@ public sealed class GetRecipeSuggestionsQueryHandler(
 		var count = Math.Clamp(query.Count, minCount, maxCount);
 		var ownerId = currentUser.UserId;
 
-		var availableTask = balanceProvider.GetAvailableIngredientNamesAsync(ownerId, cancellationToken);
+		var availableTask = balanceProvider.GetAvailableIngredientsAsync(ownerId, cancellationToken);
 		var dietaryTask = dietaryProvider.GetAsync(ownerId, cancellationToken);
 		await Task.WhenAll(availableTask, dietaryTask);
 
@@ -34,7 +34,7 @@ public sealed class GetRecipeSuggestionsQueryHandler(
 
 		var dietary = dietaryTask.Result;
 		return await suggestionService.SuggestAsync(
-			available,
+			(IReadOnlyCollection<string>)available.Keys.ToList(),
 			dietary.DietaryType,
 			dietary.Restrictions,
 			count,

--- a/src/Yumney.Recipes.Infrastructure/Services/HttpIngredientBalanceProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/HttpIngredientBalanceProvider.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Shared.Common;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
@@ -6,28 +8,55 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
 /// <summary>
 /// HTTP-backed <see cref="IIngredientBalanceProvider"/> for callers in the
 /// Recipes module. Calls the Shopping API balance endpoint and projects the
-/// returned items to a lowercased name set used for case-insensitive matching.
+/// returned items to a name → freshness map used for case-insensitive
+/// matching plus perishable-first ranking.
 /// </summary>
 public sealed class HttpIngredientBalanceProvider(IHttpClientFactory httpClientFactory) : IIngredientBalanceProvider
 {
-	public async Task<IReadOnlySet<string>> GetAvailableIngredientNamesAsync(string ownerId, CancellationToken cancellationToken = default)
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		Converters = { new JsonStringEnumConverter() },
+	};
+#pragma warning restore SA1311
+
+	public async Task<IReadOnlyDictionary<string, Freshness>> GetAvailableIngredientsAsync(string ownerId, CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("shopping-api");
-		var dto = await client.GetFromJsonAsync<BalanceDto>("/api/v1/shopping-lists/balance", cancellationToken);
+		var dto = await client.GetFromJsonAsync<BalanceDto>("/api/v1/shopping-lists/balance", jsonOptions, cancellationToken);
 
-		if (dto?.Items is null)
+		var result = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
+		if (dto?.Items is null) return result;
+
+		foreach (var item in dto.Items)
 		{
-			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			var name = item.ItemName.Trim();
+			if (name.Length == 0) continue;
+
+			// Last write wins. Items with the same name but different units
+			// share a freshness slot — the most "urgent" wins so the matcher
+			// is not misled by a fresher duplicate.
+			if (!result.TryGetValue(name, out var existing) || Compare(item.Freshness, existing) > 0)
+			{
+				result[name] = item.Freshness;
+			}
 		}
 
-		return dto.Items
-			.Select(i => i.ItemName.Trim())
-			.Where(n => n.Length > 0)
-			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		return result;
 	}
+
+	private static int Compare(Freshness a, Freshness b) => Urgency(a).CompareTo(Urgency(b));
+
+	private static int Urgency(Freshness freshness) => freshness switch
+	{
+		Freshness.CheckIt => 3,
+		Freshness.UseSoon => 2,
+		Freshness.Fresh => 1,
+		_ => 0,
+	};
 
 #pragma warning disable SA1313, SA1402, SA1649
 	private sealed record BalanceDto(IReadOnlyList<BalanceItemDto> Items);
 
-	private sealed record BalanceItemDto(string ItemName);
+	private sealed record BalanceItemDto(string ItemName, Freshness Freshness);
 }

--- a/src/Yumney.Shared/Common/IIngredientBalanceProvider.cs
+++ b/src/Yumney.Shared/Common/IIngredientBalanceProvider.cs
@@ -1,14 +1,14 @@
 namespace SmartSolutionsLab.Yumney.Shared.Common;
 
 /// <summary>
-/// Cross-module read access to a user's "available ingredients" set —
-/// the union of at-home ledger items (Bought − Consumed − Removed &gt; 0)
-/// and staples. Returned names are lowercased / trimmed to match
-/// case-insensitively against recipe ingredient names.
-/// Implementations: Shopping module (in-process) and a HTTP client for
-/// callers in other modules (e.g., Recipes' "What Can I Cook?" matcher).
+/// Cross-module read access to a user's "available ingredients" — the union
+/// of at-home ledger items (Bought − Consumed − Removed &gt; 0) and staples,
+/// keyed by the lowercased / trimmed name and tagged with freshness so
+/// downstream callers (e.g. recipe matching) can rank perishables first.
+/// Staples and pantry-class items always come back as
+/// <see cref="Freshness.NotTracked"/>.
 /// </summary>
 public interface IIngredientBalanceProvider
 {
-	Task<IReadOnlySet<string>> GetAvailableIngredientNamesAsync(string ownerId, CancellationToken cancellationToken = default);
+	Task<IReadOnlyDictionary<string, Freshness>> GetAvailableIngredientsAsync(string ownerId, CancellationToken cancellationToken = default);
 }

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
@@ -149,14 +149,70 @@ public class GetCookableRecipesQueryHandlerTests
 	}
 
 	[Fact]
+	public async Task HandleAsync_WithinSameTier_RecipesUsingUseSoonOutrankFresh()
+	{
+		ConfigureBalance(("flour", Freshness.Fresh), ("milk", Freshness.UseSoon), ("eggs", Freshness.Fresh));
+		ConfigureRecipes(
+			MakeRecipe("FreshOnly", "Flour", "Eggs"),
+			MakeRecipe("UsesMilk", "Flour", "Milk"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("UsesMilk", "FreshOnly");
+	}
+
+	[Fact]
+	public async Task HandleAsync_MoreUrgentIngredients_RankedHigherWithinTier()
+	{
+		ConfigureBalance(
+			("flour", Freshness.Fresh),
+			("milk", Freshness.UseSoon),
+			("chicken", Freshness.CheckIt));
+		ConfigureRecipes(
+			MakeRecipe("OneUrgent", "Flour", "Milk"),
+			MakeRecipe("TwoUrgent", "Milk", "Chicken"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("TwoUrgent", "OneUrgent");
+	}
+
+	[Fact]
+	public async Task HandleAsync_NotTrackedDoesNotCountAsUrgent()
+	{
+		ConfigureBalance(("salt", Freshness.NotTracked), ("milk", Freshness.UseSoon));
+		ConfigureRecipes(
+			MakeRecipe("StaplesOnly", "Salt"),
+			MakeRecipe("UsesMilk", "Milk"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("UsesMilk", "StaplesOnly");
+	}
+
+	[Fact]
+	public async Task HandleAsync_TierStillBeatsPerishability()
+	{
+		// A near-match with urgent ingredients does NOT beat a full match without any urgent items.
+		ConfigureBalance(("flour", Freshness.Fresh), ("milk", Freshness.CheckIt));
+		ConfigureRecipes(
+			MakeRecipe("FullMatchFresh", "Flour"),
+			MakeRecipe("NearMatchUrgent", "Milk", "Sugar"));
+
+		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
+
+		result.Value.Select(r => r.Title).Should().Equal("FullMatchFresh", "NearMatchUrgent");
+	}
+
+	[Fact]
 	public async Task HandleAsync_BalanceProviderQueriedWithCurrentUser()
 	{
-		ConfigureBalance();
+		ConfigureBalance(Array.Empty<string>());
 		ConfigureRecipes();
 
 		await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		await balanceProvider.Received(1).GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>());
+		await balanceProvider.Received(1).GetAvailableIngredientsAsync(OwnerId, Arg.Any<CancellationToken>());
 	}
 
 	private static Recipe MakeRecipe(string title, params string[] ingredientNames)
@@ -176,7 +232,18 @@ public class GetCookableRecipesQueryHandlerTests
 
 	private void ConfigureBalance(params string[] availableNames)
 	{
-		balanceProvider.GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>())
-			.Returns((IReadOnlySet<string>)availableNames.ToHashSet(StringComparer.OrdinalIgnoreCase));
+		ConfigureBalance(availableNames.Select(n => (n, Freshness.Fresh)).ToArray());
+	}
+
+	private void ConfigureBalance(params (string Name, Freshness Freshness)[] items)
+	{
+		var dict = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (name, freshness) in items)
+		{
+			dict[name] = freshness;
+		}
+
+		balanceProvider.GetAvailableIngredientsAsync(OwnerId, Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyDictionary<string, Freshness>)dict);
 	}
 }

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeSuggestionsQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeSuggestionsQueryHandlerTests.cs
@@ -184,14 +184,16 @@ public class GetRecipeSuggestionsQueryHandlerTests
 
 		await handler.HandleAsync(new GetRecipeSuggestionsQuery());
 
-		await balanceProvider.Received(1).GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>());
+		await balanceProvider.Received(1).GetAvailableIngredientsAsync(OwnerId, Arg.Any<CancellationToken>());
 		await dietaryProvider.Received(1).GetAsync(OwnerId, Arg.Any<CancellationToken>());
 	}
 
 	private void ConfigureBalance(params string[] names)
 	{
-		balanceProvider.GetAvailableIngredientNamesAsync(OwnerId, Arg.Any<CancellationToken>())
-			.Returns((IReadOnlySet<string>)names.ToHashSet(StringComparer.OrdinalIgnoreCase));
+		var dict = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
+		foreach (var name in names) dict[name] = Freshness.Fresh;
+		balanceProvider.GetAvailableIngredientsAsync(OwnerId, Arg.Any<CancellationToken>())
+			.Returns((IReadOnlyDictionary<string, Freshness>)dict);
 	}
 
 	private void ConfigureDietary(string? dietaryType, IReadOnlyList<string> restrictions)

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpIngredientBalanceProviderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpIngredientBalanceProviderTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services;
+
+public class HttpIngredientBalanceProviderTests
+{
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_EmptyResponse_ReturnsEmptyDictionary()
+	{
+		var sut = CreateSut("""{ "items": [] }""");
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_NullItems_ReturnsEmptyDictionary()
+	{
+		var sut = CreateSut("""{ "items": null }""");
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_DeserializesEnumAsString()
+	{
+		var sut = CreateSut("""
+            {
+              "items": [
+                { "itemName": "Milk", "freshness": "UseSoon" },
+                { "itemName": "Salt", "freshness": "NotTracked" }
+              ]
+            }
+            """);
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result["Milk"].Should().Be(Freshness.UseSoon);
+		result["Salt"].Should().Be(Freshness.NotTracked);
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_LookupIsCaseInsensitive()
+	{
+		var sut = CreateSut("""{ "items": [ { "itemName": "Milk", "freshness": "Fresh" } ] }""");
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.ContainsKey("milk").Should().BeTrue();
+		result.ContainsKey("MILK").Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_TrimsWhitespaceFromNames()
+	{
+		var sut = CreateSut("""{ "items": [ { "itemName": "  Milk  ", "freshness": "Fresh" } ] }""");
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.Should().ContainSingle().Which.Key.Should().Be("Milk");
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_BlankName_Skipped()
+	{
+		var sut = CreateSut("""
+            {
+              "items": [
+                { "itemName": "   ", "freshness": "Fresh" },
+                { "itemName": "Eggs", "freshness": "Fresh" }
+              ]
+            }
+            """);
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.Should().ContainSingle().Which.Key.Should().Be("Eggs");
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_DuplicateNameMostUrgentWins()
+	{
+		// Same name with different freshness (e.g. "milk in liters" UseSoon and
+		// "milk in ml" Fresh). The matcher needs the urgent one to surface.
+		var sut = CreateSut("""
+            {
+              "items": [
+                { "itemName": "Milk", "freshness": "Fresh" },
+                { "itemName": "milk", "freshness": "UseSoon" },
+                { "itemName": "MILK", "freshness": "NotTracked" }
+              ]
+            }
+            """);
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result.Should().ContainSingle().Which.Value.Should().Be(Freshness.UseSoon);
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_DuplicateNameOrderIndependent()
+	{
+		// Same scenario but reversed order — most-urgent first, then less urgent.
+		var sut = CreateSut("""
+            {
+              "items": [
+                { "itemName": "Chicken", "freshness": "CheckIt" },
+                { "itemName": "Chicken", "freshness": "Fresh" }
+              ]
+            }
+            """);
+
+		var result = await sut.GetAvailableIngredientsAsync("owner-1");
+
+		result["Chicken"].Should().Be(Freshness.CheckIt);
+	}
+
+	[Fact]
+	public async Task GetAvailableIngredientsAsync_HttpError_PropagatesException()
+	{
+		var sut = CreateSut(string.Empty, HttpStatusCode.InternalServerError);
+
+		var act = () => sut.GetAvailableIngredientsAsync("owner-1");
+
+		await act.Should().ThrowAsync<HttpRequestException>();
+	}
+
+	private static HttpIngredientBalanceProvider CreateSut(string responseBody, HttpStatusCode status = HttpStatusCode.OK)
+	{
+		var handler = new StubHttpMessageHandler(responseBody, status);
+		var client = new HttpClient(handler) { BaseAddress = new Uri("http://shopping-api") };
+
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient("shopping-api").Returns(client);
+
+		return new HttpIngredientBalanceProvider(factory);
+	}
+
+	private sealed class StubHttpMessageHandler(string body, HttpStatusCode status) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			var response = new HttpResponseMessage(status)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			};
+			return Task.FromResult(response);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Closes the loop between **US-341** (which exposed per-item `Freshness` on the balance) and **US-342** (which originally deferred perishable-first ranking — explicitly noted in both PRs as a follow-up).
- Recipes using `UseSoon` / `CheckIt` ingredients now outrank ones using only `Fresh` / `NotTracked` items, **within the same tier**. Tier still wins: a Full match without urgents beats a Near match with urgents.

## Final ranking order
1. Tier (Full before Near)
2. **NEW:** urgent ingredient count desc (count of `UseSoon` + `CheckIt` items the recipe matches)
3. Missing count asc
4. Title alphabetical

## API surface change
- `IIngredientBalanceProvider.GetAvailableIngredientNamesAsync` → `GetAvailableIngredientsAsync` returning `IReadOnlyDictionary<string, Freshness>` keyed by lowercased name. Internal contract — only used by Recipes' two query handlers.
- `HttpIngredientBalanceProvider` now deserializes with `JsonStringEnumConverter` to match the API's enum-as-string contract for `Freshness`. Duplicate-name collisions (e.g. "milk" with multiple units) resolve to the **most urgent** freshness so Fresh duplicates don't mask UseSoon stock.

## Closes
None directly — this completes the perishable ranking item that AC TC-342-03 called for in US-342, using freshness data US-341 added.

## Test plan
- [x] Build green with `TreatWarningsAsErrors=true`
- [x] `dotnet format --verify-no-changes` clean
- [x] **4 new ranking tests** in `GetCookableRecipesQueryHandlerTests`:
  - Urgent ingredient beats fresh-only (1 vs 0)
  - Two urgent ingredients beat one (2 vs 1)
  - `NotTracked` (staples / pantry) does NOT count as urgent
  - Tier still beats urgency: Full+Fresh > Near+CheckIt
- [x] Existing 11 cookable + 8 suggestion handler tests adapted to the dict-shaped contract — all green
- [x] All Recipes test suites + Architecture (165 + 233 + 161 + 92 + 117 = 768 total)
- [ ] Manual smoke once merged: hit `/api/v1/recipes/what-can-i-cook` after a meat purchase older than 1 day; recipes using that meat should rank above other Full matches.