### PR TITLE
refactor(mealplan): drop single-letter lambda vars + Identifier-suffix parameters (Phase 2)

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -23,7 +23,7 @@ public sealed class ConfirmMealCommandHandler(
 		switch (newState)
 		{
 			case MealState.Cooked:
-				var slot = plan.GetVisibleSlots().FirstOrDefault(s => s.Day == day && s.MealType == mealType);
+				var slot = plan.GetVisibleSlots().FirstOrDefault(slot => slot.Day == day && slot.MealType == mealType);
 				var ingredients = slot?.Recipe is not null
 					? await FetchIngredientsAsync(slot.Recipe.RecipeIdentifier.Value, cancellationToken)
 					: [];
@@ -46,8 +46,8 @@ public sealed class ConfirmMealCommandHandler(
 	{
 		var ingredients = await ingredientProvider.GetIngredientsAsync(recipeId, cancellationToken);
 		return ingredients
-			.Where(i => i.Amount.HasValue && i.Amount.Value > 0m)
-			.Select(i => new CookedIngredient(i.Name, i.Amount!.Value, i.Unit))
+			.Where(ingredient => ingredient.Amount.HasValue && ingredient.Amount.Value > 0m)
+			.Select(ingredient => new CookedIngredient(ingredient.Name, ingredient.Amount!.Value, ingredient.Unit))
 			.ToList();
 	}
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeReference.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeReference.cs
@@ -8,16 +8,16 @@ public sealed record SlotRecipeReference : IValueObject
 
 	public SlotRecipeTitle Title { get; }
 
-	private SlotRecipeReference(SlotRecipeIdentifier recipeIdentifier, SlotRecipeTitle title)
+	private SlotRecipeReference(SlotRecipeIdentifier recipe, SlotRecipeTitle title)
 	{
-		RecipeIdentifier = recipeIdentifier;
+		RecipeIdentifier = recipe;
 		Title = title;
 	}
 
-	public static SlotRecipeReference From(SlotRecipeIdentifier recipeIdentifier, SlotRecipeTitle title) => new(recipeIdentifier, title);
+	public static SlotRecipeReference From(SlotRecipeIdentifier recipe, SlotRecipeTitle title) => new(recipe, title);
 
-	public static SlotRecipeReference From(Guid recipeIdentifier, string title) =>
-		From(SlotRecipeIdentifier.From(recipeIdentifier), SlotRecipeTitle.From(title));
+	public static SlotRecipeReference From(Guid recipe, string title) =>
+		From(SlotRecipeIdentifier.From(recipe), SlotRecipeTitle.From(title));
 
 	public override string ToString() => $"{Title} ({RecipeIdentifier})";
 }

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeeklyPlan.cs
@@ -28,8 +28,8 @@ public sealed class WeeklyPlan : EventSourcedAggregate<WeeklyPlanIdentifier>
 
 	public IReadOnlyList<MealSlot> Slots =>
 		slots.Values
-			.OrderBy(s => s.Day)
-			.ThenBy(s => s.MealType)
+			.OrderBy(slot => slot.Day)
+			.ThenBy(slot => slot.MealType)
 			.ToList()
 			.AsReadOnly();
 
@@ -71,8 +71,8 @@ public sealed class WeeklyPlan : EventSourcedAggregate<WeeklyPlanIdentifier>
 		return IsExtendedMode
 			? Slots
 			: slots.Values
-				.Where(s => s.MealType == MealType.Dinner)
-				.OrderBy(s => s.Day)
+				.Where(slot => slot.MealType == MealType.Dinner)
+				.OrderBy(slot => slot.Day)
 				.ToList()
 				.AsReadOnly();
 	}
@@ -80,9 +80,9 @@ public sealed class WeeklyPlan : EventSourcedAggregate<WeeklyPlanIdentifier>
 	public IReadOnlyList<MealSlot> GetUnconfirmedPastMeals(DayOfWeek today)
 	{
 		return slots.Values
-			.Where(s => s.ContentType == SlotContentType.Recipe && s.State == MealState.Planned && s.Day < today)
-			.OrderBy(s => s.Day)
-			.ThenBy(s => s.MealType)
+			.Where(slot => slot.ContentType == SlotContentType.Recipe && slot.State == MealState.Planned && slot.Day < today)
+			.OrderBy(slot => slot.Day)
+			.ThenBy(slot => slot.MealType)
 			.ToList();
 	}
 

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
@@ -67,11 +67,11 @@ public sealed partial class EfCoreMealPlanEventStore(
 
 		var storedEvents = await context.Set<StoredEvent>()
 			.AsNoTracking()
-			.Where(e => e.AggregateId == aggregateId)
-			.OrderBy(e => e.Version)
+			.Where(stored => stored.AggregateId == aggregateId)
+			.OrderBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
 
-		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+		var events = storedEvents.Select(DeserializeEvent).Where(deserialized => deserialized is not null).Cast<IDomainEvent>();
 
 		return WeeklyPlan.FromEvents(WeeklyPlanIdentifier.From(aggregateId), events);
 	}
@@ -159,7 +159,7 @@ public sealed partial class EfCoreMealPlanEventStore(
 					confirmed.Recipe.RecipeIdentifier.Value,
 					confirmed.Servings.Value,
 					confirmed.Ingredients
-						.Select(i => new MealConfirmedIngredient(i.Name, i.Quantity, i.Unit))
+						.Select(ingredient => new MealConfirmedIngredient(ingredient.Name, ingredient.Quantity, ingredient.Unit))
 						.ToList());
 				await PublishAsync(crossModule, cancellationToken);
 			}


### PR DESCRIPTION
## Summary

Phase 2 / MealPlan module — applies the naming rules locked in PR #515 (now merged).

## Lambda parameter renames

| File | Before | After |
|---|---|---|
| `WeeklyPlan.Slots` | `OrderBy(s =>) ThenBy(s =>)` | `slot =>` |
| `WeeklyPlan.GetVisibleSlots` | `Where(s =>) OrderBy(s =>)` | `slot =>` |
| `WeeklyPlan.GetUnconfirmedPastMeals` | `Where/OrderBy/ThenBy(s =>)` | `slot =>` |
| `ConfirmMealCommandHandler` | `FirstOrDefault(s =>) Where(i =>) Select(i =>)` | `slot =>`, `ingredient =>` |
| `EfCoreMealPlanEventStore` (`LoadAsync`) | `Where(e =>) OrderBy(e =>) Where(e =>)` | `stored =>`, `deserialized =>` |
| `EfCoreMealPlanEventStore` (cross-module event payload mapper) | `Select(i =>)` | `ingredient =>` |

## Identifier-suffix parameter renames

`SlotRecipeReference` private constructor + `From(SlotRecipeIdentifier, SlotRecipeTitle)` overload — parameter `SlotRecipeIdentifier recipeIdentifier` → `recipe`. The other `From(Guid, string)` overload keeps its `recipeIdentifier` parameter because the rule targets variables holding **value objects** whose type ends in `Identifier`; raw `Guid` is a primitive.

`MealPlanEndpoints` destructure bindings (`var (day, recipeIdentifier, ...)`) and `HttpRecipeIngredientProvider`'s `Guid recipeIdentifier` parameter stay unchanged for the same reason.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] MealPlan.Application.Tests — 46 passed
- [x] MealPlan.Domain.Tests — 78 passed
- [x] MealPlan.Infrastructure.Tests — 4 passed
- [x] Architecture.Tests — 117 passed

4 files, +19 / −19. Pure rename, no behaviour change.