### PR TITLE
refactor(users): unify DTO mapping behind ToDto / ToDtos (Phase 1)

### DIFF
--- a/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
+++ b/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
@@ -4,15 +4,13 @@ namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
 
 public static class UserActivityMappingExtensions
 {
-	extension(UserActivity activity)
-	{
-		public UserActivityDto ToDto()
-		{
-			return new UserActivityDto(
-				activity.Type.Value,
-				activity.RecipeIdentifier?.Value,
-				activity.RecipeTitle?.Value,
-				activity.OccurredAt);
-		}
-	}
+	public static UserActivityDto ToDto(this UserActivity activity) =>
+		new(
+			activity.Type.Value,
+			activity.RecipeIdentifier?.Value,
+			activity.RecipeTitle?.Value,
+			activity.OccurredAt);
+
+	public static IReadOnlyList<UserActivityDto> ToDtos(this IEnumerable<UserActivity> activities) =>
+		activities.Select(activity => activity.ToDto()).ToList();
 }

--- a/src/Yumney.Users.Application/DTOs/UserProfileMappingExtensions.cs
+++ b/src/Yumney.Users.Application/DTOs/UserProfileMappingExtensions.cs
@@ -4,24 +4,19 @@ namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
 
 public static class UserProfileMappingExtensions
 {
-	extension(AppUserProfile profile)
-	{
-		public UserProfileDto ToDto()
-		{
-			var dietary = profile.DietaryProfile;
-			var dietaryDto = new DietaryProfileDto(
-				dietary.DietaryType?.Value,
-				dietary.Restrictions.Select(r => r.Value).ToList(),
-				dietary.BalanceGoals.MinVeggieMeals,
-				dietary.BalanceGoals.MaxRedMeatMeals,
-				dietary.CookingEffort?.Value);
+	public static UserProfileDto ToDto(this AppUserProfile profile) =>
+		new(
+			profile.DisplayName.Value,
+			profile.PreferredLanguage.Value,
+			profile.PreferredUnitSystem.Value,
+			profile.DefaultServings.Value,
+			profile.DietaryProfile.ToDto());
 
-			return new UserProfileDto(
-				profile.DisplayName.Value,
-				profile.PreferredLanguage.Value,
-				profile.PreferredUnitSystem.Value,
-				profile.DefaultServings.Value,
-				dietaryDto);
-		}
-	}
+	public static DietaryProfileDto ToDto(this DietaryProfile dietary) =>
+		new(
+			dietary.DietaryType?.Value,
+			dietary.Restrictions.Select(restriction => restriction.Value).ToList(),
+			dietary.BalanceGoals.MinVeggieMeals,
+			dietary.BalanceGoals.MaxRedMeatMeals,
+			dietary.CookingEffort?.Value);
 }

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -14,8 +14,6 @@ public sealed class GetRecentActivityQueryHandler(IUserActivityRepository activi
 
 		var recentActivities = await activities.GetRecentAsync(owner, query.Limit, cancellationToken);
 
-		var dtos = recentActivities.Select(a => a.ToDto()).ToList();
-
-		return Result.Success<IReadOnlyList<UserActivityDto>>(dtos);
+		return Result.Success(recentActivities.ToDtos());
 	}
 }


### PR DESCRIPTION
## Summary

Phase 1 / Users module of the per-module mapping sweep. Gated by the conventions in PR #515.

## Changes

`UserActivityMappingExtensions` and `UserProfileMappingExtensions` converted from the C# 14 `extension(T)` block syntax to the classic `this T` parameter style.

**Why the syntax change:** The block form tripped CA1708 ("members of `extension(...)` should differ by more than case") when a single static class hosted multiple extension targets. The `this T` form is functionally identical, matches the Phase 0 canonical signatures, and avoids the analyzer collision.

**Added:**
- `IEnumerable<UserActivity>.ToDtos()`
- `DietaryProfile.ToDto()` — extracted from the inline `DietaryProfileDto` construction inside the parent profile mapper. `AppUserProfile.ToDto()` now composes via `profile.DietaryProfile.ToDto()`.

**Call site updated:**
- `GetRecentActivityQueryHandler` now uses `recentActivities.ToDtos()` instead of `Select(a => a.ToDto()).ToList()` — drops the single-letter `a` lambda and shrinks the handler body.

## What this PR doesn't do

- Variable renames (Phase 2).
- Other modules (separate Phase 1 PRs — MealPlan is #516).
- `RegisterUserResultDto` / `ResendVerificationEmailResultDto` / `SuggestionsResponseDto` constructions in handlers — those build from string primitives, not domain projections, so they stay inline per the rule's intent.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Users.Application.Tests — 35 passed
- [x] Users.Domain.Tests — 219 passed
- [x] Users.Infrastructure.Tests — 19 passed
- [x] Architecture.Tests — 117 passed (no architecture rule changes)

## Diff size

3 files, +24 / −33. Net **−9 lines**.