### PR TITLE
refactor(users): drop single-letter lambda vars + Identifier-suffix parameters (Phase 2)

### DIFF
--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -42,9 +42,9 @@ public sealed class GetSuggestionsQueryHandler(IUserActivityRepository activitie
 			actions.Add("try_something_new");
 		}
 
-		var hasRecentImport = recentActivities.Any(a =>
-			a.Type == ActivityType.RecipeImported &&
-			a.OccurredAt > now.AddHours(recentImportLookbackHours));
+		var hasRecentImport = recentActivities.Any(activity =>
+			activity.Type == ActivityType.RecipeImported &&
+			activity.OccurredAt > now.AddHours(recentImportLookbackHours));
 
 		if (hasRecentImport)
 		{

--- a/src/Yumney.Users.Domain/UserActivity/UserActivity.cs
+++ b/src/Yumney.Users.Domain/UserActivity/UserActivity.cs
@@ -21,7 +21,7 @@ public sealed class UserActivity : Entity<UserActivityIdentifier>
 	public static UserActivity Record(
 		OwnerIdentifier owner,
 		ActivityType type,
-		RecipeIdentifierSnapshot? recipeIdentifier = null,
+		RecipeIdentifierSnapshot? recipe = null,
 		RecipeTitleSnapshot? recipeTitle = null)
 	{
 		return new UserActivity
@@ -29,7 +29,7 @@ public sealed class UserActivity : Entity<UserActivityIdentifier>
 			Id = UserActivityIdentifier.New(),
 			Owner = owner,
 			Type = type,
-			RecipeIdentifier = recipeIdentifier,
+			RecipeIdentifier = recipe,
 			RecipeTitle = recipeTitle,
 			OccurredAt = DateTime.UtcNow,
 		};

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryRestrictionsConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/DietaryRestrictionsConverter.cs
@@ -5,8 +5,8 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
 
 internal sealed class DietaryRestrictionsConverter()
 	: ValueConverter<IReadOnlyList<DietaryRestriction>, string>(
-		v => string.Join(',', v.Select(r => r.Value)),
-		v => ConvertFromString(v))
+		restrictions => string.Join(',', restrictions.Select(restriction => restriction.Value)),
+		serialized => ConvertFromString(serialized))
 {
 	private static IReadOnlyList<DietaryRestriction> ConvertFromString(string value) =>
 		string.IsNullOrEmpty(value)

--- a/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
@@ -19,8 +19,8 @@ public sealed class UserActivityRepository(UsersDbContext context) : IUserActivi
 	{
 		return await activities
 			.AsNoTracking()
-			.Where(a => a.Owner == owner)
-			.OrderByDescending(a => a.OccurredAt)
+			.Where(activity => activity.Owner == owner)
+			.OrderByDescending(activity => activity.OccurredAt)
 			.Take(limit.Value)
 			.ToListAsync(cancellationToken);
 	}

--- a/src/Yumney.Users.Infrastructure/Services/StaplesProvider.cs
+++ b/src/Yumney.Users.Infrastructure/Services/StaplesProvider.cs
@@ -15,12 +15,12 @@ public sealed class StaplesProvider(IStaplesListRepository staplesLists) : IStap
 		if (staples is null)
 		{
 			return StaplesList.DefaultItems
-				.Select(i => i.Value.ToLowerInvariant())
+				.Select(item => item.Value.ToLowerInvariant())
 				.ToHashSet(StringComparer.OrdinalIgnoreCase);
 		}
 
 		return staples.Items
-			.Select(i => i.Value.ToLowerInvariant())
+			.Select(item => item.Value.ToLowerInvariant())
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2 / Users module — applies the naming rules locked in CLAUDE.md by PR #515 (now merged). First module of the variable-naming sweep, picked first because it's the smallest and validates the approach for Shopping/MealPlan/Recipes that follow.

## Lambda parameter renames

| File | Before | After |
|---|---|---|
| `GetSuggestionsQueryHandler` | `Any(a => …)` | `Any(activity => …)` |
| `DietaryRestrictionsConverter` | `v => v.Select(r => r.Value)` | `restrictions => restrictions.Select(restriction => restriction.Value)`; read-direction lambda is `serialized` |
| `UserActivityRepository` | `Where(a => a.Owner …)` and `OrderByDescending(a => a.OccurredAt)` | `activity =>` |
| `StaplesProvider` | `Select(i => i.Value …)` (×2) | `Select(item => item.Value …)` |

## Identifier-suffix parameter rename

`UserActivity.Record(...)` parameter `RecipeIdentifierSnapshot? recipeIdentifier` → `recipe`. The DTO/entity property `RecipeIdentifier` is a public domain/serialization contract and keeps its `Identifier` suffix per the convention.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Users.Application.Tests — 35 passed
- [x] Users.Domain.Tests — 219 passed
- [x] Users.Infrastructure.Tests — 19 passed
- [x] Architecture.Tests — 117 passed

5 files, +11 / −11. Pure rename, no behaviour change.