### PR TITLE
refactor(test): drop sut + single-letter lambda vars (Phase 3)

### DIFF
--- a/tests/Yumney.Architecture.Tests/CqrsSeparationTests.cs
+++ b/tests/Yumney.Architecture.Tests/CqrsSeparationTests.cs
@@ -23,18 +23,18 @@ public class CqrsSeparationTests
 			var assembly = Assembly.Load($"Yumney.{module}.Application");
 
 			var queryHandlers = assembly.GetTypes()
-				.Where(t => t is { IsClass: true, IsAbstract: false })
-				.Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == queryHandlerInterface))
+				.Where(type => type is { IsClass: true, IsAbstract: false })
+				.Where(type => type.GetInterfaces().Any(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == queryHandlerInterface))
 				.ToList();
 
 			foreach (var handler in queryHandlers)
 			{
 				var ctorParams = handler
 					.GetConstructors()
-					.SelectMany(c => c.GetParameters())
-					.Select(p => p.ParameterType);
+					.SelectMany(ctor => ctor.GetParameters())
+					.Select(parameter => parameter.ParameterType);
 
-				var uowDependency = ctorParams.FirstOrDefault(t => unitOfWorkBase.IsAssignableFrom(t));
+				var uowDependency = ctorParams.FirstOrDefault(type => unitOfWorkBase.IsAssignableFrom(type));
 				if (uowDependency is not null)
 				{
 					violations.Add($"{handler.FullName} depends on {uowDependency.Name}");

--- a/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
+++ b/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
@@ -13,29 +13,29 @@ public class EventConsumerRegistrationTests
 	public void EveryIntegrationEvent_HasAtLeastOneHandler()
 	{
 		var assemblies = InfrastructureModules
-			.Select(m => Assembly.Load($"Yumney.{m}.Infrastructure"))
+			.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure"))
 			.ToList();
 
 		var integrationEventType = typeof(IIntegrationEvent);
 		var handlerInterfaceType = typeof(IIntegrationEventHandler<>);
 
 		var integrationEvents = assemblies
-			.SelectMany(a => a.GetTypes())
-			.Where(t => integrationEventType.IsAssignableFrom(t) && t is { IsClass: true, IsAbstract: false })
+			.SelectMany(assembly => assembly.GetTypes())
+			.Where(type => integrationEventType.IsAssignableFrom(type) && type is { IsClass: true, IsAbstract: false })
 			.ToList();
 
 		var handledEventTypes = assemblies
-			.SelectMany(a => a.GetTypes())
-			.SelectMany(t => t.GetInterfaces())
-			.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == handlerInterfaceType)
-			.Select(i => i.GetGenericArguments()[0])
+			.SelectMany(assembly => assembly.GetTypes())
+			.SelectMany(type => type.GetInterfaces())
+			.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == handlerInterfaceType)
+			.Select(iface => iface.GetGenericArguments()[0])
 			.ToHashSet();
 
 		integrationEvents.Should().NotBeEmpty("at least one integration event must exist across modules");
 
 		var missing = integrationEvents
-			.Where(e => !handledEventTypes.Contains(e))
-			.Select(e => e.FullName)
+			.Where(eventType => !handledEventTypes.Contains(eventType))
+			.Select(eventType => eventType.FullName)
 			.ToList();
 
 		missing.Should().BeEmpty(
@@ -47,23 +47,23 @@ public class EventConsumerRegistrationTests
 	public void EveryIntegrationEventHandler_HandlesAKnownIntegrationEvent()
 	{
 		var assemblies = InfrastructureModules
-			.Select(m => Assembly.Load($"Yumney.{m}.Infrastructure"))
+			.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure"))
 			.ToList();
 
 		var integrationEventType = typeof(IIntegrationEvent);
 		var handlerInterfaceType = typeof(IIntegrationEventHandler<>);
 
 		var handlerEventTargets = assemblies
-			.SelectMany(a => a.GetTypes())
-			.SelectMany(t => t.GetInterfaces())
-			.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == handlerInterfaceType)
-			.Select(i => i.GetGenericArguments()[0])
+			.SelectMany(assembly => assembly.GetTypes())
+			.SelectMany(type => type.GetInterfaces())
+			.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == handlerInterfaceType)
+			.Select(iface => iface.GetGenericArguments()[0])
 			.Distinct()
 			.ToList();
 
 		var nonEventHandlerTargets = handlerEventTargets
-			.Where(t => !integrationEventType.IsAssignableFrom(t))
-			.Select(t => t.FullName)
+			.Where(type => !integrationEventType.IsAssignableFrom(type))
+			.Select(type => type.FullName)
 			.ToList();
 
 		nonEventHandlerTargets.Should().BeEmpty(

--- a/tests/Yumney.Architecture.Tests/FileSizeTests.cs
+++ b/tests/Yumney.Architecture.Tests/FileSizeTests.cs
@@ -26,7 +26,7 @@ public class FileSizeTests
 		oversized.Should().BeEmpty(
 			"files exceeding {0} lines per CLAUDE.md: {1}",
 			MaxLinesPerFile,
-			string.Join(Environment.NewLine, oversized.Select(f => $"  {f.LineCount} lines — {Path.GetRelativePath(srcRoot, f.Path)}")));
+			string.Join(Environment.NewLine, oversized.Select(file => $"  {file.LineCount} lines — {Path.GetRelativePath(srcRoot, file.Path)}")));
 	}
 
 	private static bool IsTrackedSourceFile(string path)

--- a/tests/Yumney.Integration.Tests/CrossModule/GenerateShoppingListScalingTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/GenerateShoppingListScalingTests.cs
@@ -77,7 +77,7 @@ public class GenerateShoppingListScalingTests(AspireFixture fixture) : IAsyncLif
 				var response = await mealplanClient.GetAsync($"{WeekPath}/planned-recipes");
 				var planned = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var titles = planned.GetProperty("recipes").EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				titles.Should().Contain(recipeATitle);
 				titles.Should().Contain(recipeBTitle);
@@ -104,14 +104,14 @@ public class GenerateShoppingListScalingTests(AspireFixture fixture) : IAsyncLif
 				var merged = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var items = merged.GetProperty("items").EnumerateArray().ToList();
 
-				var pasta = items.SingleOrDefault(i =>
-					string.Equals(i.GetProperty("itemName").GetString(), "Pasta", StringComparison.OrdinalIgnoreCase) &&
-					i.GetProperty("unit").GetString() == "g");
+				var pasta = items.SingleOrDefault(entry =>
+					string.Equals(entry.GetProperty("itemName").GetString(), "Pasta", StringComparison.OrdinalIgnoreCase) &&
+					entry.GetProperty("unit").GetString() == "g");
 				pasta.ValueKind.Should().NotBe(JsonValueKind.Undefined, "Pasta should be present once after the merge");
 				pasta.GetProperty("totalQuantity").GetDecimal().Should().Be(450m, "200g × 1.5 + 100g × 1.5 = 450g");
 
-				var sauce = items.SingleOrDefault(i =>
-					string.Equals(i.GetProperty("itemName").GetString(), "Tomato Sauce", StringComparison.OrdinalIgnoreCase));
+				var sauce = items.SingleOrDefault(entry =>
+					string.Equals(entry.GetProperty("itemName").GetString(), "Tomato Sauce", StringComparison.OrdinalIgnoreCase));
 				sauce.ValueKind.Should().NotBe(JsonValueKind.Undefined);
 				sauce.GetProperty("totalQuantity").GetDecimal().Should().Be(300m, "200ml × 1.5 = 300ml");
 			},
