### PR TITLE
refactor(shopping): drop single-letter lambda vars (Phase 2)

### DIFF
--- a/src/Yumney.Shopping.Api/Requests/CreateShoppingListRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/CreateShoppingListRequest.cs
@@ -11,11 +11,11 @@ public sealed record CreateShoppingListRequest(
 	public (ShoppingListTitle Title, IReadOnlyList<CommandItem> Items, RecipeReference? RecipeReference) ToValueObjects() =>
 	(
 		ShoppingListTitle.From(Title),
-		Items.Select(i => new CommandItem(
-			ItemName.From(i.Name),
+		Items.Select(item => new CommandItem(
+			ItemName.From(item.Name),
 			Quantity.FromNullable(
-				Amount.FromNullable(i.Amount),
-				Unit.FromNullable(i.Unit))))
+				Amount.FromNullable(item.Amount),
+				Unit.FromNullable(item.Unit))))
 			.ToList(),
 		Domain.ShoppingList.RecipeReference.FromNullable(RecipeIdentifier));
 }

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListCommandHandler.cs
@@ -15,7 +15,7 @@ public sealed class CreateShoppingListCommandHandler(IShoppingListEventStore eve
 		var owner = currentUser.AsOwner();
 
 		var items = itemCommands
-			.Select(i => Domain.ShoppingList.ShoppingListItem.Create(i.Name, i.Quantity))
+			.Select(item => Domain.ShoppingList.ShoppingListItem.Create(item.Name, item.Quantity))
 			.ToList();
 		var shoppingList = ShoppingList.Create(title, owner, items, recipeReference);
 

--- a/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
@@ -46,13 +46,13 @@ public sealed class ExportShoppingListQueryHandler(
 	{
 		var list = await readModel.GetByOwnerAsync(currentUser.UserId, cancellationToken: cancellationToken);
 
-		var openItems = list.Items.Where(i => !i.IsBought).ToList();
+		var openItems = list.Items.Where(item => !item.IsBought).ToList();
 		if (openItems.Count == 0)
 			return string.Empty;
 
 		var grouped = openItems
-			.GroupBy(i => i.Category)
-			.OrderBy(g => IngredientCategory.From(g.Key).DisplayOrder);
+			.GroupBy(item => item.Category)
+			.OrderBy(group => IngredientCategory.From(group.Key).DisplayOrder);
 
 		var sb = new StringBuilder();
 

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -22,12 +22,12 @@ public sealed class GetIngredientBalanceQueryHandler(
 		var staples = staplesTask.Result;
 
 		var atHomeNames = atHomeItems
-			.Select(i => i.ItemName)
+			.Select(item => item.ItemName)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
 		List<IngredientBalanceItemDto> items = [.. atHomeItems];
 
-		foreach (var staple in staples.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+		foreach (var staple in staples.OrderBy(staple => staple, StringComparer.OrdinalIgnoreCase))
 		{
 			if (atHomeNames.Contains(staple)) continue;
 
@@ -41,8 +41,8 @@ public sealed class GetIngredientBalanceQueryHandler(
 		}
 
 		List<IngredientBalanceItemDto> sorted = [.. items
-			.OrderBy(i => IngredientCategory.From(i.Category).DisplayOrder)
-			.ThenBy(i => i.ItemName, StringComparer.OrdinalIgnoreCase)];
+			.OrderBy(item => IngredientCategory.From(item.Category).DisplayOrder)
+			.ThenBy(item => item.ItemName, StringComparer.OrdinalIgnoreCase)];
 
 		return new IngredientBalanceDto(sorted);
 	}

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingList.cs
@@ -142,13 +142,13 @@ public sealed class ShoppingList : EventSourcedAggregate<ShoppingListIdentifier>
 
 	private void EnsureItemExists(ShoppingListItemIdentifier itemId)
 	{
-		var item = items.FirstOrDefault(i => i.Id == itemId);
+		var item = items.FirstOrDefault(candidate => candidate.Id == itemId);
 		Ensure.That(item!).IsNotNull();
 	}
 
 	private ShoppingListItem FindItem(ShoppingListItemIdentifier itemId)
 	{
-		var item = items.FirstOrDefault(i => i.Id == itemId);
+		var item = items.FirstOrDefault(candidate => candidate.Id == itemId);
 		Ensure.That(item!).IsNotNull();
 		return item!;
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingEventStore.cs
@@ -60,11 +60,11 @@ public sealed partial class EfCoreShoppingEventStore(
 
 		var storedEvents = await context.Set<StoredEvent>()
 			.AsNoTracking()
-			.Where(e => e.AggregateId == aggregateId)
-			.OrderBy(e => e.Version)
+			.Where(stored => stored.AggregateId == aggregateId)
+			.OrderBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
 
-		var events = storedEvents.Select(DeserializeEvent).Where(e => e is not null).Cast<IDomainEvent>();
+		var events = storedEvents.Select(DeserializeEvent).Where(deserialized => deserialized is not null).Cast<IDomainEvent>();
 
 		return ShoppingLedger.FromEvents(ShoppingLedgerIdentifier.From(aggregateId), ownerId, events);
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/EfCoreShoppingListEventStore.cs
@@ -29,15 +29,15 @@ public sealed partial class EfCoreShoppingListEventStore(
 
 		var storedEvents = await context.Set<ShoppingListStoredEvent>()
 			.AsNoTracking()
-			.Where(e => e.AggregateId == aggregateId)
-			.OrderBy(e => e.Version)
+			.Where(stored => stored.AggregateId == aggregateId)
+			.OrderBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
 
 		if (storedEvents.Count == 0) return null;
 
 		var events = storedEvents
-			.Select(s => ShoppingListEventSerializer.Deserialize(s.EventType, s.EventData))
-			.Where(e => e is not null)
+			.Select(stored => ShoppingListEventSerializer.Deserialize(stored.EventType, stored.EventData))
+			.Where(deserialized => deserialized is not null)
 			.Cast<IDomainEvent>();
 
 		return ShoppingList.FromEvents(identifier, events);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -15,7 +15,7 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 		SortingOptions<ShoppingListSortField> sorting,
 		CancellationToken cancellationToken = default)
 	{
-		var query = context.ShoppingListSummaryReadItems.Where(s => s.OwnerId == owner.Value);
+		var query = context.ShoppingListSummaryReadItems.Where(summary => summary.OwnerId == owner.Value);
 
 		query = ApplySorting(query, sorting);
 
@@ -23,11 +23,11 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 		var items = await query
 			.Skip(paging.Skip)
 			.Take(paging.PageSize.Value)
-			.Select(s => new ShoppingListSummary(
-				ShoppingListIdentifier.From(s.Id),
-				ShoppingListTitle.From(s.Title),
-				ItemCount.From(s.ItemCount),
-				s.CreatedAt))
+			.Select(summary => new ShoppingListSummary(
+				ShoppingListIdentifier.From(summary.Id),
+				ShoppingListTitle.From(summary.Title),
+				ItemCount.From(summary.ItemCount),
+				summary.CreatedAt))
 			.ToListAsync(cancellationToken);
 
 		return (items, ItemCount.From(totalCount));
@@ -38,7 +38,7 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 		CancellationToken cancellationToken = default)
 	{
 		var summary = await context.ShoppingListSummaryReadItems
-			.FirstOrDefaultAsync(s => s.Id == identifier.Value, cancellationToken)
+			.FirstOrDefaultAsync(row => row.Id == identifier.Value, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(ShoppingList), identifier.Value);
 
 		var itemRows = await context.ShoppingListItemReadItems
@@ -57,8 +57,8 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 		var ownerValue = owner.Value;
 		var recipeValue = recipeReference.Value;
 		var ids = await context.ShoppingListSummaryReadItems
-			.Where(s => s.OwnerId == ownerValue && s.RecipeIdentifier == recipeValue)
-			.Select(s => s.Id)
+			.Where(summary => summary.OwnerId == ownerValue && summary.RecipeIdentifier == recipeValue)
+			.Select(summary => summary.Id)
 			.ToListAsync(cancellationToken);
 		return ids.Select(ShoppingListIdentifier.From).ToList();
 	}
@@ -69,10 +69,10 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 	{
 		return (sorting.SortBy, sorting.Direction) switch
 		{
-			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(s => s.Title),
-			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(s => s.Title),
-			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(s => s.CreatedAt),
-			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(s => s.CreatedAt),
+			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(summary => summary.Title),
+			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(summary => summary.Title),
+			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(summary => summary.CreatedAt),
+			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(summary => summary.CreatedAt),
 			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
 		};
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
@@ -10,7 +10,7 @@ public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext c
 	public async Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(string ownerId, CancellationToken cancellationToken = default)
 	{
 		var rows = await context.IngredientBalanceReadItems
-			.Where(r => r.OwnerId == ownerId)
+			.Where(row => row.OwnerId == ownerId)
 			.ToListAsync(cancellationToken);
 
 		var now = timeProvider.GetUtcNow().UtcDateTime;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
@@ -14,11 +14,11 @@ public sealed class ShoppingLedgerReadModelRepository(ShoppingReadDbContext cont
 		var today = DateTime.UtcNow.Date;
 
 		var query = context.ShoppingLedgerReadItems
-			.Where(r => r.OwnerId == ownerId);
+			.Where(row => row.OwnerId == ownerId);
 
 		if (!includePastBought)
 		{
-			query = query.Where(r => !r.IsBought || r.BoughtAt == null || r.BoughtAt >= today);
+			query = query.Where(row => !row.IsBought || row.BoughtAt == null || row.BoughtAt >= today);
 		}
 
 		var readItems = await query.ToListAsync(cancellationToken);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -129,7 +129,7 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 	private async Task SetAllCheckedAsync(Guid listId, bool isChecked, CancellationToken cancellationToken)
 	{
 		var items = await context.Set<ShoppingListItemReadItem>()
-			.Where(i => i.ListId == listId)
+			.Where(item => item.ListId == listId)
 			.ToListAsync(cancellationToken);
 		foreach (var item in items)
 		{

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjectionRebuilder.cs
@@ -23,12 +23,12 @@ public sealed partial class ShoppingListProjectionRebuilder(
 
 		var ownerByAggregate = await context.Set<ShoppingListAggregateMetadata>()
 			.AsNoTracking()
-			.ToDictionaryAsync(m => m.AggregateId, m => m.OwnerId, cancellationToken);
+			.ToDictionaryAsync(metadata => metadata.AggregateId, metadata => metadata.OwnerId, cancellationToken);
 
 		var storedEvents = await context.Set<ShoppingListStoredEvent>()
 			.AsNoTracking()
-			.OrderBy(e => e.AggregateId)
-			.ThenBy(e => e.Version)
+			.OrderBy(stored => stored.AggregateId)
+			.ThenBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
 
 		var replayed = 0;


### PR DESCRIPTION
## Summary

Phase 2 / Shopping module — applies the lambda-naming rule from PR #515 (now merged).

Identifier-suffix variable rename has no targets in this module: the only candidates were `RecipeReference recipeReference` parameters, but `RecipeReference` ends in `Reference`, not `Identifier`, so the strict rule doesn't apply. (Worth a follow-up convention if we want to cover Reference-suffix types too — flag and discuss separately.)

## Lambda parameter renames (~30 sites across 11 files)

**Api / Application:**

| File | Before | After |
|---|---|---|
| `CreateShoppingListRequest` | `Items.Select(i =>)` | `item =>` |
| `CreateShoppingListCommandHandler` | `Select(i =>)` | `item =>` |
| `ExportShoppingListQueryHandler` | `Where(i =>) GroupBy(i =>) OrderBy(g =>)` | `item =>`, `group =>` |
| `GetIngredientBalanceQueryHandler` | `Select(i =>) OrderBy(s =>) OrderBy(i =>) ThenBy(i =>)` | `item =>`, `staple =>` |

**Domain:**

| File | Before | After |
|---|---|---|
| `ShoppingList.EnsureItemExists` / `FindItem` | `FirstOrDefault(i =>)` | `candidate =>` (the result is already named `item`; the lambda parameter binds the candidate being tested) |

**Infrastructure event stores:**

| File | Before | After |
|---|---|---|
| `EfCoreShoppingEventStore` | `Where(e =>) OrderBy(e =>) Where(e =>)` | `stored =>`, `deserialized =>` |
| `EfCoreShoppingListEventStore` | `Where(e =>) OrderBy(e =>) Select(s =>) Where(e =>)` | `stored =>`, `deserialized =>` |

**Infrastructure read-model:**

| File | Before | After |
|---|---|---|
| `EfCoreShoppingListProjectionRepository` | `Where/Select/OrderBy(s =>)` (multiple) | `summary =>`, `row =>` |
| `IngredientBalanceReadModelRepository` | `Where(r =>)` | `row =>` |
| `ShoppingLedgerReadModelRepository` | `Where(r =>)` (×2) | `row =>` |
| `ShoppingListProjection.SetAllCheckedAsync` | `Where(i =>)` | `item =>` |
| `ShoppingListProjectionRebuilder` | `ToDictionaryAsync(m =>, m =>)`, `OrderBy(e =>) ThenBy(e =>)` | `metadata =>`, `stored =>` |

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Shopping.Application.Tests — 122 passed
- [x] Shopping.Domain.Tests — 176 passed
- [x] Shopping.Infrastructure.Tests — 31 passed
- [x] Shopping.Api.Tests — 21 passed
- [x] Architecture.Tests — 117 passed

12 files, +41 / −41. Pure rename, no behaviour change.