### PR TITLE
refactor: cleanup multi-type files, DI registrations, Api Request suffix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,39 @@ handler.HandleAsync(command);
 
 Method-name pattern (`{Method}_{Scenario}_{ExpectedResult}`) is unchanged.
 
+### API request types — no `Request` suffix
+
+API request DTOs in `*.Api/Requests/` and their FluentValidation
+validators in `*.Api/Requests/Validator/` carry **no `Request` suffix or
+infix**. The `Requests` namespace already conveys "this is an API
+request DTO"; repeating it on every type name is noise.
+
+```csharp
+// ❌ FORBIDDEN
+public sealed record ImportRecipeRequest(string Url);
+public sealed class ImportRecipeRequestValidator : AbstractValidator<ImportRecipeRequest> { … }
+
+// ✅ REQUIRED
+public sealed record ImportRecipe(string Url);
+public sealed class ImportRecipeValidator : AbstractValidator<ImportRecipe> { … }
+```
+
+**Call-site qualification by location:**
+
+| Code lives in | Qualification | Example |
+|---|---|---|
+| `*.Api/{Module}Endpoints.cs` | `using Requests = SmartSolutionsLab.Yumney.{Module}.Api.Requests;` then `Requests.X` | `Requests.ImportRecipe request, IValidator<Requests.ImportRecipe> validator` |
+| `*.Api/Requests/` (request types themselves) | unqualified — same namespace | `List<SaveRecipeIngredient> Ingredients` |
+| `*.Api/Requests/Validator/` | unqualified — sibling namespace, no ambiguity | `AbstractValidator<SaveRecipe>` |
+| `*.Api.Tests/Requests/...` | partial qualifier `Api.Requests.X` resolved via parent-namespace lookup | `var request = new Api.Requests.ImportRecipe(...);` |
+
+**Why the test files use `Api.Requests.X` instead of the alias:** the test
+class's containing namespace ends in `Requests` (`SmartSolutionsLab.Yumney.{Module}.Api.Tests.Requests`),
+so a `using Requests = ...Api.Requests;` alias would shadow the local
+namespace and the compiler would refuse to resolve type members. The
+partial qualifier `Api.Requests.X` resolves cleanly via the parent
+namespace `SmartSolutionsLab.Yumney.{Module}.Api`.
+
 ## Code Style
 
 ### Backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,7 +874,7 @@ Scopes: recipes, shopping, users, account, shared, api, shell, infra, ui
 | Event Bus | In-process (IDomainEventDispatcher + IEventBus), swappable to RabbitMQ/MassTransit |
 | Validation | FluentValidation + Ensure.That() |
 | LLM | Microsoft Semantic Kernel |
-| HTML Parsing | HtmlAgilityPack + AngleSharp |
+| HTML Parsing | AngleSharp |
 | Auth | Keycloak (OIDC via .NET Aspire) |
 | API Docs | Scalar |
 | Logging | Serilog |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,6 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <!-- LLM & Scraping -->
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -1,7 +1,5 @@
 <Solution>
-  <Folder Name="/src/">
-    <Project Path="src/Yumney.Shared.Events.Wolverine/Yumney.Shared.Events.Wolverine.csproj" />
-  </Folder>
+  <Folder Name="/src/" />
   <Folder Name="/src/Host/">
     <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
     <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
@@ -11,6 +9,7 @@
   <Folder Name="/src/Shared/">
     <Project Path="src/Yumney.Shared/Yumney.Shared.csproj" />
     <Project Path="src/Yumney.Shared.CQRS/Yumney.Shared.CQRS.csproj" />