@@ -127,7 +127,7 @@ public class GenerateShoppingListScalingTests(AspireFixture fixture) : IAsyncLif
 		var request = new
 		{
 			title,
-			ingredients = ingredients.Select(i => new { name = i.Name, amount = i.Amount, unit = i.Unit }).ToArray(),
+			ingredients = ingredients.Select(ingredient => new { name = ingredient.Name, amount = ingredient.Amount, unit = ingredient.Unit }).ToArray(),
 			steps = new object[] { new { number = 1, description = "Cook." } },
 			servings = recipeServings,
 		};
@@ -170,9 +170,9 @@ public class GenerateShoppingListScalingTests(AspireFixture fixture) : IAsyncLif
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
 			var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-				.Where(s => s.OwnerId == userId).ToListAsync();
+				.Where(summary => summary.OwnerId == userId).ToListAsync();
 			var items = await ctx.Set<ShoppingListItemReadItem>()
-				.Where(i => i.OwnerId == userId).ToListAsync();
+				.Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -181,14 +181,14 @@ public class GenerateShoppingListScalingTests(AspireFixture fixture) : IAsyncLif
 		await using (var readCtx = await fixture.CreateShoppingReadDbContextAsync())
 		{
 			var balanceRows = await readCtx.IngredientBalanceReadItems
-				.Where(r => r.OwnerId == userId).ToListAsync();
+				.Where(row => row.OwnerId == userId).ToListAsync();
 			readCtx.RemoveRange(balanceRows);
 			await readCtx.SaveChangesAsync();
 		}
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/HappyPathJourneyTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/HappyPathJourneyTests.cs
@@ -123,7 +123,7 @@ public class HappyPathJourneyTests(AspireFixture fixture) : IAsyncLifetime
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var planned = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var recipes = planned.GetProperty("recipes").EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				recipes.Should().Contain(title);
 			},
@@ -146,7 +146,7 @@ public class HappyPathJourneyTests(AspireFixture fixture) : IAsyncLifetime
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var merged = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var names = merged.GetProperty("items").EnumerateArray()
-					.Select(i => i.GetProperty("itemName").GetString())
+					.Select(entry => entry.GetProperty("itemName").GetString())
 					.ToList();
 				names.Should().Contain("Pasta");
 				names.Should().Contain("Tomato Sauce");
@@ -178,7 +178,7 @@ public class HappyPathJourneyTests(AspireFixture fixture) : IAsyncLifetime
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var rows = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var titles = rows.EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				titles.Should().Contain(recipeTitle);
 			},
@@ -205,9 +205,9 @@ public class HappyPathJourneyTests(AspireFixture fixture) : IAsyncLifetime
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
 			var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-				.Where(s => s.OwnerId == userId).ToListAsync();
+				.Where(summary => summary.OwnerId == userId).ToListAsync();
 			var items = await ctx.Set<ShoppingListItemReadItem>()
-				.Where(i => i.OwnerId == userId).ToListAsync();
+				.Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -215,7 +215,7 @@ public class HappyPathJourneyTests(AspireFixture fixture) : IAsyncLifetime
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/HistorySurvivesRecipeDeletionTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/HistorySurvivesRecipeDeletionTests.cs
@@ -121,7 +121,7 @@ public class HistorySurvivesRecipeDeletionTests(AspireFixture fixture) : IAsyncL
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var planned = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var titles = planned.GetProperty("recipes").EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				titles.Should().Contain(title);
 			},
@@ -150,7 +150,7 @@ public class HistorySurvivesRecipeDeletionTests(AspireFixture fixture) : IAsyncL
 		response.StatusCode.Should().Be(HttpStatusCode.OK);
 		var rows = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 		return rows.EnumerateArray()
-			.Select(r => r.GetProperty("recipeTitle").GetString())
+			.Select(entry => entry.GetProperty("recipeTitle").GetString())
 			.ToList();
 	}
 
@@ -166,9 +166,9 @@ public class HistorySurvivesRecipeDeletionTests(AspireFixture fixture) : IAsyncL
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
 			var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-				.Where(s => s.OwnerId == userId).ToListAsync();
+				.Where(summary => summary.OwnerId == userId).ToListAsync();
 			var items = await ctx.Set<ShoppingListItemReadItem>()
-				.Where(i => i.OwnerId == userId).ToListAsync();
+				.Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -176,7 +176,7 @@ public class HistorySurvivesRecipeDeletionTests(AspireFixture fixture) : IAsyncL
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/InboxPipelineInvocationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/InboxPipelineInvocationTests.cs
@@ -73,8 +73,8 @@ public class InboxPipelineInvocationTests(AspireFixture fixture) : IAsyncLifetim
 			{
 				await using var ctx = await fixture.CreateShoppingDbContextAsync();
 				var matchingRow = await ctx.InboxMessages
-					.Where(m => m.ConsumerName == expectedConsumer && m.ProcessedAt >= startedAt)
-					.OrderByDescending(m => m.ProcessedAt)
+					.Where(message => message.ConsumerName == expectedConsumer && message.ProcessedAt >= startedAt)
+					.OrderByDescending(message => message.ProcessedAt)
 					.FirstOrDefaultAsync();
 
 				matchingRow.Should().NotBeNull(
@@ -124,7 +124,7 @@ public class InboxPipelineInvocationTests(AspireFixture fixture) : IAsyncLifetim
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var planned = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var titles = planned.GetProperty("recipes").EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				titles.Should().Contain(title);
 			},
@@ -156,9 +156,9 @@ public class InboxPipelineInvocationTests(AspireFixture fixture) : IAsyncLifetim
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
 			var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-				.Where(s => s.OwnerId == userId).ToListAsync();
+				.Where(summary => summary.OwnerId == userId).ToListAsync();
 			var items = await ctx.Set<ShoppingListItemReadItem>()
-				.Where(i => i.OwnerId == userId).ToListAsync();
+				.Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -166,7 +166,7 @@ public class InboxPipelineInvocationTests(AspireFixture fixture) : IAsyncLifetim
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/MealConfirmedLedgerConsumptionTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/MealConfirmedLedgerConsumptionTests.cs
@@ -84,16 +84,16 @@ public class MealConfirmedLedgerConsumptionTests(AspireFixture fixture) : IAsync
 			{
 				await using var ctx = await fixture.CreateShoppingDbContextAsync();
 				var ledgerAggregateIds = await ctx.Set<AggregateMetadata>()
-					.Where(m => m.OwnerId == userId)
-					.Select(m => m.AggregateId)
+					.Where(metadata => metadata.OwnerId == userId)
+					.Select(metadata => metadata.AggregateId)
 					.ToListAsync();
 
 				ledgerAggregateIds.Should().NotBeEmpty(
 					"the AddManualItem calls in step 4 should have created a ledger aggregate");
 
 				var consumedEvents = await ctx.Set<StoredEvent>()
-					.Where(e => ledgerAggregateIds.Contains(e.AggregateId)
-						&& e.EventType == nameof(ShoppingItemConsumed))
+					.Where(stored => ledgerAggregateIds.Contains(stored.AggregateId)
+						&& stored.EventType == nameof(ShoppingItemConsumed))
 					.ToListAsync();
 
 				consumedEvents.Should().HaveCountGreaterThanOrEqualTo(
@@ -162,7 +162,7 @@ public class MealConfirmedLedgerConsumptionTests(AspireFixture fixture) : IAsync
 				response.StatusCode.Should().Be(HttpStatusCode.OK);
 				var planned = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var titles = planned.GetProperty("recipes").EnumerateArray()
-					.Select(r => r.GetProperty("recipeTitle").GetString())
+					.Select(entry => entry.GetProperty("recipeTitle").GetString())
 					.ToList();
 				titles.Should().Contain(title);
 			},
@@ -203,9 +203,9 @@ public class MealConfirmedLedgerConsumptionTests(AspireFixture fixture) : IAsync
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
 			var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-				.Where(s => s.OwnerId == userId).ToListAsync();
+				.Where(summary => summary.OwnerId == userId).ToListAsync();
 			var items = await ctx.Set<ShoppingListItemReadItem>()
-				.Where(i => i.OwnerId == userId).ToListAsync();
+				.Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -214,14 +214,14 @@ public class MealConfirmedLedgerConsumptionTests(AspireFixture fixture) : IAsync
 		await using (var readCtx = await fixture.CreateShoppingReadDbContextAsync())
 		{
 			var balanceRows = await readCtx.IngredientBalanceReadItems
-				.Where(r => r.OwnerId == userId).ToListAsync();
+				.Where(row => row.OwnerId == userId).ToListAsync();
 			readCtx.RemoveRange(balanceRows);
 			await readCtx.SaveChangesAsync();
 		}
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/OwnershipIsolationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/OwnershipIsolationTests.cs
@@ -115,7 +115,7 @@ public class OwnershipIsolationTests(AspireFixture fixture) : IAsyncLifetime
 				listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 				var page = await listResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 				var ids = page.GetProperty("items").EnumerateArray()
-					.Select(i => i.GetProperty("identifier").GetGuid())
+					.Select(entry => entry.GetProperty("identifier").GetGuid())
 					.ToList();
 				ids.Should().NotContain(listId);
 			},
@@ -159,10 +159,10 @@ public class OwnershipIsolationTests(AspireFixture fixture) : IAsyncLifetime
 				var ownerResponse = await userAMealPlan.GetAsync(weekPath);
 				ownerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 				var ownerPlan = await ownerResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-				var ownerHasFridayDinner = ownerPlan.GetProperty("slots").EnumerateArray().Any(s =>
-					s.GetProperty("day").GetString() == "Friday" &&
-					s.GetProperty("mealType").GetString() == "Dinner" &&
-					!s.GetProperty("isEmpty").GetBoolean());
+				var ownerHasFridayDinner = ownerPlan.GetProperty("slots").EnumerateArray().Any(slot =>
+					slot.GetProperty("day").GetString() == "Friday" &&
+					slot.GetProperty("mealType").GetString() == "Dinner" &&
+					!slot.GetProperty("isEmpty").GetBoolean());
 				ownerHasFridayDinner.Should().BeTrue("user A's projection should have caught up");
 			},
 			timeout: TimeSpan.FromSeconds(15));
