### PR TITLE
refactor(shared): replace var with explicit collection types per CLAUDE.md

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -46,9 +46,6 @@ public sealed class ConfirmMealCommandHandler(
 	private async Task<IReadOnlyList<CookedIngredient>> FetchIngredientsAsync(SlotRecipeIdentifier recipe, CancellationToken cancellationToken)
 	{
 		var ingredients = await recipeIngredients.LookupAsync(recipe, cancellationToken);
-		return ingredients
-			.Where(ingredient => ingredient.Amount.HasValue && ingredient.Amount.Value > 0m)
-			.Select(ingredient => new CookedIngredient(ingredient.Name, ingredient.Amount!.Value, ingredient.Unit))
-			.ToList();
+		return ingredients.ToCookedIngredients();
 	}
 }

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -21,7 +21,7 @@ public sealed class GenerateShoppingListCommandHandler(
 		var planned = await readModel.GetPlannedRecipesAsync(owner, week, cancellationToken);
 		if (planned.Recipes.Count == 0) return GenerateShoppingListErrors.NoRecipes;
 
-		var merged = new Dictionary<string, MergedItem>(StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, MergedItem> merged = new(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var recipe in planned.Recipes)
 		{
@@ -59,7 +59,7 @@ public sealed class GenerateShoppingListCommandHandler(
 	{
 		var staples = await staplesProvider.GetStapleNamesAsync(owner, cancellationToken);
 		var staplesSkipped = 0;
-		var itemsToAdd = new List<ShoppingItemRequest>();
+		List<ShoppingItemRequest> itemsToAdd = [];
 
 		foreach (var (name, quantity, unit) in merged.Values)
 		{

--- a/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.Events;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
@@ -27,5 +28,11 @@ public static class WeeklyPlanMappingExtensions
 			.OrderBy(slot => slot.Day)
 			.ThenBy(slot => slot.MealType)
 			.Select(slot => slot.ToDto())
+			.ToList();
+
+	public static IReadOnlyList<CookedIngredient> ToCookedIngredients(this IEnumerable<RecipeIngredientLookupResult> ingredients) =>
+		ingredients
+			.Where(ingredient => ingredient.Amount.HasValue && ingredient.Amount.Value > 0m)
+			.Select(ingredient => new CookedIngredient(ingredient.Name, ingredient.Amount!.Value, ingredient.Unit))
 			.ToList();
 }

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetCookableRecipesQueryHandler.cs
@@ -25,11 +25,11 @@ public sealed class GetCookableRecipesQueryHandler(
 		await Task.WhenAll(recipesTask, availableTask);
 
 		var available = availableTask.Result;
-		var matches = new List<RankedMatch>();
+		List<RankedMatch> matches = [];
 
 		foreach (var recipe in recipesTask.Result)
 		{
-			var missing = new List<string>();
+			List<string> missing = [];
 			var urgentCount = 0;
 
 			foreach (var ingredient in recipe.Ingredients)

--- a/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
+++ b/src/Yumney.Recipes.Extraction/Services/JsonLdRecipeParser.cs
@@ -134,7 +134,7 @@ public static partial class JsonLdRecipeParser
 
 	private static List<ExtractedIngredientDto> ReadIngredients(JsonElement recipe)
 	{
-		var list = new List<ExtractedIngredientDto>();
+		List<ExtractedIngredientDto> list = [];
 		if (!recipe.TryGetProperty("recipeIngredient", out var ingredients) || ingredients.ValueKind != JsonValueKind.Array)
 		{
 			return list;
@@ -155,7 +155,7 @@ public static partial class JsonLdRecipeParser
 	{
 		if (!recipe.TryGetProperty("recipeInstructions", out var instructions)) return [];
 
-		var flat = new List<string>();
+		List<string> flat = [];
 		FlattenInstructions(instructions, flat);
 
 		return flat

--- a/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
@@ -65,7 +65,7 @@ public static class DefaultQuantityResolver
 #pragma warning disable SA1117 // Parameters should be on same line or each on its own line
 	private static Dictionary<string, Quantity> BuildItemDefaults()
 	{
-		var defaults = new Dictionary<string, Quantity>(StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, Quantity> defaults = new(StringComparer.OrdinalIgnoreCase);
 
 		// Liquids → 1L
 		AddWithAliases(defaults, Q(1, "L"),

--- a/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetSuggestionsQueryHandler.cs
@@ -34,7 +34,7 @@ public sealed class GetSuggestionsQueryHandler(IUserActivityRepository activitie
 	{
 		var now = DateTime.UtcNow;
 		var hour = now.Hour;
-		var actions = new List<string>(BuildTimeOfDayActions(hour));
+		List<string> actions = new(BuildTimeOfDayActions(hour));
 
 		if (now.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
 		{


### PR DESCRIPTION
## Summary

- Replaces `var x = new List<...>()` / `var x = new Dictionary<...>()` with explicit-type initializers across 8 call-sites — CLAUDE.md mandates this so the type is visible at the declaration
- Extracts the inline `new CookedIngredient(...)` projection in `ConfirmMealCommandHandler` into a new `ToCookedIngredients()` extension on `WeeklyPlanMappingExtensions`, removing the last inline DTO/domain construction outside the mapper file
- Pure refactor — no behavior change

Surfaced by the backend refactoring scan; companion to the test-coverage issues (#533–#536).

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] `dotnet test` for affected projects (MealPlan / Recipes / Shopping / Users Application) — 467/467 pass