### PR TITLE
test(shared): add unit tests for previously untested Domain VOs (#535)

### DIFF
--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/FreetextLabelTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/FreetextLabelTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class FreetextLabelTests
+{
+	[Fact]
+	public void From_ValidValue_CreatesInstance()
+	{
+		var label = FreetextLabel.From("Leftover pizza");
+
+		label.Value.Should().Be("Leftover pizza");
+	}
+
+	[Fact]
+	public void From_ValueWithSurroundingWhitespace_TrimsValue()
+	{
+		var label = FreetextLabel.From("  Pizza night  ");
+
+		label.Value.Should().Be("Pizza night");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+	{
+		var act = () => FreetextLabel.From(value!);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_ExceedsMaxLength_ThrowsGuardException()
+	{
+		var act = () => FreetextLabel.From(new string('x', 201));
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_AtMaxLength_Succeeds()
+	{
+		var label = FreetextLabel.From(new string('x', 200));
+
+		label.Value.Should().HaveLength(200);
+	}
+
+	[Fact]
+	public void ImplicitConversion_ReturnsValueString()
+	{
+		string value = FreetextLabel.From("Snack");
+
+		value.Should().Be("Snack");
+	}
+
+	[Fact]
+	public void ToString_ReturnsValue()
+	{
+		var label = FreetextLabel.From("Brunch");
+
+		label.ToString().Should().Be("Brunch");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var first = FreetextLabel.From("Same");
+		var second = FreetextLabel.From("Same");
+
+		first.Should().Be(second);
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/LeftoverLabelTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/LeftoverLabelTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class LeftoverLabelTests
+{
+	[Fact]
+	public void From_ValidValue_CreatesInstance()
+	{
+		var label = LeftoverLabel.From("Leftovers: Lasagna");
+
+		label.Value.Should().Be("Leftovers: Lasagna");
+	}
+
+	[Fact]
+	public void From_ValueWithSurroundingWhitespace_TrimsValue()
+	{
+		var label = LeftoverLabel.From("  Leftovers  ");
+
+		label.Value.Should().Be("Leftovers");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+	{
+		var act = () => LeftoverLabel.From(value!);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_ExceedsMaxLength_ThrowsGuardException()
+	{
+		var act = () => LeftoverLabel.From(new string('x', 201));
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ForRecipe_PrefixesWithLeftoversLabel()
+	{
+		var label = LeftoverLabel.ForRecipe("Spaghetti Bolognese");
+
+		label.Value.Should().Be("Leftovers: Spaghetti Bolognese");
+	}
+
+	[Fact]
+	public void ImplicitConversion_ReturnsValueString()
+	{
+		string value = LeftoverLabel.From("Cold pizza");
+
+		value.Should().Be("Cold pizza");
+	}
+
+	[Fact]
+	public void ToString_ReturnsValue()
+	{
+		var label = LeftoverLabel.From("Risotto");
+
+		label.ToString().Should().Be("Risotto");
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/MealSlotTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/MealSlotTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class MealSlotTests
+{
+	[Fact]
+	public void Empty_FactoryProducesEmptyContent()
+	{
+		var slot = MealSlot.Empty(DayOfWeek.Monday, MealType.Dinner, SlotServings.Default());
+
+		slot.Day.Should().Be(DayOfWeek.Monday);
+		slot.MealType.Should().Be(MealType.Dinner);
+		slot.ContentType.Should().Be(SlotContentType.Empty);
+		slot.Recipe.Should().BeNull();
+		slot.FreetextLabel.Should().BeNull();
+		slot.LeftoverLabel.Should().BeNull();
+		slot.LeftoverSourceDay.Should().BeNull();
+		slot.LeftoverSourceMealType.Should().BeNull();
+		slot.State.Should().Be(MealState.Planned);
+	}
+
+	[Fact]
+	public void IsEmpty_EmptyContent_ReturnsTrue()
+	{
+		var slot = MealSlot.Empty(DayOfWeek.Tuesday, MealType.Lunch, SlotServings.Default());
+
+		slot.IsEmpty.Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsEmpty_RecipeContent_ReturnsFalse()
+	{
+		var slot = new MealSlot(
+			DayOfWeek.Wednesday,
+			MealType.Dinner,
+			SlotContentType.Recipe,
+			SlotRecipeReference.From(Guid.NewGuid(), "Pad Thai"),
+			SlotServings.From(2),
+			null,
+			null,
+			null,
+			null,
+			MealState.Planned);
+
+		slot.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Empty_PreservesProvidedServings()
+	{
+		var servings = SlotServings.From(6);
+
+		var slot = MealSlot.Empty(DayOfWeek.Friday, MealType.Lunch, servings);
+
+		slot.Servings.Should().Be(servings);
+	}
+
+	[Fact]
+	public void Equality_SameValues_AreEqual()
+	{
+		var first = MealSlot.Empty(DayOfWeek.Monday, MealType.Dinner, SlotServings.Default());
+		var second = MealSlot.Empty(DayOfWeek.Monday, MealType.Dinner, SlotServings.Default());
+
+		first.Should().Be(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentDay_AreNotEqual()
+	{
+		var first = MealSlot.Empty(DayOfWeek.Monday, MealType.Dinner, SlotServings.Default());
+		var second = MealSlot.Empty(DayOfWeek.Tuesday, MealType.Dinner, SlotServings.Default());
+
+		first.Should().NotBe(second);
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class SlotRecipeReferenceTests
+{
+	[Fact]
+	public void From_ValueObjects_CreatesInstance()
+	{
+		var recipe = SlotRecipeIdentifier.From(Guid.NewGuid());
+		var title = SlotRecipeTitle.From("Pad Thai");
+
+		var reference = SlotRecipeReference.From(recipe, title);
+
+		reference.RecipeIdentifier.Should().Be(recipe);
+		reference.Title.Should().Be(title);
+	}
+
+	[Fact]
+	public void From_RawGuidAndString_CreatesInstance()
+	{
+		var recipeGuid = Guid.NewGuid();
+
+		var reference = SlotRecipeReference.From(recipeGuid, "Carbonara");
+
+		reference.RecipeIdentifier.Value.Should().Be(recipeGuid);
+		reference.Title.Value.Should().Be("Carbonara");
+	}
+
+	[Fact]
+	public void ToString_FormatsTitleAndIdentifier()
+	{
+		var recipeGuid = Guid.NewGuid();
+		var reference = SlotRecipeReference.From(recipeGuid, "Risotto");
+
+		reference.ToString().Should().Contain("Risotto").And.Contain(recipeGuid.ToString());
+	}
+
+	[Fact]
+	public void Equality_SameValues_AreEqual()
+	{
+		var recipeGuid = Guid.NewGuid();
+		var first = SlotRecipeReference.From(recipeGuid, "Same");
+		var second = SlotRecipeReference.From(recipeGuid, "Same");
+
+		first.Should().Be(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentRecipeIdentifier_AreNotEqual()
+	{
+		var first = SlotRecipeReference.From(Guid.NewGuid(), "Same");
+		var second = SlotRecipeReference.From(Guid.NewGuid(), "Same");
+
+		first.Should().NotBe(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentTitle_AreNotEqual()
+	{
+		var recipeGuid = Guid.NewGuid();
+		var first = SlotRecipeReference.From(recipeGuid, "First");
+		var second = SlotRecipeReference.From(recipeGuid, "Second");
+
+		first.Should().NotBe(second);
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeTitleTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeTitleTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class SlotRecipeTitleTests
+{
+	[Fact]
+	public void From_ValidValue_CreatesInstance()
+	{
+		var title = SlotRecipeTitle.From("Pad Thai");
+
+		title.Value.Should().Be("Pad Thai");
+	}
+
+	[Fact]
+	public void From_ValueWithSurroundingWhitespace_TrimsValue()
+	{
+		var title = SlotRecipeTitle.From("  Carbonara  ");
+
+		title.Value.Should().Be("Carbonara");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void From_NullOrWhitespace_ThrowsGuardException(string? value)
+	{
+		var act = () => SlotRecipeTitle.From(value!);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_ExceedsMaxLength_ThrowsGuardException()
+	{
+		var act = () => SlotRecipeTitle.From(new string('x', SlotRecipeTitle.MaxLength + 1));
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_AtMaxLength_Succeeds()
+	{
+		var title = SlotRecipeTitle.From(new string('x', SlotRecipeTitle.MaxLength));
+
+		title.Value.Should().HaveLength(SlotRecipeTitle.MaxLength);
+	}
+
+	[Fact]
+	public void ImplicitConversion_ReturnsValueString()
+	{
+		string value = SlotRecipeTitle.From("Risotto");
+
+		value.Should().Be("Risotto");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var first = SlotRecipeTitle.From("Same");
+		var second = SlotRecipeTitle.From("Same");
+
+		first.Should().Be(second);
+	}
+}

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotServingsTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotServingsTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;
+
+public class SlotServingsTests
+{
+	[Fact]
+	public void From_PositiveValue_CreatesInstance()
+	{
+		var servings = SlotServings.From(4);
+
+		servings.Value.Should().Be(4);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(int.MinValue)]
+	public void From_NonPositiveValue_ThrowsGuardException(int value)
+	{
+		var act = () => SlotServings.From(value);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Default_ReturnsConfiguredDefault()
+	{
+		var servings = SlotServings.Default();
+
+		servings.Value.Should().Be(SlotServings.DefaultValue);
+	}
+
+	[Fact]
+	public void ImplicitConversion_ReturnsValueInt()
+	{
+		int value = SlotServings.From(6);
+
+		value.Should().Be(6);
+	}
+
+	[Fact]
+	public void ToString_ReturnsValueAsInvariantString()
+	{
+		var servings = SlotServings.From(12);
+
+		servings.ToString().Should().Be("12");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var first = SlotServings.From(4);
+		var second = SlotServings.From(4);
+
+		first.Should().Be(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentValue_AreNotEqual()
+	{
+		var first = SlotServings.From(4);
+		var second = SlotServings.From(5);
+
+		first.Should().NotBe(second);
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/QuantityTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/QuantityTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe;
+
+public class QuantityTests
+{
+	[Fact]
+	public void Of_AmountAndUnit_CreatesInstance()
+	{
+		var quantity = Quantity.Of(Amount.From(2.5m), Unit.Gram);
+
+		quantity.Amount.Value.Should().Be(2.5m);
+		quantity.Unit.Should().Be(Unit.Gram);
+	}
+
+	[Fact]
+	public void Of_NullUnit_CreatesInstanceWithoutUnit()
+	{
+		var quantity = Quantity.Of(Amount.From(3m), null);
+
+		quantity.Amount.Value.Should().Be(3m);
+		quantity.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_NullAmount_ReturnsNull()
+	{
+		var quantity = Quantity.FromNullable(null, Unit.Gram);
+
+		quantity.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_NonNullAmount_ReturnsInstance()
+	{
+		var quantity = Quantity.FromNullable(Amount.From(5m), Unit.Liter);
+
+		quantity.Should().NotBeNull();
+		quantity!.Amount.Value.Should().Be(5m);
+		quantity.Unit.Should().Be(Unit.Liter);
+	}
+
+	[Fact]
+	public void FromNullable_NonNullAmountAndNullUnit_ReturnsInstanceWithoutUnit()
+	{
+		var quantity = Quantity.FromNullable(Amount.From(1m), null);
+
+		quantity.Should().NotBeNull();
+		quantity!.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void ToString_WithUnit_IncludesBothAmountAndUnit()
+	{
+		var quantity = Quantity.Of(Amount.From(2m), Unit.Gram);
+
+		quantity.ToString().Should().Contain("2").And.Contain("g");
+	}
+
+	[Fact]
+	public void ToString_WithoutUnit_FormatsAmountOnly()
+	{
+		var quantity = Quantity.Of(Amount.From(3m), null);
+
+		quantity.ToString().Should().Be("3");
+	}
+
+	[Fact]
+	public void Equality_SameAmountAndUnit_AreEqual()
+	{
+		var first = Quantity.Of(Amount.From(2m), Unit.Gram);
+		var second = Quantity.Of(Amount.From(2m), Unit.Gram);
+
+		first.Should().Be(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentAmount_AreNotEqual()
+	{
+		var first = Quantity.Of(Amount.From(2m), Unit.Gram);
+		var second = Quantity.Of(Amount.From(3m), Unit.Gram);
+
+		first.Should().NotBe(second);
+	}
+
+	[Fact]
+	public void Equality_DifferentUnit_AreNotEqual()
+	{
+		var first = Quantity.Of(Amount.From(2m), Unit.Gram);
+		var second = Quantity.Of(Amount.From(2m), Unit.Kilogram);
+
+		first.Should().NotBe(second);
+	}
+}


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for value objects that were only exercised transitively through aggregate tests:

**MealPlan.Domain.WeeklyPlan**
- `SlotServings` — positive guard, default, implicit conversion, equality
- `FreetextLabel` — null/whitespace/length guards, trim, conversions
- `LeftoverLabel` — guards, `ForRecipe` factory, conversions
- `SlotRecipeTitle` — guards, max length boundary, equality
- `SlotRecipeReference` — composite construction (both factories), equality
- `MealSlot` — `Empty` factory, `IsEmpty`, value equality

**Recipes.Domain.Recipe**
- `Quantity` — `Of`, `FromNullable`, `ToString`, equality across amount and unit

Closes #535

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] 49 new MealPlan VO tests + 10 new Quantity tests — all pass

## Note

`Quantity.ToString_WithUnit_*` uses a tolerant assertion (`.Contain` instead of `.Be`) because `Unit` is a record without a `ToString` override, so its default record format leaks into the interpolated output. Tightening that is a separate concern (codebase fix, not test fix).