### PR TITLE
refactor(recipes): drop single-letter lambda vars + Identifier-suffix parameters (Phase 2)

### DIFF
--- a/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
+++ b/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
@@ -60,9 +60,9 @@ internal static class RequestMappingExtensions
 	{
 		public IEnumerable<ChatHistoryEntry> MapToChatHistoryEntries()
 		{
-			return history.Select(h => new ChatHistoryEntry(
-				ChatRole.From(h.Role),
-				ChatMessageContent.From(h.Content)));
+			return history.Select(message => new ChatHistoryEntry(
+				ChatRole.From(message.Role),
+				ChatMessageContent.From(message.Content)));
 		}
 	}
 }

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeRequest.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeRequest.cs
@@ -42,6 +42,6 @@ public sealed record SaveRecipeRequest(
 		imageUrl = Domain.Recipe.ImageUrl.FromNullable(ImageUrl);
 		language = RecipeLanguage.FromNullable(Language);
 		sourceUrl = RecipeUrl.FromNullable(SourceUrl);
-		tags = Tags?.Select(t => RecipeTag.From(t)).ToList();
+		tags = Tags?.Select(tag => RecipeTag.From(tag)).ToList();
 	}
 }

--- a/src/Yumney.Recipes.Api/Requests/UpdateRecipeRequest.cs
+++ b/src/Yumney.Recipes.Api/Requests/UpdateRecipeRequest.cs
@@ -36,6 +36,6 @@ public sealed record UpdateRecipeRequest(
 			CookingTime.FromNullable(CookTimeMinutes));
 		difficulty = Domain.Recipe.Difficulty.FromNullable(Difficulty);
 		imageUrl = Domain.Recipe.ImageUrl.FromNullable(ImageUrl);
-		tags = Tags?.Select(t => RecipeTag.From(t)).ToList();
+		tags = Tags?.Select(tag => RecipeTag.From(tag)).ToList();
 	}
 }

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -22,8 +22,8 @@ public sealed class SaveRecipeCommandHandler(
 			return SaveRecipeErrors.AlreadyImported;
 		}
 