@@ -220,9 +220,9 @@ public class OwnershipIsolationTests(AspireFixture fixture) : IAsyncLifetime
 
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
 		var summaries = await ctx.Set<ShoppingListSummaryReadItem>()
-			.Where(s => s.OwnerId == userId).ToListAsync();
+			.Where(summary => summary.OwnerId == userId).ToListAsync();
 		var items = await ctx.Set<ShoppingListItemReadItem>()
-			.Where(i => i.OwnerId == userId).ToListAsync();
+			.Where(item => item.OwnerId == userId).ToListAsync();
 		ctx.RemoveRange(summaries);
 		ctx.RemoveRange(items);
 		await ctx.SaveChangesAsync();
@@ -231,6 +231,6 @@ public class OwnershipIsolationTests(AspireFixture fixture) : IAsyncLifetime
 	private Task CleanupRecipesForOwnerAsync(string userId) =>
 		AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r =>
-				r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe =>
+				recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -114,8 +114,8 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		await fixture.ResetShoppingListEventStoreAsync(owner);
 		await using (var ctx = await fixture.CreateShoppingDbContextAsync())
 		{
-			var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == userId).ToListAsync();
-			var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == userId).ToListAsync();
+			var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(summary => summary.OwnerId == userId).ToListAsync();
+			var items = await ctx.Set<ShoppingListItemReadItem>().Where(item => item.OwnerId == userId).ToListAsync();
 			ctx.RemoveRange(summaries);
 			ctx.RemoveRange(items);
 			await ctx.SaveChangesAsync();
@@ -123,6 +123,6 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == global::SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.OwnerIdentifier.From(userId)));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -181,17 +181,17 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var context = await CreateShoppingDbContextAsync();
 		var aggregateIds = await context.Set<AggregateMetadata>()
-			.Where(m => m.OwnerId == owner.Value)
-			.Select(m => m.AggregateId)
+			.Where(metadata => metadata.OwnerId == owner.Value)
+			.Select(metadata => metadata.AggregateId)
 			.ToListAsync();
 
 		if (aggregateIds.Count == 0) return;
 
 		var events = await context.Set<StoredEvent>()
-			.Where(e => aggregateIds.Contains(e.AggregateId))
+			.Where(stored => aggregateIds.Contains(stored.AggregateId))
 			.ToListAsync();
 		var metadata = await context.Set<AggregateMetadata>()
-			.Where(m => aggregateIds.Contains(m.AggregateId))
+			.Where(row => aggregateIds.Contains(row.AggregateId))
 			.ToListAsync();
 
 		context.RemoveRange(events);
@@ -203,17 +203,17 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var writeContext = await CreateShoppingDbContextAsync();
 		var aggregateIds = await writeContext.Set<ShoppingListAggregateMetadata>()
-			.Where(m => m.OwnerId == owner.Value)
-			.Select(m => m.AggregateId)
+			.Where(metadata => metadata.OwnerId == owner.Value)
+			.Select(metadata => metadata.AggregateId)
 			.ToListAsync();
 
 		if (aggregateIds.Count > 0)
 		{
 			await writeContext.Set<ShoppingListStoredEvent>()
-				.Where(e => aggregateIds.Contains(e.AggregateId))
+				.Where(stored => aggregateIds.Contains(stored.AggregateId))
 				.ExecuteDeleteAsync();
 			await writeContext.Set<ShoppingListAggregateMetadata>()
-				.Where(m => aggregateIds.Contains(m.AggregateId))
+				.Where(row => aggregateIds.Contains(row.AggregateId))
 				.ExecuteDeleteAsync();
 		}
 
@@ -225,10 +225,10 @@ public sealed class AspireFixture : IAsyncLifetime
 		// every Shopping integration class against one shared database).
 		await using var readContext = await CreateShoppingReadDbContextAsync();
 		await readContext.Set<ShoppingListItemReadItem>()
-			.Where(i => i.OwnerId == owner.Value)
+			.Where(item => item.OwnerId == owner.Value)
 			.ExecuteDeleteAsync();
 		await readContext.Set<ShoppingListSummaryReadItem>()
-			.Where(s => s.OwnerId == owner.Value)
+			.Where(summary => summary.OwnerId == owner.Value)
 			.ExecuteDeleteAsync();
 	}
 
@@ -236,7 +236,7 @@ public sealed class AspireFixture : IAsyncLifetime
 	{
 		await using var context = await CreateShoppingDbContextAsync();
 		var items = await context.Set<ShoppingLedgerReadItem>()
-			.Where(r => r.OwnerId == ownerId)
+			.Where(row => row.OwnerId == ownerId)
 			.ToListAsync();
 
 		if (items.Count == 0) return;

--- a/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
@@ -18,11 +18,11 @@ public static class RecipeFactory
 		IReadOnlyList<string>? tags = null)
 	{
 		var recipeIngredients = (ingredients ?? [("Default Ingredient", null, null)])
-			.Select(i => Ingredient.Create(
-				IngredientName.From(i.Name),
+			.Select(spec => Ingredient.Create(
+				IngredientName.From(spec.Name),
 				Quantity.FromNullable(
-					Amount.FromNullable(i.Amount),
-					Unit.FromNullable(i.Unit))))
+					Amount.FromNullable(spec.Amount),
+					Unit.FromNullable(spec.Unit))))
 			.ToList();
 
 		var recipeSteps = (steps ?? ["Default step"])

