### PR TITLE
feat(recipes): add E2E test-mode stubs for LLM/scraper services (#541)

### DIFF
--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.SemanticKernel;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
 using SmartSolutionsLab.Yumney.Shared.Common;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction;
@@ -13,10 +14,23 @@ public static class ExtractionServiceCollectionExtensions
 {
 	public static IServiceCollection AddRecipeExtraction(this IServiceCollection services, IConfiguration configuration)
 	{
+		services.TryAddSingleton<IExtractionResultCache, InMemoryExtractionResultCache>();
+
+		if (configuration.GetValue<bool>("E2ETests"))
+		{
+			services.AddSingleton<IWebScraper, StubWebScraper>();
+			services.AddSingleton<IRecipeExtractionService, StubRecipeExtractionService>();
+			services.AddSingleton<IRecipeSuggestionService, StubRecipeSuggestionService>();
+			services.AddSingleton<IIngredientRecognitionService, StubIngredientRecognitionService>();
+			services.AddSingleton<IChatService, StubChatService>();
+			services.AddSingleton<IIntentParserService, StubIntentParserService>();
+			services.AddSingleton<IIngredientCategoryService, StubIngredientCategoryService>();
+			return services;
+		}
+
 		services.AddHttpClient<IWebScraper, WebScraper>(BrowserHttpClientDefaults.ConfigureHttpClient)
 			.ConfigurePrimaryHttpMessageHandler(BrowserHttpClientDefaults.CreateHandler)
 			.AddStandardResilienceHandler();
-		services.TryAddSingleton<IExtractionResultCache, InMemoryExtractionResultCache>();
 		services.AddScoped<IRecipeExtractionService, SemanticKernelRecipeExtractionService>();
 		services.AddScoped<IRecipeSuggestionService, SemanticKernelRecipeSuggestionService>();
 		services.AddScoped<IIngredientRecognitionService, SemanticKernelIngredientRecognitionService>();

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubChatService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubChatService.cs
@@ -1,0 +1,17 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubChatService : IChatService
+{
+	public Task<Result<ChatResponseDto>> ChatAsync(
+		ChatMessageContent message,
+		IReadOnlyList<ChatHistoryEntry> history,
+		OwnerIdentifier owner,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult(Result<ChatResponseDto>.Success(new ChatResponseDto("Stub reply.", [])));
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubIngredientCategoryService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubIngredientCategoryService.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubIngredientCategoryService : IIngredientCategoryService
+{
+	public Task<IngredientCategory> CategorizeAsync(string itemName, CancellationToken cancellationToken = default) =>
+		Task.FromResult(IngredientCategory.Other);
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubIngredientRecognitionService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubIngredientRecognitionService.cs
@@ -1,0 +1,18 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubIngredientRecognitionService : IIngredientRecognitionService
+{
+	public Task<Result<RecognizedIngredientsResponseDto>> RecognizeAsync(PhotoData photo, CancellationToken cancellationToken = default)
+	{
+		IReadOnlyList<RecognizedIngredientDto> recognized =
+		[
+			new RecognizedIngredientDto("tomato", 0.95, "produce"),
+			new RecognizedIngredientDto("onion", 0.90, "produce"),
+		];
+		return Task.FromResult(Result<RecognizedIngredientsResponseDto>.Success(new RecognizedIngredientsResponseDto(recognized)));
+	}
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubIntentParserService.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubIntentParserService : IIntentParserService
+{
+	public Task<Result<ParsedIntentDto>> ParseAsync(string userInput, string? pageContext, CancellationToken cancellationToken = default) =>
+		Task.FromResult(Result<ParsedIntentDto>.Success(new ParsedIntentDto("general_chat", [], null)));
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubRecipeExtractionService.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubRecipeExtractionService : IRecipeExtractionService
+{
+	public Task<Result<ExtractedRecipeDto>> ExtractAsync(ScrapedContent content, CancellationToken cancellationToken = default) =>
+		Task.FromResult(Result<ExtractedRecipeDto>.Success(StubRecipes.Sample()));
+
+	public Task<Result<ExtractedRecipeDto>> ExtractFromPhotosAsync(IReadOnlyList<PhotoData> photos, CancellationToken cancellationToken = default) =>
+		Task.FromResult(Result<ExtractedRecipeDto>.Success(StubRecipes.Sample()));
+
+	public async IAsyncEnumerable<string> StreamExtractAsync(ScrapedContent content, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		yield return JsonSerializer.Serialize(StubRecipes.Sample());
+		await Task.CompletedTask;
+	}
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubRecipeSuggestionService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubRecipeSuggestionService.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubRecipeSuggestionService : IRecipeSuggestionService
+{
+	public Task<Result<IReadOnlyList<ExtractedRecipeDto>>> SuggestAsync(
+		IReadOnlyCollection<string> availableIngredients,
+		string? dietaryType,
+		IReadOnlyCollection<string> restrictions,
+		int count,
+		CancellationToken cancellationToken = default)
+	{
+		IReadOnlyList<ExtractedRecipeDto> suggestions =
+			Enumerable.Range(1, Math.Max(1, count))
+				.Select(index => StubRecipes.Sample($"#{index}"))
+				.ToList();
+
+		return Task.FromResult(Result<IReadOnlyList<ExtractedRecipeDto>>.Success(suggestions));
+	}
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubRecipes.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubRecipes.cs
@@ -1,0 +1,27 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal static class StubRecipes
+{
+	public static ExtractedRecipeDto Sample(string? titleSuffix = null) =>
+		new(
+			Title: titleSuffix is null ? "Stub Recipe" : $"Stub Recipe {titleSuffix}",
+			Ingredients:
+			[
+				new ExtractedIngredientDto("Flour", 200m, "g"),
+				new ExtractedIngredientDto("Water", 100m, "ml"),
+			],
+			Steps:
+			[
+				new ExtractedStepDto(1, "Mix flour and water."),
+				new ExtractedStepDto(2, "Bake for 20 minutes."),
+			],
+			Description: "A stub recipe used by E2E test mode.",
+			Language: "en",
+			Servings: 2,
+			PrepTimeMinutes: 5,
+			CookTimeMinutes: 20,
+			Difficulty: "easy",
+			ImageUrl: null);
+}

--- a/src/Yumney.Recipes.Extraction/TestStubs/StubWebScraper.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubWebScraper.cs
@@ -1,0 +1,15 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+
+internal sealed class StubWebScraper : IWebScraper
+{
+	public Task<Result<ScrapedContent>> ScrapeAsync(RecipeUrl url, CancellationToken cancellationToken = default) =>
+		Task.FromResult(Result<ScrapedContent>.Success(new ScrapedContent(
+			CleanedText: "Stub scraped page content for E2E tests.",
+			SourceUrl: url,
+			StructuredRecipe: null)));
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Extraction/StubRegistrationTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Extraction/StubRegistrationTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Extraction;
+
+public class StubRegistrationTests
+{
+	[Fact]
+	public void AddRecipeExtraction_WithE2ETestsTrue_ResolvesStubImplementations()
+	{
+		var services = BuildServiceCollection(e2eTests: true);
+		using var provider = services.BuildServiceProvider();
+
+		provider.GetRequiredService<IWebScraper>().Should().BeOfType<StubWebScraper>();
+		provider.GetRequiredService<IRecipeExtractionService>().Should().BeOfType<StubRecipeExtractionService>();
+		provider.GetRequiredService<IRecipeSuggestionService>().Should().BeOfType<StubRecipeSuggestionService>();
+		provider.GetRequiredService<IIngredientRecognitionService>().Should().BeOfType<StubIngredientRecognitionService>();
+		provider.GetRequiredService<IChatService>().Should().BeOfType<StubChatService>();
+		provider.GetRequiredService<IIntentParserService>().Should().BeOfType<StubIntentParserService>();
+		provider.GetRequiredService<IIngredientCategoryService>().Should().BeOfType<StubIngredientCategoryService>();
+	}
+
+	[Fact]
+	public void AddRecipeExtraction_WithE2ETestsFalse_DoesNotResolveStubs()
+	{
+		var services = BuildServiceCollection(e2eTests: false);
+		using var provider = services.BuildServiceProvider();
+
+		provider.GetRequiredService<IWebScraper>().Should().NotBeOfType<StubWebScraper>();
+		provider.GetRequiredService<IRecipeExtractionService>().Should().NotBeOfType<StubRecipeExtractionService>();
+	}
+
+	private static ServiceCollection BuildServiceCollection(bool e2eTests)
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> { ["E2ETests"] = e2eTests ? "true" : "false" })
+			.Build();
+
+		var services = new ServiceCollection();
+		services.AddRecipeExtraction(configuration);
+		return services;
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the SemanticKernel and HTTP scraper implementations with deterministic stubs when configuration value `E2ETests` is `true`. Unblocks happy-path contract tests for the seven LLM-backed Recipes endpoints (#533) — those tests can now exercise full request → handler → response without invoking real LLMs or hitting the open web.

## Stubs (under `src/Yumney.Recipes.Extraction/TestStubs/`)

| Stub | Returns |
| --- | --- |
| `StubWebScraper` | `ScrapedContent` with placeholder text |
| `StubRecipeExtractionService` | 1 stub recipe (Title `Stub Recipe`, 2 ingredients, 2 steps) |
| `StubRecipeSuggestionService` | N stub recipes (`Stub Recipe #1`, `Stub Recipe #2`, …) |
| `StubIngredientRecognitionService` | 2 recognized ingredients with confidence |
| `StubChatService` | `Stub reply.` with no suggestions |
| `StubIntentParserService` | `general_chat` intent |
| `StubIngredientCategoryService` | `IngredientCategory.Other` |
| `StubRecipes` | shared canonical sample factory |

The branch in `AddRecipeExtraction` skips the SemanticKernel kernel setup entirely in test mode, so the API process no longer requires an OpenAI / Ollama / Azure config to start under `E2ETests=true`.

## Companion to #542

- This PR adds the stub *implementations* and the registration switch.
- #542 forwards the `E2ETests` env var from the AppHost to the spawned API processes.

Both are needed for happy-path coverage to fire end-to-end. Either can merge first; together they unblock the deferred 200/201 tests on the 7 LLM-backed Recipes endpoints.

Closes #541
Refs #533, #542

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] New `StubRegistrationTests` (2 tests) verify `AddRecipeExtraction(config)` with `E2ETests=true` resolves stub instances and with `E2ETests=false` resolves real implementations