### PR TITLE
fix(shopping): preserve Source tag when meal-plan adds items via HTTP

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
@@ -13,10 +13,10 @@ public sealed class HttpShoppingListWriter(IHttpClientFactory httpClientFactory)
 
 		foreach (var (itemName, quantity, unit, source) in items)
 		{
-			AddItemRequest request = new(owner.Value, itemName, quantity, unit, source);
+			AddItemRequest request = new(itemName, quantity, unit, source);
 			await client.PostAsJsonAsync("/api/v1/shopping-lists/items", request, cancellationToken);
 		}
 	}
 
-	private sealed record AddItemRequest(string OwnerId, string Name, decimal Quantity, string? Unit, string Source);
+	private sealed record AddItemRequest(string Name, decimal Quantity, string? Unit, string Source);
 }

--- a/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
@@ -1,14 +1,16 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record AddManualItemRequest(string Name, decimal? Quantity = null, string? Unit = null)
+public sealed record AddManualItemRequest(string Name, decimal? Quantity = null, string? Unit = null, string? Source = null)
 {
-	public void Deconstruct(out ItemName itemName, out Quantity? quantity)
+	public void Deconstruct(out ItemName itemName, out Quantity? quantity, out ItemSource source)
 	{
 		itemName = ItemName.From(Name.Trim());
 		quantity = Shopping.Domain.ShoppingList.Quantity.FromNullable(
 			Amount.FromNullable(Quantity),
 			Shopping.Domain.ShoppingList.Unit.FromNullable(Unit));
+		source = string.IsNullOrWhiteSpace(Source) ? ItemSource.Manual : ItemSource.From(Source);
 	}
 }

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -134,8 +134,8 @@ public static class ShoppingEndpoints
 			var validation = await validator.ValidateAsync(request, cancellationToken);
 			if (validation.HasFailed()) return validation.ToValidationProblem();
 
-			var (itemName, quantity) = request;
-			var command = new AddManualItemCommand(itemName, quantity);
+			var (itemName, quantity, source) = request;
+			var command = new AddManualItemCommand(itemName, quantity, source);
 
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.IsSuccess

--- a/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/AddManualItemCommand.cs
@@ -1,10 +1,12 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
 public sealed record AddManualItemCommand(
 	ItemName ItemName,
-	Quantity? Quantity) : ICommand<Result<AddedItemDto>>;
+	Quantity? Quantity,
+	ItemSource Source) : ICommand<Result<AddedItemDto>>;