--- a/tests/Yumney.Integration.Tests/MealPlan/CopyPlanToWeekFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/CopyPlanToWeekFlowTests.cs
@@ -150,10 +150,10 @@ public class CopyPlanToWeekFlowTests(AspireFixture fixture)
 
 	private static JsonElement FindMondayDinner(JsonElement plan)
 	{
-		var slot = plan.GetProperty("slots").EnumerateArray().FirstOrDefault(s =>
-			s.GetProperty("day").GetString() == "Monday" &&
-			s.GetProperty("mealType").GetString() == "Dinner" &&
-			!s.GetProperty("isEmpty").GetBoolean());
+		var slot = plan.GetProperty("slots").EnumerateArray().FirstOrDefault(candidate =>
+			candidate.GetProperty("day").GetString() == "Monday" &&
+			candidate.GetProperty("mealType").GetString() == "Dinner" &&
+			!candidate.GetProperty("isEmpty").GetBoolean());
 		slot.ValueKind.Should().NotBe(
 			JsonValueKind.Undefined,
 			"Monday Dinner slot must be populated for the assertion to be meaningful");

--- a/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
@@ -108,10 +108,10 @@ public class MealPlanFlowTests(AspireFixture fixture)
 			var plan = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 			var slots = plan.GetProperty("slots");
 			wednesdayDinner = slots.EnumerateArray()
-				.FirstOrDefault(s =>
-					s.GetProperty("day").GetString() == "Wednesday" &&
-					s.GetProperty("mealType").GetString() == "Dinner" &&
-					!s.GetProperty("isEmpty").GetBoolean());
+				.FirstOrDefault(slot =>
+					slot.GetProperty("day").GetString() == "Wednesday" &&
+					slot.GetProperty("mealType").GetString() == "Dinner" &&
+					!slot.GetProperty("isEmpty").GetBoolean());
 			if (wednesdayDinner.ValueKind != JsonValueKind.Undefined) break;
 			await Task.Delay(250);
 		}

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/DeleteRecipeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/DeleteRecipeContractTests.cs
@@ -59,6 +59,6 @@ public class DeleteRecipeContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipeByIdContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipeByIdContractTests.cs
@@ -101,9 +101,9 @@ public class GetRecipeByIdContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.RecipeFavorites.Where(f => f.Owner == owner));
+			ctx => ctx.RecipeFavorites.Where(favorite => favorite.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipesContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipesContractTests.cs
@@ -94,6 +94,6 @@ public class GetRecipesContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ToggleFavoriteContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ToggleFavoriteContractTests.cs
@@ -82,9 +82,9 @@ public class ToggleFavoriteContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.RecipeFavorites.Where(f => f.Owner == owner));
+			ctx => ctx.RecipeFavorites.Where(favorite => favorite.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/UpdateRecipeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/UpdateRecipeContractTests.cs
@@ -127,6 +127,6 @@ public class UpdateRecipeContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/WhatCanICookContractTests.cs
@@ -78,6 +78,6 @@ public class WhatCanICookContractTests(AspireFixture fixture) : IAsyncLifetime
 		var owner = OwnerIdentifier.From(userId);
 		await AspireFixture.CleanupAsync(
 			fixture.CreateRecipesDbContextAsync,
-			ctx => ctx.Recipes.Where(r => r.Owner == owner));
+			ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeFavoriteTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeFavoriteTests.cs
@@ -27,7 +27,7 @@ public class RecipeFavoriteTests(AspireFixture fixture) : IAsyncLifetime
 
 	public Task DisposeAsync() => AspireFixture.CleanupAsync(
 		fixture.CreateRecipesDbContextAsync,
-		ctx => ctx.Recipes.Where(r => r.Owner == owner));
+		ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 
 	[Fact]
 	public async Task IsFavoritedAsync_NotFavorited_ReturnsFalse()

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
@@ -50,7 +50,7 @@ public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
 
 	public Task DisposeAsync() => AspireFixture.CleanupAsync(
 		fixture.CreateRecipesDbContextAsync,
-		ctx => ctx.Recipes.Where(r => r.Owner == owner));
+		ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 
 	[Fact]
 	public async Task Filter_ByDifficulty_ReturnsOnlyMatching()
@@ -76,7 +76,7 @@ public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
 		var (items, _) = await recipes.GetByOwnerAsync(
 			owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
 
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.Contain("Quick Vegan Salad")
 			.And.Contain("Vegan Curry")
 			.And.NotContain("Beef Wellington")
@@ -93,7 +93,7 @@ public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
 		var (items, _) = await recipes.GetByOwnerAsync(
 			owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
 
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.Contain("Quick Vegan Salad")
 			.And.Contain("Vegan Curry")
 			.And.NotContain("Beef Wellington");
@@ -110,7 +110,7 @@ public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
 			owner, DefaultPaging, DefaultSorting, search: null, filter: filter);
 
 		totalCount.Should().Be(ItemCount.From(2));
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.Contain("Quick Vegan Salad")
 			.And.Contain("Vegan Curry");
 	}

--- a/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
@@ -17,7 +17,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 
 	public Task DisposeAsync() => AspireFixture.CleanupAsync(
 		fixture.CreateRecipesDbContextAsync,
-		ctx => ctx.Recipes.Where(r => r.Owner == owner));
+		ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 
 	[Fact]
 	public async Task AddAsync_NewRecipe_PersistsWithAllRelationsAndOptionalFields()
@@ -42,7 +42,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 		saved.Description!.Value.Should().Contain("Bolognese");
 		saved.Servings.Should().Be(Servings.From(6));
 		saved.Ingredients.Should().HaveCount(10);
-		saved.Ingredients.Select(i => i.Name).Should().Contain(IngredientName.From("Mozzarella"));
+		saved.Ingredients.Select(ingredient => ingredient.Name).Should().Contain(IngredientName.From("Mozzarella"));
 		saved.Steps.Should().HaveCount(5);
 		saved.Steps.First(s => s.Number == StepNumber.From(1)).Description.Value
 			.Should().Contain("Brown the ground beef");
@@ -110,7 +110,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 		var recipes = new RecipeRepository(readContext);
 		var loaded = await recipes.GetByIdAsync(recipe.Id);
 
-		loaded.Tags.Select(t => t.Value).Should().BeEquivalentTo(["italian", "pasta", "comfort-food"]);
+		loaded.Tags.Select(tag => tag.Value).Should().BeEquivalentTo(["italian", "pasta", "comfort-food"]);
 	}
 
 	[Fact]
@@ -148,7 +148,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 		{
 			await AspireFixture.CleanupAsync(
 				fixture.CreateRecipesDbContextAsync,
-				ctx => ctx.Recipes.Where(r => r.Owner == otherOwner));
+				ctx => ctx.Recipes.Where(recipe => recipe.Owner == otherOwner));
 		}
 	}
 
@@ -175,7 +175,7 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 		var recipes = new RecipeRepository(readContext);
 		var (items, _) = await recipes.GetByOwnerAsync(owner, paging, sorting);
 
-		items.Single().Tags.Select(t => t.Value).Should().BeEquivalentTo(["italian", "pasta", "comfort-food"]);
+		items.Single().Tags.Select(tag => tag.Value).Should().BeEquivalentTo(["italian", "pasta", "comfort-food"]);
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeSearchTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeSearchTests.cs
@@ -28,7 +28,7 @@ public class RecipeSearchTests(AspireFixture fixture) : IAsyncLifetime
 
 	public Task DisposeAsync() => AspireFixture.CleanupAsync(
 		fixture.CreateRecipesDbContextAsync,
-		ctx => ctx.Recipes.Where(r => r.Owner == owner));
+		ctx => ctx.Recipes.Where(recipe => recipe.Owner == owner));
 
 	[Fact]
 	public async Task Search_ByTitle_FindsMatchingRecipe()
