### PR TITLE
refactor(mealplan): unify DTO mapping behind ToDto / ToDtos (Phase 1)

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AdjustSlotServingsCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AdjustSlotServingsCommandHandler.cs
@@ -19,6 +19,6 @@ public sealed class AdjustSlotServingsCommandHandler(IMealPlanEventStore eventSt
 		plan.AdjustServings(day, servings, mealType);
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/AssignRecipeCommandHandler.cs
@@ -17,6 +17,6 @@ public sealed class AssignRecipeCommandHandler(IMealPlanEventStore eventStore, I
 		plan.AssignRecipe(day, recipe, mealType, servings);
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ClearMealSlotCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ClearMealSlotCommandHandler.cs
@@ -19,6 +19,6 @@ public sealed class ClearMealSlotCommandHandler(IMealPlanEventStore eventStore, 
 		plan.ClearSlot(day, mealType);
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -39,7 +39,7 @@ public sealed class ConfirmMealCommandHandler(
 
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 
 	private async Task<IReadOnlyList<CookedIngredient>> FetchIngredientsAsync(Guid recipeId, CancellationToken cancellationToken)

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
@@ -24,6 +24,6 @@ public sealed class CookWithLeftoversCommandHandler(IMealPlanEventStore eventSto
 
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/CopyPlanToWeekCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/CopyPlanToWeekCommandHandler.cs
@@ -30,7 +30,7 @@ public sealed class CopyPlanToWeekCommandHandler(IMealPlanEventStore eventStore,
 
 		await eventStore.SaveAsync(target, cancellationToken);
 
-		return new WeeklyPlanDto(targetWeek.Value, target.IsExtendedMode, target.GetVisibleSlots().ToOrderedDtos());
+		return target.ToDto(targetWeek);
 	}
 
 	private static void ApplySlot(WeeklyPlan target, MealSlot slot)

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/SwapMealSlotsCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/SwapMealSlotsCommandHandler.cs
@@ -19,6 +19,6 @@ public sealed class SwapMealSlotsCommandHandler(IMealPlanEventStore eventStore, 
 		plan.SwapSlots(sourceDay, targetDay, mealType);
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ToggleExtendedModeCommandHandler.cs
@@ -25,6 +25,6 @@ public sealed class ToggleExtendedModeCommandHandler(IMealPlanEventStore eventSt
 
 		await eventStore.SaveAsync(plan, cancellationToken);
 
-		return new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos());
+		return plan.ToDto(week);
 	}
 }

--- a/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
@@ -2,11 +2,13 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public static class MealSlotMappingExtensions
+public static class WeeklyPlanMappingExtensions
 {
-	public static MealSlotDto ToDto(this MealSlot slot)
-	{
-		return new MealSlotDto(
+	public static WeeklyPlanDto ToDto(this WeeklyPlan plan, WeekIdentifier week) =>
+		new(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToDtos());
+
+	public static MealSlotDto ToDto(this MealSlot slot) =>
+		new(
 			slot.Day.ToString(),
 			slot.MealType.ToString(),
 			slot.ContentType.ToString(),
@@ -19,14 +21,11 @@ public static class MealSlotMappingExtensions
 			slot.LeftoverSourceDay?.ToString(),
 			slot.LeftoverSourceMealType?.ToString(),
 			slot.IsEmpty);
-	}
 
-	public static List<MealSlotDto> ToOrderedDtos(this IEnumerable<MealSlot> slots)
-	{
-		return slots
-			.OrderBy(s => s.Day)
-			.ThenBy(s => s.MealType)
-			.Select(s => s.ToDto())
+	public static IReadOnlyList<MealSlotDto> ToDtos(this IEnumerable<MealSlot> slots) =>
+		slots
+			.OrderBy(slot => slot.Day)
+			.ThenBy(slot => slot.MealType)
+			.Select(slot => slot.ToDto())
 			.ToList();
-	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
@@ -1,0 +1,51 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+
+public static class MealPlanReadModelMappingExtensions
+{
+	public static MealSlotDto ToDto(this MealPlanSlotReadItem row) =>
+		new(
+			row.Day,
+			row.MealType,
+			row.ContentType,
+			row.State,
+			row.RecipeIdentifier,
+			row.RecipeTitle,
+			row.Servings,
+			row.FreetextLabel,
+			row.LeftoverLabel,
+			row.LeftoverSourceDay,
+			row.LeftoverSourceMealType,
+			row.ContentType == SlotContentType.Empty.ToString());
+
+	public static IReadOnlyList<MealSlotDto> ToDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
+		rows
+			.Select(row => row.ToDto())
+			.OrderBy(slot => Enum.Parse<DayOfWeek>(slot.Day))
+			.ThenBy(slot => Enum.Parse<MealType>(slot.MealType))
+			.ToList();
+
+	public static PlannedRecipeDto ToPlannedRecipeDto(this MealPlanSlotReadItem row) =>
+		new(
+			row.RecipeIdentifier!.Value,
+			row.RecipeTitle ?? string.Empty,
+			row.Servings,
+			row.Day,
+			row.MealType);
+
+	public static IReadOnlyList<PlannedRecipeDto> ToPlannedRecipeDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
+		rows.Select(row => row.ToPlannedRecipeDto()).ToList();
+
+	public static MealHistoryEntryDto ToHistoryEntryDto(this MealPlanSlotReadItem row) =>
+		new(
+			row.RecipeIdentifier,
+			row.RecipeTitle ?? string.Empty,
+			row.Week,
+			row.Day,
+			row.MealType);
+
+	public static IReadOnlyList<MealHistoryEntryDto> ToHistoryEntryDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
+		rows.Select(row => row.ToHistoryEntryDto()).ToList();
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -21,7 +21,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		var weekValue = week.Value;
 
 		var weekItem = await context.MealPlanWeekReadItems
-			.FirstOrDefaultAsync(w => w.OwnerId == ownerId && w.Week == weekValue, cancellationToken);
+			.FirstOrDefaultAsync(weekRow => weekRow.OwnerId == ownerId && weekRow.Week == weekValue, cancellationToken);
 
 		if (weekItem is null)
 		{
@@ -29,20 +29,14 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		}
 
 		var slotRows = await context.MealPlanSlotReadItems
-			.Where(s => s.OwnerId == ownerId && s.Week == weekValue)
+			.Where(slot => slot.OwnerId == ownerId && slot.Week == weekValue)
 			.ToListAsync(cancellationToken);
 
 		var visible = weekItem.IsExtendedMode
 			? slotRows
-			: slotRows.Where(s => s.MealType == MealType.Dinner.ToString()).ToList();
+			: slotRows.Where(slot => slot.MealType == MealType.Dinner.ToString()).ToList();
 
-		var slotDtos = visible
-			.Select(ToDto)
-			.OrderBy(d => Enum.Parse<DayOfWeek>(d.Day))
-			.ThenBy(d => Enum.Parse<MealType>(d.MealType))
-			.ToList();
-
-		return new WeeklyPlanDto(weekValue, weekItem.IsExtendedMode, slotDtos);
+		return new WeeklyPlanDto(weekValue, weekItem.IsExtendedMode, visible.ToDtos());
 	}
 
 	public async Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
@@ -52,22 +46,13 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		var recipeContent = SlotContentType.Recipe.ToString();
 
 		var slotRows = await context.MealPlanSlotReadItems
-			.Where(s => s.OwnerId == ownerId
-				&& s.Week == weekValue
-				&& s.ContentType == recipeContent
-				&& s.RecipeIdentifier != null)
+			.Where(slot => slot.OwnerId == ownerId
+				&& slot.Week == weekValue
+				&& slot.ContentType == recipeContent
+				&& slot.RecipeIdentifier != null)
 			.ToListAsync(cancellationToken);
 
-		var recipes = slotRows
-			.Select(s => new PlannedRecipeDto(
-				s.RecipeIdentifier!.Value,
-				s.RecipeTitle ?? string.Empty,
-				s.Servings,
-				s.Day,
-				s.MealType))
-			.ToList();
-
-		return new WeeklyPlannedRecipesDto(weekValue, recipes);
+		return new WeeklyPlannedRecipesDto(weekValue, slotRows.ToPlannedRecipeDtos());
 	}
 
 	public async Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(OwnerIdentifier owner, string? term, int limit, CancellationToken cancellationToken = default)
@@ -76,49 +61,26 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		var cookedState = MealState.Cooked.ToString();
 
 		var query = context.MealPlanSlotReadItems
-			.Where(s => s.OwnerId == ownerId && s.State == cookedState && s.RecipeTitle != null);
+			.Where(slot => slot.OwnerId == ownerId && slot.State == cookedState && slot.RecipeTitle != null);
 
 		if (!string.IsNullOrWhiteSpace(term))
 		{
 			var pattern = $"%{term.Trim()}%";
-			query = query.Where(s => EF.Functions.ILike(s.RecipeTitle!, pattern));
+			query = query.Where(slot => EF.Functions.ILike(slot.RecipeTitle!, pattern));
 		}
 
 		var rows = await query
-			.OrderByDescending(s => s.Week)
-			.ThenBy(s => s.Day)
-			.ThenBy(s => s.MealType)
+			.OrderByDescending(slot => slot.Week)
+			.ThenBy(slot => slot.Day)
+			.ThenBy(slot => slot.MealType)
 			.Take(limit)
 			.ToListAsync(cancellationToken);
 
-		return rows
-			.Select(s => new MealHistoryEntryDto(
-				s.RecipeIdentifier,
-				s.RecipeTitle ?? string.Empty,
-				s.Week,
-				s.Day,
-				s.MealType))
-			.ToList();
+		return rows.ToHistoryEntryDtos();
 	}
 
-	private static MealSlotDto ToDto(MealPlanSlotReadItem row) =>
-		new(
-			row.Day,
-			row.MealType,
-			row.ContentType,
-			row.State,
-			row.RecipeIdentifier,
-			row.RecipeTitle,
-			row.Servings,
-			row.FreetextLabel,
-			row.LeftoverLabel,
-			row.LeftoverSourceDay,
-			row.LeftoverSourceMealType,
-			row.ContentType == SlotContentType.Empty.ToString());
-
-	private static List<MealSlotDto> EmptyDinnerSlots(int defaultServings)
-	{
-		return allDays
+	private static List<MealSlotDto> EmptyDinnerSlots(int defaultServings) =>
+		allDays
 			.Select(day => new MealSlotDto(
 				day.ToString(),
 				MealType.Dinner.ToString(),
@@ -133,5 +95,4 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 				null,
 				true))
 			.ToList();
-	}
 }

--- a/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
@@ -77,11 +77,11 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 	{
 		if (store.TryGetValue((owner.Value, week.Value), out var plan))
 		{
-			return Task.FromResult(new WeeklyPlanDto(week.Value, plan.IsExtendedMode, plan.GetVisibleSlots().ToOrderedDtos()));
+			return Task.FromResult(plan.ToDto(week));
 		}
 
 		var emptyPlan = WeeklyPlan.Create(owner, week);
-		return Task.FromResult(new WeeklyPlanDto(week.Value, false, emptyPlan.GetVisibleSlots().ToOrderedDtos()));
+		return Task.FromResult(emptyPlan.ToDto(week));
 	}
 
 	public Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

Phase 1 of the per-module mapping sweep, gated by the conventions in PR #515. Single source of truth for every WeeklyPlan and MealSlot projection in the module — no inline `new ...Dto(...)` projections, single `ToDto` / `ToDtos` per source type.

> **Note**: PR base is `refactor/no-us-coding-conventions` (PR #515) — this builds on that branch's CLAUDE.md additions. Re-target to `develop` once #515 merges, or merge #515 first.

## Changes

**Domain → DTO** (`Application/DTOs/WeeklyPlanMappingExtensions.cs`, renamed from `MealSlotMappingExtensions.cs`):

```csharp
WeeklyPlan.ToDto(week)                  // new
MealSlot.ToDto()                        // kept
IEnumerable<MealSlot>.ToDtos()          // renamed from ToOrderedDtos,
                                        // returns IReadOnlyList<MealSlotDto>
```

**Read-model row → DTO** (`Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs`, new):

```csharp
MealPlanSlotReadItem.ToDto()                       // was private helper in repo
IEnumerable<MealPlanSlotReadItem>.ToDtos()         // applies day/mealtype ordering
MealPlanSlotReadItem.ToPlannedRecipeDto()
IEnumerable<...>.ToPlannedRecipeDtos()
MealPlanSlotReadItem.ToHistoryEntryDto()
IEnumerable<...>.ToHistoryEntryDtos()
```

Located in Infrastructure (not Application) because the EF entity `MealPlanSlotReadItem` lives there and Application is forbidden from referencing Infrastructure.

## Call sites updated

- **9 command handlers** (Adjust, Assign, ClearSlot, ConfirmMeal, CookWithLeftovers, CopyPlanToWeek, SwapSlots, ToggleExtendedMode):
  ```csharp
  // before
  return new WeeklyPlanDto(week.Value, plan.IsExtendedMode,
                           plan.GetVisibleSlots().ToOrderedDtos());
  // after
  return plan.ToDto(week);
  ```
- **`MealPlanReadModelRepository`**: `GetPlannedRecipesAsync` and `SearchCookedHistoryAsync` go through the new row mappers. `GetByOwnerAndWeekAsync` keeps its `new WeeklyPlanDto(...)` because it has no `WeeklyPlan` aggregate to project from — it assembles primitives + already-mapped slots.
- **`MealPlanTestFixture`** (in-memory fake): same handler-side replacement.

## What this PR doesn't do

- Variable renames (single-letter `s`/`x`/`r` lambda params, `recipeIdentifier` → `recipe`/`recipeRef`) — those land in a separate Phase 2 PR.
- Other modules — Recipes / Shopping / Users get their own Phase 1 PRs.
- `GenerateShoppingListResultDto` construction in `GenerateShoppingListCommandHandler` — built from two `int`s, not a projection.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] MealPlan.Application.Tests — 46 passed
- [x] MealPlan.Domain.Tests — 78 passed
- [x] MealPlan.Infrastructure.Tests — 4 passed
- [x] Architecture.Tests — 117 passed
- [ ] CI integration suite covers the full read/write paths via existing tests (`HappyPathJourneyTests`, `MealHistoryFlowTests`, `CopyPlanToWeekFlowTests` once that PR also lands).

## Diff size

12 files, +89 / −78. Net **−5 lines** before counting the new mapper file (which itself replaces in-place duplication).