-		var ingredients = ingredientCommands.Select(i => i.ToDomain()).ToList();
-		var steps = stepCommands.Select(s => s.ToDomain()).ToList();
+		var ingredients = ingredientCommands.Select(ingredient => ingredient.ToDomain()).ToList();
+		var steps = stepCommands.Select(step => step.ToDomain()).ToList();
 
 		var recipe = Recipe.Create(
 			title,

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -24,8 +24,8 @@ public sealed class UpdateRecipeCommandHandler(
 			return UpdateRecipeErrors.AccessDenied;
 		}
 
-		var ingredients = ingredientCommands.Select(i => i.ToDomain()).ToList();
-		var steps = stepCommands.Select(s => s.ToDomain()).ToList();
+		var ingredients = ingredientCommands.Select(ingredient => ingredient.ToDomain()).ToList();
+		var steps = stepCommands.Select(step => step.ToDomain()).ToList();
 
 		recipe.Update(
 			title,

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
@@ -54,11 +54,11 @@ public sealed class GetCookableRecipesQueryHandler(
 		}
 
 		IReadOnlyList<CookableRecipeDto> ranked = [.. matches
-			.OrderBy(m => m.Dto.Tier == CookableRecipeMatchTier.Full ? 0 : 1)
-			.ThenByDescending(m => m.UrgentIngredientCount)
-			.ThenBy(m => m.Dto.MissingIngredients.Count)
-			.ThenBy(m => m.Dto.Title, StringComparer.OrdinalIgnoreCase)
-			.Select(m => m.Dto)];
+			.OrderBy(match => match.Dto.Tier == CookableRecipeMatchTier.Full ? 0 : 1)
+			.ThenByDescending(match => match.UrgentIngredientCount)
+			.ThenBy(match => match.Dto.MissingIngredients.Count)
+			.ThenBy(match => match.Dto.Title, StringComparer.OrdinalIgnoreCase)
+			.Select(match => match.Dto)];
 
 		return Result<IReadOnlyList<CookableRecipeDto>>.Success(ranked);
 	}

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipesQueryHandler.cs
@@ -21,11 +21,11 @@ public sealed class GetRecipesQueryHandler(
 
 		var favoritedIds = await favorites.GetFavoritedIdsAsync(
 			owner,
-			items.Select(r => r.Id).ToList(),
+			items.Select(recipe => recipe.Id).ToList(),
 			cancellationToken);
 
 		var dtoItems = items
-			.Select(r => r.ToListItemDto(favoritedIds.Contains(r.Id.Value)))
+			.Select(recipe => recipe.ToListItemDto(favoritedIds.Contains(recipe.Id.Value)))
 			.ToList();
 
 		return PagedResultExtensions.With(dtoItems, totalCount, paging);

--- a/src/Yumney.Recipes.Domain/RecipeFavorite/IRecipeFavoriteRepository.cs
+++ b/src/Yumney.Recipes.Domain/RecipeFavorite/IRecipeFavoriteRepository.cs
@@ -6,18 +6,18 @@ public interface IRecipeFavoriteRepository
 {
 	Task<bool> IsFavoritedAsync(
 		OwnerIdentifier owner,
-		RecipeIdentifier recipeIdentifier,
+		RecipeIdentifier recipe,
 		CancellationToken cancellationToken = default);
 
 	Task<IReadOnlySet<Guid>> GetFavoritedIdsAsync(
 		OwnerIdentifier owner,
-		IReadOnlyCollection<RecipeIdentifier> recipeIdentifiers,
+		IReadOnlyCollection<RecipeIdentifier> recipes,
 		CancellationToken cancellationToken = default);
 
 	Task AddAsync(RecipeFavorite favorite, CancellationToken cancellationToken = default);
 
 	Task RemoveAsync(
 		OwnerIdentifier owner,
-		RecipeIdentifier recipeIdentifier,
+		RecipeIdentifier recipe,
 		CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Recipes.Domain/RecipeFavorite/RecipeFavorite.cs
+++ b/src/Yumney.Recipes.Domain/RecipeFavorite/RecipeFavorite.cs
@@ -22,15 +22,15 @@ public sealed class RecipeFavorite : AggregateRoot<RecipeFavoriteIdentifier>
 	{
 	}
 
-	public static RecipeFavorite Create(RecipeIdentifier recipeIdentifier, OwnerIdentifier owner)
+	public static RecipeFavorite Create(RecipeIdentifier recipe, OwnerIdentifier owner)
 	{
-		Ensure.That(recipeIdentifier).IsNotNull();
+		Ensure.That(recipe).IsNotNull();
 		Ensure.That(owner).IsNotNull();
 
 		return new RecipeFavorite
 		{
 			Id = RecipeFavoriteIdentifier.New(),
-			RecipeIdentifier = recipeIdentifier,
+			RecipeIdentifier = recipe,
 			Owner = owner,
 			FavoritedAt = DateTime.UtcNow,
 		};

--- a/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
+++ b/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
@@ -100,7 +100,7 @@ public static partial class JsonLdRecipeParser
 		return type.ValueKind switch
 		{
 			JsonValueKind.String => IsRecipeType(type.GetString()),
-			JsonValueKind.Array => type.EnumerateArray().Any(t => IsRecipeType(t.GetString())),
+			JsonValueKind.Array => type.EnumerateArray().Any(element => IsRecipeType(element.GetString())),
 			_ => false,
 		};
 	}
@@ -203,7 +203,7 @@ public static partial class JsonLdRecipeParser
 		{
 			JsonValueKind.Number when yield.TryGetInt32(out var i) => i,
 			JsonValueKind.String => ParseLeadingInt(yield.GetString()),
-			JsonValueKind.Array => yield.EnumerateArray().Select(e => ReadServingsValue(e)).FirstOrDefault(v => v is not null),
+			JsonValueKind.Array => yield.EnumerateArray().Select(element => ReadServingsValue(element)).FirstOrDefault(value => value is not null),
 			_ => null,
 		};
 	}
@@ -246,7 +246,7 @@ public static partial class JsonLdRecipeParser
 		return image.ValueKind switch
 		{
 			JsonValueKind.String => image.GetString(),
-			JsonValueKind.Array => image.EnumerateArray().Select(e => ReadImageValue(e)).FirstOrDefault(v => v is not null),
+			JsonValueKind.Array => image.EnumerateArray().Select(element => ReadImageValue(element)).FirstOrDefault(value => value is not null),
 			JsonValueKind.Object => ReadImageValue(image),
 			_ => null,
 		};

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -106,7 +106,7 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
 	{
 		var recipeList = userRecipes.Count == 0
 			? "(no recipes yet)"
-			: string.Join("\n", userRecipes.Select(r => $"- {r.Title.Value}"));
+			: string.Join("\n", userRecipes.Select(recipe => $"- {recipe.Title.Value}"));
 
 		return $$"""
             You are a friendly, concise cooking assistant for the Yumney recipe app.

--- a/src/Yumney.Recipes.Extraction/Services/WebScraper.cs
+++ b/src/Yumney.Recipes.Extraction/Services/WebScraper.cs
@@ -130,7 +130,7 @@ public sealed partial class WebScraper(HttpClient httpClient, IOptions<ScrapingO
 
 			// Schema.org hints can surface multiple fragments (one per itemprop) —
 			// concatenate them in document order so nothing is lost.
-			var combined = string.Join("\n", matches.Select(m => m.TextContent.Trim())).Trim();
+			var combined = string.Join("\n", matches.Select(node => node.TextContent.Trim())).Trim();
 			if (combined.Length > 0) return combined;
 		}
 

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
@@ -8,28 +8,28 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 {
 	private readonly DbSet<RecipeFavorite> favorites = context.RecipeFavorites;
 
-	public async Task<bool> IsFavoritedAsync(OwnerIdentifier owner, RecipeIdentifier recipeIdentifier, CancellationToken cancellationToken = default)
+	public async Task<bool> IsFavoritedAsync(OwnerIdentifier owner, RecipeIdentifier recipe, CancellationToken cancellationToken = default)
 	{
 		return await favorites
 			.AsNoTracking()
-			.AnyAsync(f => f.Owner == owner && f.RecipeIdentifier == recipeIdentifier, cancellationToken);
+			.AnyAsync(favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe, cancellationToken);
 	}
 
 	public async Task<IReadOnlySet<Guid>> GetFavoritedIdsAsync(
 		OwnerIdentifier owner,
-		IReadOnlyCollection<RecipeIdentifier> recipeIdentifiers,
+		IReadOnlyCollection<RecipeIdentifier> recipes,
 		CancellationToken cancellationToken = default)
 	{
-		if (recipeIdentifiers.Count == 0) return new HashSet<Guid>();
+		if (recipes.Count == 0) return new HashSet<Guid>();
 
-		var idList = recipeIdentifiers.ToList();
+		var idList = recipes.ToList();
 		var favorited = await favorites
 			.AsNoTracking()
-			.Where(f => f.Owner == owner && idList.Contains(f.RecipeIdentifier))
-			.Select(f => f.RecipeIdentifier)
+			.Where(favorite => favorite.Owner == owner && idList.Contains(favorite.RecipeIdentifier))
+			.Select(favorite => favorite.RecipeIdentifier)
 			.ToListAsync(cancellationToken);
 
-		return favorited.Select(r => r.Value).ToHashSet();
+		return favorited.Select(recipeId => recipeId.Value).ToHashSet();
 	}
 
 	public async Task AddAsync(RecipeFavorite favorite, CancellationToken cancellationToken = default)
@@ -37,10 +37,10 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 		await favorites.AddAsync(favorite, cancellationToken);
 	}
 
-	public async Task RemoveAsync(OwnerIdentifier owner, RecipeIdentifier recipeIdentifier, CancellationToken cancellationToken = default)
+	public async Task RemoveAsync(OwnerIdentifier owner, RecipeIdentifier recipe, CancellationToken cancellationToken = default)
 	{
 		await favorites
-			.Where(f => f.Owner == owner && f.RecipeIdentifier == recipeIdentifier)
+			.Where(favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe)
 			.ExecuteDeleteAsync(cancellationToken);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -17,28 +17,28 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 	{
 		return await recipes
 			.AsNoTracking()
-			.Include(r => r.Ingredients)
-			.Include(r => r.Steps.OrderBy(s => s.Number))
-			.Include(r => r.Tags)
+			.Include(recipe => recipe.Ingredients)
+			.Include(recipe => recipe.Steps.OrderBy(step => step.Number))
+			.Include(recipe => recipe.Tags)
 			.AsSplitQuery()
-			.FirstOrDefaultAsync(r => r.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(recipe => recipe.Id == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(Recipe), identifier.Value);
 	}
 
 	public async Task<Recipe> GetByIdForUpdateAsync(RecipeIdentifier identifier, CancellationToken cancellationToken = default)
 	{
 		return await recipes
-			.Include(r => r.Ingredients)
-			.Include(r => r.Steps.OrderBy(s => s.Number))
-			.Include(r => r.Tags)
+			.Include(recipe => recipe.Ingredients)
+			.Include(recipe => recipe.Steps.OrderBy(step => step.Number))
+			.Include(recipe => recipe.Tags)
 			.AsSplitQuery()
-			.FirstOrDefaultAsync(r => r.Id == identifier, cancellationToken)
+			.FirstOrDefaultAsync(recipe => recipe.Id == identifier, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(Recipe), identifier.Value);
 	}
 
 	public async Task<bool> ExistsBySourceUrlAsync(RecipeUrl sourceUrl, OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
-		return await recipes.AnyAsync(r => r.SourceUrl == sourceUrl && r.Owner == owner, cancellationToken);
+		return await recipes.AnyAsync(recipe => recipe.SourceUrl == sourceUrl && recipe.Owner == owner, cancellationToken);
 	}
 
 	public void Remove(Recipe recipe)
@@ -52,8 +52,8 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 	{
 		return await recipes
 			.AsNoTracking()
-			.Where(r => r.Owner == owner)
-			.Include(r => r.Ingredients)
+			.Where(recipe => recipe.Owner == owner)
+			.Include(recipe => recipe.Ingredients)
 			.AsSplitQuery()
 			.ToListAsync(cancellationToken);
 	}
@@ -66,16 +66,16 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 		RecipeFilter? filter = null,
 		CancellationToken cancellationToken = default)
 	{
-		var query = recipes.AsNoTracking().Where(r => r.Owner == owner);
+		var query = recipes.AsNoTracking().Where(recipe => recipe.Owner == owner);
 
 		if (search is not null)
 		{
 			var pattern = $"%{search.Value}%";
 
-			query = query.Where(r =>
-				EF.Functions.ILike(r.Title, pattern) ||
-				(r.Description != null && EF.Functions.ILike(r.Description, pattern)) ||
-				r.Ingredients.Any(i => EF.Functions.ILike(i.Name, pattern)));
+			query = query.Where(recipe =>
+				EF.Functions.ILike(recipe.Title, pattern) ||
+				(recipe.Description != null && EF.Functions.ILike(recipe.Description, pattern)) ||
+				recipe.Ingredients.Any(ingredient => EF.Functions.ILike(ingredient.Name, pattern)));
 		}
 
 		query = ApplyFilter(query, owner, filter);
@@ -83,7 +83,7 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 
 		var totalCount = await query.CountAsync(cancellationToken);
 		var items = await query
-			.Include(r => r.Tags)
+			.Include(recipe => recipe.Tags)
 			.AsSplitQuery()
 			.Skip(paging.Skip)
 			.Take(paging.PageSize.Value)
@@ -96,10 +96,10 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 	{
 		return (sorting.SortBy, sorting.Direction) switch
 		{
-			(RecipeSortField.Name, SortDirection.Ascending) => query.OrderBy(r => r.Title),
-			(RecipeSortField.Name, SortDirection.Descending) => query.OrderByDescending(r => r.Title),
-			(RecipeSortField.Date, SortDirection.Ascending) => query.OrderBy(r => r.CreatedAt),
-			(RecipeSortField.Date, SortDirection.Descending) => query.OrderByDescending(r => r.CreatedAt),
+			(RecipeSortField.Name, SortDirection.Ascending) => query.OrderBy(recipe => recipe.Title),
+			(RecipeSortField.Name, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.Title),
+			(RecipeSortField.Date, SortDirection.Ascending) => query.OrderBy(recipe => recipe.CreatedAt),
+			(RecipeSortField.Date, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.CreatedAt),
 			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
 		};
 	}
@@ -110,19 +110,19 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 
 		if (filter.Difficulty is not null)
 		{
-			query = query.Where(r => r.Difficulty == filter.Difficulty);
+			query = query.Where(recipe => recipe.Difficulty == filter.Difficulty);
 		}
 
 		if (filter.MaxPrepTime is not null)
 		{
 			var maxPrep = filter.MaxPrepTime;
-			query = query.Where(r => r.Timing != null && r.Timing.Preparation != null && r.Timing.Preparation <= maxPrep);
+			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Preparation != null && recipe.Timing.Preparation <= maxPrep);
 		}
 
 		if (filter.MaxCookTime is not null)
 		{
 			var maxCook = filter.MaxCookTime;
-			query = query.Where(r => r.Timing != null && r.Timing.Cooking != null && r.Timing.Cooking <= maxCook);
+			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Cooking != null && recipe.Timing.Cooking <= maxCook);
 		}
 
 		if (filter.Tags is not null && filter.Tags.Count > 0)
@@ -131,16 +131,16 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 			foreach (var requiredTag in filter.Tags)
 			{
 				var tagValue = requiredTag.Value;
-				query = query.Where(r => r.Tags.Any(t => t.Value == tagValue));
+				query = query.Where(recipe => recipe.Tags.Any(tag => tag.Value == tagValue));
 			}
 		}
 
 		if (filter.FavoritesOnly == true)
 		{
 			var favoriteRecipeIds = context.RecipeFavorites
-				.Where(f => f.Owner == owner)
-				.Select(f => f.RecipeIdentifier);
-			query = query.Where(r => favoriteRecipeIds.Contains(r.Id));
+				.Where(favorite => favorite.Owner == owner)
+				.Select(favorite => favorite.RecipeIdentifier);
+			query = query.Where(recipe => favoriteRecipeIds.Contains(recipe.Id));
 		}
 
 		return query;

--- a/src/Yumney.Recipes.Infrastructure/Services/RecipeIngredientProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/RecipeIngredientProvider.cs
@@ -12,10 +12,10 @@ public sealed class RecipeIngredientProvider(IRecipeRepository recipes) : IRecip
 		var recipe = await recipes.GetByIdAsync(RecipeIdentifier.From(recipeIdentifier), cancellationToken);
 
 		return recipe.Ingredients
-			.Select(i => new RecipeIngredientInfo(
-				i.Name.Value,
-				i.Quantity?.Amount.Value,
-				i.Quantity?.Unit?.Value,
+			.Select(ingredient => new RecipeIngredientInfo(
+				ingredient.Name.Value,
+				ingredient.Quantity?.Amount.Value,
+				ingredient.Quantity?.Unit?.Value,
 				recipe.Servings?.Value))
 			.ToList();
 	}


### PR DESCRIPTION
## Summary

Phase 2 / Recipes module — final per-module sweep applying the naming rules from PR #515 (now merged).

## Identifier-suffix parameter renames

| File | Before | After |
|---|---|---|
| `IRecipeFavoriteRepository.IsFavoritedAsync` | `RecipeIdentifier recipeIdentifier` | `recipe` |
| `IRecipeFavoriteRepository.GetFavoritedIdsAsync` | `IReadOnlyCollection<RecipeIdentifier> recipeIdentifiers` | `recipes` |
| `IRecipeFavoriteRepository.RemoveAsync` | `RecipeIdentifier recipeIdentifier` | `recipe` |
| `RecipeFavorite.Create` | `RecipeIdentifier recipeIdentifier` | `recipe` |
| `RecipeFavoriteRepository` (impl, all matching) | `recipeIdentifier` / `recipeIdentifiers` | `recipe` / `recipes` |

`RecipeIngredientProvider.GetIngredientsAsync(Guid recipeIdentifier, …)` stays unchanged — rule targets value objects whose type ends in `Identifier`; raw `Guid` is a primitive.

## Lambda parameter renames (~40 sites across 13 files)

**Api / Application:**

| File | Renames |
|---|---|
| `SaveRecipeRequest`, `UpdateRecipeRequest` | `t → tag` |
| `RequestMappingExtensions` | `h → message` |
| `SaveRecipeCommandHandler`, `UpdateRecipeCommandHandler` | `i → ingredient`, `s → step` |
| `GetCookableRecipesQueryHandler` | `m → match` |
| `GetRecipesQueryHandler` | `r → recipe` (both sites) |

**Extraction:**

| File | Renames |
|---|---|
| `JsonLdRecipeParser` | `t → element`, `e → element`, `v → value` |
| `SemanticKernelChatService` | `r → recipe` |
| `WebScraper` | `m → node` |

**Infrastructure:**

| File | Renames |
|---|---|
| `RecipeFavoriteRepository` | `f → favorite`, `r → recipeId` |
| `RecipeRepository` | `r → recipe`, `s → step`, `i → ingredient`, `t → tag`, `f → favorite` |
| `RecipeIngredientProvider` | `i → ingredient` |

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Recipes.Application.Tests — 165 passed
- [x] Recipes.Domain.Tests — 233 passed
- [x] Recipes.Infrastructure.Tests — 101 passed
- [x] Recipes.Api.Tests — 161 passed
- [x] Architecture.Tests — 117 passed

15 files, +69 / −69. Pure rename, no behaviour change.

## Phase 2 complete

| Module | PR |
|---|---|
| Users | #521 |
| MealPlan | #522 |
| Shopping | #523 |
| Recipes | #524 (this) |