@@ -101,7 +101,7 @@ public class RecipeSearchTests(AspireFixture fixture) : IAsyncLifetime
 			owner, DefaultPaging, DefaultSorting, SearchTerm.From("butter"));
 
 		totalCount.Should().Be(ItemCount.From(2));
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.Contain("Classic Lasagne")
 			.And.Contain("Chocolate Fudge Cake");
 	}
@@ -170,7 +170,7 @@ public class RecipeSearchTests(AspireFixture fixture) : IAsyncLifetime
 		var (items, _) = await recipes.GetByOwnerAsync(
 			owner, DefaultPaging, sorting);
 
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.ContainInOrder("Chocolate Fudge Cake", "Classic Lasagne", "Roasted Tomato Soup");
 	}
 
@@ -184,7 +184,7 @@ public class RecipeSearchTests(AspireFixture fixture) : IAsyncLifetime
 			owner, DefaultPaging, DefaultSorting, SearchTerm.From("tomato"));
 
 		((int)totalCount).Should().BeGreaterThanOrEqualTo(2);
-		items.Select(r => r.Title.Value).Should()
+		items.Select(recipe => recipe.Title.Value).Should()
 			.Contain("Roasted Tomato Soup")
 			.And.Contain("Classic Lasagne");
 	}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/CheckOffAllItemsContractTests.cs
@@ -44,7 +44,7 @@ public class CheckOffAllItemsContractTests(AspireFixture fixture) : IAsyncLifeti
 		{
 			var detail = await GetListAsync(client, listId);
 			detail.GetProperty("items").EnumerateArray()
-				.Select(i => i.GetProperty("isChecked").GetBoolean())
+				.Select(entry => entry.GetProperty("isChecked").GetBoolean())
 				.Should().AllBeEquivalentTo(true);
 		});
 	}
@@ -65,7 +65,7 @@ public class CheckOffAllItemsContractTests(AspireFixture fixture) : IAsyncLifeti
 		{
 			var detail = await GetListAsync(client, listId);
 			detail.GetProperty("items").EnumerateArray()
-				.Select(i => i.GetProperty("isChecked").GetBoolean())
+				.Select(entry => entry.GetProperty("isChecked").GetBoolean())
 				.Should().AllBeEquivalentTo(false);
 		});
 	}

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetShoppingListsContractTests.cs
@@ -86,7 +86,7 @@ public class GetShoppingListsContractTests(AspireFixture fixture) : IAsyncLifeti
 			response.StatusCode.Should().Be(HttpStatusCode.OK);
 			var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 			var titles = body.GetProperty("items").EnumerateArray()
-				.Select(i => i.GetProperty("title").GetString()).ToList();
+				.Select(entry => entry.GetProperty("title").GetString()).ToList();
 			titles.Should().Equal("Alpha", "Bravo", "Charlie");
 		});
 	}

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingEventStoreTests.cs
@@ -52,7 +52,7 @@ public class EfCoreShoppingEventStoreTests(AspireFixture fixture) : IAsyncLifeti
 
 		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
 		var stored = await verifyContext.Set<StoredEvent>()
-			.Where(e => e.AggregateId == ledger.Identifier).ToListAsync();
+			.Where(stored => stored.AggregateId == ledger.Identifier).ToListAsync();
 		var metadata = await verifyContext.Set<AggregateMetadata>()
 			.SingleAsync(m => m.AggregateId == ledger.Identifier);
 		stored.Should().HaveCount(1);
@@ -84,8 +84,8 @@ public class EfCoreShoppingEventStoreTests(AspireFixture fixture) : IAsyncLifeti
 
 		await using var verifyContext = await fixture.CreateShoppingDbContextAsync();
 		var versions = await verifyContext.Set<StoredEvent>()
-			.Where(e => e.AggregateId == ledger.Identifier)
-			.OrderBy(e => e.Version).Select(e => e.Version).ToListAsync();
+			.Where(stored => stored.AggregateId == ledger.Identifier)
+			.OrderBy(stored => stored.Version).Select(stored => stored.Version).ToListAsync();
 		versions.Should().Equal(1, 2);
 	}
 

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/EfCoreShoppingListEventStoreTests.cs
@@ -45,8 +45,8 @@ public class EfCoreShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLi
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var stored = await verify.Set<ShoppingListStoredEvent>()
-			.Where(e => e.AggregateId == list.Identifier.Value)
-			.OrderBy(e => e.Version)
+			.Where(stored => stored.AggregateId == list.Identifier.Value)
+			.OrderBy(stored => stored.Version)
 			.ToListAsync();
 		var metadata = await verify.Set<ShoppingListAggregateMetadata>()
 			.SingleAsync(m => m.AggregateId == list.Identifier.Value);
@@ -79,8 +79,8 @@ public class EfCoreShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLi
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var stored = await verify.Set<ShoppingListStoredEvent>()
-			.Where(e => e.AggregateId == list.Identifier.Value)
-			.OrderBy(e => e.Version)
+			.Where(stored => stored.AggregateId == list.Identifier.Value)
+			.OrderBy(stored => stored.Version)
 			.ToListAsync();
 
 		stored.Should().HaveCount(3);

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
@@ -23,8 +23,8 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 	{
 		await fixture.ResetShoppingListEventStoreAsync(owner);
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
-		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(summary => summary.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(item => item.OwnerId == owner.Value).ToListAsync();
 		ctx.RemoveRange(summaries);
 		ctx.RemoveRange(items);
 		await ctx.SaveChangesAsync();
@@ -44,7 +44,7 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
 		summary.Title.Should().Be("Weekly Groceries");
 		summary.ItemCount.Should().Be(2);
-		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).ToListAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(item => item.ListId == listId.Value).ToListAsync();
 		items.Should().HaveCount(2);
 		items.Count(i => i.IsChecked).Should().Be(1);
 	}
@@ -65,7 +65,7 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 		await RunRebuildAsync();
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == listId.Value);
-		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == listId.Value).CountAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(item => item.ListId == listId.Value).CountAsync();
 		summary.ItemCount.Should().Be(3);
 		items.Should().Be(3);
 	}