--- a/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/AddManualItemCommandHandler.cs
@@ -12,17 +12,17 @@ public sealed class AddManualItemCommandHandler(IShoppingEventStore eventStore, 
 {
 	public async Task<Result<AddedItemDto>> HandleAsync(AddManualItemCommand command, CancellationToken cancellationToken = default)
 	{
-		var (itemName, explicitQuantity) = command;
+		var (itemName, explicitQuantity, source) = command;
 		var ownerId = OwnerIdentifier.From(currentUser.UserId);
 
 		var quantity = explicitQuantity ?? DefaultQuantityResolver.Resolve(itemName.Value);
 		var category = IngredientCategoryResolver.Resolve(itemName.Value) ?? IngredientCategory.Other;
 
 		var ledger = await eventStore.LoadAsync(ownerId, cancellationToken) ?? ShoppingLedger.Create(ownerId);
-		ledger.AddItem(itemName, quantity, ItemSource.Manual);
+		ledger.AddItem(itemName, quantity, source);
 
 		await eventStore.SaveAsync(ledger, cancellationToken);
 
-		return ledger.ToAddedItemDto(itemName, quantity, category, ItemSource.Manual);
+		return ledger.ToAddedItemDto(itemName, quantity, category, source);
 	}
 }

--- a/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/AddManualItemCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class AddManualItemCommandHandlerTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(existingLedger);
 
-		var command = new AddManualItemCommand(ItemName.From("Potatoes"), Quantity.Of(Amount.From(2), Unit.From("kg")));
+		var command = new AddManualItemCommand(ItemName.From("Potatoes"), Quantity.Of(Amount.From(2), Unit.From("kg")), ItemSource.Manual);
 
 		var result = await handler.HandleAsync(command);
 
@@ -45,7 +45,7 @@ public class AddManualItemCommandHandlerTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(existingLedger);
 
-		var command = new AddManualItemCommand(ItemName.From("Milk"), null);
+		var command = new AddManualItemCommand(ItemName.From("Milk"), null, ItemSource.Manual);
 
 		var result = await handler.HandleAsync(command);
 
@@ -61,7 +61,7 @@ public class AddManualItemCommandHandlerTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(existingLedger);
 
-		var command = new AddManualItemCommand(ItemName.From("Chicken"), Quantity.Of(Amount.From(500), Unit.From("g")));
+		var command = new AddManualItemCommand(ItemName.From("Chicken"), Quantity.Of(Amount.From(500), Unit.From("g")), ItemSource.Manual);
 
 		var result = await handler.HandleAsync(command);
 
@@ -75,7 +75,7 @@ public class AddManualItemCommandHandlerTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns((ShoppingLedger?)null);
 
-		var command = new AddManualItemCommand(ItemName.From("Salt"), null);
+		var command = new AddManualItemCommand(ItemName.From("Salt"), null, ItemSource.Manual);
 
 		var result = await handler.HandleAsync(command);
 
@@ -90,10 +90,24 @@ public class AddManualItemCommandHandlerTests
 		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
 			.Returns(existingLedger);
 
-		var command = new AddManualItemCommand(ItemName.From("Bread"), null);
+		var command = new AddManualItemCommand(ItemName.From("Bread"), null, ItemSource.Manual);
 
 		var result = await handler.HandleAsync(command);
 
 		result.Value.Source.Should().Be("manual");
+	}
+
+	[Fact]
+	public async Task HandleAsync_MealPlanSource_TagsItemAsMealPlan()
+	{
+		var existingLedger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+		eventStore.LoadAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+			.Returns(existingLedger);
+
+		var command = new AddManualItemCommand(ItemName.From("Pasta"), null, ItemSource.MealPlan);
+
+		var result = await handler.HandleAsync(command);
+
+		result.Value.Source.Should().Be("meal-plan");
 	}
 }


### PR DESCRIPTION
## Summary

Pre-existing semantic bug surfaced by review of the cross-module contract series (#527-#531).

When MealPlan's \`GenerateShoppingList\` flow adds items via \`HttpShoppingListWriter\`, it sends \`Source=\"meal-plan\"\` in the POST body — but the Shopping endpoint's \`AddManualItemRequest\` only accepted \`{Name, Quantity, Unit}\` and \`AddManualItemCommandHandler\` hardcoded \`ItemSource.Manual\`. Result: meal-plan-generated items were silently re-tagged as manually-added in the ledger, hiding the provenance from downstream consumers (UI grouping, projections).

- \`AddManualItemRequest\` gains an optional \`Source\` field; the \`Deconstruct\` emits \`ItemSource\` (defaulting to \`Manual\` when null/empty — frontend manual-add UIs aren't affected)
- \`AddManualItemCommand\` carries \`ItemSource\`; handler uses it instead of hardcoding \`Manual\`
- \`HttpShoppingListWriter\` drops the unused \`OwnerId\` field from its POST body — wire shape now exactly matches what the server reads
- New test: \`Source=meal-plan\` round-trips through the handler

Diff: 6 files, +33/−15.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] All 1851 unit tests pass (added one for the meal-plan source path)
- [x] All 120 architecture tests pass
- [ ] Once merged: spot-check via integration test or manual run that a meal-plan-generated shopping list shows items tagged \`meal-plan\` (not \`manual\`) in the ledger projection