+    <Project Path="src/Yumney.Shared.Events.Wolverine/Yumney.Shared.Events.Wolverine.csproj" />
     <Project Path="src/Yumney.Shared.Events/Yumney.Shared.Events.csproj" />
     <Project Path="src/Yumney.Shared.Events.InProcess/Yumney.Shared.Events.InProcess.csproj" />
     <Project Path="src/Yumney.Shared.Guards/Yumney.Shared.Guards.csproj" />

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
@@ -7,6 +6,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using Requests = SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -42,7 +42,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> AssignRecipe(
 			int year,
 			int weekNumber,
-			AssignRecipeRequest request,
+			Requests.AssignRecipe request,
 			ICommandHandler<AssignRecipeCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -64,7 +64,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> ToggleExtendedMode(
 			int year,
 			int weekNumber,
-			ToggleExtendedModeRequest request,
+			Requests.ToggleExtendedMode request,
 			ICommandHandler<ToggleExtendedModeCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -84,7 +84,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> AdjustServings(
 			int year,
 			int weekNumber,
-			AdjustServingsRequest request,
+			Requests.AdjustServings request,
 			ICommandHandler<AdjustSlotServingsCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -173,7 +173,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> CookWithLeftovers(
 			int year,
 			int weekNumber,
-			CookWithLeftoversRequest request,
+			Requests.CookWithLeftovers request,
 			ICommandHandler<CookWithLeftoversCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -197,7 +197,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> ClearSlot(
 			int year,
 			int weekNumber,
-			[FromBody] ClearSlotRequest request,
+			[FromBody] Requests.ClearSlot request,
 			ICommandHandler<ClearMealSlotCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -223,7 +223,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> SwapSlots(
 			int year,
 			int weekNumber,
-			SwapSlotsRequest request,
+			Requests.SwapSlots request,
 			ICommandHandler<SwapMealSlotsCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -238,7 +238,7 @@ public static class MealPlanEndpoints
 		static async Task<IResult> ConfirmMeal(
 			int year,
 			int weekNumber,
-			ConfirmMealRequest request,
+			Requests.ConfirmMeal request,
 			ICommandHandler<ConfirmMealCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -180,7 +180,14 @@ public static class MealPlanEndpoints
 			var week = WeekIdentifier.From(year, weekNumber);
 			var (cookDay, recipeIdentifier, recipeTitle, totalServings, eatServings, leftoverDay, mealType) = request;
 			var recipe = SlotRecipeReference.From(recipeIdentifier, recipeTitle);
-			var command = new CookWithLeftoversCommand(week, cookDay, recipe, SlotServings.From(totalServings), SlotServings.From(eatServings), leftoverDay, mealType);
+			var command = new CookWithLeftoversCommand(
+				week,
+				cookDay,
+				recipe,
+				SlotServings.From(totalServings),
+				SlotServings.From(eatServings),
+				leftoverDay,
+				mealType);
 
 			var result = await handler.HandleAsync(command, cancellationToken);
 
@@ -197,6 +204,7 @@ public static class MealPlanEndpoints
 			var week = WeekIdentifier.From(year, weekNumber);
 			var (day, mealType) = request;
 			var command = new ClearMealSlotCommand(week, day, mealType);
+
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}
@@ -222,6 +230,7 @@ public static class MealPlanEndpoints
 			var week = WeekIdentifier.From(year, weekNumber);
 			var (sourceDay, targetDay, mealType) = request;
 			var command = new SwapMealSlotsCommand(week, sourceDay, targetDay, mealType);
+
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}
@@ -236,6 +245,7 @@ public static class MealPlanEndpoints
 			var week = WeekIdentifier.From(year, weekNumber);
 			var (day, mealType, state) = request;
 			var command = new ConfirmMealCommand(week, day, mealType, state);
+
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}
@@ -247,7 +257,9 @@ public static class MealPlanEndpoints
 			CancellationToken cancellationToken)
 		{
 			var week = WeekIdentifier.From(year, weekNumber);
-			var result = await handler.HandleAsync(new GenerateShoppingListCommand(week), cancellationToken);
+			var command = new GenerateShoppingListCommand(week);
+
+			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}
 	}

--- a/src/Yumney.MealPlan.Api/Requests/AdjustServings.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AdjustServings.cs
@@ -2,4 +2,4 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record ClearSlotRequest(DayOfWeek Day, MealType MealType = MealType.Dinner);
+public sealed record AdjustServings(DayOfWeek Day, MealType MealType, int Servings);

--- a/src/Yumney.MealPlan.Api/Requests/AssignRecipe.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AssignRecipe.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record AssignRecipeRequest(
+public sealed record AssignRecipe(
 	DayOfWeek Day,
 	Guid RecipeIdentifier,
 	string RecipeTitle,

--- a/src/Yumney.MealPlan.Api/Requests/ClearSlot.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ClearSlot.cs
@@ -2,4 +2,4 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record ConfirmMealRequest(DayOfWeek Day, MealType MealType, MealState State);
+public sealed record ClearSlot(DayOfWeek Day, MealType MealType = MealType.Dinner);

--- a/src/Yumney.MealPlan.Api/Requests/ConfirmMeal.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ConfirmMeal.cs
@@ -2,4 +2,4 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record AdjustServingsRequest(DayOfWeek Day, MealType MealType, int Servings);
+public sealed record ConfirmMeal(DayOfWeek Day, MealType MealType, MealState State);

--- a/src/Yumney.MealPlan.Api/Requests/CookWithLeftovers.cs
+++ b/src/Yumney.MealPlan.Api/Requests/CookWithLeftovers.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record CookWithLeftoversRequest(
+public sealed record CookWithLeftovers(
 	DayOfWeek CookDay,
 	Guid RecipeIdentifier,
 	string RecipeTitle,

--- a/src/Yumney.MealPlan.Api/Requests/SwapSlots.cs
+++ b/src/Yumney.MealPlan.Api/Requests/SwapSlots.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
-public sealed record SwapSlotsRequest(
+public sealed record SwapSlots(
 	DayOfWeek SourceDay,
 	DayOfWeek TargetDay,
 	MealType MealType = MealType.Dinner);

--- a/src/Yumney.MealPlan.Api/Requests/ToggleExtendedMode.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ToggleExtendedMode.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
+
+public sealed record ToggleExtendedMode(bool Enable);

--- a/src/Yumney.MealPlan.Api/Requests/ToggleExtendedModeRequest.cs
+++ b/src/Yumney.MealPlan.Api/Requests/ToggleExtendedModeRequest.cs
@@ -1,3 +1,0 @@
-namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
-
-public sealed record ToggleExtendedModeRequest(bool Enable);

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -11,9 +11,12 @@ public sealed class GenerateShoppingListCommandHandler(
 	IRecipeIngredientLookup recipeIngredients,
 	IStaplesProvider staplesProvider,
 	IShoppingListWriter shoppingListWriter,
-	ICurrentUser currentUser) : ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResultDto>>
+	ICurrentUser currentUser)
+	: ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResultDto>>
 {
-	public async Task<Result<GenerateShoppingListResultDto>> HandleAsync(GenerateShoppingListCommand command, CancellationToken cancellationToken = default)
+	public async Task<Result<GenerateShoppingListResultDto>> HandleAsync(
+		GenerateShoppingListCommand command,
+		CancellationToken cancellationToken = default)
 	{
 		var week = command.Week;
 		var owner = currentUser.AsOwner();
@@ -25,7 +28,8 @@ public sealed class GenerateShoppingListCommandHandler(
 
 		foreach (var recipe in planned.Recipes)
 		{
-			var ingredients = await recipeIngredients.LookupAsync(SlotRecipeIdentifier.From(recipe.RecipeIdentifier), cancellationToken);
+			var recipeRef = SlotRecipeIdentifier.From(recipe.RecipeIdentifier);
+			var ingredients = await recipeIngredients.LookupAsync(recipeRef, cancellationToken);
 			var recipeServings = (ingredients.Count > 0 ? ingredients[0].RecipeServings : null) ?? recipe.Servings;
 			var scaleFactor = recipeServings > 0 ? (decimal)recipe.Servings / recipeServings : 1m;
 

--- a/src/Yumney.MealPlan.Application/DTOs/MealHistoryEntryDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealHistoryEntryDto.cs
@@ -1,9 +1,5 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-/// <summary>
-/// One row of cooked-meal history (US-331 search result). Only Cooked slots
-/// are returned — Planned and Skipped are not part of "what I cooked".
-/// </summary>
 public sealed record MealHistoryEntryDto(
 	Guid? RecipeIdentifier,
 	string RecipeTitle,

--- a/src/Yumney.MealPlan.Application/DTOs/RecipeIngredientLookupResult.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/RecipeIngredientLookupResult.cs
@@ -1,3 +1,7 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public sealed record RecipeIngredientLookupResult(string Name, decimal? Amount, string? Unit, int? RecipeServings);
+public sealed record RecipeIngredientLookupResult(
+	string Name,
+	decimal? Amount,
+	string? Unit,
+	int? RecipeServings);

--- a/src/Yumney.MealPlan.Application/DTOs/ShoppingItemRequest.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/ShoppingItemRequest.cs
@@ -1,3 +1,7 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public sealed record ShoppingItemRequest(string ItemName, decimal Quantity, string? Unit, string Source);
+public sealed record ShoppingItemRequest(
+	string ItemName,
+	decimal Quantity,
+	string? Unit,
+	string Source);

--- a/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanDto.cs
@@ -1,3 +1,6 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-public sealed record WeeklyPlanDto(string Week, bool IsExtendedMode, IReadOnlyList<MealSlotDto> Slots);
+public sealed record WeeklyPlanDto(
+	string Week,
+	bool IsExtendedMode,
+	IReadOnlyList<MealSlotDto> Slots);

--- a/src/Yumney.MealPlan.Application/DTOs/WeeklyPlannedRecipesDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/WeeklyPlannedRecipesDto.cs
@@ -1,8 +1,5 @@
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 
-/// <summary>
-/// All recipes planned for a week — input for shopping list generation.
-/// </summary>
 public sealed record WeeklyPlannedRecipesDto(
 	string Week,
 	IReadOnlyList<PlannedRecipeDto> Recipes);

--- a/src/Yumney.MealPlan.Application/Interfaces/IMealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IMealPlanReadModelRepository.cs
@@ -3,39 +3,21 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 
-/// <summary>
-/// Read model repository for the meal plan projection.
-/// </summary>
 public interface IMealPlanReadModelRepository
 {
-	/// <summary>
-	/// Returns the weekly plan view. If no plan exists, returns a placeholder
-	/// view with seven empty Dinner slots so the UI can render the empty week.
-	/// </summary>
-	/// <param name="owner">The owner identifier.</param>
-	/// <param name="week">The week identifier.</param>
-	/// <param name="cancellationToken">Cancellation token.</param>
-	/// <returns>The weekly plan view.</returns>
-	Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default);
+	Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(
+		OwnerIdentifier owner,
+		WeekIdentifier week,
+		CancellationToken cancellationToken = default);
 
-	/// <summary>
-	/// Returns the planned recipes for the week (Recipe-typed slots only).
-	/// Empty result if no plan exists.
-	/// </summary>
-	/// <param name="owner">The owner identifier.</param>
-	/// <param name="week">The week identifier.</param>
-	/// <param name="cancellationToken">Cancellation token.</param>
-	/// <returns>The planned recipes for the week.</returns>
-	Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default);
+	Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(
+		OwnerIdentifier owner,
+		WeekIdentifier week,
+		CancellationToken cancellationToken = default);
 
-	/// <summary>
-	/// Searches cooked-state slots by recipe title (case-insensitive substring),
-	/// newest week first. Empty / null term returns the most recent cooked meals.
-	/// </summary>
-	/// <param name="owner">The owner identifier.</param>
-	/// <param name="term">Optional substring to match against the slot's recipe title.</param>
-	/// <param name="limit">Max number of rows to return.</param>
-	/// <param name="cancellationToken">Cancellation token.</param>
-	/// <returns>The matching history entries, newest first.</returns>
-	Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(OwnerIdentifier owner, string? term, int limit, CancellationToken cancellationToken = default);
+	Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(
+		OwnerIdentifier owner,
+		string? term,
+		int limit,
+		CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.MealPlan.Application/Interfaces/IRecipeIngredientLookup.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IRecipeIngredientLookup.cs
@@ -5,5 +5,7 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 
 public interface IRecipeIngredientLookup
 {
-	Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(SlotRecipeIdentifier recipe, CancellationToken cancellationToken = default);
+	Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
+		SlotRecipeIdentifier recipe,
+		CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.MealPlan.Application/Interfaces/IShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IShoppingListWriter.cs
@@ -5,5 +5,8 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 
 public interface IShoppingListWriter
 {
-	Task AddItemsAsync(OwnerIdentifier owner, IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default);
+	Task AddItemsAsync(
+		OwnerIdentifier owner,
+		IReadOnlyList<ShoppingItemRequest> items,
+		CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetPlannedRecipesQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetPlannedRecipesQueryHandler.cs
@@ -8,7 +8,9 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
 public sealed class GetPlannedRecipesQueryHandler(IMealPlanReadModelRepository readModel, ICurrentUser currentUser)
 	: IQueryHandler<GetPlannedRecipesQuery, Result<WeeklyPlannedRecipesDto>>
 {
-	public async Task<Result<WeeklyPlannedRecipesDto>> HandleAsync(GetPlannedRecipesQuery query, CancellationToken cancellationToken = default)
+	public async Task<Result<WeeklyPlannedRecipesDto>> HandleAsync(
+		GetPlannedRecipesQuery query,
+		CancellationToken cancellationToken = default)
 	{
 		var owner = currentUser.AsOwner();
 		return await readModel.GetPlannedRecipesAsync(owner, query.Week, cancellationToken);

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/SearchMealHistoryQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/SearchMealHistoryQueryHandler.cs
@@ -13,11 +13,14 @@ public sealed class SearchMealHistoryQueryHandler(IMealPlanReadModelRepository r
 	private const int maxLimit = 100;
 #pragma warning restore SA1303
 
-	public async Task<Result<IReadOnlyList<MealHistoryEntryDto>>> HandleAsync(SearchMealHistoryQuery query, CancellationToken cancellationToken = default)
+	public async Task<Result<IReadOnlyList<MealHistoryEntryDto>>> HandleAsync(
+		SearchMealHistoryQuery query,
+		CancellationToken cancellationToken = default)
 	{
 		var owner = currentUser.AsOwner();
 		var limit = Math.Clamp(query.Limit, minLimit, maxLimit);
-		return Result<IReadOnlyList<MealHistoryEntryDto>>.Success(
-			await readModel.SearchCookedHistoryAsync(owner, query.Term, limit, cancellationToken));
+
+		var result = await readModel.SearchCookedHistoryAsync(owner, query.Term, limit, cancellationToken);
+		return Result<IReadOnlyList<MealHistoryEntryDto>>.Success(result);
 	}
 }

--- a/src/Yumney.MealPlan.Application/Queries/SearchMealHistoryQuery.cs
+++ b/src/Yumney.MealPlan.Application/Queries/SearchMealHistoryQuery.cs
@@ -4,11 +4,7 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
 
-/// <summary>
-/// "When did I last cook X?" (US-331). Returns cooked-state meal slots whose
-/// recipe title matches the term (case-insensitive substring), newest first.
-/// Empty term returns the most recent cooked meals across all recipes — useful
-/// for the history view's default state.
-/// </summary>
-public sealed record SearchMealHistoryQuery(string? Term = null, int Limit = 20)
+public sealed record SearchMealHistoryQuery(
+	string? Term = null,
+	int Limit = 20)
 	: IQuery<Result<IReadOnlyList<MealHistoryEntryDto>>>;

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
@@ -7,7 +7,9 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
 public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFactory) : IRecipeIngredientLookup
 {
-	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(SlotRecipeIdentifier recipe, CancellationToken cancellationToken = default)
+	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
+		SlotRecipeIdentifier recipe,
+		CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("recipes-api");
 		var url = $"/api/v1/recipes/{recipe.Value}";

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
@@ -7,11 +7,14 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
 public sealed class HttpShoppingListWriter(IHttpClientFactory httpClientFactory) : IShoppingListWriter
 {
-	public async Task AddItemsAsync(OwnerIdentifier owner, IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default)
+	public async Task AddItemsAsync(
+		OwnerIdentifier owner,
+		IReadOnlyList<ShoppingItemRequest> items,
+		CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("shopping-api");
 
-		foreach (var (itemName, quantity, unit, source) in items)
+		await foreach (var (itemName, quantity, unit, source) in items.ToAsyncEnumerable().WithCancellation(cancellationToken))
 		{
 			AddItemRequest request = new(itemName, quantity, unit, source);
 			await client.PostAsJsonAsync("/api/v1/shopping-lists/items", request, cancellationToken);

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
-using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Web;
 

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
@@ -22,14 +23,18 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 			.MigrationsHistoryTable("__MealPlanMigrationsHistory")
 			.EnableRetryOnFailure();
 
+		services.AddQueryCounting();
+
 		services.AddDbContext<MealPlanDbContext>((_, options) =>
 		{
 			options.UseNpgsql(connectionString, contextOptions);
 		});
 
-		services.AddDbContext<MealPlanReadDbContext>(options =>
+		services.AddDbContext<MealPlanReadDbContext>((sp, options) =>
 		{
-			options.UseNpgsql(connectionString, contextOptions);
+			options
+				.UseNpgsql(connectionString, contextOptions)
+				.AddInterceptors(sp.GetRequiredService<QueryCountingInterceptor>());
 		});
 
 		services.AddScoped<IMealPlanEventStore, EfCoreMealPlanEventStore>();

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -1,7 +1,5 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
@@ -18,50 +16,23 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 {
 	public static IServiceCollection AddMealPlanInfrastructure(this IServiceCollection services, IConfiguration configuration)
 	{
-		var connectionString = configuration.GetConnectionString("mealplandb");
-		Action<NpgsqlDbContextOptionsBuilder> contextOptions = builder => builder
-			.MigrationsHistoryTable("__MealPlanMigrationsHistory")
-			.EnableRetryOnFailure();
-
-		services.AddQueryCounting();
-
-		services.AddDbContext<MealPlanDbContext>((_, options) =>
-		{
-			options.UseNpgsql(connectionString, contextOptions);
-		});
-
-		services.AddDbContext<MealPlanReadDbContext>((sp, options) =>
-		{
-			options
-				.UseNpgsql(connectionString, contextOptions)
-				.AddInterceptors(sp.GetRequiredService<QueryCountingInterceptor>());
-		});
+		services.AddYumneyNpgsqlDbContext<MealPlanDbContext>(configuration, "mealplandb", "__MealPlanMigrationsHistory");
+		services.AddYumneyNpgsqlDbContext<MealPlanReadDbContext>(
+			configuration,
+			"mealplandb",
+			"__MealPlanMigrationsHistory",
+			typeof(QueryCountingInterceptor));
 
 		services.AddScoped<IMealPlanEventStore, EfCoreMealPlanEventStore>();
 		services.AddScoped<IMealPlanReadModelRepository, MealPlanReadModelRepository>();
-		services.AddScoped<IIntegrationEventHandler<WeeklyPlanCreatedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ExtendedModeEnabledIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ExtendedModeDisabledIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<RecipeAssignedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealSetAsFreetextIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<LeftoverAssignedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealSlotClearedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ServingsAdjustedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealMarkedAsCookedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealMarkedAsSkippedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealResetToPlannedIntegrationEvent>, MealPlanProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealSlotsSwappedIntegrationEvent>, MealPlanProjectionHandler>();
+		services.AddIntegrationEventHandlersFromAssemblyContaining<MealPlanProjectionHandler>();
 
 		services.AddScoped<IRecipeIngredientLookup, HttpRecipeIngredientLookup>();
 		services.AddScoped<IShoppingListWriter, HttpShoppingListWriter>();
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
-		services.AddTransient<AuthTokenDelegatingHandler>();
-		services.AddHttpClient("recipes-api", client => client.BaseAddress = new Uri("http://recipes-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
-		services.AddHttpClient("shopping-api", client => client.BaseAddress = new Uri("http://shopping-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
-		services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
+		services.AddYumneyServiceClient("recipes-api");
+		services.AddYumneyServiceClient("shopping-api");
+		services.AddYumneyServiceClient("users-api");
 		services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb");
 
 		return services;

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
@@ -57,16 +57,14 @@ public sealed partial class EfCoreMealPlanEventStore(
 		var ownerValue = owner.Value;
 		var weekValue = week.Value;
 
-		var metadata = await context.Set<AggregateMetadata>()
-			.AsNoTracking()
+		var metadata = await context.Set<AggregateMetadata>().AsNoTracking()
 			.FirstOrDefaultAsync(m => m.OwnerId == ownerValue && m.Week == weekValue, cancellationToken);
 
 		if (metadata is null) return null;
 
 		var aggregateId = metadata.AggregateId;
 
-		var storedEvents = await context.Set<StoredEvent>()
-			.AsNoTracking()
+		var storedEvents = await context.Set<StoredEvent>().AsNoTracking()
 			.Where(stored => stored.AggregateId == aggregateId)
 			.OrderBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
@@ -126,7 +124,11 @@ public sealed partial class EfCoreMealPlanEventStore(
 		LogEventsSaved(plan.Owner.Value, plan.Week.Value, uncommitted.Count, plan.Version);
 	}
 
-	private async Task PublishEventsAsync(string ownerId, string week, List<IDomainEvent> events, CancellationToken cancellationToken)
+	private async Task PublishEventsAsync(
+		string ownerId,
+		string week,
+		List<IDomainEvent> events,
+		CancellationToken cancellationToken)
 	{
 		foreach (var @event in events)
 		{
@@ -158,8 +160,10 @@ public sealed partial class EfCoreMealPlanEventStore(
 					ownerId,
 					confirmed.Recipe.RecipeIdentifier.Value,
 					confirmed.Servings.Value,
-					confirmed.Ingredients
-						.Select(ingredient => new MealConfirmedIngredient(ingredient.Name, ingredient.Quantity, ingredient.Unit))
+					confirmed.Ingredients.Select(ingredient => new MealConfirmedIngredient(
+							ingredient.Name,
+							ingredient.Quantity,
+							ingredient.Unit))
 						.ToList());
 				await PublishAsync(crossModule, cancellationToken);
 			}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/EfCoreMealPlanEventStore.cs
@@ -69,7 +69,10 @@ public sealed partial class EfCoreMealPlanEventStore(
 			.OrderBy(stored => stored.Version)
 			.ToListAsync(cancellationToken);
 
-		var events = storedEvents.Select(DeserializeEvent).Where(deserialized => deserialized is not null).Cast<IDomainEvent>();
+		var events = storedEvents
+			.Select(DeserializeEvent)
+			.Where(deserialized => deserialized is not null)
+			.Cast<IDomainEvent>();
 
 		return WeeklyPlan.FromEvents(WeeklyPlanIdentifier.From(aggregateId), events);
 	}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
@@ -27,8 +27,13 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 #pragma warning disable SA1311
 	private static readonly DayOfWeek[] allDays =
 	[
-		DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday,
-		DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday,
+		DayOfWeek.Monday,
+		DayOfWeek.Tuesday,
+		DayOfWeek.Wednesday,
+		DayOfWeek.Thursday,
+		DayOfWeek.Friday,
+		DayOfWeek.Saturday,
+		DayOfWeek.Sunday,
 	];
 #pragma warning restore SA1311
 
@@ -55,7 +60,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in allDays)
 		{
-			await UpsertSlotAsync(ownerId, week, day.ToString(), MealType.Dinner.ToString(), defaultServings, cancellationToken);
+			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Dinner), defaultServings, cancellationToken);
 		}
 	}
 
@@ -75,8 +80,8 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in allDays)
 		{
-			await UpsertSlotAsync(ownerId, week, day.ToString(), MealType.Breakfast.ToString(), defaultServings, cancellationToken);
-			await UpsertSlotAsync(ownerId, week, day.ToString(), MealType.Lunch.ToString(), defaultServings, cancellationToken);
+			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Breakfast), defaultServings, cancellationToken);
+			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Lunch), defaultServings, cancellationToken);
 		}
 	}
 
@@ -95,7 +100,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.ContentType = SlotContentType.Recipe.ToString();
+		slot.ContentType = nameof(SlotContentType.Recipe);
 		slot.RecipeIdentifier = inner.Recipe.RecipeIdentifier.Value;
 		slot.RecipeTitle = inner.Recipe.Title.Value;
 		slot.FreetextLabel = null;
@@ -116,7 +121,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.ContentType = SlotContentType.Freetext.ToString();
+		slot.ContentType = nameof(SlotContentType.Freetext);
 		slot.FreetextLabel = inner.Label.Value;
 		slot.RecipeIdentifier = null;
 		slot.RecipeTitle = null;
@@ -132,7 +137,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.ContentType = SlotContentType.Leftover.ToString();
+		slot.ContentType = nameof(SlotContentType.Leftover);
 		slot.LeftoverLabel = LeftoverLabel.ForRecipe(inner.SourceRecipeTitle).Value;
 		slot.LeftoverSourceDay = inner.SourceDay.ToString();
 		slot.LeftoverSourceMealType = inner.SourceMealType.ToString();
@@ -153,7 +158,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.ContentType = SlotContentType.Empty.ToString();
+		slot.ContentType = nameof(SlotContentType.Empty);
 		slot.RecipeIdentifier = null;
 		slot.RecipeTitle = null;
 		slot.FreetextLabel = null;
@@ -179,7 +184,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.State = MealState.Cooked.ToString();
+		slot.State = nameof(MealState.Cooked);
 		slot.LastUpdated = DateTime.UtcNow;
 		await context.SaveChangesAsync(cancellationToken);
 	}
@@ -189,7 +194,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.State = MealState.Skipped.ToString();
+		slot.State = nameof(MealState.Skipped);
 		slot.LastUpdated = DateTime.UtcNow;
 		await context.SaveChangesAsync(cancellationToken);
 	}
@@ -199,7 +204,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var inner = @event.Inner;
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
-		slot.State = MealState.Planned.ToString();
+		slot.State = nameof(MealState.Planned);
 		slot.LastUpdated = DateTime.UtcNow;
 		await context.SaveChangesAsync(cancellationToken);
 	}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
@@ -18,7 +18,7 @@ public static class MealPlanReadModelMappingExtensions
 			row.LeftoverLabel,
 			row.LeftoverSourceDay,
 			row.LeftoverSourceMealType,
-			row.ContentType == SlotContentType.Empty.ToString());
+			row.ContentType == nameof(SlotContentType.Empty));
 
 	public static IReadOnlyList<MealSlotDto> ToDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
 		rows
@@ -36,7 +36,9 @@ public static class MealPlanReadModelMappingExtensions
 			row.MealType);
 
 	public static IReadOnlyList<PlannedRecipeDto> ToPlannedRecipeDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
-		rows.Select(row => row.ToPlannedRecipeDto()).ToList();
+		rows
+			.Select(row => row.ToPlannedRecipeDto())
+			.ToList();
 
 	public static MealHistoryEntryDto ToHistoryEntryDto(this MealPlanSlotReadItem row) =>
 		new(
@@ -47,5 +49,7 @@ public static class MealPlanReadModelMappingExtensions
 			row.MealType);
 
 	public static IReadOnlyList<MealHistoryEntryDto> ToHistoryEntryDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
-		rows.Select(row => row.ToHistoryEntryDto()).ToList();
+		rows
+			.Select(row => row.ToHistoryEntryDto())
+			.ToList();
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -15,7 +15,10 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 	];
 #pragma warning restore SA1311
 
-	public async Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+	public async Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(
+		OwnerIdentifier owner,
+		WeekIdentifier week,
+		CancellationToken cancellationToken = default)
 	{
 		var ownerId = owner.Value;
 		var weekValue = week.Value;
@@ -39,7 +42,10 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		return new WeeklyPlanDto(weekValue, weekItem.IsExtendedMode, visible.ToDtos());
 	}
 
-	public async Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+	public async Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(
+		OwnerIdentifier owner,
+		WeekIdentifier week,
+		CancellationToken cancellationToken = default)
 	{
 		var ownerId = owner.Value;
 		var weekValue = week.Value;
@@ -55,7 +61,11 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		return new WeeklyPlannedRecipesDto(weekValue, slotRows.ToPlannedRecipeDtos());
 	}
 
-	public async Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(OwnerIdentifier owner, string? term, int limit, CancellationToken cancellationToken = default)
+	public async Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(
+		OwnerIdentifier owner,
+		string? term,
+		int limit,
+		CancellationToken cancellationToken = default)
 	{
 		var ownerId = owner.Value;
 		var cookedState = MealState.Cooked.ToString();

--- a/src/Yumney.Recipes.Api/Program.cs
+++ b/src/Yumney.Recipes.Api/Program.cs
@@ -1,5 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Api;
 using SmartSolutionsLab.Yumney.Recipes.Application;
+using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Recipes.Extraction;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
@@ -7,7 +8,7 @@ using SmartSolutionsLab.Yumney.Shared.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddYumneyDefaults();
+builder.AddYumneyDefaults(typeof(ShoppingListCreatedHandler).Assembly);
 
 builder.Services
 	.AddRecipesApi()

--- a/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ public static class RecipesApiServiceCollectionExtensions
 {
 	public static IServiceCollection AddRecipesApi(this IServiceCollection services)
 	{
-		services.AddValidatorsFromAssemblyContaining<ImportRecipeRequestValidator>();
+		services.AddValidatorsFromAssemblyContaining<ImportRecipeValidator>();
 		services.AddValidatorsFromAssemblyContaining<PhotoDataValidator>();
 
 		return services;

--- a/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Api/RecipesApiServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
 using FluentValidation;
-using Microsoft.Extensions.DependencyInjection;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using System.Text.Json;
 using FluentValidation;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.Common;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
@@ -11,6 +10,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using Requests = SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -144,8 +144,8 @@ public static partial class RecipesEndpoints
 			.RequireRateLimiting("RecipeImport");
 
 		static async Task<IResult> Import(
-			ImportRecipeRequest request,
-			IValidator<ImportRecipeRequest> validator,
+			Requests.ImportRecipe request,
+			IValidator<Requests.ImportRecipe> validator,
 			ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>> handler,
 			CancellationToken cancellationToken)
 		{

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
@@ -8,6 +7,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using Requests = SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -81,8 +81,8 @@ public static partial class RecipesEndpoints
 			.ProducesProblem(StatusCodes.Status409Conflict);
 
 		static async Task<IResult> Save(
-			SaveRecipeRequest request,
-			IValidator<SaveRecipeRequest> validator,
+			Requests.SaveRecipe request,
+			IValidator<Requests.SaveRecipe> validator,
 			ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -117,8 +117,8 @@ public static partial class RecipesEndpoints
 
 		static async Task<IResult> Update(
 			Guid identifier,
-			UpdateRecipeRequest request,
-			IValidator<UpdateRecipeRequest> validator,
+			Requests.UpdateRecipe request,
+			IValidator<Requests.UpdateRecipe> validator,
 			ICommandHandler<UpdateRecipeCommand, Result<RecipeDetailDto>> handler,
 			CancellationToken cancellationToken)
 		{

--- a/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
+++ b/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
@@ -8,7 +8,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
 internal static class RequestMappingExtensions
 {
-	extension(SaveRecipeIngredientRequest request)
+	extension(SaveRecipeIngredient request)
 	{
 		public SaveRecipeIngredientItem ToCommandItem()
 		{
@@ -22,7 +22,7 @@ internal static class RequestMappingExtensions
 		}
 	}
 
-	extension(IEnumerable<SaveRecipeIngredientRequest> items)
+	extension(IEnumerable<SaveRecipeIngredient> items)
 	{
 		public IEnumerable<SaveRecipeIngredientItem> MapToRecipeIngredientItems()
 		{
@@ -30,7 +30,7 @@ internal static class RequestMappingExtensions
 		}
 	}
 
-	extension(SaveRecipeStepRequest request)
+	extension(SaveRecipeStep request)
 	{
 		public SaveRecipeStepItem ToCommandItem()
 		{
@@ -42,7 +42,7 @@ internal static class RequestMappingExtensions
 		}
 	}
 
-	extension(IEnumerable<SaveRecipeStepRequest> items)
+	extension(IEnumerable<SaveRecipeStep> items)
 	{
 		public IEnumerable<SaveRecipeStepItem> MapToRecipeStepItems()
 		{

--- a/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
+++ b/src/Yumney.Recipes.Api/RequestMappingExtensions.cs
@@ -26,10 +26,7 @@ internal static class RequestMappingExtensions
 	{
 		public IEnumerable<SaveRecipeIngredientItem> MapToRecipeIngredientItems()
 		{
-			foreach (var item in items)
-			{
-				yield return item.ToCommandItem();
-			}
+			return items.Select(item => item.ToCommandItem());
 		}
 	}
 
@@ -49,10 +46,7 @@ internal static class RequestMappingExtensions
 	{
 		public IEnumerable<SaveRecipeStepItem> MapToRecipeStepItems()
 		{
-			foreach (var item in items)
-			{
-				yield return item.ToCommandItem();
-			}
+			return items.Select(item => item.ToCommandItem());
 		}
 	}
 

--- a/src/Yumney.Recipes.Api/Requests/ImportRecipe.cs
+++ b/src/Yumney.Recipes.Api/Requests/ImportRecipe.cs
@@ -1,3 +1,3 @@
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
-public sealed record ImportRecipeRequest(string Url);
+public sealed record ImportRecipe(string Url);

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipe.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipe.cs
@@ -3,11 +3,11 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
-public sealed record SaveRecipeRequest(
+public sealed record SaveRecipe(
 	string Title,
 	string? Description,
-	List<SaveRecipeIngredientRequest> Ingredients,
-	List<SaveRecipeStepRequest> Steps,
+	List<SaveRecipeIngredient> Ingredients,
+	List<SaveRecipeStep> Steps,
 	int? Servings,
 	int? PrepTimeMinutes,
 	int? CookTimeMinutes,

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeIngredient.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeIngredient.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
+
+public sealed record SaveRecipeIngredient(string Name, decimal? Amount, string? Unit);

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeIngredientRequest.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeIngredientRequest.cs
@@ -1,3 +1,0 @@
-namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
-
-public sealed record SaveRecipeIngredientRequest(string Name, decimal? Amount, string? Unit);

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeStep.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeStep.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
+
+public sealed record SaveRecipeStep(int Number, string Description);

--- a/src/Yumney.Recipes.Api/Requests/SaveRecipeStepRequest.cs
+++ b/src/Yumney.Recipes.Api/Requests/SaveRecipeStepRequest.cs
@@ -1,3 +1,0 @@
-namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
-
-public sealed record SaveRecipeStepRequest(int Number, string Description);

--- a/src/Yumney.Recipes.Api/Requests/UpdateRecipe.cs
+++ b/src/Yumney.Recipes.Api/Requests/UpdateRecipe.cs
@@ -3,11 +3,11 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
-public sealed record UpdateRecipeRequest(
+public sealed record UpdateRecipe(
 	string Title,
 	string? Description,
-	List<SaveRecipeIngredientRequest> Ingredients,
-	List<SaveRecipeStepRequest> Steps,
+	List<SaveRecipeIngredient> Ingredients,
+	List<SaveRecipeStep> Steps,
 	int? Servings,
 	int? PrepTimeMinutes,
 	int? CookTimeMinutes,

--- a/src/Yumney.Recipes.Api/Requests/Validator/ImportRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/ImportRecipeValidator.cs
@@ -4,9 +4,9 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 
-public sealed class ImportRecipeRequestValidator : AbstractValidator<ImportRecipeRequest>
+public sealed class ImportRecipeValidator : AbstractValidator<ImportRecipe>
 {
-	public ImportRecipeRequestValidator()
+	public ImportRecipeValidator()
 	{
 		RuleFor(x => x.Url)
 			.NotEmpty()

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeIngredientValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeIngredientValidator.cs
@@ -3,9 +3,9 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 
-public sealed class SaveRecipeIngredientRequestValidator : AbstractValidator<SaveRecipeIngredientRequest>
+public sealed class SaveRecipeIngredientValidator : AbstractValidator<SaveRecipeIngredient>
 {
-	public SaveRecipeIngredientRequestValidator()
+	public SaveRecipeIngredientValidator()
 	{
 		RuleFor(i => i.Name)
 			.NotEmpty()

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeStepValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeStepValidator.cs
@@ -3,9 +3,9 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 
-public sealed class SaveRecipeStepRequestValidator : AbstractValidator<SaveRecipeStepRequest>
+public sealed class SaveRecipeStepValidator : AbstractValidator<SaveRecipeStep>
 {
-	public SaveRecipeStepRequestValidator()
+	public SaveRecipeStepValidator()
 	{
 		RuleFor(s => s.Number)
 			.GreaterThan(0);

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeValidator.cs
@@ -5,14 +5,33 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 
-public sealed class UpdateRecipeRequestValidator : AbstractValidator<UpdateRecipeRequest>
+public sealed class SaveRecipeValidator : AbstractValidator<SaveRecipe>
 {
-	public UpdateRecipeRequestValidator()
+	public SaveRecipeValidator()
 	{
 		RuleFor(x => x.Title)
 			.NotEmpty()
 			.MaximumLength(RecipeTitle.MaxLength);
 
+		RuleFor(x => x.SourceUrl!)
+			.MustBeValidHttpUrl(RecipeUrl.MaxLength)
+			.When(x => x.SourceUrl.HasValue());
+
+		ConfigureOptionalFieldRules();
+
+		RuleFor(x => x.Ingredients)
+			.NotEmpty()
+			.WithMessage("At least one ingredient is required.");
+		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
+
+		RuleFor(x => x.Steps)
+			.NotEmpty()
+			.WithMessage("At least one step is required.");
+		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepValidator());
+	}
+
+	private void ConfigureOptionalFieldRules()
+	{
 		RuleFor(x => x.Description)
 			.MaximumLength(RecipeDescription.MaxLength)
 			.When(x => x.Description is not null);
@@ -37,15 +56,5 @@ public sealed class UpdateRecipeRequestValidator : AbstractValidator<UpdateRecip
 		RuleFor(x => x.CookTimeMinutes)
 			.GreaterThanOrEqualTo(0)
 			.When(x => x.CookTimeMinutes.HasValue);
-
-		RuleFor(x => x.Ingredients)
-			.NotEmpty()
-			.WithMessage("At least one ingredient is required.");
-		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientRequestValidator());
-
-		RuleFor(x => x.Steps)
-			.NotEmpty()
-			.WithMessage("At least one step is required.");
-		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepRequestValidator());
 	}
 }

--- a/src/Yumney.Recipes.Api/Requests/Validator/UpdateRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/UpdateRecipeValidator.cs
@@ -5,33 +5,14 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 
-public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeRequest>
+public sealed class UpdateRecipeValidator : AbstractValidator<UpdateRecipe>
 {
-	public SaveRecipeRequestValidator()
+	public UpdateRecipeValidator()
 	{
 		RuleFor(x => x.Title)
 			.NotEmpty()
 			.MaximumLength(RecipeTitle.MaxLength);
 
-		RuleFor(x => x.SourceUrl!)
-			.MustBeValidHttpUrl(RecipeUrl.MaxLength)
-			.When(x => x.SourceUrl.HasValue());
-
-		ConfigureOptionalFieldRules();
-
-		RuleFor(x => x.Ingredients)
-			.NotEmpty()
-			.WithMessage("At least one ingredient is required.");
-		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientRequestValidator());
-
-		RuleFor(x => x.Steps)
-			.NotEmpty()
-			.WithMessage("At least one step is required.");
-		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepRequestValidator());
-	}
-
-	private void ConfigureOptionalFieldRules()
-	{
 		RuleFor(x => x.Description)
 			.MaximumLength(RecipeDescription.MaxLength)
 			.When(x => x.Description is not null);
@@ -56,5 +37,15 @@ public sealed class SaveRecipeRequestValidator : AbstractValidator<SaveRecipeReq
 		RuleFor(x => x.CookTimeMinutes)
 			.GreaterThanOrEqualTo(0)
 			.When(x => x.CookTimeMinutes.HasValue);
+
+		RuleFor(x => x.Ingredients)
+			.NotEmpty()
+			.WithMessage("At least one ingredient is required.");
+		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
+
+		RuleFor(x => x.Steps)
+			.NotEmpty()
+			.WithMessage("At least one step is required.");
+		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepValidator());
 	}
 }

--- a/src/Yumney.Recipes.Api/StreamingJsonFieldDetector.cs
+++ b/src/Yumney.Recipes.Api/StreamingJsonFieldDetector.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
 /// <summary>
@@ -131,7 +133,7 @@ internal sealed class StreamingJsonFieldDetector
 					// waits for the next chunk.
 					if (i + 5 >= json.Length) return (-1, string.Empty);
 					var hex = json.AsSpan(i + 2, 4);
-					if (!ushort.TryParse(hex, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var code))
+					if (!ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var code))
 					{
 						return (-1, string.Empty);
 					}

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListCreatedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListCreatedHandler.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
+
+// Stub consumer: the event is published by Shopping but Recipes does not yet
+// react to it. Registered so the architecture test that requires every
+// integration event to have at least one handler stays green; replace the
+// no-op with real logic when a Recipes-side reaction is defined.
+public sealed class ShoppingListCreatedHandler : IIntegrationEventHandler<ShoppingListCreatedCrossModuleIntegrationEvent>
+{
+	public Task HandleAsync(ShoppingListCreatedCrossModuleIntegrationEvent @event, CancellationToken cancellationToken = default) =>
+		Task.CompletedTask;
+}

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListRecipeReferenceClearedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListRecipeReferenceClearedHandler.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
+
+// Stub consumer: the event is published by Shopping but Recipes does not yet
+// react to it. Registered so the architecture test that requires every
+// integration event to have at least one handler stays green; replace the
+// no-op with real logic when a Recipes-side reaction is defined.
+public sealed class ShoppingListRecipeReferenceClearedHandler : IIntegrationEventHandler<ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent>
+{
+	public Task HandleAsync(ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent @event, CancellationToken cancellationToken = default) =>
+		Task.CompletedTask;
+}

--- a/src/Yumney.Recipes.Application/RecipesApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Application/RecipesApplicationServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application;
 
@@ -9,6 +12,8 @@ public static class RecipesApplicationServiceCollectionExtensions
 	public static IServiceCollection AddRecipesApplication(this IServiceCollection services)
 	{
 		services.AddHandlersFromAssemblyContaining<ImportRecipeCommandHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedCrossModuleIntegrationEvent>, ShoppingListCreatedHandler>();
+		services.AddScoped<IIntegrationEventHandler<ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent>, ShoppingListRecipeReferenceClearedHandler>();
 
 		return services;
 	}

--- a/src/Yumney.Recipes.Application/RecipesApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Application/RecipesApplicationServiceCollectionExtensions.cs
@@ -1,9 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
-using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application;
 
@@ -12,8 +10,7 @@ public static class RecipesApplicationServiceCollectionExtensions
 	public static IServiceCollection AddRecipesApplication(this IServiceCollection services)
 	{
 		services.AddHandlersFromAssemblyContaining<ImportRecipeCommandHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedCrossModuleIntegrationEvent>, ShoppingListCreatedHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent>, ShoppingListRecipeReferenceClearedHandler>();
+		services.AddIntegrationEventHandlersFromAssemblyContaining<ImportRecipeCommandHandler>();
 
 		return services;
 	}

--- a/src/Yumney.Recipes.Extraction/Yumney.Recipes.Extraction.csproj
+++ b/src/Yumney.Recipes.Extraction/Yumney.Recipes.Extraction.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" />
-    <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
   </ItemGroup>

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -16,23 +16,19 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 {
 	public static IServiceCollection AddRecipesInfrastructure(this IServiceCollection services, IConfiguration configuration)
 	{
-		services.AddDbContext<RecipesDbContext>((sp, options) =>
-		{
-			var connectionString = configuration.GetConnectionString("recipesdb");
-			options.UseNpgsql(connectionString, x => x.MigrationsHistoryTable("__RecipesMigrationsHistory").EnableRetryOnFailure())
-				   .AddInterceptors(sp.GetRequiredService<DomainEventDispatchInterceptor>());
-		});
+		services.AddYumneyNpgsqlDbContext<RecipesDbContext>(
+			configuration,
+			"recipesdb",
+			"__RecipesMigrationsHistory",
+			typeof(DomainEventDispatchInterceptor));
 
 		services.AddScoped<IRecipeRepository, RecipeRepository>();
 		services.AddScoped<IRecipeFavoriteRepository, RecipeFavoriteRepository>();
 		services.AddScoped<IRecipesUnitOfWork, RecipesUnitOfWork>();
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
-		services.AddTransient<AuthTokenDelegatingHandler>();
-		services.AddHttpClient("shopping-api", client => client.BaseAddress = new Uri("http://shopping-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
-		services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
+		services.AddYumneyServiceClient("shopping-api");
+		services.AddYumneyServiceClient("users-api");
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
 		return services;

--- a/src/Yumney.Shared.Events/CrossModule/MealConfirmedIngredient.cs
+++ b/src/Yumney.Shared.Events/CrossModule/MealConfirmedIngredient.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+public sealed record MealConfirmedIngredient(string Name, decimal Quantity, string? Unit);

--- a/src/Yumney.Shared.Events/CrossModule/MealConfirmedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/MealConfirmedIntegrationEvent.cs
@@ -11,5 +11,3 @@ public sealed record MealConfirmedIntegrationEvent(
 	Guid RecipeIdentifier,
 	int Servings,
 	IReadOnlyList<MealConfirmedIngredient> Ingredients) : IntegrationEvent;
-
-public sealed record MealConfirmedIngredient(string Name, decimal Quantity, string? Unit);

--- a/src/Yumney.Shared.Events/IntegrationEventHandlerRegistration.cs
+++ b/src/Yumney.Shared.Events/IntegrationEventHandlerRegistration.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events;
+
+public static class IntegrationEventHandlerRegistration
+{
+	public static IServiceCollection AddIntegrationEventHandlersFromAssemblyContaining<T>(this IServiceCollection services) =>
+		services.AddIntegrationEventHandlers(typeof(T).Assembly);
+
+	public static IServiceCollection AddIntegrationEventHandlers(this IServiceCollection services, Assembly assembly)
+	{
+		var openHandler = typeof(IIntegrationEventHandler<>);
+
+		var implementations = assembly.GetTypes()
+			.Where(type => type is { IsAbstract: false, IsInterface: false })
+			.Select(type => (Implementation: type, Interfaces: type.GetInterfaces()
+				.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == openHandler)
+				.ToArray()))
+			.Where(pair => pair.Interfaces.Length > 0);
+
+		// Register the concrete handler once as scoped, then point every
+		// IIntegrationEventHandler<TEvent> at that single instance per scope.
+		// Without the concrete registration, a handler that consumes N events
+		// would be instantiated N times per scope.
+		foreach (var (implementation, interfaces) in implementations)
+		{
+			services.AddScoped(implementation);
+			foreach (var iface in interfaces)
+			{
+				services.AddScoped(iface, sp => sp.GetRequiredService(implementation));
+			}
+		}
+
+		return services;
+	}
+}

--- a/src/Yumney.Shared.Events/Yumney.Shared.Events.csproj
+++ b/src/Yumney.Shared.Events/Yumney.Shared.Events.csproj
@@ -4,4 +4,8 @@
     <ProjectReference Include="..\Yumney.Shared\Yumney.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
 </Project>

--- a/src/Yumney.Shared.Persistence/NpgsqlDbContextRegistration.cs
+++ b/src/Yumney.Shared.Persistence/NpgsqlDbContextRegistration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SmartSolutionsLab.Yumney.Shared.Persistence;
+
+public static class NpgsqlDbContextRegistration
+{
+	public static IServiceCollection AddYumneyNpgsqlDbContext<TContext>(
+		this IServiceCollection services,
+		IConfiguration configuration,
+		string connectionName,
+		string migrationsHistoryTable,
+		params Type[] interceptorTypes)
+		where TContext : DbContext
+	{
+		var connectionString = configuration.GetConnectionString(connectionName);
+
+		services.AddDbContext<TContext>((sp, options) =>
+		{
+			options.UseNpgsql(connectionString, npgsql => npgsql
+				.MigrationsHistoryTable(migrationsHistoryTable)
+				.EnableRetryOnFailure());
+
+			foreach (var interceptorType in interceptorTypes)
+			{
+				options.AddInterceptors((IInterceptor)sp.GetRequiredService(interceptorType));
+			}
+		});
+
+		return services;
+	}
+}

--- a/src/Yumney.Shared.Persistence/Yumney.Shared.Persistence.csproj
+++ b/src/Yumney.Shared.Persistence/Yumney.Shared.Persistence.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
 </Project>

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
 using RedisRateLimiting;
@@ -64,6 +65,8 @@ public static class HostBuilderExtensions
 		builder.AddWolverineEventBus(eventHandlerAssemblies);
 
 		builder.Services.AddScoped<DomainEventDispatchInterceptor>();
+		builder.Services.AddQueryCounting();
+		builder.Services.TryAddSingleton(TimeProvider.System);
 
 		var configuration = builder.Configuration;
 

--- a/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -9,7 +9,9 @@ using SmartSolutionsLab.Yumney.Shared.Guards;
 namespace SmartSolutionsLab.Yumney.Shared.Web.Middleware;
 
 #pragma warning disable SA1601
-public sealed partial class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger)
+public sealed partial class GlobalExceptionHandlerMiddleware(
+	RequestDelegate next,
+	ILogger<GlobalExceptionHandlerMiddleware> logger)
 {
 	public async Task InvokeAsync(HttpContext context)
 	{
@@ -51,7 +53,7 @@ public sealed partial class GlobalExceptionHandlerMiddleware(RequestDelegate nex
 	{
 		context.Response.StatusCode = (int)statusCode;
 
-		var problemDetails = new ProblemDetails
+		ProblemDetails problemDetails = new()
 		{
 			Status = (int)statusCode,
 			Title = title,

--- a/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
@@ -8,7 +8,7 @@ public sealed class RequestContextMiddleware(RequestDelegate next, ILogger<Reque
 {
 	public async Task InvokeAsync(HttpContext context)
 	{
-		var userId = context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+		var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
 			?? context.User?.FindFirst(KeycloakClaimTypes.Subject)?.Value
 			?? "anonymous";
 

--- a/src/Yumney.Shared.Web/YumneyServiceClientRegistration.cs
+++ b/src/Yumney.Shared.Web/YumneyServiceClientRegistration.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+public static class YumneyServiceClientRegistration
+{
+	public static IServiceCollection AddYumneyServiceClient(this IServiceCollection services, string serviceName)
+	{
+		services.AddHttpContextAccessor();
+		services.TryAddTransient<AuthTokenDelegatingHandler>();
+
+		services.AddHttpClient(serviceName, client => client.BaseAddress = new Uri($"http://{serviceName}"))
+			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
+
+		return services;
+	}
+}

--- a/src/Yumney.Shopping.Api/Requests/AddManualItem.cs
+++ b/src/Yumney.Shopping.Api/Requests/AddManualItem.cs
@@ -4,7 +4,7 @@ using ShoppingList = SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record AddManualItemRequest(
+public sealed record AddManualItem(
 	string Name,
 	decimal? Quantity = null,
 	string? Unit = null,

--- a/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/AddManualItemRequest.cs
@@ -1,16 +1,21 @@
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using ShoppingList = SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record AddManualItemRequest(string Name, decimal? Quantity = null, string? Unit = null, string? Source = null)
+public sealed record AddManualItemRequest(
+	string Name,
+	decimal? Quantity = null,
+	string? Unit = null,
+	string? Source = null)
 {
 	public void Deconstruct(out ItemName itemName, out Quantity? quantity, out ItemSource source)
 	{
-		itemName = ItemName.From(Name.Trim());
-		quantity = Shopping.Domain.ShoppingList.Quantity.FromNullable(
+		itemName = ItemName.From(Name);
+		quantity = ShoppingList.Quantity.FromNullable(
 			Amount.FromNullable(Quantity),
-			Shopping.Domain.ShoppingList.Unit.FromNullable(Unit));
+			ShoppingList.Unit.FromNullable(Unit));
 		source = string.IsNullOrWhiteSpace(Source) ? ItemSource.Manual : ItemSource.From(Source);
 	}
 }

--- a/src/Yumney.Shopping.Api/Requests/CheckOffItem.cs
+++ b/src/Yumney.Shopping.Api/Requests/CheckOffItem.cs
@@ -1,3 +1,3 @@
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record CheckOffItemRequest(bool IsChecked);
+public sealed record CheckOffItem(bool IsChecked);

--- a/src/Yumney.Shopping.Api/Requests/CreateShoppingList.cs
+++ b/src/Yumney.Shopping.Api/Requests/CreateShoppingList.cs
@@ -3,7 +3,7 @@ using CommandItem = SmartSolutionsLab.Yumney.Shopping.Application.Commands.Shopp
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record CreateShoppingListRequest(
+public sealed record CreateShoppingList(
 	string Title,
 	List<ShoppingListItem> Items,
 	Guid? RecipeIdentifier = null)

--- a/src/Yumney.Shopping.Api/Requests/EndShoppingMode.cs
+++ b/src/Yumney.Shopping.Api/Requests/EndShoppingMode.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record EndShoppingMode(bool AcceptPendingChanges = false);

--- a/src/Yumney.Shopping.Api/Requests/EndShoppingModeRequest.cs
+++ b/src/Yumney.Shopping.Api/Requests/EndShoppingModeRequest.cs
@@ -1,3 +1,0 @@
-namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
-
-public sealed record EndShoppingModeRequest(bool AcceptPendingChanges = false);

--- a/src/Yumney.Shopping.Api/Requests/MarkAsFrozen.cs
+++ b/src/Yumney.Shopping.Api/Requests/MarkAsFrozen.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record MarkAsFrozenRequest(string Name, string? Unit = null)
+public sealed record MarkAsFrozen(string Name, string? Unit = null)
 {
 	public (ItemName ItemName, Unit? Unit) ToValueObjects() =>
 		(ItemName.From(Name), Shopping.Domain.ShoppingList.Unit.FromNullable(Unit));

--- a/src/Yumney.Shopping.Api/Requests/RemoveItem.cs
+++ b/src/Yumney.Shopping.Api/Requests/RemoveItem.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
-public sealed record RemoveItemRequest(string Name, decimal? Quantity = null, string? Unit = null, string? Reason = null)
+public sealed record RemoveItem(string Name, decimal? Quantity = null, string? Unit = null, string? Reason = null)
 {
 	public void Deconstruct(out ItemName itemName, out Quantity? quantity, out RemovalReason? reason)
 	{

--- a/src/Yumney.Shopping.Api/Requests/Validator/AddManualItemValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/AddManualItemValidator.cs
@@ -2,9 +2,9 @@ using FluentValidation;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 
-public sealed class RemoveItemRequestValidator : AbstractValidator<RemoveItemRequest>
+public sealed class AddManualItemValidator : AbstractValidator<AddManualItem>
 {
-	public RemoveItemRequestValidator()
+	public AddManualItemValidator()
 	{
 		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
 	}

--- a/src/Yumney.Shopping.Api/Requests/Validator/CreateShoppingListValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/CreateShoppingListValidator.cs
@@ -3,9 +3,9 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 
-public sealed class CreateShoppingListRequestValidator : AbstractValidator<CreateShoppingListRequest>
+public sealed class CreateShoppingListValidator : AbstractValidator<CreateShoppingList>
 {
-	public CreateShoppingListRequestValidator()
+	public CreateShoppingListValidator()
 	{
 		RuleFor(x => x.Title)
 			.NotEmpty()

--- a/src/Yumney.Shopping.Api/Requests/Validator/MarkAsFrozenValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/MarkAsFrozenValidator.cs
@@ -2,9 +2,9 @@ using FluentValidation;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 
-public sealed class AddManualItemRequestValidator : AbstractValidator<AddManualItemRequest>
+public sealed class MarkAsFrozenValidator : AbstractValidator<MarkAsFrozen>
 {
-	public AddManualItemRequestValidator()
+	public MarkAsFrozenValidator()
 	{
 		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
 	}

--- a/src/Yumney.Shopping.Api/Requests/Validator/RemoveItemValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/RemoveItemValidator.cs
@@ -2,9 +2,9 @@ using FluentValidation;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 
-public sealed class MarkAsFrozenRequestValidator : AbstractValidator<MarkAsFrozenRequest>
+public sealed class RemoveItemValidator : AbstractValidator<RemoveItem>
 {
-	public MarkAsFrozenRequestValidator()
+	public RemoveItemValidator()
 	{
 		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
 	}

--- a/src/Yumney.Shopping.Api/ShoppingApiServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Api/ShoppingApiServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ public static class ShoppingApiServiceCollectionExtensions
 {
 	public static IServiceCollection AddShoppingApi(this IServiceCollection services)
 	{
-		services.AddValidatorsFromAssemblyContaining<CreateShoppingListRequestValidator>();
+		services.AddValidatorsFromAssemblyContaining<CreateShoppingListValidator>();
 
 		return services;
 	}

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -3,11 +3,11 @@ using Microsoft.AspNetCore.Mvc;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Requests = SmartSolutionsLab.Yumney.Shopping.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api;
 
@@ -24,8 +24,8 @@ public static class ShoppingEndpoints
 			.ProducesValidationProblem();
 
 		static async Task<IResult> Create(
-			CreateShoppingListRequest request,
-			IValidator<CreateShoppingListRequest> validator,
+			Requests.CreateShoppingList request,
+			IValidator<Requests.CreateShoppingList> validator,
 			ICommandHandler<CreateShoppingListCommand, Result<ShoppingListDetailDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -86,7 +86,7 @@ public static class ShoppingEndpoints
 		static async Task<IResult> CheckOffItem(
 			Guid identifier,
 			Guid itemId,
-			CheckOffItemRequest request,
+			Requests.CheckOffItem request,
 			ICommandHandler<CheckOffItemCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
@@ -107,7 +107,7 @@ public static class ShoppingEndpoints
 
 		static async Task<IResult> CheckOffAllItems(
 			Guid identifier,
-			CheckOffItemRequest request,
+			Requests.CheckOffItem request,
 			ICommandHandler<CheckOffAllItemsCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
@@ -124,8 +124,8 @@ public static class ShoppingEndpoints
 			.ProducesProblem(StatusCodes.Status400BadRequest);
 
 		static async Task<IResult> AddManualItem(
-			AddManualItemRequest request,
-			IValidator<AddManualItemRequest> validator,
+			Requests.AddManualItem request,
+			IValidator<Requests.AddManualItem> validator,
 			ICommandHandler<AddManualItemCommand, Result<AddedItemDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -148,8 +148,8 @@ public static class ShoppingEndpoints
 			.ProducesProblem(StatusCodes.Status400BadRequest);
 
 		static async Task<IResult> RemoveItem(
-			[FromBody] RemoveItemRequest request,
-			IValidator<RemoveItemRequest> validator,
+			[FromBody] Requests.RemoveItem request,
+			IValidator<Requests.RemoveItem> validator,
 			ICommandHandler<RemoveShoppingItemCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
@@ -196,7 +196,7 @@ public static class ShoppingEndpoints
 			.Produces(StatusCodes.Status204NoContent);
 
 		static async Task<IResult> EndShoppingMode(
-			EndShoppingModeRequest request,
+			Requests.EndShoppingMode request,
 			ICommandHandler<EndShoppingModeCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
@@ -213,8 +213,8 @@ public static class ShoppingEndpoints
 			.ProducesValidationProblem();
 
 		static async Task<IResult> MarkAsFrozen(
-			MarkAsFrozenRequest request,
-			IValidator<MarkAsFrozenRequest> validator,
+			Requests.MarkAsFrozen request,
+			IValidator<Requests.MarkAsFrozen> validator,
 			ICommandHandler<MarkAsFrozenCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -111,9 +111,7 @@ public static class ShoppingEndpoints
 			ICommandHandler<CheckOffAllItemsCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
-			var command = new CheckOffAllItemsCommand(
-				ShoppingListIdentifier.From(identifier),
-				request.IsChecked);
+			var command = new CheckOffAllItemsCommand(ShoppingListIdentifier.From(identifier), request.IsChecked);
 
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToNoContent();
@@ -202,8 +200,9 @@ public static class ShoppingEndpoints
 			ICommandHandler<EndShoppingModeCommand, Result> handler,
 			CancellationToken cancellationToken)
 		{
-			var result = await handler.HandleAsync(new EndShoppingModeCommand(request.AcceptPendingChanges), cancellationToken);
+			var command = new EndShoppingModeCommand(request.AcceptPendingChanges);
 
+			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToNoContent();
 		}
 

--- a/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
+++ b/src/Yumney.Shopping.Application/Common/DefaultQuantityResolver.cs
@@ -45,8 +45,7 @@ public static class DefaultQuantityResolver
 	}
 
 #pragma warning disable SA1204
-	private static Quantity Q(decimal amount, string unit) =>
-		Quantity.Of(Amount.From(amount), Unit.FromNullable(unit));
+	private static Quantity Q(decimal amount, string unit) => Quantity.Of(Amount.From(amount), Unit.FromNullable(unit));
 
 	private static string Normalize(string input)
 	{

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
@@ -11,9 +11,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers
 /// publishing user that still references the deleted recipe. The user's list
 /// and items are preserved — only the broken link is severed.
 /// </summary>
-public sealed class RecipeDeletedHandler(
-	IShoppingListProjectionRepository projection,
-	IShoppingListEventStore eventStore)
+public sealed class RecipeDeletedHandler(IShoppingListProjectionRepository projection, IShoppingListEventStore eventStore)
 	: IIntegrationEventHandler<RecipeDeletedIntegrationEvent>
 {
 	/// <inheritdoc />

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingLedgerReadModelRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingLedgerReadModelRepository.cs
@@ -1,18 +1,9 @@
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
-/// <summary>
-/// Read model repository for the shopping list projection.
-/// </summary>
 public interface IShoppingLedgerReadModelRepository
 {
-	/// <summary>
-	/// Gets the merged shopping list. By default, hides items bought before today.
-	/// </summary>
-	/// <param name="ownerId">The owner user identifier.</param>
-	/// <param name="includePastBought">If true, includes items bought before today.</param>
-	/// <param name="cancellationToken">Cancellation token.</param>
-	/// <returns>The merged shopping list DTO.</returns>
-	Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, bool includePastBought = false, CancellationToken cancellationToken = default);
+	Task<MergedShoppingListDto> GetByOwnerAsync(OwnerIdentifier owner, bool includePastBought = false, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingListProjectionRepository.cs
@@ -1,5 +1,4 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
@@ -18,35 +17,10 @@ public interface IShoppingListProjectionRepository
 		SortingOptions<ShoppingListSortField> sorting,
 		CancellationToken cancellationToken = default);
 
-	/// <summary>
-	/// Loads the projection-shaped detail for one list. Throws
-	/// <see cref="EntityNotFoundException"/> if no projection row exists.
-	/// </summary>
-	/// <param name="identifier">The list identifier.</param>
-	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-	/// <returns>The owner-tagged DTO for the list.</returns>
-	Task<ShoppingListProjectedDetail> GetByIdAsync(
-		ShoppingListIdentifier identifier,
-		CancellationToken cancellationToken = default);
+	Task<ShoppingListProjectedDetail> GetByIdAsync(ShoppingListIdentifier identifier, CancellationToken cancellationToken = default);
 
-	/// <summary>
-	/// Returns the identifiers of every list owned by <paramref name="owner"/> whose
-	/// summary row references the given recipe. Used by integration handlers (e.g.
-	/// recipe deletion) to find the aggregates that need a follow-up command.
-	/// </summary>
-	/// <param name="owner">List owner.</param>
-	/// <param name="recipeReference">Recipe pointer to match.</param>
-	/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-	/// <returns>List identifiers, possibly empty.</returns>
 	Task<IReadOnlyList<ShoppingListIdentifier>> FindIdsByRecipeAsync(
 		OwnerIdentifier owner,
 		RecipeReference recipeReference,
 		CancellationToken cancellationToken = default);
 }
-
-/// <summary>
-/// Projection-shaped result of <see cref="IShoppingListProjectionRepository.GetByIdAsync"/>.
-/// Carries the owner separately so the query handler can apply access control
-/// without rebuilding the aggregate.
-/// </summary>
-public sealed record ShoppingListProjectedDetail(string OwnerId, ShoppingListDetailDto Dto);

--- a/src/Yumney.Shopping.Application/Interfaces/ShoppingListProjectedDetail.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/ShoppingListProjectedDetail.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+public sealed record ShoppingListProjectedDetail(string OwnerId, ShoppingListDetailDto Dto);

--- a/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
@@ -10,9 +10,8 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 /// Exports the shopping list as formatted text grouped by category.
 /// Only includes unbought items. Does not change any item state.
 /// </summary>
-public sealed class ExportShoppingListQueryHandler(
-	IShoppingLedgerReadModelRepository readModel,
-	ICurrentUser currentUser) : IQueryHandler<ExportShoppingListQuery, Result<string>>
+public sealed class ExportShoppingListQueryHandler(IShoppingLedgerReadModelRepository readModel, ICurrentUser currentUser)
+	: IQueryHandler<ExportShoppingListQuery, Result<string>>
 {
 #pragma warning disable SA1311
 	private static readonly Dictionary<string, string> categoryEmojis = new()

--- a/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/ExportShoppingListQueryHandler.cs
@@ -44,7 +44,7 @@ public sealed class ExportShoppingListQueryHandler(
 
 	public async Task<Result<string>> HandleAsync(ExportShoppingListQuery query, CancellationToken cancellationToken = default)
 	{
-		var list = await readModel.GetByOwnerAsync(currentUser.UserId, cancellationToken: cancellationToken);
+		var list = await readModel.GetByOwnerAsync(currentUser.AsOwner(), cancellationToken: cancellationToken);
 
 		var openItems = list.Items.Where(item => !item.IsBought).ToList();
 		if (openItems.Count == 0)

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
@@ -5,9 +5,8 @@ using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
-public sealed class GetMergedShoppingListQueryHandler(
-	IShoppingLedgerReadModelRepository readModel,
-	ICurrentUser currentUser) : IQueryHandler<GetMergedShoppingListQuery, Result<MergedShoppingListDto>>
+public sealed class GetMergedShoppingListQueryHandler(IShoppingLedgerReadModelRepository readModel, ICurrentUser currentUser)
+	: IQueryHandler<GetMergedShoppingListQuery, Result<MergedShoppingListDto>>
 {
 	public async Task<Result<MergedShoppingListDto>> HandleAsync(GetMergedShoppingListQuery query, CancellationToken cancellationToken = default)
 	{

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetMergedShoppingListQueryHandler.cs
@@ -11,7 +11,6 @@ public sealed class GetMergedShoppingListQueryHandler(
 {
 	public async Task<Result<MergedShoppingListDto>> HandleAsync(GetMergedShoppingListQuery query, CancellationToken cancellationToken = default)
 	{
-		var ownerId = currentUser.UserId;
-		return await readModel.GetByOwnerAsync(ownerId, query.IncludePastBought, cancellationToken);
+		return await readModel.GetByOwnerAsync(currentUser.AsOwner(), query.IncludePastBought, cancellationToken);
 	}
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListByIdQueryHandler.cs
@@ -5,9 +5,7 @@ using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
-public sealed class GetShoppingListByIdQueryHandler(
-	IShoppingListProjectionRepository projection,
-	ICurrentUser currentUser)
+public sealed class GetShoppingListByIdQueryHandler(IShoppingListProjectionRepository projection, ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListByIdQuery, Result<ShoppingListDetailDto>>
 {
 	public async Task<Result<ShoppingListDetailDto>> HandleAsync(

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetShoppingListsQueryHandler.cs
@@ -5,9 +5,7 @@ using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 
-public sealed class GetShoppingListsQueryHandler(
-	IShoppingListProjectionRepository projection,
-	ICurrentUser currentUser)
+public sealed class GetShoppingListsQueryHandler(IShoppingListProjectionRepository projection, ICurrentUser currentUser)
 	: IQueryHandler<GetShoppingListsQuery, Result<PagedResult<ShoppingListSummaryDto>>>
 {
 	public async Task<Result<PagedResult<ShoppingListSummaryDto>>> HandleAsync(

--- a/src/Yumney.Shopping.Application/ShoppingApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Application/ShoppingApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application;
@@ -9,6 +10,7 @@ public static class ShoppingApplicationServiceCollectionExtensions
 	public static IServiceCollection AddShoppingApplication(this IServiceCollection services)
 	{
 		services.AddHandlersFromAssemblyContaining<CreateShoppingListCommandHandler>();
+		services.AddIntegrationEventHandlersFromAssemblyContaining<CreateShoppingListCommandHandler>();
 
 		return services;
 	}

--- a/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItemIdentifier.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/ShoppingListItemIdentifier.cs
@@ -12,7 +12,7 @@ public sealed record ShoppingListItemIdentifier : IValueObject
 		Value = Ensure.That(value).IsNotEmpty().AndReturn();
 	}
 
-	public static ShoppingListItemIdentifier New() => new(Guid.CreateVersion7());
+	public static ShoppingListItemIdentifier New() => From(Guid.CreateVersion7());
 
 	public static ShoppingListItemIdentifier From(Guid value) => new(value);
 

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -9,7 +9,8 @@ public sealed class HttpStaplesProvider(IHttpClientFactory httpClientFactory) : 
 	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("users-api");
-		List<string> staples = await client.GetFromJsonAsync<List<string>>("/api/v1/users/staples", cancellationToken) ?? [];
+		var url = "/api/v1/users/staples";
+		List<string> staples = await client.GetFromJsonAsync<List<string>>(url, cancellationToken) ?? [];
 
 		return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
@@ -3,18 +3,19 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
 public sealed class ShoppingLedgerReadModelRepository(ShoppingReadDbContext context) : IShoppingLedgerReadModelRepository
 {
-	/// <inheritdoc />
-	public async Task<MergedShoppingListDto> GetByOwnerAsync(string ownerId, bool includePastBought = false, CancellationToken cancellationToken = default)
+	public async Task<MergedShoppingListDto> GetByOwnerAsync(OwnerIdentifier owner, bool includePastBought = false, CancellationToken cancellationToken = default)
 	{
 		var today = DateTime.UtcNow.Date;
+		var ownerValue = owner.Value;
 
 		var query = context.ShoppingLedgerReadItems
-			.Where(row => row.OwnerId == ownerId);
+			.Where(row => row.OwnerId == ownerValue);
 
 		if (!includePastBought)
 		{

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -34,7 +33,6 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddIntegrationEventHandlersFromAssemblyContaining<ShoppingListProjection>();
-		services.AddIntegrationEventHandlersFromAssemblyContaining<RecipeDeletedHandler>();
 		services.AddYumneyServiceClient("users-api");
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -28,14 +28,18 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 			.MigrationsHistoryTable("__ShoppingMigrationsHistory")
 			.EnableRetryOnFailure();
 
+		services.AddQueryCounting();
+
 		services.AddDbContext<ShoppingDbContext>(options =>
 		{
 			options.UseNpgsql(connectionString, contextOptions);
 		});
 
-		services.AddDbContext<ShoppingReadDbContext>(options =>
+		services.AddDbContext<ShoppingReadDbContext>((sp, options) =>
 		{
-			options.UseNpgsql(connectionString, contextOptions);
+			options
+				.UseNpgsql(connectionString, contextOptions)
+				.AddInterceptors(sp.GetRequiredService<QueryCountingInterceptor>());
 		});
 
 		services.AddScoped<IShoppingListEventStore, EfCoreShoppingListEventStore>();

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -1,11 +1,6 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
-using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web;
 using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
@@ -23,59 +18,24 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 {
 	public static IServiceCollection AddShoppingInfrastructure(this IServiceCollection services, IConfiguration configuration)
 	{
-		var connectionString = configuration.GetConnectionString("shoppingdb");
-		Action<NpgsqlDbContextOptionsBuilder> contextOptions = builder => builder
-			.MigrationsHistoryTable("__ShoppingMigrationsHistory")
-			.EnableRetryOnFailure();
-
-		services.AddQueryCounting();
-
-		services.AddDbContext<ShoppingDbContext>(options =>
-		{
-			options.UseNpgsql(connectionString, contextOptions);
-		});
-
-		services.AddDbContext<ShoppingReadDbContext>((sp, options) =>
-		{
-			options
-				.UseNpgsql(connectionString, contextOptions)
-				.AddInterceptors(sp.GetRequiredService<QueryCountingInterceptor>());
-		});
+		services.AddYumneyNpgsqlDbContext<ShoppingDbContext>(configuration, "shoppingdb", "__ShoppingMigrationsHistory");
+		services.AddYumneyNpgsqlDbContext<ShoppingReadDbContext>(
+			configuration,
+			"shoppingdb",
+			"__ShoppingMigrationsHistory",
+			typeof(QueryCountingInterceptor));
 
 		services.AddScoped<IShoppingListEventStore, EfCoreShoppingListEventStore>();
 		services.AddScoped<IShoppingEventStore, EfCoreShoppingEventStore>();
 		services.AddScoped<IShoppingLedgerReadModelRepository, ShoppingLedgerReadModelRepository>();
 		services.AddScoped<IShoppingListProjectionRepository, EfCoreShoppingListProjectionRepository>();
 		services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedIntegrationEvent>, ShoppingLedgerProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, ShoppingLedgerProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, ShoppingLedgerProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, ShoppingLedgerProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemQuantityAdjustedIntegrationEvent>, ShoppingLedgerProjectionHandler>();
-		services.AddScoped<ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingListCreatedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<ListItemAddedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<ListItemCheckedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<ListItemUncheckedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<AllItemsCheckedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<AllItemsUncheckedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<RecipeReferenceClearedIntegrationEvent>, ShoppingListProjection>();
-		services.AddScoped<IIntegrationEventHandler<RecipeDeletedIntegrationEvent>, RecipeDeletedHandler>();
-		services.AddScoped<IIntegrationEventHandler<MealConfirmedIntegrationEvent>, MealConfirmedHandler>();
-		services.AddScoped<IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemBoughtIntegrationEvent>, IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemConsumedIntegrationEvent>, IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemRemovedIntegrationEvent>, IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemUndoBoughtIntegrationEvent>, IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemAddedAsAtHomeIntegrationEvent>, IngredientBalanceProjectionHandler>();
-		services.AddScoped<IIntegrationEventHandler<ShoppingItemMarkedAsFrozenIntegrationEvent>, IngredientBalanceProjectionHandler>();
 		services.AddScoped<IIngredientBalanceReadModelRepository, IngredientBalanceReadModelRepository>();
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
-		services.AddTransient<AuthTokenDelegatingHandler>();
-		services.AddHttpClient("users-api", client => client.BaseAddress = new Uri("http://users-api"))
-			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
-		services.TryAddSingleton(TimeProvider.System);
+		services.AddIntegrationEventHandlersFromAssemblyContaining<ShoppingListProjection>();
+		services.AddIntegrationEventHandlersFromAssemblyContaining<RecipeDeletedHandler>();
+		services.AddYumneyServiceClient("users-api");
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
 		return services;

--- a/src/Yumney.Users.Api/AuthEndpoints.cs
+++ b/src/Yumney.Users.Api/AuthEndpoints.cs
@@ -2,10 +2,10 @@ using FluentValidation;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using SmartSolutionsLab.Yumney.Users.Api.Requests;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 using SmartSolutionsLab.Yumney.Users.Application.DTOs;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Requests = SmartSolutionsLab.Yumney.Users.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Users.Api;
 
@@ -26,8 +26,8 @@ public static class AuthEndpoints
 			.ProducesProblem(StatusCodes.Status429TooManyRequests);
 
 		static async Task<IResult> Register(
-			RegisterUserRequest request,
-			IValidator<RegisterUserRequest> validator,
+			Requests.RegisterUser request,
+			IValidator<Requests.RegisterUser> validator,
 			ICommandHandler<RegisterUserCommand, Result<RegisterUserResultDto>> handler,
 			CancellationToken cancellationToken)
 		{
@@ -50,8 +50,8 @@ public static class AuthEndpoints
 			.ProducesProblem(StatusCodes.Status429TooManyRequests);
 
 		static async Task<IResult> ResendVerificationEmail(
-			ResendVerificationEmailRequest request,
-			IValidator<ResendVerificationEmailRequest> validator,
+			Requests.ResendVerificationEmail request,
+			IValidator<Requests.ResendVerificationEmail> validator,
 			ICommandHandler<ResendVerificationEmailCommand, Result> handler,
 			ILoggerFactory loggerFactory,
 			CancellationToken cancellationToken)

--- a/src/Yumney.Users.Api/Requests/RegisterUser.cs
+++ b/src/Yumney.Users.Api/Requests/RegisterUser.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
 
-public sealed record RegisterUserRequest(string Email, string Password, string DisplayName)
+public sealed record RegisterUser(string Email, string Password, string DisplayName)
 {
 	public (Email Email, Password Password, DisplayName DisplayName) ToValueObjects() =>
 		(Domain.AppUserProfile.Email.From(Email), Domain.AppUserProfile.Password.From(Password), Domain.AppUserProfile.DisplayName.From(DisplayName));

--- a/src/Yumney.Users.Api/Requests/RegisterUserValidator.cs
+++ b/src/Yumney.Users.Api/Requests/RegisterUserValidator.cs
@@ -3,9 +3,9 @@ using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
 
-public sealed class RegisterUserRequestValidator : AbstractValidator<RegisterUserRequest>
+public sealed class RegisterUserValidator : AbstractValidator<RegisterUser>
 {
-	public RegisterUserRequestValidator()
+	public RegisterUserValidator()
 	{
 		RuleFor(x => x.Email)
 			.NotEmpty()

--- a/src/Yumney.Users.Api/Requests/ResendVerificationEmail.cs
+++ b/src/Yumney.Users.Api/Requests/ResendVerificationEmail.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
+
+public sealed record ResendVerificationEmail(string Email);

--- a/src/Yumney.Users.Api/Requests/ResendVerificationEmailRequest.cs
+++ b/src/Yumney.Users.Api/Requests/ResendVerificationEmailRequest.cs
@@ -1,3 +1,0 @@
-namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
-
-public sealed record ResendVerificationEmailRequest(string Email);

--- a/src/Yumney.Users.Api/Requests/ResendVerificationEmailValidator.cs
+++ b/src/Yumney.Users.Api/Requests/ResendVerificationEmailValidator.cs
@@ -3,9 +3,9 @@ using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
 
-public sealed class ResendVerificationEmailRequestValidator : AbstractValidator<ResendVerificationEmailRequest>
+public sealed class ResendVerificationEmailValidator : AbstractValidator<ResendVerificationEmail>
 {
-	public ResendVerificationEmailRequestValidator()
+	public ResendVerificationEmailValidator()
 	{
 		RuleFor(x => x.Email)
 			.NotEmpty()

--- a/src/Yumney.Users.Api/UsersApiServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Api/UsersApiServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ public static class UsersApiServiceCollectionExtensions
 {
 	public static IServiceCollection AddUsersApi(this IServiceCollection services)
 	{
-		services.AddValidatorsFromAssemblyContaining<RegisterUserRequestValidator>();
+		services.AddValidatorsFromAssemblyContaining<RegisterUserValidator>();
 
 		return services;
 	}

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -21,13 +21,11 @@ public static class UsersInfrastructureServiceCollectionExtensions
 			.ValidateDataAnnotations()
 			.ValidateOnStart();
 
-		services.AddDbContext<UsersDbContext>((sp, options) =>
-		{
-			var connectionString = configuration.GetConnectionString("usersdb");
-			options
-				.UseNpgsql(connectionString, x => x.MigrationsHistoryTable("__UsersMigrationsHistory").EnableRetryOnFailure())
-				.AddInterceptors(sp.GetRequiredService<DomainEventDispatchInterceptor>());
-		});
+		services.AddYumneyNpgsqlDbContext<UsersDbContext>(
+			configuration,
+			"usersdb",
+			"__UsersMigrationsHistory",
+			typeof(DomainEventDispatchInterceptor));
 
 		services.AddScoped<IAppUserProfileRepository, AppUserProfileRepository>();
 		services.AddScoped<IUserActivityRepository, UserActivityRepository>();

--- a/tests/Yumney.Architecture.Tests/DependencyInjectionSmokeTests.cs
+++ b/tests/Yumney.Architecture.Tests/DependencyInjectionSmokeTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.MealPlan.Application;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
+using SmartSolutionsLab.Yumney.Recipes.Application;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shopping.Application;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Architecture.Tests;
+
+/// <summary>
+/// Locks in the auto-discovered DI registrations behind the Phase 2 helpers.
+/// For each module, builds the same DI graph the real Program.cs assembles
+/// (minus Aspire/Keycloak), then asserts that every <c>IIntegrationEventHandler&lt;T&gt;</c>
+/// implementation discoverable in {Module}.Application + {Module}.Infrastructure
+/// is resolvable as each of the interfaces it implements.
+/// Catches the case where the assembly-scanner type-arg drifts away from the
+/// module's own assembly (e.g. accidental copy-paste between modules).
+/// </summary>
+public class DependencyInjectionSmokeTests
+{
+	[Fact]
+	public void RecipesModule_RegistersEveryDiscoveredHandler()
+	{
+		ServiceCollection services = [];
+		services.AddRecipesApplication();
+		services.AddRecipesInfrastructure(EmptyConfiguration());
+
+		AssertEveryHandlerInterfaceIsRegistered(services, ["Yumney.Recipes.Application", "Yumney.Recipes.Infrastructure"]);
+	}
+
+	[Fact]
+	public void ShoppingModule_RegistersEveryDiscoveredHandler()
+	{
+		ServiceCollection services = [];
+		services.AddShoppingApplication();
+		services.AddShoppingInfrastructure(EmptyConfiguration());
+
+		AssertEveryHandlerInterfaceIsRegistered(services, ["Yumney.Shopping.Application", "Yumney.Shopping.Infrastructure"]);
+	}
+
+	[Fact]
+	public void MealPlanModule_RegistersEveryDiscoveredHandler()
+	{
+		ServiceCollection services = [];
+		services.AddMealPlanApplication();
+		services.AddMealPlanInfrastructure(EmptyConfiguration());
+
+		AssertEveryHandlerInterfaceIsRegistered(services, ["Yumney.MealPlan.Application", "Yumney.MealPlan.Infrastructure"]);
+	}
+
+	private static IConfiguration EmptyConfiguration() =>
+		new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+	private static void AssertEveryHandlerInterfaceIsRegistered(IServiceCollection services, IReadOnlyList<string> assemblyNames)
+	{
+		var openHandler = typeof(IIntegrationEventHandler<>);
+		List<(Type Implementation, Type Interface)> expected = [];
+		foreach (var assemblyName in assemblyNames)
+		{
+			var assembly = Assembly.Load(assemblyName);
+			expected.AddRange(assembly.GetTypes()
+				.Where(type => type is { IsAbstract: false, IsInterface: false })
+				.SelectMany(type => type.GetInterfaces()
+					.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == openHandler)
+					.Select(iface => (Implementation: type, Interface: iface))));
+		}
+
+		expected.Should().NotBeEmpty("at least one handler is expected so the test is meaningful");
+
+		foreach (var (implementation, iface) in expected)
+		{
+			var because =
+				$"{iface.FullName} (from {implementation.FullName}) must be registered in DI — " +
+				"the auto-scanner most likely missed the assembly. Check that the relevant Add*() " +
+				"call passes a type from the right assembly to AddIntegrationEventHandlersFromAssemblyContaining<T>.";
+			services.Should().Contain(descriptor => descriptor.ServiceType == iface, because);
+		}
+	}
+}

--- a/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
+++ b/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using Xunit;
@@ -7,24 +9,22 @@ namespace SmartSolutionsLab.Yumney.Architecture.Tests;
 
 public class EventConsumerRegistrationTests
 {
-	private static readonly string[] InfrastructureModules = ["Recipes", "Shopping", "Users", "MealPlan"];
+	private static readonly string[] Modules = ["Recipes", "Shopping", "Users", "MealPlan"];
 
 	[Fact]
 	public void EveryIntegrationEvent_HasAtLeastOneHandler()
 	{
-		var assemblies = InfrastructureModules
-			.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure"))
-			.ToList();
+		var (eventAssemblies, handlerAssemblies) = LoadAssemblies();
 
 		var integrationEventType = typeof(IIntegrationEvent);
 		var handlerInterfaceType = typeof(IIntegrationEventHandler<>);
 
-		var integrationEvents = assemblies
+		var integrationEvents = eventAssemblies
 			.SelectMany(assembly => assembly.GetTypes())
 			.Where(type => integrationEventType.IsAssignableFrom(type) && type is { IsClass: true, IsAbstract: false })
 			.ToList();
 
-		var handledEventTypes = assemblies
+		var handledEventTypes = handlerAssemblies
 			.SelectMany(assembly => assembly.GetTypes())
 			.SelectMany(type => type.GetInterfaces())
 			.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == handlerInterfaceType)
@@ -46,14 +46,12 @@ public class EventConsumerRegistrationTests
 	[Fact]
 	public void EveryIntegrationEventHandler_HandlesAKnownIntegrationEvent()
 	{
-		var assemblies = InfrastructureModules
-			.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure"))
-			.ToList();
+		var (_, handlerAssemblies) = LoadAssemblies();
 
 		var integrationEventType = typeof(IIntegrationEvent);
 		var handlerInterfaceType = typeof(IIntegrationEventHandler<>);
 
-		var handlerEventTargets = assemblies
+		var handlerEventTargets = handlerAssemblies
 			.SelectMany(assembly => assembly.GetTypes())
 			.SelectMany(type => type.GetInterfaces())
 			.Where(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == handlerInterfaceType)
@@ -68,5 +66,109 @@ public class EventConsumerRegistrationTests
 
 		nonEventHandlerTargets.Should().BeEmpty(
 			"every IIntegrationEventHandler<T> must target a type implementing IIntegrationEvent");
+	}
+
+	[Theory]
+	[InlineData("Recipes")]
+	[InlineData("Shopping")]
+	[InlineData("Users")]
+	[InlineData("MealPlan")]
+	public void AddYumneyDefaults_PassesEveryAssemblyWithHandlers(string module)
+	{
+		var handlerInterfaceType = typeof(IIntegrationEventHandler<>);
+		var moduleAssemblies = new[] { $"Yumney.{module}.Application", $"Yumney.{module}.Infrastructure" }
+			.Select(name => Assembly.Load(name))
+			.ToList();
+
+		var requiredAssemblies = moduleAssemblies
+			.Where(assembly => HasIntegrationHandlers(assembly, handlerInterfaceType))
+			.Select(assembly => assembly.GetName().Name!)
+			.ToHashSet();
+
+		var programText = File.ReadAllText(Path.Combine(SolutionRoot.Path, "src", $"Yumney.{module}.Api", "Program.cs"));
+		var argumentList = ExtractAddYumneyDefaultsArguments(programText);
+		var coveredAssemblies = ResolveTypeofAssemblyNames(argumentList, moduleAssemblies);
+
+		foreach (var required in requiredAssemblies)
+		{
+			var because = $"src/Yumney.{module}.Api/Program.cs must pass typeof(SomethingIn{required}).Assembly to AddYumneyDefaults — " +
+				$"otherwise integration event handlers in {required} will never be wired into Wolverine.";
+			coveredAssemblies.Should().Contain(required, because);
+		}
+	}
+
+	private static (List<Assembly> EventAssemblies, List<Assembly> HandlerAssemblies) LoadAssemblies()
+	{
+		List<Assembly> eventAssemblies = [Assembly.Load("Yumney.Shared.Events")];
+		eventAssemblies.AddRange(Modules.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure")));
+
+		List<Assembly> handlerAssemblies = [];
+		foreach (var module in Modules)
+		{
+			handlerAssemblies.Add(Assembly.Load($"Yumney.{module}.Application"));
+			handlerAssemblies.Add(Assembly.Load($"Yumney.{module}.Infrastructure"));
+		}
+
+		return (eventAssemblies, handlerAssemblies);
+	}
+
+	private static bool HasIntegrationHandlers(Assembly assembly, Type handlerInterfaceType) =>
+		assembly.GetTypes()
+			.SelectMany(type => type.GetInterfaces())
+			.Any(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == handlerInterfaceType);
+
+	private static string ExtractAddYumneyDefaultsArguments(string programText)
+	{
+		const string startMarker = "AddYumneyDefaults(";
+		var startIndex = programText.IndexOf(startMarker, StringComparison.Ordinal);
+		startIndex.Should().BeGreaterThanOrEqualTo(0, "Program.cs must call AddYumneyDefaults(...)");
+
+		var contentStart = startIndex + startMarker.Length;
+		var depth = 1;
+		var index = contentStart;
+		while (index < programText.Length && depth > 0)
+		{
+			var ch = programText[index];
+			if (ch == '(') depth++;
+			else if (ch == ')') depth--;
+			if (depth == 0) break;
+			index++;
+		}
+
+		return programText[contentStart..index];
+	}
+
+	private static HashSet<string> ResolveTypeofAssemblyNames(string argumentList, IEnumerable<Assembly> candidateAssemblies)
+	{
+		HashSet<string> covered = [];
+		foreach (Match match in Regex.Matches(argumentList, @"typeof\s*\(\s*([A-Za-z_][\w.]*)\s*\)"))
+		{
+			var typeName = match.Groups[1].Value;
+			var assembly = candidateAssemblies
+				.FirstOrDefault(asm => asm.GetTypes().Any(type => type.Name == typeName || type.FullName == typeName));
+			if (assembly is not null)
+			{
+				covered.Add(assembly.GetName().Name!);
+			}
+		}
+
+		return covered;
+	}
+}
+
+internal static class SolutionRoot
+{
+	public static string Path { get; } = Locate();
+
+	private static string Locate([CallerFilePath] string callerFilePath = "")
+	{
+		var directory = new DirectoryInfo(System.IO.Path.GetDirectoryName(callerFilePath)!);
+		while (directory is not null && !File.Exists(System.IO.Path.Combine(directory.FullName, "Yumney.slnx")))
+		{
+			directory = directory.Parent;
+		}
+
+		return directory?.FullName
+			?? throw new InvalidOperationException("Yumney.slnx not found walking up from test source location.");
 	}
 }

--- a/tests/Yumney.Architecture.Tests/ExternalDependencyIsolationTests.cs
+++ b/tests/Yumney.Architecture.Tests/ExternalDependencyIsolationTests.cs
@@ -5,11 +5,6 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Architecture.Tests;
 
-/// <summary>
-/// Guard rails around third-party adapters: external SDKs (Semantic
-/// Kernel, AngleSharp, HtmlAgilityPack) belong in dedicated adapter
-/// projects, not in Domain, Application, or Api.
-/// </summary>
 public class ExternalDependencyIsolationTests
 {
 	[Theory]
@@ -42,14 +37,7 @@ public class ExternalDependencyIsolationTests
 			.HaveDependencyOn("AngleSharp")
 			.GetResult();
 
-		var htmlAgilityResult = Types.InAssembly(assembly)
-			.ShouldNot()
-			.HaveDependencyOn("HtmlAgilityPack")
-			.GetResult();
-
 		angleResult.IsSuccessful.Should().BeTrue(
 			$"{assemblyName} must not reference AngleSharp directly.");
-		htmlAgilityResult.IsSuccessful.Should().BeTrue(
-			$"{assemblyName} must not reference HtmlAgilityPack directly.");
 	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/OwnershipIsolationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/OwnershipIsolationTests.cs
@@ -99,7 +99,7 @@ public class OwnershipIsolationTests(AspireFixture fixture) : IAsyncLifetime
 
 		// User B cannot mutate user A's list either — check-all is the only
 		// cross-user write attack vector that takes the list id from the URL.
-		// The endpoint requires a CheckOffItemRequest body; without it ASP.NET
+		// The endpoint requires a CheckOffItem body; without it ASP.NET
 		// fails at model binding with 500 before the handler's owner check
 		// even runs, masking the real assertion.
 		var checkAllResponse = await userBShopping.PutAsJsonAsync(

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingLedgerReadModelQueryBudgetTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingLedgerReadModelQueryBudgetTests.cs
@@ -1,0 +1,71 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Testing;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Shopping.ReadModel;
+
+[Collection(AspireCollection.Name)]
+public class ShoppingLedgerReadModelQueryBudgetTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task GetByOwnerAsync_AnyRowCount_IssuesExactlyOneCommand()
+	{
+		var owner = OwnerIdentifier.From($"budget-{Guid.NewGuid():N}");
+		await SeedAsync(owner, count: 3);
+
+		var connectionString = await fixture.App.GetConnectionStringAsync("shoppingdb");
+		await using var provider = BuildProvider(connectionString!);
+		await using var scope = provider.CreateAsyncScope();
+
+		var counter = scope.ServiceProvider.GetRequiredService<IQueryCounter>();
+		var repository = ActivatorUtilities.CreateInstance<ShoppingLedgerReadModelRepository>(scope.ServiceProvider);
+
+		counter.Reset();
+		var result = await repository.GetByOwnerAsync(owner);
+
+		counter.Count.Should().Be(1, "GetByOwnerAsync must issue a single SELECT — N+1 regression otherwise");
+		result.Items.Should().HaveCount(3);
+	}
+
+	private static ServiceProvider BuildProvider(string connectionString)
+	{
+		ServiceCollection services = [];
+		services.AddQueryCounting();
+		services.AddDbContext<ShoppingReadDbContext>((sp, options) =>
+		{
+			options
+				.UseNpgsql(connectionString)
+				.AddInterceptors(sp.GetRequiredService<QueryCountingInterceptor>());
+		});
+
+		return services.BuildServiceProvider();
+	}
+
+	private async Task SeedAsync(OwnerIdentifier owner, int count)
+	{
+		await using var context = await fixture.CreateShoppingReadDbContextAsync();
+		for (var index = 0; index < count; index++)
+		{
+			context.ShoppingLedgerReadItems.Add(new ShoppingLedgerReadItem
+			{
+				Id = Guid.CreateVersion7(),
+				OwnerId = owner.Value,
+				ItemName = $"Item-{index}",
+				TotalQuantity = 1,
+				Unit = "pc",
+				LastUpdated = DateTime.UtcNow,
+			});
+		}
+
+		await context.SaveChangesAsync();
+	}
+}

--- a/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanEventStore.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanEventStore.cs
@@ -1,0 +1,33 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests;
+
+internal sealed class FakeMealPlanEventStore : IMealPlanEventStore
+{
+	private readonly Dictionary<(string Owner, string Week), WeeklyPlan> store = [];
+
+	public int SaveCount { get; private set; }
+
+	public WeeklyPlan? LastSavedPlan { get; private set; }
+
+	public Task<WeeklyPlan?> LoadAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+	{
+		store.TryGetValue((owner.Value, week.Value), out var plan);
+		return Task.FromResult(plan);
+	}
+
+	public Task SaveAsync(WeeklyPlan plan, CancellationToken cancellationToken = default)
+	{
+		store[(plan.Owner.Value, plan.Week.Value)] = plan;
+		LastSavedPlan = plan;
+		SaveCount++;
+		plan.MarkCommitted();
+		return Task.CompletedTask;
+	}
+
+	public void Seed(WeeklyPlan plan)
+	{
+		plan.MarkCommitted();
+		store[(plan.Owner.Value, plan.Week.Value)] = plan;
+	}
+}

--- a/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
@@ -1,0 +1,72 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests;
+
+internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelRepository
+{
+	private readonly Dictionary<(string Owner, string Week), WeeklyPlan> store = [];
+
+	public Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+	{
+		if (store.TryGetValue((owner.Value, week.Value), out var plan))
+		{
+			return Task.FromResult(plan.ToDto(week));
+		}
+
+		var emptyPlan = WeeklyPlan.Create(owner, week);
+		return Task.FromResult(emptyPlan.ToDto(week));
+	}
+
+	public Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
+	{
+		if (!store.TryGetValue((owner.Value, week.Value), out var plan))
+		{
+			return Task.FromResult(new WeeklyPlannedRecipesDto(week.Value, []));
+		}
+
+		var recipes = plan.Slots
+			.Where(slot => slot.ContentType == SlotContentType.Recipe && slot.Recipe is not null)
+			.Select(slot => new PlannedRecipeDto(
+				slot.Recipe!.RecipeIdentifier.Value,
+				slot.Recipe.Title.Value,
+				slot.Servings.Value,
+				slot.Day.ToString(),
+				slot.MealType.ToString()))
+			.ToList();
+
+		return Task.FromResult(new WeeklyPlannedRecipesDto(week.Value, recipes));
+	}
+
+	public Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(OwnerIdentifier owner, string? term, int limit, CancellationToken cancellationToken = default)
+	{
+		IEnumerable<MealHistoryEntryDto> rows = store
+			.Where(kv => kv.Key.Owner == owner.Value)
+			.SelectMany(kv => kv.Value.Slots
+				.Where(slot => slot.State == MealState.Cooked && slot.Recipe is not null)
+				.Select(slot => new MealHistoryEntryDto(
+					slot.Recipe!.RecipeIdentifier.Value,
+					slot.Recipe.Title.Value,
+					kv.Key.Week,
+					slot.Day.ToString(),
+					slot.MealType.ToString())));
+
+		if (!string.IsNullOrWhiteSpace(term))
+		{
+			rows = rows.Where(entry => entry.RecipeTitle.Contains(term.Trim(), StringComparison.OrdinalIgnoreCase));
+		}
+
+		return Task.FromResult<IReadOnlyList<MealHistoryEntryDto>>(rows
+			.OrderByDescending(entry => entry.Week)
+			.ThenBy(entry => entry.Day)
+			.ThenBy(entry => entry.MealType)
+			.Take(limit)
+			.ToList());
+	}
+
+	public void Seed(WeeklyPlan plan)
+	{
+		store[(plan.Owner.Value, plan.Week.Value)] = plan;
+	}
+}

--- a/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
@@ -1,6 +1,4 @@
 using NSubstitute;
-using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
-using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
 
@@ -36,102 +34,5 @@ internal static class MealPlanTestFixture
 		var currentUser = Substitute.For<ICurrentUser>();
 		currentUser.UserId.Returns("user-123");
 		return currentUser;
-	}
-}
-
-internal sealed class FakeMealPlanEventStore : IMealPlanEventStore
-{
-	private readonly Dictionary<(string Owner, string Week), WeeklyPlan> store = [];
-
-	public int SaveCount { get; private set; }
-
-	public WeeklyPlan? LastSavedPlan { get; private set; }
-
-	public Task<WeeklyPlan?> LoadAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
-	{
-		store.TryGetValue((owner.Value, week.Value), out var plan);
-		return Task.FromResult(plan);
-	}
-
-	public Task SaveAsync(WeeklyPlan plan, CancellationToken cancellationToken = default)
-	{
-		store[(plan.Owner.Value, plan.Week.Value)] = plan;
-		LastSavedPlan = plan;
-		SaveCount++;
-		plan.MarkCommitted();
-		return Task.CompletedTask;
-	}
-
-	public void Seed(WeeklyPlan plan)
-	{
-		plan.MarkCommitted();
-		store[(plan.Owner.Value, plan.Week.Value)] = plan;
-	}
-}
-
-internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelRepository
-{
-	private readonly Dictionary<(string Owner, string Week), WeeklyPlan> store = [];
-
-	public Task<WeeklyPlanDto> GetByOwnerAndWeekAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
-	{
-		if (store.TryGetValue((owner.Value, week.Value), out var plan))
-		{
-			return Task.FromResult(plan.ToDto(week));
-		}
-
-		var emptyPlan = WeeklyPlan.Create(owner, week);
-		return Task.FromResult(emptyPlan.ToDto(week));
-	}
-
-	public Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
-	{
-		if (!store.TryGetValue((owner.Value, week.Value), out var plan))
-		{
-			return Task.FromResult(new WeeklyPlannedRecipesDto(week.Value, []));
-		}
-
-		var recipes = plan.Slots
-			.Where(slot => slot.ContentType == SlotContentType.Recipe && slot.Recipe is not null)
-			.Select(slot => new PlannedRecipeDto(
-				slot.Recipe!.RecipeIdentifier.Value,
-				slot.Recipe.Title.Value,
-				slot.Servings.Value,
-				slot.Day.ToString(),
-				slot.MealType.ToString()))
-			.ToList();
-
-		return Task.FromResult(new WeeklyPlannedRecipesDto(week.Value, recipes));
-	}
-
-	public Task<IReadOnlyList<MealHistoryEntryDto>> SearchCookedHistoryAsync(OwnerIdentifier owner, string? term, int limit, CancellationToken cancellationToken = default)
-	{
-		IEnumerable<MealHistoryEntryDto> rows = store
-			.Where(kv => kv.Key.Owner == owner.Value)
-			.SelectMany(kv => kv.Value.Slots
-				.Where(slot => slot.State == MealState.Cooked && slot.Recipe is not null)
-				.Select(slot => new MealHistoryEntryDto(
-					slot.Recipe!.RecipeIdentifier.Value,
-					slot.Recipe.Title.Value,
-					kv.Key.Week,
-					slot.Day.ToString(),
-					slot.MealType.ToString())));
-
-		if (!string.IsNullOrWhiteSpace(term))
-		{
-			rows = rows.Where(entry => entry.RecipeTitle.Contains(term.Trim(), StringComparison.OrdinalIgnoreCase));
-		}
-
-		return Task.FromResult<IReadOnlyList<MealHistoryEntryDto>>(rows
-			.OrderByDescending(entry => entry.Week)
-			.ThenBy(entry => entry.Day)
-			.ThenBy(entry => entry.MealType)
-			.Take(limit)
-			.ToList());
-	}
-
-	public void Seed(WeeklyPlan plan)
-	{
-		store[(plan.Owner.Value, plan.Week.Value)] = plan;
 	}
 }

--- a/tests/Yumney.Recipes.Api.Tests/Requests/ImportRecipeValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/ImportRecipeValidatorTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests;
 
-public class ImportRecipeRequestValidatorTests
+public class ImportRecipeValidatorTests
 {
-	private readonly ImportRecipeRequestValidator validator = new();
+	private readonly ImportRecipeValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidHttpsUrl_IsValid()
 	{
-		var request = new ImportRecipeRequest("https://example.com/recipe/123");
+		var request = new ImportRecipe("https://example.com/recipe/123");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +22,7 @@ public class ImportRecipeRequestValidatorTests
 	[Fact]
 	public void Validate_ValidHttpUrl_IsValid()
 	{
-		var request = new ImportRecipeRequest("http://example.com/recipe/123");
+		var request = new ImportRecipe("http://example.com/recipe/123");
 
 		var result = validator.Validate(request);
 
@@ -32,7 +32,7 @@ public class ImportRecipeRequestValidatorTests
 	[Fact]
 	public void Validate_UrlWithQueryParams_IsValid()
 	{
-		var request = new ImportRecipeRequest("https://example.com/recipe?id=123&lang=en");
+		var request = new ImportRecipe("https://example.com/recipe?id=123&lang=en");
 
 		var result = validator.Validate(request);
 
@@ -44,7 +44,7 @@ public class ImportRecipeRequestValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyUrl_IsNotValid(string url)
 	{
-		var request = new ImportRecipeRequest(url);
+		var request = new ImportRecipe(url);
 
 		var result = validator.Validate(request);
 
@@ -58,7 +58,7 @@ public class ImportRecipeRequestValidatorTests
 	[InlineData("example.com/recipe")]
 	public void Validate_InvalidUrl_IsNotValid(string url)
 	{
-		var request = new ImportRecipeRequest(url);
+		var request = new ImportRecipe(url);
 
 		var result = validator.Validate(request);
 
@@ -71,7 +71,7 @@ public class ImportRecipeRequestValidatorTests
 	{
 		var path = new string('a', 2040);
 		var url = $"https://x.com/{path}";
-		var request = new ImportRecipeRequest(url);
+		var request = new ImportRecipe(url);
 
 		var result = validator.Validate(request);
 
@@ -85,7 +85,7 @@ public class ImportRecipeRequestValidatorTests
 		var prefix = "https://x.com/";
 		var path = new string('a', 2048 - prefix.Length);
 		var url = $"{prefix}{path}";
-		var request = new ImportRecipeRequest(url);
+		var request = new ImportRecipe(url);
 
 		var result = validator.Validate(request);
 
@@ -97,7 +97,7 @@ public class ImportRecipeRequestValidatorTests
 	[Fact]
 	public void Validate_NullUrl_IsNotValid()
 	{
-		var request = new ImportRecipeRequest(null!);
+		var request = new ImportRecipe(null!);
 
 		var result = validator.Validate(request);
 
@@ -108,7 +108,7 @@ public class ImportRecipeRequestValidatorTests
 	[Fact]
 	public void Validate_UrlWithFragment_IsValid()
 	{
-		var request = new ImportRecipeRequest(
+		var request = new ImportRecipe(
 			"https://example.com/recipe#ingredients");
 
 		var result = validator.Validate(request);

--- a/tests/Yumney.Recipes.Api.Tests/Requests/SaveRecipeValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/SaveRecipeValidatorTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests;
 
-public class UpdateRecipeRequestValidatorTests
+public class SaveRecipeValidatorTests
 {
-	private readonly UpdateRecipeRequestValidator validator = new();
+	private readonly SaveRecipeValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
@@ -44,13 +44,45 @@ public class UpdateRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_TitleAtMaxLength_HasNoError()
+	public void Validate_NullSourceUrl_HasNoError()
 	{
-		var request = CreateValidRequest() with { Title = new string('a', 200) };
+		var request = CreateValidRequest() with { SourceUrl = null };
 
 		var result = validator.TestValidate(request);
 
-		result.ShouldNotHaveValidationErrorFor(x => x.Title);
+		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
+	}
+
+	[Fact]
+	public void Validate_EmptySourceUrl_HasNoError()
+	{
+		var request = CreateValidRequest() with { SourceUrl = string.Empty };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
+	}
+
+	[Fact]
+	public void Validate_ValidRequestWithNullSourceUrl_HasNoErrors()
+	{
+		var request = CreateValidRequest() with { SourceUrl = null };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveAnyValidationErrors();
+	}
+
+	[Theory]
+	[InlineData("not-a-url")]
+	[InlineData("ftp://example.com")]
+	public void Validate_InvalidSourceUrl_HasError(string sourceUrl)
+	{
+		var request = CreateValidRequest() with { SourceUrl = sourceUrl };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldHaveValidationErrorFor(x => x.SourceUrl);
 	}
 
 	[Fact]
@@ -68,7 +100,7 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest(string.Empty, null, null)],
+			Ingredients = [new SaveRecipeIngredient(string.Empty, null, null)],
 		};
 
 		var result = validator.TestValidate(request);
@@ -91,12 +123,42 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Steps = [new SaveRecipeStepRequest(1, string.Empty)],
+			Steps = [new SaveRecipeStep(1, string.Empty)],
 		};
 
 		var result = validator.TestValidate(request);
 
 		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_ValidHttpUrl_HasNoError()
+	{
+		var request = CreateValidRequest() with { SourceUrl = "http://example.com/recipe" };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
+	}
+
+	[Fact]
+	public void Validate_ValidHttpsUrl_HasNoError()
+	{
+		var request = CreateValidRequest() with { SourceUrl = "https://example.com/recipe" };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
+	}
+
+	[Fact]
+	public void Validate_TitleAtMaxLength_HasNoError()
+	{
+		var request = CreateValidRequest() with { Title = new string('a', 200) };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.Title);
 	}
 
 	[Fact]
@@ -135,16 +197,6 @@ public class UpdateRecipeRequestValidatorTests
 		var result = validator.TestValidate(request);
 
 		result.ShouldHaveValidationErrorFor(x => x.Servings);
-	}
-
-	[Fact]
-	public void Validate_PositiveServings_HasNoError()
-	{
-		var request = CreateValidRequest() with { Servings = 1 };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.Servings);
 	}
 
 	[Fact]
@@ -188,6 +240,55 @@ public class UpdateRecipeRequestValidatorTests
 	}
 
 	[Fact]
+	public void Validate_PositiveServings_HasNoError()
+	{
+		var request = CreateValidRequest() with { Servings = 1 };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.Servings);
+	}
+
+	[Fact]
+	public void Validate_SourceUrlExceedsMaxLength_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			SourceUrl = "https://example.com/" + new string('a', 2040),
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldHaveValidationErrorFor(x => x.SourceUrl);
+	}
+
+	[Fact]
+	public void Validate_IngredientNameExceedsMaxLength_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			Ingredients = [new SaveRecipeIngredient(new string('a', 201), null, null)],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_StepDescriptionExceedsMaxLength_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			Steps = [new SaveRecipeStep(1, new string('a', 2001))],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
 	public void Validate_DescriptionExceedsMaxLength_HasError()
 	{
 		var request = CreateValidRequest() with { Description = new string('a', 2001) };
@@ -211,16 +312,6 @@ public class UpdateRecipeRequestValidatorTests
 	public void Validate_DifficultyExceedsMaxLength_HasError()
 	{
 		var request = CreateValidRequest() with { Difficulty = new string('a', 51) };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldHaveValidationErrorFor(x => x.Difficulty);
-	}
-
-	[Fact]
-	public void Validate_EmptyDifficulty_HasError()
-	{
-		var request = CreateValidRequest() with { Difficulty = string.Empty };
 
 		var result = validator.TestValidate(request);
 
@@ -261,16 +352,13 @@ public class UpdateRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_IngredientNameExceedsMaxLength_HasError()
+	public void Validate_EmptyDifficulty_HasError()
 	{
-		var request = CreateValidRequest() with
-		{
-			Ingredients = [new SaveRecipeIngredientRequest(new string('a', 201), null, null)],
-		};
+		var request = CreateValidRequest() with { Difficulty = string.Empty };
 
 		var result = validator.TestValidate(request);
 
-		result.IsValid.Should().BeFalse();
+		result.ShouldHaveValidationErrorFor(x => x.Difficulty);
 	}
 
 	[Fact]
@@ -278,7 +366,7 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", -1, "g")],
+			Ingredients = [new SaveRecipeIngredient("Flour", -1, "g")],
 		};
 
 		var result = validator.TestValidate(request);
@@ -291,51 +379,12 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", 0, "g")],
+			Ingredients = [new SaveRecipeIngredient("Flour", 0, "g")],
 		};
 
 		var result = validator.TestValidate(request);
 
 		result.ShouldNotHaveAnyValidationErrors();
-	}
-
-	[Fact]
-	public void Validate_IngredientWithNullAmountAndUnit_HasNoError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Ingredients = [new SaveRecipeIngredientRequest("Salt", null, null)],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveAnyValidationErrors();
-	}
-
-	[Fact]
-	public void Validate_IngredientUnitExceedsMaxLength_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", 500, new string('a', 51))],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Validate_StepDescriptionExceedsMaxLength_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Steps = [new SaveRecipeStepRequest(1, new string('a', 2001))],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
 	}
 
 	[Fact]
@@ -343,7 +392,7 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Steps = [new SaveRecipeStepRequest(0, "Cook pasta")],
+			Steps = [new SaveRecipeStep(0, "Cook pasta")],
 		};
 
 		var result = validator.TestValidate(request);
@@ -356,7 +405,7 @@ public class UpdateRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Steps = [new SaveRecipeStepRequest(-1, "Cook pasta")],
+			Steps = [new SaveRecipeStep(-1, "Cook pasta")],
 		};
 
 		var result = validator.TestValidate(request);
@@ -364,17 +413,44 @@ public class UpdateRecipeRequestValidatorTests
 		result.IsValid.Should().BeFalse();
 	}
 
-	private static UpdateRecipeRequest CreateValidRequest()
+	[Fact]
+	public void Validate_IngredientWithNullAmountAndUnit_HasNoError()
 	{
-		return new UpdateRecipeRequest(
+		var request = CreateValidRequest() with
+		{
+			Ingredients = [new SaveRecipeIngredient("Salt", null, null)],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveAnyValidationErrors();
+	}
+
+	[Fact]
+	public void Validate_IngredientUnitExceedsMaxLength_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			Ingredients = [new SaveRecipeIngredient("Flour", 500, new string('a', 51))],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	private static SaveRecipe CreateValidRequest()
+	{
+		return new SaveRecipe(
 			"Pasta Carbonara",
 			"A classic dish",
-			[new SaveRecipeIngredientRequest("Spaghetti", 400, "g")],
-			[new SaveRecipeStepRequest(1, "Cook pasta")],
+			[new SaveRecipeIngredient("Spaghetti", 400, "g")],
+			[new SaveRecipeStep(1, "Cook pasta")],
 			4,
 			10,
 			20,
 			"medium",
-			null);
+			null,
+			"https://example.com/recipe");
 	}
 }

--- a/tests/Yumney.Recipes.Api.Tests/Requests/UpdateRecipeValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/UpdateRecipeValidatorTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests;
 
-public class SaveRecipeRequestValidatorTests
+public class UpdateRecipeValidatorTests
 {
-	private readonly SaveRecipeRequestValidator validator = new();
+	private readonly UpdateRecipeValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
@@ -44,45 +44,13 @@ public class SaveRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_NullSourceUrl_HasNoError()
+	public void Validate_TitleAtMaxLength_HasNoError()
 	{
-		var request = CreateValidRequest() with { SourceUrl = null };
+		var request = CreateValidRequest() with { Title = new string('a', 200) };
 
 		var result = validator.TestValidate(request);
 
-		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
-	}
-
-	[Fact]
-	public void Validate_EmptySourceUrl_HasNoError()
-	{
-		var request = CreateValidRequest() with { SourceUrl = string.Empty };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
-	}
-
-	[Fact]
-	public void Validate_ValidRequestWithNullSourceUrl_HasNoErrors()
-	{
-		var request = CreateValidRequest() with { SourceUrl = null };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveAnyValidationErrors();
-	}
-
-	[Theory]
-	[InlineData("not-a-url")]
-	[InlineData("ftp://example.com")]
-	public void Validate_InvalidSourceUrl_HasError(string sourceUrl)
-	{
-		var request = CreateValidRequest() with { SourceUrl = sourceUrl };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldHaveValidationErrorFor(x => x.SourceUrl);
+		result.ShouldNotHaveValidationErrorFor(x => x.Title);
 	}
 
 	[Fact]
@@ -100,7 +68,7 @@ public class SaveRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest(string.Empty, null, null)],
+			Ingredients = [new SaveRecipeIngredient(string.Empty, null, null)],
 		};
 
 		var result = validator.TestValidate(request);
@@ -123,42 +91,12 @@ public class SaveRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Steps = [new SaveRecipeStepRequest(1, string.Empty)],
+			Steps = [new SaveRecipeStep(1, string.Empty)],
 		};
 
 		var result = validator.TestValidate(request);
 
 		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Validate_ValidHttpUrl_HasNoError()
-	{
-		var request = CreateValidRequest() with { SourceUrl = "http://example.com/recipe" };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
-	}
-
-	[Fact]
-	public void Validate_ValidHttpsUrl_HasNoError()
-	{
-		var request = CreateValidRequest() with { SourceUrl = "https://example.com/recipe" };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.SourceUrl);
-	}
-
-	[Fact]
-	public void Validate_TitleAtMaxLength_HasNoError()
-	{
-		var request = CreateValidRequest() with { Title = new string('a', 200) };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.Title);
 	}
 
 	[Fact]
@@ -197,6 +135,16 @@ public class SaveRecipeRequestValidatorTests
 		var result = validator.TestValidate(request);
 
 		result.ShouldHaveValidationErrorFor(x => x.Servings);
+	}
+
+	[Fact]
+	public void Validate_PositiveServings_HasNoError()
+	{
+		var request = CreateValidRequest() with { Servings = 1 };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldNotHaveValidationErrorFor(x => x.Servings);
 	}
 
 	[Fact]
@@ -240,55 +188,6 @@ public class SaveRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_PositiveServings_HasNoError()
-	{
-		var request = CreateValidRequest() with { Servings = 1 };
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldNotHaveValidationErrorFor(x => x.Servings);
-	}
-
-	[Fact]
-	public void Validate_SourceUrlExceedsMaxLength_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			SourceUrl = "https://example.com/" + new string('a', 2040),
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.ShouldHaveValidationErrorFor(x => x.SourceUrl);
-	}
-
-	[Fact]
-	public void Validate_IngredientNameExceedsMaxLength_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Ingredients = [new SaveRecipeIngredientRequest(new string('a', 201), null, null)],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Validate_StepDescriptionExceedsMaxLength_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Steps = [new SaveRecipeStepRequest(1, new string('a', 2001))],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
 	public void Validate_DescriptionExceedsMaxLength_HasError()
 	{
 		var request = CreateValidRequest() with { Description = new string('a', 2001) };
@@ -312,6 +211,16 @@ public class SaveRecipeRequestValidatorTests
 	public void Validate_DifficultyExceedsMaxLength_HasError()
 	{
 		var request = CreateValidRequest() with { Difficulty = new string('a', 51) };
+
+		var result = validator.TestValidate(request);
+
+		result.ShouldHaveValidationErrorFor(x => x.Difficulty);
+	}
+
+	[Fact]
+	public void Validate_EmptyDifficulty_HasError()
+	{
+		var request = CreateValidRequest() with { Difficulty = string.Empty };
 
 		var result = validator.TestValidate(request);
 
@@ -352,13 +261,16 @@ public class SaveRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_EmptyDifficulty_HasError()
+	public void Validate_IngredientNameExceedsMaxLength_HasError()
 	{
-		var request = CreateValidRequest() with { Difficulty = string.Empty };
+		var request = CreateValidRequest() with
+		{
+			Ingredients = [new SaveRecipeIngredient(new string('a', 201), null, null)],
+		};
 
 		var result = validator.TestValidate(request);
 
-		result.ShouldHaveValidationErrorFor(x => x.Difficulty);
+		result.IsValid.Should().BeFalse();
 	}
 
 	[Fact]
@@ -366,7 +278,7 @@ public class SaveRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", -1, "g")],
+			Ingredients = [new SaveRecipeIngredient("Flour", -1, "g")],
 		};
 
 		var result = validator.TestValidate(request);
@@ -379,7 +291,7 @@ public class SaveRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", 0, "g")],
+			Ingredients = [new SaveRecipeIngredient("Flour", 0, "g")],
 		};
 
 		var result = validator.TestValidate(request);
@@ -388,37 +300,11 @@ public class SaveRecipeRequestValidatorTests
 	}
 
 	[Fact]
-	public void Validate_ZeroStepNumber_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Steps = [new SaveRecipeStepRequest(0, "Cook pasta")],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Validate_NegativeStepNumber_HasError()
-	{
-		var request = CreateValidRequest() with
-		{
-			Steps = [new SaveRecipeStepRequest(-1, "Cook pasta")],
-		};
-
-		var result = validator.TestValidate(request);
-
-		result.IsValid.Should().BeFalse();
-	}
-
-	[Fact]
 	public void Validate_IngredientWithNullAmountAndUnit_HasNoError()
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Salt", null, null)],
+			Ingredients = [new SaveRecipeIngredient("Salt", null, null)],
 		};
 
 		var result = validator.TestValidate(request);
@@ -431,7 +317,7 @@ public class SaveRecipeRequestValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Ingredients = [new SaveRecipeIngredientRequest("Flour", 500, new string('a', 51))],
+			Ingredients = [new SaveRecipeIngredient("Flour", 500, new string('a', 51))],
 		};
 
 		var result = validator.TestValidate(request);
@@ -439,18 +325,56 @@ public class SaveRecipeRequestValidatorTests
 		result.IsValid.Should().BeFalse();
 	}
 
-	private static SaveRecipeRequest CreateValidRequest()
+	[Fact]
+	public void Validate_StepDescriptionExceedsMaxLength_HasError()
 	{
-		return new SaveRecipeRequest(
+		var request = CreateValidRequest() with
+		{
+			Steps = [new SaveRecipeStep(1, new string('a', 2001))],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_ZeroStepNumber_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			Steps = [new SaveRecipeStep(0, "Cook pasta")],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_NegativeStepNumber_HasError()
+	{
+		var request = CreateValidRequest() with
+		{
+			Steps = [new SaveRecipeStep(-1, "Cook pasta")],
+		};
+
+		var result = validator.TestValidate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	private static UpdateRecipe CreateValidRequest()
+	{
+		return new UpdateRecipe(
 			"Pasta Carbonara",
 			"A classic dish",
-			[new SaveRecipeIngredientRequest("Spaghetti", 400, "g")],
-			[new SaveRecipeStepRequest(1, "Cook pasta")],
+			[new SaveRecipeIngredient("Spaghetti", 400, "g")],
+			[new SaveRecipeStep(1, "Cook pasta")],
 			4,
 			10,
 			20,
 			"medium",
-			null,
-			"https://example.com/recipe");
+			null);
 	}
 }

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/ImportFromTextRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/ImportFromTextRequestValidatorTests.cs
@@ -1,18 +1,16 @@
 using FluentValidation.TestHelper;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
 public class ImportFromTextRequestValidatorTests
 {
-	private readonly ImportFromTextRequestValidator validator = new();
+	private readonly Api.Requests.Validator.ImportFromTextRequestValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
 	{
-		var request = new ImportFromTextRequestDto("Take 2 eggs and mix with flour...");
+		var request = new Api.Requests.ImportFromTextRequestDto("Take 2 eggs and mix with flour...");
 
 		var result = validator.TestValidate(request);
 
@@ -25,7 +23,7 @@ public class ImportFromTextRequestValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyText_HasError(string? text)
 	{
-		var request = new ImportFromTextRequestDto(text!);
+		var request = new Api.Requests.ImportFromTextRequestDto(text!);
 
 		var result = validator.TestValidate(request);
 

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/ParseIntentRequestValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/ParseIntentRequestValidatorTests.cs
@@ -1,5 +1,4 @@
 using FluentValidation.TestHelper;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using Xunit;
 
@@ -7,7 +6,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
 public class ParseIntentRequestValidatorTests
 {
-	private readonly ParseIntentRequestValidator validator = new();
+	private readonly Api.Requests.Validator.ParseIntentRequestValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeIngredientValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeIngredientValidatorTests.cs
@@ -1,7 +1,5 @@
 using FluentAssertions;
 using FluentValidation.TestHelper;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using Xunit;
 
@@ -9,12 +7,12 @@ namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
 public class SaveRecipeIngredientValidatorTests
 {
-	private readonly SaveRecipeIngredientValidator validator = new();
+	private readonly Api.Requests.Validator.SaveRecipeIngredientValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
 	{
-		var request = new SaveRecipeIngredient("Flour", 500, "g");
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 500, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -24,7 +22,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NullAmountAndUnit_HasNoErrors()
 	{
-		var request = new SaveRecipeIngredient("Salt", null, null);
+		var request = new Api.Requests.SaveRecipeIngredient("Salt", null, null);
 
 		var result = validator.TestValidate(request);
 
@@ -37,7 +35,7 @@ public class SaveRecipeIngredientValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyName_HasError(string? name)
 	{
-		var request = new SaveRecipeIngredient(name!, 100, "g");
+		var request = new Api.Requests.SaveRecipeIngredient(name!, 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -47,7 +45,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NameExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeIngredient(new string('a', IngredientName.MaxLength + 1), 100, "g");
+		var request = new Api.Requests.SaveRecipeIngredient(new string('a', IngredientName.MaxLength + 1), 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -57,7 +55,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NameAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeIngredient(new string('a', IngredientName.MaxLength), 100, "g");
+		var request = new Api.Requests.SaveRecipeIngredient(new string('a', IngredientName.MaxLength), 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -67,7 +65,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NegativeAmount_HasError()
 	{
-		var request = new SaveRecipeIngredient("Flour", -1, "g");
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", -1, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -77,7 +75,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_ZeroAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredient("Flour", 0, "g");
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 0, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -87,7 +85,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_PositiveAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredient("Flour", 500, "g");
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 500, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -97,7 +95,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NullAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredient("Flour", null, "g");
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", null, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -107,7 +105,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_UnitExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength + 1));
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength + 1));
 
 		var result = validator.TestValidate(request);
 
@@ -117,7 +115,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_UnitAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength));
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength));
 
 		var result = validator.TestValidate(request);
 
@@ -127,7 +125,7 @@ public class SaveRecipeIngredientValidatorTests
 	[Fact]
 	public void Validate_NullUnit_HasNoError()
 	{
-		var request = new SaveRecipeIngredient("Flour", 500, null);
+		var request = new Api.Requests.SaveRecipeIngredient("Flour", 500, null);
 
 		var result = validator.TestValidate(request);
 

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeIngredientValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeIngredientValidatorTests.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
-public class SaveRecipeIngredientRequestValidatorTests
+public class SaveRecipeIngredientValidatorTests
 {
-	private readonly SaveRecipeIngredientRequestValidator validator = new();
+	private readonly SaveRecipeIngredientValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 500, "g");
+		var request = new SaveRecipeIngredient("Flour", 500, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -24,7 +24,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NullAmountAndUnit_HasNoErrors()
 	{
-		var request = new SaveRecipeIngredientRequest("Salt", null, null);
+		var request = new SaveRecipeIngredient("Salt", null, null);
 
 		var result = validator.TestValidate(request);
 
@@ -37,7 +37,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyName_HasError(string? name)
 	{
-		var request = new SaveRecipeIngredientRequest(name!, 100, "g");
+		var request = new SaveRecipeIngredient(name!, 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -47,7 +47,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NameExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeIngredientRequest(new string('a', IngredientName.MaxLength + 1), 100, "g");
+		var request = new SaveRecipeIngredient(new string('a', IngredientName.MaxLength + 1), 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -57,7 +57,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NameAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest(new string('a', IngredientName.MaxLength), 100, "g");
+		var request = new SaveRecipeIngredient(new string('a', IngredientName.MaxLength), 100, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -67,7 +67,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NegativeAmount_HasError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", -1, "g");
+		var request = new SaveRecipeIngredient("Flour", -1, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -77,7 +77,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_ZeroAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 0, "g");
+		var request = new SaveRecipeIngredient("Flour", 0, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -87,7 +87,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_PositiveAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 500, "g");
+		var request = new SaveRecipeIngredient("Flour", 500, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -97,7 +97,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NullAmount_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", null, "g");
+		var request = new SaveRecipeIngredient("Flour", null, "g");
 
 		var result = validator.TestValidate(request);
 
@@ -107,7 +107,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_UnitExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 500, new string('a', Unit.MaxLength + 1));
+		var request = new SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength + 1));
 
 		var result = validator.TestValidate(request);
 
@@ -117,7 +117,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_UnitAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 500, new string('a', Unit.MaxLength));
+		var request = new SaveRecipeIngredient("Flour", 500, new string('a', Unit.MaxLength));
 
 		var result = validator.TestValidate(request);
 
@@ -127,7 +127,7 @@ public class SaveRecipeIngredientRequestValidatorTests
 	[Fact]
 	public void Validate_NullUnit_HasNoError()
 	{
-		var request = new SaveRecipeIngredientRequest("Flour", 500, null);
+		var request = new SaveRecipeIngredient("Flour", 500, null);
 
 		var result = validator.TestValidate(request);
 

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeStepValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeStepValidatorTests.cs
@@ -1,7 +1,4 @@
-using FluentAssertions;
 using FluentValidation.TestHelper;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests;
-using SmartSolutionsLab.Yumney.Recipes.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using Xunit;
 
@@ -9,12 +6,12 @@ namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
 public class SaveRecipeStepValidatorTests
 {
-	private readonly SaveRecipeStepValidator validator = new();
+	private readonly Api.Requests.Validator.SaveRecipeStepValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
 	{
-		var request = new SaveRecipeStep(1, "Cook pasta until al dente.");
+		var request = new Api.Requests.SaveRecipeStep(1, "Cook pasta until al dente.");
 
 		var result = validator.TestValidate(request);
 
@@ -24,7 +21,7 @@ public class SaveRecipeStepValidatorTests
 	[Fact]
 	public void Validate_ZeroNumber_HasError()
 	{
-		var request = new SaveRecipeStep(0, "Cook pasta.");
+		var request = new Api.Requests.SaveRecipeStep(0, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -34,7 +31,7 @@ public class SaveRecipeStepValidatorTests
 	[Fact]
 	public void Validate_NegativeNumber_HasError()
 	{
-		var request = new SaveRecipeStep(-1, "Cook pasta.");
+		var request = new Api.Requests.SaveRecipeStep(-1, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -44,7 +41,7 @@ public class SaveRecipeStepValidatorTests
 	[Fact]
 	public void Validate_PositiveNumber_HasNoError()
 	{
-		var request = new SaveRecipeStep(5, "Cook pasta.");
+		var request = new Api.Requests.SaveRecipeStep(5, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -57,7 +54,7 @@ public class SaveRecipeStepValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyDescription_HasError(string? description)
 	{
-		var request = new SaveRecipeStep(1, description!);
+		var request = new Api.Requests.SaveRecipeStep(1, description!);
 
 		var result = validator.TestValidate(request);
 
@@ -67,7 +64,7 @@ public class SaveRecipeStepValidatorTests
 	[Fact]
 	public void Validate_DescriptionExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeStep(1, new string('a', StepDescription.MaxLength + 1));
+		var request = new Api.Requests.SaveRecipeStep(1, new string('a', StepDescription.MaxLength + 1));
 
 		var result = validator.TestValidate(request);
 
@@ -77,7 +74,7 @@ public class SaveRecipeStepValidatorTests
 	[Fact]
 	public void Validate_DescriptionAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeStep(1, new string('a', StepDescription.MaxLength));
+		var request = new Api.Requests.SaveRecipeStep(1, new string('a', StepDescription.MaxLength));
 
 		var result = validator.TestValidate(request);
 

--- a/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeStepValidatorTests.cs
+++ b/tests/Yumney.Recipes.Api.Tests/Requests/Validator/SaveRecipeStepValidatorTests.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api.Tests.Requests.Validator;
 
-public class SaveRecipeStepRequestValidatorTests
+public class SaveRecipeStepValidatorTests
 {
-	private readonly SaveRecipeStepRequestValidator validator = new();
+	private readonly SaveRecipeStepValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_HasNoErrors()
 	{
-		var request = new SaveRecipeStepRequest(1, "Cook pasta until al dente.");
+		var request = new SaveRecipeStep(1, "Cook pasta until al dente.");
 
 		var result = validator.TestValidate(request);
 
@@ -24,7 +24,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[Fact]
 	public void Validate_ZeroNumber_HasError()
 	{
-		var request = new SaveRecipeStepRequest(0, "Cook pasta.");
+		var request = new SaveRecipeStep(0, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -34,7 +34,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[Fact]
 	public void Validate_NegativeNumber_HasError()
 	{
-		var request = new SaveRecipeStepRequest(-1, "Cook pasta.");
+		var request = new SaveRecipeStep(-1, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -44,7 +44,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[Fact]
 	public void Validate_PositiveNumber_HasNoError()
 	{
-		var request = new SaveRecipeStepRequest(5, "Cook pasta.");
+		var request = new SaveRecipeStep(5, "Cook pasta.");
 
 		var result = validator.TestValidate(request);
 
@@ -57,7 +57,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyDescription_HasError(string? description)
 	{
-		var request = new SaveRecipeStepRequest(1, description!);
+		var request = new SaveRecipeStep(1, description!);
 
 		var result = validator.TestValidate(request);
 
@@ -67,7 +67,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[Fact]
 	public void Validate_DescriptionExceedsMaxLength_HasError()
 	{
-		var request = new SaveRecipeStepRequest(1, new string('a', StepDescription.MaxLength + 1));
+		var request = new SaveRecipeStep(1, new string('a', StepDescription.MaxLength + 1));
 
 		var result = validator.TestValidate(request);
 
@@ -77,7 +77,7 @@ public class SaveRecipeStepRequestValidatorTests
 	[Fact]
 	public void Validate_DescriptionAtMaxLength_HasNoError()
 	{
-		var request = new SaveRecipeStepRequest(1, new string('a', StepDescription.MaxLength));
+		var request = new SaveRecipeStep(1, new string('a', StepDescription.MaxLength));
 
 		var result = validator.TestValidate(request);
 

--- a/tests/Yumney.Shared.Tests/CQRS/LoggingCommandHandlerDecoratorTests.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/LoggingCommandHandlerDecoratorTests.cs
@@ -91,7 +91,3 @@ public class LoggingCommandHandlerDecoratorTests
 		}
 	}
 }
-
-public sealed record TestCommand : ICommand<Result<string>>;
-
-public sealed record PlainCommand : ICommand<string>;

--- a/tests/Yumney.Shared.Tests/CQRS/LoggingQueryHandlerDecoratorTests.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/LoggingQueryHandlerDecoratorTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.Metrics;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -53,16 +52,5 @@ public class LoggingQueryHandlerDecoratorTests
 		Func<Task> act = () => decorator.HandleAsync(new TestQuery());
 
 		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
-	}
-}
-
-public sealed record TestQuery : IQuery<Result<int>>;
-
-internal sealed class TestMeterFactory : IMeterFactory
-{
-	public Meter Create(MeterOptions options) => new(options);
-
-	public void Dispose()
-	{
 	}
 }

--- a/tests/Yumney.Shared.Tests/CQRS/PlainCommand.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/PlainCommand.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.CQRS;
+
+public sealed record PlainCommand : ICommand<string>;

--- a/tests/Yumney.Shared.Tests/CQRS/TestCommand.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/TestCommand.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.CQRS;
+
+public sealed record TestCommand : ICommand<Result<string>>;

--- a/tests/Yumney.Shared.Tests/CQRS/TestMeterFactory.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/TestMeterFactory.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.Metrics;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.CQRS;
+
+internal sealed class TestMeterFactory : IMeterFactory
+{
+	public Meter Create(MeterOptions options) => new(options);
+
+	public void Dispose()
+	{
+	}
+}

--- a/tests/Yumney.Shared.Tests/CQRS/TestQuery.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/TestQuery.cs
@@ -1,0 +1,6 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.CQRS;
+
+public sealed record TestQuery : IQuery<Result<int>>;

--- a/tests/Yumney.Shared.Tests/Events/IntegrationEventHandlerRegistrationTests.cs
+++ b/tests/Yumney.Shared.Tests/Events/IntegrationEventHandlerRegistrationTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Events;
+
+public class IntegrationEventHandlerRegistrationTests
+{
+	[Fact]
+	public void AddIntegrationEventHandlersFromAssemblyContaining_RegistersConcreteAsScoped()
+	{
+		ServiceCollection services = [];
+
+		services.AddIntegrationEventHandlersFromAssemblyContaining<MultiEventConsumer>();
+
+		using var provider = services.BuildServiceProvider();
+		using var scope = provider.CreateScope();
+
+		var concrete = scope.ServiceProvider.GetRequiredService<MultiEventConsumer>();
+		concrete.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void AddIntegrationEventHandlersFromAssemblyContaining_PointsEveryInterfaceAtTheSameInstance()
+	{
+		ServiceCollection services = [];
+
+		services.AddIntegrationEventHandlersFromAssemblyContaining<MultiEventConsumer>();
+
+		using var provider = services.BuildServiceProvider();
+		using var scope = provider.CreateScope();
+
+		var first = scope.ServiceProvider.GetRequiredService<IIntegrationEventHandler<FirstEvent>>();
+		var second = scope.ServiceProvider.GetRequiredService<IIntegrationEventHandler<SecondEvent>>();
+
+		first.Should().BeSameAs(second, "a handler that consumes multiple events must share one instance per scope");
+	}
+
+	[Fact]
+	public void AddIntegrationEventHandlersFromAssemblyContaining_DifferentScopes_GetDifferentInstances()
+	{
+		ServiceCollection services = [];
+
+		services.AddIntegrationEventHandlersFromAssemblyContaining<MultiEventConsumer>();
+
+		using var provider = services.BuildServiceProvider();
+		using var firstScope = provider.CreateScope();
+		using var secondScope = provider.CreateScope();
+
+		var firstHandler = firstScope.ServiceProvider.GetRequiredService<IIntegrationEventHandler<FirstEvent>>();
+		var secondHandler = secondScope.ServiceProvider.GetRequiredService<IIntegrationEventHandler<FirstEvent>>();
+
+		firstHandler.Should().NotBeSameAs(secondHandler);
+	}
+
+	[Fact]
+	public void AddIntegrationEventHandlersFromAssemblyContaining_RegistersSingleEventConsumer()
+	{
+		ServiceCollection services = [];
+
+		services.AddIntegrationEventHandlersFromAssemblyContaining<SingleEventConsumer>();
+
+		using var provider = services.BuildServiceProvider();
+		using var scope = provider.CreateScope();
+
+		var handler = scope.ServiceProvider.GetRequiredService<IIntegrationEventHandler<ThirdEvent>>();
+		handler.Should().BeOfType<SingleEventConsumer>();
+	}
+}
+
+public sealed record FirstEvent : IntegrationEvent;
+
+public sealed record SecondEvent : IntegrationEvent;
+
+public sealed record ThirdEvent : IntegrationEvent;
+
+public sealed class MultiEventConsumer
+	: IIntegrationEventHandler<FirstEvent>, IIntegrationEventHandler<SecondEvent>
+{
+	public Task HandleAsync(FirstEvent @event, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+	public Task HandleAsync(SecondEvent @event, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}
+
+public sealed class SingleEventConsumer : IIntegrationEventHandler<ThirdEvent>
+{
+	public Task HandleAsync(ThirdEvent @event, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}

--- a/tests/Yumney.Shared.Tests/Web/YumneyServiceClientRegistrationTests.cs
+++ b/tests/Yumney.Shared.Tests/Web/YumneyServiceClientRegistrationTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Web;
+
+public class YumneyServiceClientRegistrationTests
+{
+	[Fact]
+	public void AddYumneyServiceClient_RegistersNamedHttpClientWithExpectedBaseAddress()
+	{
+		ServiceCollection services = [];
+
+		services.AddYumneyServiceClient("recipes-api");
+
+		using var provider = services.BuildServiceProvider();
+		var factory = provider.GetRequiredService<IHttpClientFactory>();
+		var client = factory.CreateClient("recipes-api");
+
+		client.BaseAddress.Should().Be(new Uri("http://recipes-api"));
+	}
+
+	[Fact]
+	public void AddYumneyServiceClient_CalledTwice_DoesNotDuplicateAuthHandler()
+	{
+		ServiceCollection services = [];
+
+		services.AddYumneyServiceClient("recipes-api");
+		services.AddYumneyServiceClient("shopping-api");
+
+		var matchingDescriptors = services.Where(descriptor => descriptor.ServiceType == typeof(AuthTokenDelegatingHandler)).ToList();
+		matchingDescriptors.Should().HaveCount(1, "TryAddTransient must only register the handler once even when multiple service clients are added");
+	}
+
+	[Fact]
+	public void AddYumneyServiceClient_RegistersAuthTokenDelegatingHandler()
+	{
+		ServiceCollection services = [];
+
+		services.AddYumneyServiceClient("recipes-api");
+
+		using var provider = services.BuildServiceProvider();
+		var handler = provider.GetService<AuthTokenDelegatingHandler>();
+
+		handler.Should().NotBeNull("AddYumneyServiceClient must register AuthTokenDelegatingHandler so the named HttpClient can resolve it");
+	}
+}

--- a/tests/Yumney.Shopping.Api.Tests/Requests/AddManualItemValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/AddManualItemValidatorTests.cs
@@ -1,18 +1,16 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
 public class AddManualItemValidatorTests
 {
-	private readonly AddManualItemValidator validator = new();
+	private readonly Api.Requests.Validator.AddManualItemValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new AddManualItem("Milk", 2, "L");
+		var request = new Api.Requests.AddManualItem("Milk", 2, "L");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +20,7 @@ public class AddManualItemValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new AddManualItem("Milk");
+		var request = new Api.Requests.AddManualItem("Milk");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +32,7 @@ public class AddManualItemValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new AddManualItem(name!);
+		var request = new Api.Requests.AddManualItem(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Api.Tests/Requests/AddManualItemValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/AddManualItemValidatorTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
-public class MarkAsFrozenRequestValidatorTests
+public class AddManualItemValidatorTests
 {
-	private readonly MarkAsFrozenRequestValidator validator = new();
+	private readonly AddManualItemValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new MarkAsFrozenRequest("Chicken", "g");
+		var request = new AddManualItem("Milk", 2, "L");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +22,7 @@ public class MarkAsFrozenRequestValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new MarkAsFrozenRequest("Eggs");
+		var request = new AddManualItem("Milk");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +34,7 @@ public class MarkAsFrozenRequestValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new MarkAsFrozenRequest(name!);
+		var request = new AddManualItem(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Api.Tests/Requests/CreateShoppingListValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/CreateShoppingListValidatorTests.cs
@@ -1,13 +1,11 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
 public class CreateShoppingListValidatorTests
 {
-	private readonly CreateShoppingListValidator validator = new();
+	private readonly Api.Requests.Validator.CreateShoppingListValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
@@ -56,7 +54,7 @@ public class CreateShoppingListValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Items = [new ShoppingListItem(string.Empty, null, null)],
+			Items = [new Api.Requests.ShoppingListItem(string.Empty, null, null)],
 		};
 
 		var result = validator.Validate(request);
@@ -69,7 +67,7 @@ public class CreateShoppingListValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Items = [new ShoppingListItem(new string('a', 201), null, null)],
+			Items = [new Api.Requests.ShoppingListItem(new string('a', 201), null, null)],
 		};
 
 		var result = validator.Validate(request);
@@ -82,7 +80,7 @@ public class CreateShoppingListValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Items = [new ShoppingListItem("Flour", -1, "g")],
+			Items = [new Api.Requests.ShoppingListItem("Flour", -1, "g")],
 		};
 
 		var result = validator.Validate(request);
@@ -95,7 +93,7 @@ public class CreateShoppingListValidatorTests
 	{
 		var request = CreateValidRequest() with
 		{
-			Items = [new ShoppingListItem("Flour", 500, new string('a', 51))],
+			Items = [new Api.Requests.ShoppingListItem("Flour", 500, new string('a', 51))],
 		};
 
 		var result = validator.Validate(request);
@@ -103,10 +101,10 @@ public class CreateShoppingListValidatorTests
 		result.IsValid.Should().BeFalse();
 	}
 
-	private static CreateShoppingList CreateValidRequest()
+	private static Api.Requests.CreateShoppingList CreateValidRequest()
 	{
-		return new CreateShoppingList(
+		return new Api.Requests.CreateShoppingList(
 			"Weekly Groceries",
-			[new ShoppingListItem("Flour", 500, "g")]);
+			[new Api.Requests.ShoppingListItem("Flour", 500, "g")]);
 	}
 }

--- a/tests/Yumney.Shopping.Api.Tests/Requests/CreateShoppingListValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/CreateShoppingListValidatorTests.cs
@@ -5,9 +5,9 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
-public class CreateShoppingListRequestValidatorTests
+public class CreateShoppingListValidatorTests
 {
-	private readonly CreateShoppingListRequestValidator validator = new();
+	private readonly CreateShoppingListValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
@@ -103,9 +103,9 @@ public class CreateShoppingListRequestValidatorTests
 		result.IsValid.Should().BeFalse();
 	}
 
-	private static CreateShoppingListRequest CreateValidRequest()
+	private static CreateShoppingList CreateValidRequest()
 	{
-		return new CreateShoppingListRequest(
+		return new CreateShoppingList(
 			"Weekly Groceries",
 			[new ShoppingListItem("Flour", 500, "g")]);
 	}

--- a/tests/Yumney.Shopping.Api.Tests/Requests/MarkAsFrozenValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/MarkAsFrozenValidatorTests.cs
@@ -1,18 +1,16 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
 public class MarkAsFrozenValidatorTests
 {
-	private readonly MarkAsFrozenValidator validator = new();
+	private readonly Api.Requests.Validator.MarkAsFrozenValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new MarkAsFrozen("Chicken", "g");
+		var request = new Api.Requests.MarkAsFrozen("Chicken", "g");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +20,7 @@ public class MarkAsFrozenValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new MarkAsFrozen("Eggs");
+		var request = new Api.Requests.MarkAsFrozen("Eggs");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +32,7 @@ public class MarkAsFrozenValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new MarkAsFrozen(name!);
+		var request = new Api.Requests.MarkAsFrozen(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Api.Tests/Requests/MarkAsFrozenValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/MarkAsFrozenValidatorTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
-public class AddManualItemRequestValidatorTests
+public class MarkAsFrozenValidatorTests
 {
-	private readonly AddManualItemRequestValidator validator = new();
+	private readonly MarkAsFrozenValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new AddManualItemRequest("Milk", 2, "L");
+		var request = new MarkAsFrozen("Chicken", "g");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +22,7 @@ public class AddManualItemRequestValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new AddManualItemRequest("Milk");
+		var request = new MarkAsFrozen("Eggs");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +34,7 @@ public class AddManualItemRequestValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new AddManualItemRequest(name!);
+		var request = new MarkAsFrozen(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Api.Tests/Requests/RemoveItemValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/RemoveItemValidatorTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
-public class RemoveItemRequestValidatorTests
+public class RemoveItemValidatorTests
 {
-	private readonly RemoveItemRequestValidator validator = new();
+	private readonly RemoveItemValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new RemoveItemRequest("Eggs", 6, "pc", "not needed");
+		var request = new RemoveItem("Eggs", 6, "pc", "not needed");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +22,7 @@ public class RemoveItemRequestValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new RemoveItemRequest("Eggs");
+		var request = new RemoveItem("Eggs");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +34,7 @@ public class RemoveItemRequestValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new RemoveItemRequest(name!);
+		var request = new RemoveItem(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Api.Tests/Requests/RemoveItemValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/RemoveItemValidatorTests.cs
@@ -1,18 +1,16 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests;
-using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
 
 public class RemoveItemValidatorTests
 {
-	private readonly RemoveItemValidator validator = new();
+	private readonly Api.Requests.Validator.RemoveItemValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new RemoveItem("Eggs", 6, "pc", "not needed");
+		var request = new Api.Requests.RemoveItem("Eggs", 6, "pc", "not needed");
 
 		var result = validator.Validate(request);
 
@@ -22,7 +20,7 @@ public class RemoveItemValidatorTests
 	[Fact]
 	public void Validate_NameOnly_IsValid()
 	{
-		var request = new RemoveItem("Eggs");
+		var request = new Api.Requests.RemoveItem("Eggs");
 
 		var result = validator.Validate(request);
 
@@ -34,7 +32,7 @@ public class RemoveItemValidatorTests
 	[InlineData("")]
 	public void Validate_EmptyName_IsInvalid(string? name)
 	{
-		var request = new RemoveItem(name!);
+		var request = new Api.Requests.RemoveItem(name!);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/ExportShoppingListQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
@@ -24,7 +25,7 @@ public class ExportShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_NoItems_ReturnsEmptyString()
 	{
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto([]));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -39,7 +40,7 @@ public class ExportShoppingListQueryHandlerTests
 		List<MergedShoppingItemDto> items = [
 			new("Milk", 2, 2, "L", "dairy", true, [])
 		];
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -56,7 +57,7 @@ public class ExportShoppingListQueryHandlerTests
 			new("Milk", 2, 2, "L", "dairy", false, []),
 			new("Onion", 3, 3, "pc", "produce", false, []),
 		};
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -78,7 +79,7 @@ public class ExportShoppingListQueryHandlerTests
 			new("Milk", 2, 2, "L", "dairy", true, []),
 			new("Eggs", 6, 6, "pc", "dairy", false, [])
 		];
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -94,7 +95,7 @@ public class ExportShoppingListQueryHandlerTests
 		{
 			new("Milk", 5.3m, 6, "L", "dairy", false, []),
 		};
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());
@@ -110,7 +111,7 @@ public class ExportShoppingListQueryHandlerTests
 			new("Soap", 1, 1, "pc", "household", false, []),
 			new("Onion", 1, 1, "pc", "produce", false, [])
 		];
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new ExportShoppingListQuery());

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetMergedShoppingListQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Queries;
@@ -24,7 +25,7 @@ public class GetMergedShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_EmptyReadModel_ReturnsEmptyList()
 	{
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto([]));
 
 		var result = await handler.HandleAsync(new GetMergedShoppingListQuery());
@@ -41,7 +42,7 @@ public class GetMergedShoppingListQueryHandlerTests
 			new("Milk", 2, 2, "L", "dairy", false, []),
 			new("Chicken", 500, 500, "g", "meat-fish", false, []),
 		};
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto(items));
 
 		var result = await handler.HandleAsync(new GetMergedShoppingListQuery());
@@ -53,33 +54,33 @@ public class GetMergedShoppingListQueryHandlerTests
 	[Fact]
 	public async Task HandleAsync_DelegatesToReadModel()
 	{
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto([]));
 
 		await handler.HandleAsync(new GetMergedShoppingListQuery());
 
-		await readModel.Received(1).GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+		await readModel.Received(1).GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
 	public async Task HandleAsync_DefaultQuery_HidesPastBoughtItems()
 	{
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto([]));
 
 		await handler.HandleAsync(new GetMergedShoppingListQuery());
 
-		await readModel.Received(1).GetByOwnerAsync("user-123", false, Arg.Any<CancellationToken>());
+		await readModel.Received(1).GetByOwnerAsync(OwnerIdentifier.From("user-123"), false, Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
 	public async Task HandleAsync_IncludePastBought_ForwardsToReadModel()
 	{
-		readModel.GetByOwnerAsync("user-123", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+		readModel.GetByOwnerAsync(OwnerIdentifier.From("user-123"), Arg.Any<bool>(), Arg.Any<CancellationToken>())
 			.Returns(new MergedShoppingListDto([]));
 
 		await handler.HandleAsync(new GetMergedShoppingListQuery(IncludePastBought: true));
 
-		await readModel.Received(1).GetByOwnerAsync("user-123", true, Arg.Any<CancellationToken>());
+		await readModel.Received(1).GetByOwnerAsync(OwnerIdentifier.From("user-123"), true, Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
@@ -11,7 +11,7 @@ public class RegisterUserValidatorTests
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new RegisterUser("test@example.com", "Password1", "Test User");
+		RegisterUser request = new RegisterUser("test@example.com", "Password1", "Test User");
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
@@ -1,17 +1,16 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Users.Api.Requests;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Tests.Requests;
 
 public class RegisterUserValidatorTests
 {
-	private readonly RegisterUserValidator validator = new();
+	private readonly Api.Requests.RegisterUserValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		RegisterUser request = new RegisterUser("test@example.com", "Password1", "Test User");
+		var request = new Api.Requests.RegisterUser("test@example.com", "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -24,7 +23,7 @@ public class RegisterUserValidatorTests
 	[InlineData("not-an-email")]
 	public void Validate_InvalidEmail_IsNotValid(string email)
 	{
-		var request = new RegisterUser(email, "Password1", "Test User");
+		var request = new Api.Requests.RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -39,7 +38,7 @@ public class RegisterUserValidatorTests
 	[InlineData("NoDigitsHere")]
 	public void Validate_WeakPassword_IsNotValid(string password)
 	{
-		var request = new RegisterUser("test@example.com", password, "Test User");
+		var request = new Api.Requests.RegisterUser("test@example.com", password, "Test User");
 
 		var result = validator.Validate(request);
 
@@ -52,7 +51,7 @@ public class RegisterUserValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyDisplayName_IsNotValid(string displayName)
 	{
-		var request = new RegisterUser("test@example.com", "Password1", displayName);
+		var request = new Api.Requests.RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -66,7 +65,7 @@ public class RegisterUserValidatorTests
 	[InlineData("user_name@example.co.uk")]
 	public void Validate_EmailWithSpecialChars_IsValid(string email)
 	{
-		var request = new RegisterUser(email, "Password1", "Test User");
+		var request = new Api.Requests.RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -79,7 +78,7 @@ public class RegisterUserValidatorTests
 		var localPart = new string('a', 242);
 		var email = $"{localPart}@example.com";
 
-		var request = new RegisterUser(email, "Password1", "Test User");
+		var request = new Api.Requests.RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -92,7 +91,7 @@ public class RegisterUserValidatorTests
 		var localPart = new string('a', 243);
 		var email = $"{localPart}@example.com";
 
-		var request = new RegisterUser(email, "Password1", "Test User");
+		var request = new Api.Requests.RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -104,7 +103,7 @@ public class RegisterUserValidatorTests
 	public void Validate_DisplayNameAtMaxLength_IsValid()
 	{
 		var displayName = new string('A', 200);
-		var request = new RegisterUser("test@example.com", "Password1", displayName);
+		var request = new Api.Requests.RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -115,7 +114,7 @@ public class RegisterUserValidatorTests
 	public void Validate_DisplayNameExceedsMaxLength_IsNotValid()
 	{
 		var displayName = new string('A', 201);
-		var request = new RegisterUser("test@example.com", "Password1", displayName);
+		var request = new Api.Requests.RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -126,7 +125,7 @@ public class RegisterUserValidatorTests
 	[Fact]
 	public void Validate_PasswordAtMinLength_IsValid()
 	{
-		var request = new RegisterUser("test@example.com", "Abcdef1x", "Test User");
+		var request = new Api.Requests.RegisterUser("test@example.com", "Abcdef1x", "Test User");
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/RegisterUserValidatorTests.cs
@@ -4,14 +4,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Tests.Requests;
 
-public class RegisterUserRequestValidatorTests
+public class RegisterUserValidatorTests
 {
-	private readonly RegisterUserRequestValidator validator = new();
+	private readonly RegisterUserValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new RegisterUserRequest("test@example.com", "Password1", "Test User");
+		var request = new RegisterUser("test@example.com", "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -24,7 +24,7 @@ public class RegisterUserRequestValidatorTests
 	[InlineData("not-an-email")]
 	public void Validate_InvalidEmail_IsNotValid(string email)
 	{
-		var request = new RegisterUserRequest(email, "Password1", "Test User");
+		var request = new RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -39,7 +39,7 @@ public class RegisterUserRequestValidatorTests
 	[InlineData("NoDigitsHere")]
 	public void Validate_WeakPassword_IsNotValid(string password)
 	{
-		var request = new RegisterUserRequest("test@example.com", password, "Test User");
+		var request = new RegisterUser("test@example.com", password, "Test User");
 
 		var result = validator.Validate(request);
 
@@ -52,7 +52,7 @@ public class RegisterUserRequestValidatorTests
 	[InlineData("   ")]
 	public void Validate_EmptyDisplayName_IsNotValid(string displayName)
 	{
-		var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
+		var request = new RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -66,7 +66,7 @@ public class RegisterUserRequestValidatorTests
 	[InlineData("user_name@example.co.uk")]
 	public void Validate_EmailWithSpecialChars_IsValid(string email)
 	{
-		var request = new RegisterUserRequest(email, "Password1", "Test User");
+		var request = new RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -79,7 +79,7 @@ public class RegisterUserRequestValidatorTests
 		var localPart = new string('a', 242);
 		var email = $"{localPart}@example.com";
 
-		var request = new RegisterUserRequest(email, "Password1", "Test User");
+		var request = new RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -92,7 +92,7 @@ public class RegisterUserRequestValidatorTests
 		var localPart = new string('a', 243);
 		var email = $"{localPart}@example.com";
 
-		var request = new RegisterUserRequest(email, "Password1", "Test User");
+		var request = new RegisterUser(email, "Password1", "Test User");
 
 		var result = validator.Validate(request);
 
@@ -104,7 +104,7 @@ public class RegisterUserRequestValidatorTests
 	public void Validate_DisplayNameAtMaxLength_IsValid()
 	{
 		var displayName = new string('A', 200);
-		var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
+		var request = new RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -115,7 +115,7 @@ public class RegisterUserRequestValidatorTests
 	public void Validate_DisplayNameExceedsMaxLength_IsNotValid()
 	{
 		var displayName = new string('A', 201);
-		var request = new RegisterUserRequest("test@example.com", "Password1", displayName);
+		var request = new RegisterUser("test@example.com", "Password1", displayName);
 
 		var result = validator.Validate(request);
 
@@ -126,7 +126,7 @@ public class RegisterUserRequestValidatorTests
 	[Fact]
 	public void Validate_PasswordAtMinLength_IsValid()
 	{
-		var request = new RegisterUserRequest("test@example.com", "Abcdef1x", "Test User");
+		var request = new RegisterUser("test@example.com", "Abcdef1x", "Test User");
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Users.Api.Tests/Requests/ResendVerificationEmailValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/ResendVerificationEmailValidatorTests.cs
@@ -4,14 +4,14 @@ using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Tests.Requests;
 
-public class ResendVerificationEmailRequestValidatorTests
+public class ResendVerificationEmailValidatorTests
 {
-	private readonly ResendVerificationEmailRequestValidator validator = new();
+	private readonly ResendVerificationEmailValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new ResendVerificationEmailRequest("test@example.com");
+		var request = new ResendVerificationEmail("test@example.com");
 
 		var result = validator.Validate(request);
 
@@ -24,7 +24,7 @@ public class ResendVerificationEmailRequestValidatorTests
 	[InlineData("not-an-email")]
 	public void Validate_InvalidEmail_IsNotValid(string email)
 	{
-		var request = new ResendVerificationEmailRequest(email);
+		var request = new ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 
@@ -37,7 +37,7 @@ public class ResendVerificationEmailRequestValidatorTests
 	{
 		var localPart = new string('a', 242);
 		var email = $"{localPart}@example.com";
-		var request = new ResendVerificationEmailRequest(email);
+		var request = new ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 
@@ -49,7 +49,7 @@ public class ResendVerificationEmailRequestValidatorTests
 	{
 		var localPart = new string('a', 243);
 		var email = $"{localPart}@example.com";
-		var request = new ResendVerificationEmailRequest(email);
+		var request = new ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 

--- a/tests/Yumney.Users.Api.Tests/Requests/ResendVerificationEmailValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/ResendVerificationEmailValidatorTests.cs
@@ -1,17 +1,16 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Users.Api.Requests;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Users.Api.Tests.Requests;
 
 public class ResendVerificationEmailValidatorTests
 {
-	private readonly ResendVerificationEmailValidator validator = new();
+	private readonly Api.Requests.ResendVerificationEmailValidator validator = new();
 
 	[Fact]
 	public void Validate_ValidRequest_IsValid()
 	{
-		var request = new ResendVerificationEmail("test@example.com");
+		var request = new Api.Requests.ResendVerificationEmail("test@example.com");
 
 		var result = validator.Validate(request);
 
@@ -24,7 +23,7 @@ public class ResendVerificationEmailValidatorTests
 	[InlineData("not-an-email")]
 	public void Validate_InvalidEmail_IsNotValid(string email)
 	{
-		var request = new ResendVerificationEmail(email);
+		var request = new Api.Requests.ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 
@@ -37,7 +36,7 @@ public class ResendVerificationEmailValidatorTests
 	{
 		var localPart = new string('a', 242);
 		var email = $"{localPart}@example.com";
-		var request = new ResendVerificationEmail(email);
+		var request = new Api.Requests.ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 
@@ -49,7 +48,7 @@ public class ResendVerificationEmailValidatorTests
 	{
 		var localPart = new string('a', 243);
 		var email = $"{localPart}@example.com";
-		var request = new ResendVerificationEmail(email);
+		var request = new Api.Requests.ResendVerificationEmail(email);
 
 		var result = validator.Validate(request);
 


### PR DESCRIPTION
## Summary
- Split multi-type files into one-type-per-file across Shared, plus tidy XML docs and long signatures
- Phase 1 + 2 of DI registration cleanup: introduce shared helpers, adopt across all module composition roots, lock in with arch/smoke tests
- Drop the `Request` suffix on every Api request DTO + validator (Users, MealPlan, Shopping, Recipes) and codify the rule in `CLAUDE.md`
- Smaller drive-bys: wire `QueryCountingInterceptor` into read DbContexts, tighten event-consumer arch tests, drop unused HtmlAgilityPack, use `OwnerIdentifier` on the shopping ledger read-model interface

## Test plan
- [ ] `dotnet build -p:TreatWarningsAsErrors=true`
- [ ] `dotnet format --verify-no-changes`
- [ ] `dotnet test`