@@ -84,8 +84,8 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 	private async Task TruncateProjectionsForOwnerAsync()
 	{
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
-		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(summary => summary.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(item => item.OwnerId == owner.Value).ToListAsync();
 		ctx.RemoveRange(summaries);
 		ctx.RemoveRange(items);
 		await ctx.SaveChangesAsync();
@@ -98,7 +98,7 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 		var store = new EfCoreShoppingListEventStore(ctx, bus, NullLogger<EfCoreShoppingListEventStore>.Instance);
 
 		var items = itemNames
-			.Select(n => ShoppingListItem.Create(ItemName.From(n), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.Select(name => ShoppingListItem.Create(ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram)))
 			.ToList();
 		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
 		await store.SaveAsync(list);

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionTests.cs
@@ -21,8 +21,8 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task DisposeAsync()
 	{
 		await using var ctx = await fixture.CreateShoppingDbContextAsync();
-		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(s => s.OwnerId == owner.Value).ToListAsync();
-		var items = await ctx.Set<ShoppingListItemReadItem>().Where(i => i.OwnerId == owner.Value).ToListAsync();
+		var summaries = await ctx.Set<ShoppingListSummaryReadItem>().Where(summary => summary.OwnerId == owner.Value).ToListAsync();
+		var items = await ctx.Set<ShoppingListItemReadItem>().Where(item => item.OwnerId == owner.Value).ToListAsync();
 		ctx.RemoveRange(summaries);
 		ctx.RemoveRange(items);
 		await ctx.SaveChangesAsync();
@@ -85,7 +85,7 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
-		var items = await verify.Set<ShoppingListItemReadItem>().Where(i => i.ListId == aggregateId).CountAsync();
+		var items = await verify.Set<ShoppingListItemReadItem>().Where(item => item.ListId == aggregateId).CountAsync();
 		var summary = await verify.Set<ShoppingListSummaryReadItem>().SingleAsync(s => s.Id == aggregateId);
 		items.Should().Be(1);
 		summary.ItemCount.Should().Be(1);
@@ -123,7 +123,7 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		var items = await verify.Set<ShoppingListItemReadItem>()
-			.Where(i => i.ListId == aggregateId).ToListAsync();
+			.Where(item => item.ListId == aggregateId).ToListAsync();
 		items.Should().HaveCount(2);
 		items.Should().OnlyContain(i => i.IsChecked);
 	}
@@ -170,7 +170,7 @@ public class ShoppingListProjectionTests(AspireFixture fixture) : IAsyncLifetime
 		}
 
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
-		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(s => s.Id == aggregateId).CountAsync();
+		var rows = await verify.Set<ShoppingListSummaryReadItem>().Where(summary => summary.Id == aggregateId).CountAsync();
 		rows.Should().Be(1);
 	}
 

--- a/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/ProfileEndpointsContractTests.cs
@@ -130,6 +130,6 @@ public class ProfileEndpointsContractTests(AspireFixture fixture) : IAsyncLifeti
 		if (id is null) return Task.CompletedTask;
 		return AspireFixture.CleanupAsync(
 			fixture.CreateUsersDbContextAsync,
-			ctx => ctx.AppUserProfiles.Where(p => p.KeycloakUserId == id));
+			ctx => ctx.AppUserProfiles.Where(profile => profile.KeycloakUserId == id));
 	}
 }

--- a/tests/Yumney.Integration.Tests/Users/UserProfilePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/UserProfilePersistenceTests.cs
@@ -19,7 +19,7 @@ public class UserProfilePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 
 	public Task DisposeAsync() => AspireFixture.CleanupAsync(
 		fixture.CreateUsersDbContextAsync,
-		ctx => ctx.AppUserProfiles.Where(p => p.KeycloakUserId == keycloakId));
+		ctx => ctx.AppUserProfiles.Where(profile => profile.KeycloakUserId == keycloakId));
 
 	[Fact]
 	public async Task AddAsync_NewProfile_PersistsWithDefaultPreferences()

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/CopyPlanToWeekCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/CopyPlanToWeekCommandHandlerTests.cs
@@ -51,7 +51,7 @@ public class CopyPlanToWeekCommandHandlerTests
 		result.IsSuccess.Should().BeTrue();
 		var saved = eventStore.LastSavedPlan!;
 		saved.Week.Should().Be(TargetWeek);
-		saved.Slots.Where(s => s.ContentType == SlotContentType.Recipe).Should().HaveCount(2);
+		saved.Slots.Where(slot => slot.ContentType == SlotContentType.Recipe).Should().HaveCount(2);
 		saved.Slots.Should().Contain(s => s.Recipe != null && s.Recipe.Title.Value == "Pasta" && s.Day == DayOfWeek.Monday);
 		saved.Slots.Should().Contain(s => s.Recipe != null && s.Recipe.Title.Value == "Soup" && s.Day == DayOfWeek.Wednesday);
 	}
@@ -83,7 +83,7 @@ public class CopyPlanToWeekCommandHandlerTests
 
 		result.IsSuccess.Should().BeTrue();
 		eventStore.LastSavedPlan!.Slots
-			.Where(s => s.ContentType == SlotContentType.Leftover)
+			.Where(slot => slot.ContentType == SlotContentType.Leftover)
 			.Should().BeEmpty();
 	}
 

--- a/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
@@ -92,13 +92,13 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 		}
 
 		var recipes = plan.Slots
-			.Where(s => s.ContentType == SlotContentType.Recipe && s.Recipe is not null)
-			.Select(s => new PlannedRecipeDto(
-				s.Recipe!.RecipeIdentifier.Value,
-				s.Recipe.Title.Value,
-				s.Servings.Value,
-				s.Day.ToString(),
-				s.MealType.ToString()))
+			.Where(slot => slot.ContentType == SlotContentType.Recipe && slot.Recipe is not null)
+			.Select(slot => new PlannedRecipeDto(
+				slot.Recipe!.RecipeIdentifier.Value,
+				slot.Recipe.Title.Value,
+				slot.Servings.Value,
+				slot.Day.ToString(),
+				slot.MealType.ToString()))
 			.ToList();
 
 		return Task.FromResult(new WeeklyPlannedRecipesDto(week.Value, recipes));
@@ -109,23 +109,23 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 		IEnumerable<MealHistoryEntryDto> rows = store
 			.Where(kv => kv.Key.Owner == owner.Value)
 			.SelectMany(kv => kv.Value.Slots
-				.Where(s => s.State == MealState.Cooked && s.Recipe is not null)
-				.Select(s => new MealHistoryEntryDto(
-					s.Recipe!.RecipeIdentifier.Value,
-					s.Recipe.Title.Value,
+				.Where(slot => slot.State == MealState.Cooked && slot.Recipe is not null)
+				.Select(slot => new MealHistoryEntryDto(
+					slot.Recipe!.RecipeIdentifier.Value,
+					slot.Recipe.Title.Value,
 					kv.Key.Week,
-					s.Day.ToString(),
-					s.MealType.ToString())));
+					slot.Day.ToString(),
+					slot.MealType.ToString())));
 
 		if (!string.IsNullOrWhiteSpace(term))
 		{
-			rows = rows.Where(r => r.RecipeTitle.Contains(term.Trim(), StringComparison.OrdinalIgnoreCase));
+			rows = rows.Where(entry => entry.RecipeTitle.Contains(term.Trim(), StringComparison.OrdinalIgnoreCase));
 		}
 
 		return Task.FromResult<IReadOnlyList<MealHistoryEntryDto>>(rows
-			.OrderByDescending(r => r.Week)
-			.ThenBy(r => r.Day)
-			.ThenBy(r => r.MealType)
+			.OrderByDescending(entry => entry.Week)
+			.ThenBy(entry => entry.Day)
+			.ThenBy(entry => entry.MealType)
 			.Take(limit)
 			.ToList());
 	}

--- a/tests/Yumney.MealPlan.Application.Tests/Queries/SearchMealHistoryQueryHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Queries/SearchMealHistoryQueryHandlerTests.cs
@@ -93,7 +93,7 @@ public class SearchMealHistoryQueryHandlerTests
 
 		var result = await handler.HandleAsync(new SearchMealHistoryQuery());
 
-		result.Value.Select(r => r.RecipeTitle).Should().Equal("New Soup", "Old Soup");
+		result.Value.Select(entry => entry.RecipeTitle).Should().Equal("New Soup", "Old Soup");
 	}
 
 	[Fact]

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -167,7 +167,7 @@ public class WeeklyPlanTests
 	{
 		var plan = CreatePlan();
 
-		var days = plan.Slots.Select(s => s.Day).ToList();
+		var days = plan.Slots.Select(slot => slot.Day).ToList();
 		days.Should().Contain(DayOfWeek.Monday);
 		days.Should().Contain(DayOfWeek.Tuesday);
 		days.Should().Contain(DayOfWeek.Wednesday);

--- a/tests/Yumney.Recipes.Api.Tests/RecipeFilterParserTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/RecipeFilterParserTests.cs
@@ -46,7 +46,7 @@ public class RecipeFilterParserTests
 		var result = RecipeFilterParser.Build("vegan,italian,quick", null, null, null);
 
 		result!.Tags.Should().HaveCount(3);
-		result.Tags!.Select(t => t.Value).Should().Contain("vegan").And.Contain("italian").And.Contain("quick");
+		result.Tags!.Select(tag => tag.Value).Should().Contain("vegan").And.Contain("italian").And.Contain("quick");
 	}
 
 	[Fact]
