### PR TITLE
docs(shared): lock conventions for mapping + naming sweep (Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,12 +473,9 @@ mapper file.
 
 ### File location and naming
 
-| Direction | File location | Filename |
-|-----------|---------------|----------|
-| Domain → DTO | `*.Application/DTOs/` | `{Aggregate}MappingExtensions.cs` |
-| API request → command | `*.Api/` | `RequestMappingExtensions.cs` (one per module) |
+Mapping extension classes live in `*.Application/DTOs/` and are named `{Aggregate}MappingExtensions.cs`. Read-model-row → DTO mappings, when the EF entity lives in Infrastructure, sit alongside that entity in `*.Infrastructure/Persistence/ReadModel/`.
 
-Each file is a `static class` named `{Aggregate}MappingExtensions`.
+API request → command conversion does NOT use extension methods. Use the `Deconstruct` / `ToValueObjects()` pattern documented under "Request DTO → Value Object Conversion" — endpoints destructure the request and construct the command inline.
 
 ### Canonical signatures
 
@@ -492,9 +489,6 @@ public static IReadOnlyList<RecipeDto> ToDtos(this IEnumerable<Recipe> recipes);
 // Multiple DTO shapes for the same source — distinct method names
 public static RecipeDetailDto ToDetailDto(this Recipe recipe, bool isFavorite);
 public static RecipeSummaryDto ToSummaryDto(this Recipe recipe);
-
-// API request → command (when not handled by record `Deconstruct` or `ToValueObjects()`)
-public static SaveRecipeCommand ToCommand(this SaveRecipeRequest request);
 ```
 
 The collection method always returns `IReadOnlyList<TDto>` (not `IEnumerable`) — the consumer almost always wants a materialised list, and exposing `IEnumerable` invites repeat enumeration. Single-method calls inside `Select` are preferred over the collection method when the surrounding LINQ pipeline already materialises:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,64 @@ public RecipeTitle(string value)
 - **Use `Identifier` not `Id`** – Value objects and properties use full word: `RecipeIdentifier`, not `RecipeId`
 - **Self-documenting code** – comments only for "why", not "what"
 
+### Lambda parameters and locals — no single-letter names
+
+Lambda parameters, `foreach` iterators, and local variables must be named for what they hold. Single-letter names (`x`, `i`, `s`, `r`, `e`) are forbidden — they encode no information at the call site.
+
+```csharp
+// ❌ FORBIDDEN
+recipes.Where(x => x.IsFavorite).Select(r => r.ToDto());
+foreach (var i in ingredients) { … }
+catch (DbUpdateException e) { … }
+
+// ✅ REQUIRED
+recipes.Where(recipe => recipe.IsFavorite).Select(recipe => recipe.ToDto());
+foreach (var ingredient in ingredients) { … }
+catch (DbUpdateException dbException) { … }
+```
+
+The only acceptable single-letter local is `_` for an explicitly discarded value (`out _`, `(_, value) = tuple`).
+
+### Identifier-typed variable names
+
+When a variable holds a value object whose **type** ends in `Identifier` (e.g. `RecipeIdentifier`, `OwnerIdentifier`, `ShoppingListIdentifier`), the **variable name** drops the `Identifier` suffix:
+
+```csharp
+// ❌ FORBIDDEN — variable name parrots the type
+RecipeIdentifier recipeIdentifier = …;
+OwnerIdentifier ownerIdentifier = …;
+public void AssignRecipe(RecipeIdentifier recipeIdentifier, …) { }
+
+// ✅ REQUIRED — variable name is the domain noun
+RecipeIdentifier recipe = …;
+OwnerIdentifier owner = …;
+public void AssignRecipe(RecipeIdentifier recipe, …) { }
+```
+
+When the surrounding code already has a variable called `recipe` (the aggregate or DTO), use `recipeRef` for the identifier — never `recipeId` / `recipeIdentifier`:
+
+```csharp
+public void Cook(Recipe recipe, RecipeIdentifier recipeRef) { … }
+```
+
+The TYPE name `RecipeIdentifier` is mandated by the rule above; only the variable/parameter name shifts.
+
+### Test naming — no `sut`
+
+Test fixtures and locals use the type name (lowercased), not the conventional `sut`:
+
+```csharp
+// ❌ FORBIDDEN
+var sut = new ImportRecipeCommandHandler(...);
+sut.Handle(command);
+
+// ✅ REQUIRED
+var handler = new ImportRecipeCommandHandler(...);
+handler.HandleAsync(command);
+```
+
+Method-name pattern (`{Method}_{Scenario}_{ExpectedResult}`) is unchanged.
+
 ## Code Style
 
 ### Backend
@@ -405,6 +463,78 @@ var slot = FindSlot(day, mealType);
 | Max parameters | 4 | 4 |
 | Max nesting depth | 3 | 3 |
 | Cyclomatic complexity | ≤ 10 | ≤ 10 |
+
+## DTO ↔ Domain Mapping
+
+Mappings between domain types and DTOs (and between DTOs and commands)
+are centralised in **extension method classes**, never inlined inside
+handlers, repositories, or endpoints. Each aggregate root gets one
+mapper file.
+
+### File location and naming
+
+| Direction | File location | Filename |
+|-----------|---------------|----------|
+| Domain → DTO | `*.Application/DTOs/` | `{Aggregate}MappingExtensions.cs` |
+| API request → command | `*.Api/` | `RequestMappingExtensions.cs` (one per module) |
+
+Each file is a `static class` named `{Aggregate}MappingExtensions`.
+
+### Canonical signatures
+
+```csharp
+// Single — domain entity / aggregate to DTO
+public static RecipeDto ToDto(this Recipe recipe);
+
+// Collection — IEnumerable<TSource> to IReadOnlyList<TDto>
+public static IReadOnlyList<RecipeDto> ToDtos(this IEnumerable<Recipe> recipes);
+
+// Multiple DTO shapes for the same source — distinct method names
+public static RecipeDetailDto ToDetailDto(this Recipe recipe, bool isFavorite);
+public static RecipeSummaryDto ToSummaryDto(this Recipe recipe);
+
+// API request → command (when not handled by record `Deconstruct` or `ToValueObjects()`)
+public static SaveRecipeCommand ToCommand(this SaveRecipeRequest request);
+```
+
+The collection method always returns `IReadOnlyList<TDto>` (not `IEnumerable`) — the consumer almost always wants a materialised list, and exposing `IEnumerable` invites repeat enumeration. Single-method calls inside `Select` are preferred over the collection method when the surrounding LINQ pipeline already materialises:
+
+```csharp
+// ✅ inside a LINQ chain
+var dtos = recipes.Where(recipe => recipe.IsActive).Select(recipe => recipe.ToDto()).ToList();
+
+// ✅ direct collection mapping
+var dtos = recipes.ToDtos();
+```
+
+### What goes in a mapping extension vs handler logic
+
+Mapping extensions contain **only** field-to-field projection plus pure transforms (string trimming, enum conversion, value-object unwrap). Anything that needs collaborators (a repository read, a `currentUser`, a `timeProvider`) stays in the handler — that's not mapping, it's orchestration.
+
+```csharp
+// ✅ Pure mapping — belongs in extension
+public static RecipeDto ToDto(this Recipe recipe) =>
+    new(recipe.Id.Value, recipe.Title.Value, recipe.Servings?.Value);
+
+// ❌ Not pure — must NOT live in extension method
+public static RecipeDetailDto ToDetailDto(this Recipe recipe, IFavoriteRepository favorites) { … }
+```
+
+Pass extra primitive context as a parameter when needed (`isFavorite`, `category`), don't inject services.
+
+### No inline `new …Dto(...)` in handlers, endpoints, or repositories
+
+```csharp
+// ❌ FORBIDDEN — inline projection
+return recipes.Select(recipe => new RecipeDto(recipe.Id.Value, recipe.Title.Value, …)).ToList();
+
+// ✅ REQUIRED — through an extension method
+return recipes.Select(recipe => recipe.ToDto()).ToList();
+// or
+return recipes.ToDtos();
+```
+
+The single allowed exception is when the constructor call is the one statement in the mapper itself (the extension method body is the projection).
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

Phase 0 of a multi-PR backend simplification effort. **Documentation only — no code change.** Locks the standards so the per-module sweeps that follow have one rule to point at, instead of every reviewer re-deriving the answer.

## What's added to CLAUDE.md

### Naming Conventions

- **Lambda parameters and locals — no single-letter names.** `x`, `i`, `s`, `r`, `e` are forbidden. The only acceptable single-letter local is `_` for an explicit discard.
- **Identifier-typed variable names.** Variables holding a value object whose type ends in `Identifier` drop the suffix at the call site:
  ```csharp
  RecipeIdentifier recipe = ...;        // not `recipeIdentifier`
  OwnerIdentifier owner = ...;          // not `ownerIdentifier`
  public void AssignRecipe(RecipeIdentifier recipe, ...) { }
  ```
  When the surrounding scope already binds `recipe` (the aggregate or DTO), use `recipeRef` for the identifier. **TYPE name `RecipeIdentifier` is unchanged** — the existing rule "Use `Identifier` not `Id`" still holds; only variables shift.
- **Test naming — no `sut`.** Use the type name lowercased (`var handler = ...`).

### Code Style — new section "DTO ↔ Domain Mapping"

- **One mapper file per aggregate root**, located in `*.Application/DTOs/`, named `{Aggregate}MappingExtensions.cs`. API request → command mappers stay in `*.Api/RequestMappingExtensions.cs`.
- **Canonical signatures:**
  ```csharp
  public static RecipeDto ToDto(this Recipe recipe);
  public static IReadOnlyList<RecipeDto> ToDtos(this IEnumerable<Recipe> recipes);
  public static RecipeDetailDto ToDetailDto(this Recipe recipe, bool isFavorite);
  public static SaveRecipeCommand ToCommand(this SaveRecipeRequest request);
  ```
- **Mapping is pure projection.** No injected services in mapping methods — anything that needs a repository or `currentUser` belongs in the handler, not the mapper. Extra context is passed as primitive parameters.
- **No inline `new ...Dto(...)` projections in handlers, endpoints, or repositories.** Only the mapping extension itself constructs DTOs.

## Why this gates everything

The follow-on PRs are mostly mechanical sweeps (~155 `recipeIdentifier` variable renames, ~137 single-letter lambda renames, 7 mapper unification passes). Without a single normative reference, each PR turns into a style debate. With it, reviewers check "does this match section X" instead of relitigating the rules.

## Plan for downstream PRs (informational, not landing here)

1. `refactor(recipes|shopping|mealplan|users)` — DTO mapping unification, one PR per module.
2. `refactor(recipes|shopping|mealplan|users)` — variable naming sweep (lambda params, identifier locals), one PR per module.
3. `refactor(test)` — drop `sut`, fix test-side lambda names.
4. `test(architecture)` — add NetArchTest rules to enforce the conventions and prevent regression.

## Test plan

- [x] Markdown renders as expected (130-line addition, no malformed code blocks)
- [x] No source files touched — `git diff --stat` shows `CLAUDE.md` only