### PR TITLE
refactor(recipes): unify DTO mapping behind ToDto / ToDtos (Phase 1)

### DIFF
--- a/src/Yumney.Recipes.Application/DTOs/RecipeMappingExtensions.cs
+++ b/src/Yumney.Recipes.Application/DTOs/RecipeMappingExtensions.cs
@@ -4,54 +4,69 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 
 public static class RecipeMappingExtensions
 {
-	extension(Recipe recipe)
-	{
-		public RecipeDetailDto ToDetailDto(bool isFavorite = false)
-		{
-			return new RecipeDetailDto(
-				recipe.Id.Value,
-				recipe.Title.Value,
-				recipe.Description?.Value,
-				recipe.Servings?.Value,
-				recipe.Timing?.Preparation?.Value,
-				recipe.Timing?.Cooking?.Value,
-				recipe.Difficulty?.Value,
-				recipe.ImageUrl?.Value,
-				recipe.Language?.Value,
-				recipe.SourceUrl?.Value,
-				recipe.CreatedAt,
-				recipe.Ingredients.Select(i => i.ToDto()).ToList(),
-				recipe.Steps.Select(s => s.ToDto()).ToList(),
-				recipe.Tags.Select(t => t.Value).ToList(),
-				isFavorite);
-		}
+	public static RecipeDetailDto ToDetailDto(this Recipe recipe, bool isFavorite = false) =>
+		new(
+			recipe.Id.Value,
+			recipe.Title.Value,
+			recipe.Description?.Value,
+			recipe.Servings?.Value,
+			recipe.Timing?.Preparation?.Value,
+			recipe.Timing?.Cooking?.Value,
+			recipe.Difficulty?.Value,
+			recipe.ImageUrl?.Value,
+			recipe.Language?.Value,
+			recipe.SourceUrl?.Value,
+			recipe.CreatedAt,
+			recipe.Ingredients.ToDtos(),
+			recipe.Steps.ToDtos(),
+			recipe.Tags.Select(tag => tag.Value).ToList(),
+			isFavorite);
 
-		public RecipeListItemDto ToListItemDto(bool isFavorite = false)
-		{
-			return new RecipeListItemDto(
-				recipe.Id.Value,
-				recipe.Title.Value,
-				recipe.Description?.Value,
-				recipe.Servings?.Value,
-				recipe.Timing?.Preparation?.Value,
-				recipe.Timing?.Cooking?.Value,
-				recipe.Difficulty?.Value,
-				recipe.ImageUrl?.Value,
-				recipe.CreatedAt,
-				recipe.Tags.Select(t => t.Value).ToList(),
-				isFavorite);
-		}
-	}
+	public static RecipeListItemDto ToListItemDto(this Recipe recipe, bool isFavorite = false) =>
+		new(
+			recipe.Id.Value,
+			recipe.Title.Value,
+			recipe.Description?.Value,
+			recipe.Servings?.Value,
+			recipe.Timing?.Preparation?.Value,
+			recipe.Timing?.Cooking?.Value,
+			recipe.Difficulty?.Value,
+			recipe.ImageUrl?.Value,
+			recipe.CreatedAt,
+			recipe.Tags.Select(tag => tag.Value).ToList(),
+			isFavorite);
 
-	public static RecipeIngredientDto ToDto(this Ingredient ingredient)
-	{
-		return new RecipeIngredientDto(
+	public static SavedRecipeDto ToSavedDto(this Recipe recipe) =>
+		new(recipe.Id.Value, recipe.Title.Value, recipe.CreatedAt);
+
+	public static CookableRecipeDto ToCookableDto(
+		this Recipe recipe,
+		CookableRecipeMatchTier tier,
+		IReadOnlyList<string> missingIngredients) =>
+		new(
+			RecipeIdentifier: recipe.Id.Value,
+			Title: recipe.Title.Value,
+			ImageUrl: recipe.ImageUrl?.Value,
+			Servings: recipe.Servings?.Value,
+			PrepTimeMinutes: recipe.Timing?.Preparation?.Value,
+			CookTimeMinutes: recipe.Timing?.Cooking?.Value,
+			Difficulty: recipe.Difficulty?.Value,
+			IngredientCount: recipe.Ingredients.Count,
+			Tier: tier,
+			MissingIngredients: missingIngredients);
+
+	public static RecipeIngredientDto ToDto(this Ingredient ingredient) =>
+		new(
 			ingredient.Name.Value,
 			ingredient.Quantity?.Amount.Value,
 			ingredient.Quantity?.Unit?.Value);
-	}
 
-	public static RecipeStepDto ToDto(this Step step) => new(step.Number.Value, step.Description.Value);
+	public static IReadOnlyList<RecipeIngredientDto> ToDtos(this IEnumerable<Ingredient> ingredients) =>
+		ingredients.Select(ingredient => ingredient.ToDto()).ToList();
 
-	public static SavedRecipeDto ToSavedDto(this Recipe recipe) => new(recipe.Id.Value, recipe.Title.Value, recipe.CreatedAt);
+	public static RecipeStepDto ToDto(this Step step) =>
+		new(step.Number.Value, step.Description.Value);
+
+	public static IReadOnlyList<RecipeStepDto> ToDtos(this IEnumerable<Step> steps) =>
+		steps.Select(step => step.ToDto()).ToList();
 }

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
@@ -50,19 +50,7 @@ public sealed class GetCookableRecipesQueryHandler(
 			if (tier == CookableRecipeMatchTier.Near && missing.Count > maxMissingForNearMatch) continue;
 			if (query.FullMatchOnly && tier != CookableRecipeMatchTier.Full) continue;
 
-			matches.Add(new RankedMatch(
-				new CookableRecipeDto(
-					RecipeIdentifier: recipe.Id.Value,
-					Title: recipe.Title.Value,
-					ImageUrl: recipe.ImageUrl?.Value,
-					Servings: recipe.Servings?.Value,
-					PrepTimeMinutes: recipe.Timing?.Preparation?.Value,
-					CookTimeMinutes: recipe.Timing?.Cooking?.Value,
-					Difficulty: recipe.Difficulty?.Value,
-					IngredientCount: recipe.Ingredients.Count,
-					Tier: tier,
-					MissingIngredients: missing),
-				urgentCount));
+			matches.Add(new RankedMatch(recipe.ToCookableDto(tier, missing), urgentCount));
 		}
 
 		IReadOnlyList<CookableRecipeDto> ranked = [.. matches


### PR DESCRIPTION
## Summary

Phase 1 / **Recipes** module — final per-module mapping sweep, gated by the conventions in PR #515. Brings Recipes in line with MealPlan (#516), Users (#517), and Shopping (#518).

## Changes

`RecipeMappingExtensions` converted from C# 14 `extension(Recipe)` block syntax to classic `this T` parameter style (avoids CA1708 collisions when one class hosts multiple extension targets, matches the Phase 0 canonical signatures).

**Added:**
- `IEnumerable<Ingredient>.ToDtos()`
- `IEnumerable<Step>.ToDtos()`
- `Recipe.ToCookableDto(tier, missingIngredients)` — extracts the inline `CookableRecipeDto` construction out of `GetCookableRecipesQueryHandler`. The tier and missing list are computed by the matcher in the handler, so they stay as parameters on the mapper.

**Updated:**
- `Recipe.ToDetailDto()` now composes via `Ingredients.ToDtos()` + `Steps.ToDtos()` — drops `i =>` and `s =>` single-letter lambdas in the mapper body.
- `GetCookableRecipesQueryHandler` — 12-line inline `CookableRecipeDto` construction → `recipe.ToCookableDto(tier, missing)`.

## Out of scope

- **`RequestMappingExtensions`** in `*.Api` — request → command-fragment helpers supporting the existing `Deconstruct` pattern. Not a domain → DTO projection.
- **Inline DTO constructions in `Recipes.Extraction` services** (`JsonLdRecipeParser`, `SemanticKernelChatService`, `SemanticKernelIntentParserService`) — those build DTOs from raw scraped HTML or LLM output. Not domain projections.
- **`FavoriteStateDto`** inline in `ToggleFavoriteCommandHandler` — constructed from primitives (Guid + bool).

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Recipes.Application.Tests — 165 passed
- [x] Recipes.Domain.Tests — 233 passed
- [x] Recipes.Infrastructure.Tests — 101 passed
- [x] Recipes.Api.Tests — 161 passed
- [x] Architecture.Tests — 117 passed

## Diff size

2 files, +61 / −58. Net **+3 lines**.