@@ -54,7 +54,7 @@ public class RecipeFilterParserTests
 	{
 		var result = RecipeFilterParser.Build(" vegan , italian ", null, null, null);
 
-		result!.Tags!.Select(t => t.Value).Should().Contain("vegan").And.Contain("italian");
+		result!.Tags!.Select(tag => tag.Value).Should().Contain("vegan").And.Contain("italian");
 	}
 
 	[Fact]

--- a/tests/Yumney.Recipes.Api.Tests/Requests/ImportRecipeRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/ImportRecipeRequestValidatorTests.cs
@@ -7,14 +7,14 @@ namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests;
 
 public class ImportRecipeRequestValidatorTests
 {
-	private readonly ImportRecipeRequestValidator sut = new();
+	private readonly ImportRecipeRequestValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidHttpsUrl_IsValid()
 	{
 		var request = new ImportRecipeRequest("https://example.com/recipe/123");
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeTrue();
 	}
@@ -24,7 +24,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var request = new ImportRecipeRequest("http://example.com/recipe/123");
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeTrue();
 	}
@@ -34,7 +34,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var request = new ImportRecipeRequest("https://example.com/recipe?id=123&lang=en");
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeTrue();
 	}
@@ -46,7 +46,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var request = new ImportRecipeRequest(url);
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeFalse();
 		result.Errors.Should().Contain(e => e.PropertyName == "Url");
@@ -60,7 +60,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var request = new ImportRecipeRequest(url);
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeFalse();
 		result.Errors.Should().Contain(e => e.PropertyName == "Url");
@@ -73,7 +73,7 @@ public class ImportRecipeRequestValidatorTests
 		var url = $"https://x.com/{path}";
 		var request = new ImportRecipeRequest(url);
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeFalse();
 		result.Errors.Should().Contain(e => e.PropertyName == "Url");
@@ -87,7 +87,7 @@ public class ImportRecipeRequestValidatorTests
 		var url = $"{prefix}{path}";
 		var request = new ImportRecipeRequest(url);
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.Errors.Should().NotContain(
 			e => e.PropertyName == "Url"
@@ -99,7 +99,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var request = new ImportRecipeRequest(null!);
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeFalse();
 		result.Errors.Should().Contain(e => e.PropertyName == "Url");
@@ -111,7 +111,7 @@ public class ImportRecipeRequestValidatorTests
 		var request = new ImportRecipeRequest(
 			"https://example.com/recipe#ingredients");
 
-		var result = sut.Validate(request);
+		var result = validator.Validate(request);
 
 		result.IsValid.Should().BeTrue();
 	}

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
@@ -27,8 +27,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
 			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Title.Should().Be("Pasta Carbonara");
@@ -42,8 +42,8 @@ public class ImportRecipeCommandHandlerTests
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.PageUnreachable));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.PageUnreachable);
@@ -60,8 +60,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
 			.Returns(Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.NoRecipeFound));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.NoRecipeFound);
@@ -79,8 +79,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
 			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
 
-		var sut = CreateSut();
-		await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		await extraction.Received(1).ExtractAsync(scrapedContent, Arg.Any<CancellationToken>());
 	}
@@ -93,8 +93,8 @@ public class ImportRecipeCommandHandlerTests
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.PageUnreachable));
 
-		var sut = CreateSut();
-		await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		await extraction.DidNotReceive().ExtractAsync(
 			Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>());
@@ -108,8 +108,8 @@ public class ImportRecipeCommandHandlerTests
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.ScrapeTimeout));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.ScrapeTimeout);
@@ -126,8 +126,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
 			.Returns(Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
@@ -146,8 +146,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, cts.Token)
 			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
 
-		var sut = CreateSut();
-		await sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+		var handler = CreateHandler();
+		await handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
 
 		await scraper.Received(1).ScrapeAsync(url, cts.Token);
 	}
@@ -165,8 +165,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, cts.Token)
 			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
 
-		var sut = CreateSut();
-		await sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+		var handler = CreateHandler();
+		await handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
 
 		await extraction.Received(1).ExtractAsync(scrapedContent, cts.Token);
 	}
@@ -183,8 +183,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
 			.Returns(Result<ExtractedRecipeDto>.Success(minimalRecipe));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Title.Should().Be("Simple Dish");
@@ -200,8 +200,8 @@ public class ImportRecipeCommandHandlerTests
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Failure(ImportRecipeErrors.ContentTooLarge));
 
-		var sut = CreateSut();
-		var result = await sut.HandleAsync(new ImportRecipeCommand(url));
+		var handler = CreateHandler();
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.ContentTooLarge);
@@ -217,8 +217,8 @@ public class ImportRecipeCommandHandlerTests
 		scraper.ScrapeAsync(url, cts.Token)
 			.Returns<Result<ScrapedContent>>(_ => throw new OperationCanceledException(cts.Token));
 
-		var sut = CreateSut();
-		var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+		var handler = CreateHandler();
+		var act = () => handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
 
 		await act.Should().ThrowAsync<OperationCanceledException>();
 	}
@@ -237,8 +237,8 @@ public class ImportRecipeCommandHandlerTests
 		extraction.ExtractAsync(scrapedContent, cts.Token)
 			.Returns<Result<ExtractedRecipeDto>>(_ => throw new OperationCanceledException(cts.Token));
 
-		var sut = CreateSut();
-		var act = () => sut.HandleAsync(new ImportRecipeCommand(url), cts.Token);
+		var handler = CreateHandler();
+		var act = () => handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
 
 		await act.Should().ThrowAsync<OperationCanceledException>();
 	}
@@ -246,5 +246,5 @@ public class ImportRecipeCommandHandlerTests
 	private static ExtractedRecipeDto CreateExtractedRecipe(string title = "Test Recipe") =>
 		new(title, [new ExtractedIngredientDto("Flour", 500, "g")], [new ExtractedStepDto(1, "Mix ingredients")], Servings: 4);
 
-	private ImportRecipeCommandHandler CreateSut() => new(scraper, extraction);
+	private ImportRecipeCommandHandler CreateHandler() => new(scraper, extraction);
 }

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
@@ -119,7 +119,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("Crepes", "Pancakes");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("Crepes", "Pancakes");
 	}
 
 	[Fact]
@@ -132,7 +132,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("RecipeB", "RecipeA");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("RecipeB", "RecipeA");
 	}
 
 	[Fact]
@@ -145,7 +145,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("Apple Pie", "Zuppa");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("Apple Pie", "Zuppa");
 	}
 
 	[Fact]
@@ -158,7 +158,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("UsesMilk", "FreshOnly");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("UsesMilk", "FreshOnly");
 	}
 
 	[Fact]
@@ -174,7 +174,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("TwoUrgent", "OneUrgent");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("TwoUrgent", "OneUrgent");
 	}
 
 	[Fact]
@@ -187,7 +187,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("UsesMilk", "StaplesOnly");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("UsesMilk", "StaplesOnly");
 	}
 
 	[Fact]
@@ -201,7 +201,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetCookableRecipesQuery());
 
-		result.Value.Select(r => r.Title).Should().Equal("FullMatchFresh", "NearMatchUrgent");
+		result.Value.Select(recipe => recipe.Title).Should().Equal("FullMatchFresh", "NearMatchUrgent");
 	}
 
 	[Fact]
