### PR TITLE
refactor(shopping): unify DTO mapping behind ToDto / ToDtos (Phase 1)

### DIFF
--- a/src/Yumney.Shopping.Application/DTOs/ShoppingLedgerMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingLedgerMappingExtensions.cs
@@ -6,17 +6,17 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
 public static class ShoppingLedgerMappingExtensions
 {
-	extension(ShoppingLedger ledger)
-	{
-		public AddedItemDto ToAddedItemDto(ItemName itemName, Quantity quantity, IngredientCategory category, ItemSource source)
-		{
-			return new AddedItemDto(
-				itemName.Value,
-				quantity.Amount,
-				quantity.Unit?.Value,
-				category.Value,
-				source.Value,
-				ledger.Identifier);
-		}
-	}
+	public static AddedItemDto ToAddedItemDto(
+		this ShoppingLedger ledger,
+		ItemName itemName,
+		Quantity quantity,
+		IngredientCategory category,
+		ItemSource source) =>
+		new(
+			itemName.Value,
+			quantity.Amount,
+			quantity.Unit?.Value,
+			category.Value,
+			source.Value,
+			ledger.Identifier);
 }

--- a/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/ShoppingListMappingExtensions.cs
@@ -4,35 +4,32 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 
 public static class ShoppingListMappingExtensions
 {
-	extension(ShoppingList shoppingList)
-	{
-		public ShoppingListDetailDto ToDetailDto()
-		{
-			return new ShoppingListDetailDto(
-				shoppingList.Identifier.Value,
-				shoppingList.Title.Value,
-				shoppingList.RecipeReference?.Value,
-				shoppingList.CreatedAt,
-				shoppingList.Items.Select(i => i.ToDto()).ToList());
-		}
-	}
+	public static ShoppingListDetailDto ToDetailDto(this ShoppingList shoppingList) =>
+		new(
+			shoppingList.Identifier.Value,
+			shoppingList.Title.Value,
+			shoppingList.RecipeReference?.Value,
+			shoppingList.CreatedAt,
+			shoppingList.Items.ToDtos());
 
-	public static ShoppingListSummaryDto ToSummaryDto(this ShoppingListSummary summary)
-	{
-		return new ShoppingListSummaryDto(
+	public static ShoppingListSummaryDto ToSummaryDto(this ShoppingListSummary summary) =>
+		new(
 			summary.Identifier.Value,
 			summary.Title.Value,
 			summary.ItemCount.Value,
 			summary.CreatedAt);
-	}
 
-	public static ShoppingListItemDto ToDto(this ShoppingListItem item)
-	{
-		return new ShoppingListItemDto(
+	public static IReadOnlyList<ShoppingListSummaryDto> ToSummaryDtos(this IEnumerable<ShoppingListSummary> summaries) =>
+		summaries.Select(summary => summary.ToSummaryDto()).ToList();
+
+	public static ShoppingListItemDto ToDto(this ShoppingListItem item) =>
+		new(
 			item.Id.Value,
 			item.Name.Value,
 			item.Quantity?.Amount.Value,
 			item.Quantity?.Unit?.Value,
 			item.IsChecked);
-	}
+
+	public static IReadOnlyList<ShoppingListItemDto> ToDtos(this IEnumerable<ShoppingListItem> items) =>
+		items.Select(item => item.ToDto()).ToList();
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -19,8 +19,6 @@ public sealed class GetShoppingListsQueryHandler(
 
 		var (items, totalCount) = await projection.GetByOwnerAsync(owner, paging, sorting, cancellationToken);
 
-		var shoppingListSummaryDtos = items.Select(l => l.ToSummaryDto()).ToList();
-
-		return PagedResultExtensions.With(shoppingListSummaryDtos, totalCount, paging);
+		return PagedResultExtensions.With(items.ToSummaryDtos(), totalCount, paging);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -41,20 +41,12 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 			.FirstOrDefaultAsync(s => s.Id == identifier.Value, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 
-		var items = await context.ShoppingListItemReadItems
-			.Where(i => i.ListId == identifier.Value)
-			.OrderBy(i => i.CreatedAt)
-			.Select(i => new ShoppingListItemDto(i.Id, i.Name, i.QuantityAmount, i.QuantityUnit, i.IsChecked))
+		var itemRows = await context.ShoppingListItemReadItems
+			.Where(item => item.ListId == identifier.Value)
+			.OrderBy(item => item.CreatedAt)
 			.ToListAsync(cancellationToken);
 
-		var dto = new ShoppingListDetailDto(
-			summary.Id,
-			summary.Title,
-			summary.RecipeIdentifier,
-			summary.CreatedAt,
-			items);
-
-		return new ShoppingListProjectedDetail(summary.OwnerId, dto);
+		return new ShoppingListProjectedDetail(summary.OwnerId, summary.ToDetailDto(itemRows.ToDtos()));
 	}
 
 	public async Task<IReadOnlyList<ShoppingListIdentifier>> FindIdsByRecipeAsync(

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelMappingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelMappingExtensions.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public static class IngredientBalanceReadModelMappingExtensions
+{
+	public static IngredientBalanceItemDto ToDto(
+		this IngredientBalanceReadItem row,
+		Freshness freshness,
+		int? daysSinceBought) =>
+		new(
+			ItemName: row.ItemName,
+			Quantity: row.AtHome,
+			Unit: row.Unit,
+			Category: row.Category,
+			Source: IngredientBalanceSource.AtHome,
+			Freshness: freshness,
+			DaysSinceBought: daysSinceBought);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
@@ -16,23 +16,15 @@ public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext c
 		var now = timeProvider.GetUtcNow().UtcDateTime;
 
 		return rows
-			.Where(r => r.AtHome > 0)
-			.Select(r =>
+			.Where(row => row.AtHome > 0)
+			.Select(row =>
 			{
-				var category = IngredientCategory.From(r.Category);
-				var daysSinceBought = r.LastBoughtAt is null
+				var category = IngredientCategory.From(row.Category);
+				var daysSinceBought = row.LastBoughtAt is null
 					? (int?)null
-					: Math.Max(0, (int)(now - r.LastBoughtAt.Value).TotalDays);
+					: Math.Max(0, (int)(now - row.LastBoughtAt.Value).TotalDays);
 				var freshness = ShelfLife.Classify(category, daysSinceBought);
-
-				return new IngredientBalanceItemDto(
-					ItemName: r.ItemName,
-					Quantity: r.AtHome,
-					Unit: r.Unit,
-					Category: r.Category,
-					Source: IngredientBalanceSource.AtHome,
-					Freshness: freshness,
-					DaysSinceBought: daysSinceBought);
+				return row.ToDto(freshness, daysSinceBought);
 			})
 			.ToList();
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelMappingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelMappingExtensions.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public static class ShoppingLedgerReadModelMappingExtensions
+{
+	public static MergedShoppingItemDto ToMergedItemDto(
+		this ShoppingLedgerReadItem row,
+		IReadOnlyList<ItemSourceDto> sources)
+	{
+		var rounded = QuantityRounder.RoundUp(row.TotalQuantity, row.Unit);
+		return new(
+			row.ItemName,
+			row.TotalQuantity,
+			rounded.DisplayQuantity,
+			row.Unit,
+			row.Category,
+			row.IsBought,
+			sources);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
@@ -24,17 +24,17 @@ public sealed class ShoppingLedgerReadModelRepository(ShoppingReadDbContext cont
 		var readItems = await query.ToListAsync(cancellationToken);
 
 		var dtoItems = readItems
-			.Select(r =>
-			{
-				var sources = JsonSerializer.Deserialize<List<SourceEntry>>(r.SourcesJson) ?? [];
-				var sourceDtos = sources.Select(s => new ItemSourceDto(s.Quantity, s.Source, s.OccurredAt)).ToList();
-				var rounded = QuantityRounder.RoundUp(r.TotalQuantity, r.Unit);
-				return new MergedShoppingItemDto(r.ItemName, r.TotalQuantity, rounded.DisplayQuantity, r.Unit, r.Category, r.IsBought, sourceDtos);
-			})
-			.OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
+			.Select(row => row.ToMergedItemDto(DeserializeSources(row.SourcesJson)))
+			.OrderBy(item => IngredientCategory.From(item.Category).DisplayOrder)
 			.ToList();
 
 		return new MergedShoppingListDto(dtoItems);
+	}
+
+	private static List<ItemSourceDto> DeserializeSources(string sourcesJson)
+	{
+		var sources = JsonSerializer.Deserialize<List<SourceEntry>>(sourcesJson) ?? [];
+		return sources.Select(source => new ItemSourceDto(source.Quantity, source.Source, source.OccurredAt)).ToList();
 	}
 
 	private sealed record SourceEntry(decimal Quantity, string Source, DateTime OccurredAt);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelMappingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListReadModelMappingExtensions.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public static class ShoppingListReadModelMappingExtensions
+{
+	public static ShoppingListItemDto ToDto(this ShoppingListItemReadItem row) =>
+		new(row.Id, row.Name, row.QuantityAmount, row.QuantityUnit, row.IsChecked);
+
+	public static IReadOnlyList<ShoppingListItemDto> ToDtos(this IEnumerable<ShoppingListItemReadItem> rows) =>
+		rows.Select(row => row.ToDto()).ToList();
+
+	public static ShoppingListDetailDto ToDetailDto(
+		this ShoppingListSummaryReadItem summary,
+		IReadOnlyList<ShoppingListItemDto> items) =>
+		new(
+			summary.Id,
+			summary.Title,
+			summary.RecipeIdentifier,
+			summary.CreatedAt,
+			items);
+}


### PR DESCRIPTION
## Summary

Phase 1 / Shopping module of the per-module mapping sweep. Gated by the conventions in PR #515. Brings Shopping in line with MealPlan (PR #516) and Users (PR #517).

## Application side

Both existing mappers converted from C# 14 `extension(T)` block syntax to classic `this T` parameters (avoids CA1708 collisions and matches Phase 0 canonical signatures).

`ShoppingListMappingExtensions`:
- **Added** `IEnumerable<ShoppingListItem>.ToDtos()`
- **Added** `IEnumerable<ShoppingListSummary>.ToSummaryDtos()`
- `ShoppingList.ToDetailDto()` now composes via `Items.ToDtos()`

`ShoppingLedgerMappingExtensions`:
- `ShoppingLedger.ToAddedItemDto(...)` converted to `this T` style; signature unchanged.

## Infrastructure side — three new mappers

Co-located with their EF read entities since Application can't reference Infrastructure.

```csharp
// ShoppingListReadModelMappingExtensions
ShoppingListItemReadItem.ToDto()
IEnumerable<ShoppingListItemReadItem>.ToDtos()
ShoppingListSummaryReadItem.ToDetailDto(IReadOnlyList<ShoppingListItemDto> items)

// ShoppingLedgerReadModelMappingExtensions
ShoppingLedgerReadItem.ToMergedItemDto(IReadOnlyList<ItemSourceDto> sources)

// IngredientBalanceReadModelMappingExtensions
IngredientBalanceReadItem.ToDto(Freshness freshness, int? daysSinceBought)
```

Freshness/daysSinceBought computation and source JSON deserialization stay in their repositories — those depend on injected `TimeProvider` and one-off parsing, neither is pure projection.

## Call sites updated

- `EfCoreShoppingListProjectionRepository.GetByIdAsync` — inline `new ShoppingListItemDto(...)` + `new ShoppingListDetailDto(...)` → `summary.ToDetailDto(itemRows.ToDtos())`.
- `ShoppingLedgerReadModelRepository.GetByOwnerAsync` — inline `new MergedShoppingItemDto(...)` and inline source-DTO projection → `row.ToMergedItemDto(...)`; source deserialization extracted into a private helper.
- `IngredientBalanceReadModelRepository.GetAtHomeItemsAsync` — inline `new IngredientBalanceItemDto(...)` → `row.ToDto(freshness, daysSinceBought)`.
- `GetShoppingListsQueryHandler` — `items.Select(l => l.ToSummaryDto()).ToList()` → `items.ToSummaryDtos()` (drops the single-letter `l` lambda).

## What this PR doesn't do

- Variable renames (Phase 2).
- Recipes module (final Phase 1 PR).
- `GetIngredientBalanceQueryHandler` inline `new IngredientBalanceItemDto(...)` for staples — that's constructed from primitives (staple name + null + computed category), not a domain projection, so it stays inline.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Shopping.Application.Tests — 122 passed
- [x] Shopping.Domain.Tests — 176 passed
- [x] Shopping.Infrastructure.Tests — 31 passed
- [x] Shopping.Api.Tests — 21 passed
- [x] Architecture.Tests — 117 passed

## Diff size

9 files, +113 / −70. Net **+43 lines** (3 new mapper files; in-place duplication consolidated, no behaviour change).