@@ -220,7 +220,7 @@ public class GetCookableRecipesQueryHandlerTests
 		return Recipe.Create(
 			RecipeTitle.From(title),
 			OwnerIdentifier.From(OwnerId),
-			ingredientNames.Select(n => Ingredient.Create(IngredientName.From(n), null)).ToList(),
+			ingredientNames.Select(name => Ingredient.Create(IngredientName.From(name), null)).ToList(),
 			[Step.Create(StepNumber.From(1), StepDescription.From("Cook"))]);
 	}
 
@@ -232,7 +232,7 @@ public class GetCookableRecipesQueryHandlerTests
 
 	private void ConfigureBalance(params string[] availableNames)
 	{
-		ConfigureBalance(availableNames.Select(n => (n, Freshness.Fresh)).ToArray());
+		ConfigureBalance(availableNames.Select(name => (name, Freshness.Fresh)).ToArray());
 	}
 
 	private void ConfigureBalance(params (string Name, Freshness Freshness)[] items)

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/JsonLdRecipeParserTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/JsonLdRecipeParserTests.cs
@@ -84,7 +84,7 @@ public class JsonLdRecipeParserTests
 		var result = JsonLdRecipeParser.TryParse(html);
 
 		result!.Steps.Should().HaveCount(3);
-		result.Steps.Select(s => s.Description).Should().Equal("Prepare the batter", "Bake", "Make frosting");
+		result.Steps.Select(step => step.Description).Should().Equal("Prepare the batter", "Bake", "Make frosting");
 	}
 
 	[Fact]

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceTests.cs
@@ -64,7 +64,7 @@ public class SemanticKernelChatServiceTests
 			"Tomato Soup pairs great with Grilled Cheese.", recipes);
 
 		result.Should().HaveCount(2);
-		result.Select(s => s.Title).Should().Contain("Tomato Soup").And.Contain("Grilled Cheese");
+		result.Select(suggestion => suggestion.Title).Should().Contain("Tomato Soup").And.Contain("Grilled Cheese");
 	}
 
 	[Fact]

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
@@ -59,7 +59,7 @@ public class GetIngredientBalanceQueryHandlerTests
 			i.Quantity.Should().BeNull();
 			i.Unit.Should().BeNull();
 		});
-		result.Value.Items.Select(i => i.ItemName).Should().BeEquivalentTo(["salt", "pepper"]);
+		result.Value.Items.Select(item => item.ItemName).Should().BeEquivalentTo(["salt", "pepper"]);
 	}
 
 	[Fact]
@@ -71,7 +71,7 @@ public class GetIngredientBalanceQueryHandlerTests
 		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
 
 		result.Value.Items.Should().HaveCount(2);
-		result.Value.Items.Where(i => string.Equals(i.ItemName, "Butter", StringComparison.OrdinalIgnoreCase))
+		result.Value.Items.Where(item => string.Equals(item.ItemName, "Butter", StringComparison.OrdinalIgnoreCase))
 			.Should().ContainSingle()
 			.Which.Source.Should().Be(IngredientBalanceSource.AtHome);
 	}
@@ -100,7 +100,7 @@ public class GetIngredientBalanceQueryHandlerTests
 
 		var result = await handler.HandleAsync(new GetIngredientBalanceQuery());
 
-		var names = result.Value.Items.Select(i => i.ItemName).ToList();
+		var names = result.Value.Items.Select(item => item.ItemName).ToList();
 		names.Should().Equal("Apple", "Tomato", "Yogurt");
 	}
 

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/ShoppingListWriterTests.cs
@@ -101,7 +101,7 @@ public class ShoppingListWriterTests
 		var existing = ShoppingLedger.Create(OwnerIdentifier.From(OwnerId));
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>()).Returns(existing);
 		var items = Enumerable.Range(0, 50)
-			.Select(i => new ShoppingItemRequest($"Item{i}", 1m, "pc", "manual"))
+			.Select(index => new ShoppingItemRequest($"Item{index}", 1m, "pc", "manual"))
 			.ToArray();
 
 		await writer.AddItemsAsync(OwnerId, items);

--- a/tests/Yumney.Users.Infrastructure.Tests/Services/CurrentUserProviderTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/Services/CurrentUserProviderTests.cs
@@ -94,7 +94,7 @@ public class CurrentUserProviderTests
 	private void SetupAuthenticatedUser(string userId, params string[] roles)
 	{
 		List<Claim> claims = [new("sub", userId)];
-		claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+		claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
 		var identity = new ClaimsIdentity(claims, "TestAuth");
 		var principal = new ClaimsPrincipal(identity);
 		var httpContext = new DefaultHttpContext { User = principal };

--- a/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/Services/KeycloakAdminServiceTests.cs
@@ -240,9 +240,9 @@ public class KeycloakAdminServiceTests
 				TokenRequestCount++;
 			}
 
-			var match = responses.FirstOrDefault(r =>
-				r.Method == request.Method &&
-				request.RequestUri!.PathAndQuery.StartsWith(r.PathPrefix, StringComparison.OrdinalIgnoreCase));
+			var match = responses.FirstOrDefault(response =>
+				response.Method == request.Method &&
+				request.RequestUri!.PathAndQuery.StartsWith(response.PathPrefix, StringComparison.OrdinalIgnoreCase));
 
 			if (match == default) { return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)); }
 


### PR DESCRIPTION
## Summary

Phase 3 — applies the test-naming rules from CLAUDE.md (PR #515) across the whole `tests/` tree. Tests-only sweep, pure renames, zero behaviour change.

## Drop `sut`

| File | Before | After |
|---|---|---|
| `ImportRecipeRequestValidatorTests` | `sut` private field + 9 call sites | `validator` |
| `ImportRecipeCommandHandlerTests` | `sut` (15 sites), `CreateSut()` | `handler`, `CreateHandler()` |

## Lambda parameter renames (~60 sites across 25+ files)

Same noun-of-the-domain rule as Phase 2 in `src/`. Most repeated patterns:

| Context | Before | After |
|---|---|---|
| Architecture / Reflection tests | `t`, `i`, `m`, `e`, `c`, `p` | `type`, `iface`, `module`, `eventType`, `ctor`, `parameter` |
| Repo cleanup / fixtures | `Where(s => s.OwnerId == …)` | `summary =>` / `item =>` / `row =>` |
| Recipe cleanup | `Where(r => r.Owner == …)` | `recipe =>` |
| Favorite cleanup | `Where(f => f.Owner == …)` | `favorite =>` |
| Profile cleanup | `Where(p => p.KeycloakUserId == …)` | `profile =>` |
| Event-store ordering | `OrderBy(e => e.Version)` | `stored =>` |
| Slot projections | `Where/Select(s => s.ContentType …)` | `slot =>` |
| Recipe projections | `Select(r => r.Title)` | `recipe =>` |
| Tag/ingredient projections | `Select(t => t.Value)`, `Select(i => i.Name)` | `tag =>`, `ingredient =>` |
| JSON traversal | `Select(r => r.GetProperty(…))`, `SingleOrDefault(i => i.GetProperty(…))` | `entry =>` |
| Misc | `Select(n => …)`, `Select(role => new Claim …)`, `responses.FirstOrDefault(r => …)`, `oversized.Select(f => …)` | `name =>`, `role =>`, `response =>`, `file =>` |

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] **1,858 unit tests pass** across all 19 test projects — every Recipes (660), Shopping (350), MealPlan (128), Users (297), Architecture (117), Shared (306) test project green.

46 files, +224 / −224. Pure rename, no behaviour change.

## Phases done

- Phase 0 — conventions doc (#515 ✅ merged)
- Phase 1 — DTO mapping unification, 4 PRs (✅ merged)
- Phase 2 — variable naming sweep in `src/`, 4 PRs (✅ merged)
- **Phase 3 — test naming sweep (this)**

Phase 4 (architecture-test enforcement to prevent regression) remains.