### PR TITLE
feat(recipes): create shopping list with adjusted servings (US-080)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -92,6 +92,7 @@
     "createShoppingList": {
       "title": "Einkaufsliste erstellen",
       "preview": "{{count}} Zutaten für {{servings}} Portionen",
+      "previewNoServings": "{{count}} Zutaten",
       "confirm": "Liste erstellen",
       "creating": "Wird erstellt...",
       "cancel": "Abbrechen",

--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -89,6 +89,16 @@
         "generic": "Rezept konnte nicht gelöscht werden. Bitte versuche es später erneut."
       }
     },
+    "createShoppingList": {
+      "title": "Einkaufsliste erstellen",
+      "preview": "{{count}} Zutaten für {{servings}} Portionen",
+      "confirm": "Liste erstellen",
+      "creating": "Wird erstellt...",
+      "cancel": "Abbrechen",
+      "errors": {
+        "generic": "Einkaufsliste konnte nicht erstellt werden. Bitte versuche es später erneut."
+      }
+    },
     "resetServings": "Zurücksetzen",
     "a11y": {
       "decreaseServings": "Portionen verringern",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -89,6 +89,16 @@
         "generic": "Failed to delete recipe. Please try again later."
       }
     },
+    "createShoppingList": {
+      "title": "Create shopping list",
+      "preview": "{{count}} ingredients for {{servings}} servings",
+      "confirm": "Create list",
+      "creating": "Creating...",
+      "cancel": "Cancel",
+      "errors": {
+        "generic": "Failed to create shopping list. Please try again later."
+      }
+    },
     "resetServings": "Reset",
     "a11y": {
       "decreaseServings": "Decrease servings",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -92,6 +92,7 @@
     "createShoppingList": {
       "title": "Create shopping list",
       "preview": "{{count}} ingredients for {{servings}} servings",
+      "previewNoServings": "{{count}} ingredients",
       "confirm": "Create list",
       "creating": "Creating...",
       "cancel": "Cancel",

--- a/client/apps/recipes/src/app/api.ts
+++ b/client/apps/recipes/src/app/api.ts
@@ -5,9 +5,12 @@
 export {
   RecipeApiService,
   MealPlanApiService,
+  ShoppingApiService,
   type RecipeListItem,
   type RecipeListResponse,
   type RecipeDetail,
   type ImportRecipeResponse,
   type GetRecipesParams,
+  type CreateShoppingListItem,
+  type ShoppingListDetail,
 } from '@yumney/shared/api-client';

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
@@ -1,0 +1,67 @@
+<div class="create-shopping-list-overlay" (click)="onOverlayClick($event)" *transloco="let t">
+  <div
+    class="create-shopping-list-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="create-shopping-list-title"
+    data-testid="create-shopping-list-dialog"
+  >
+    <header class="dialog-header">
+      <h2 id="create-shopping-list-title" class="dialog-title">
+        {{ t('recipes.detail.createShoppingList.title') }}
+      </h2>
+      <p class="dialog-subtitle" data-testid="create-shopping-list-suggested-title">
+        {{ suggestedTitle() }}
+      </p>
+    </header>
+
+    <section class="dialog-preview" aria-labelledby="create-shopping-list-preview-heading">
+      <h3 id="create-shopping-list-preview-heading" class="preview-heading">
+        {{
+          t('recipes.detail.createShoppingList.preview', {
+            count: ingredients().length,
+            servings: desiredServings(),
+          })
+        }}
+      </h3>
+      <ul class="preview-list">
+        @for (ingredient of ingredients(); track ingredient.name) {
+          <li>
+            @if (ingredient.amount !== null) {
+              <span class="preview-amount">{{ ingredient.amount }}</span>
+            }
+            @if (ingredient.unit) {
+              <span class="preview-unit">{{ ingredient.unit }}</span>
+            }
+            <span class="preview-name">{{ ingredient.name }}</span>
+          </li>
+        }
+      </ul>
+    </section>
+
+    <div class="dialog-actions">
+      <button
+        type="button"
+        class="btn-secondary"
+        [disabled]="isCreating()"
+        (click)="onCancel()"
+        data-testid="create-shopping-list-cancel"
+      >
+        {{ t('recipes.detail.createShoppingList.cancel') }}
+      </button>
+      <button
+        type="button"
+        class="btn-primary"
+        [disabled]="isCreating()"
+        (click)="onConfirm()"
+        data-testid="create-shopping-list-confirm"
+      >
+        {{
+          isCreating()
+            ? t('recipes.detail.createShoppingList.creating')
+            : t('recipes.detail.createShoppingList.confirm')
+        }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
@@ -17,12 +17,20 @@
 
     <section class="dialog-preview" aria-labelledby="create-shopping-list-preview-heading">
       <h3 id="create-shopping-list-preview-heading" class="preview-heading">
-        {{
-          t('recipes.detail.createShoppingList.preview', {
-            count: ingredients().length,
-            servings: desiredServings(),
-          })
-        }}
+        @if (desiredServings() !== null) {
+          {{
+            t('recipes.detail.createShoppingList.preview', {
+              count: ingredients().length,
+              servings: desiredServings(),
+            })
+          }}
+        } @else {
+          {{
+            t('recipes.detail.createShoppingList.previewNoServings', {
+              count: ingredients().length,
+            })
+          }}
+        }
       </h3>
       <ul class="preview-list">
         @for (ingredient of ingredients(); track ingredient.name) {

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.scss
@@ -1,0 +1,110 @@
+@use 'buttons';
+@use 'glass';
+
+.create-shopping-list-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--yn-z-modal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--yn-space-5);
+  background: var(--yn-overlay);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+}
+
+.create-shopping-list-dialog {
+  @include glass.glass-dialog;
+  width: min(560px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-6);
+  padding: var(--yn-space-7);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .create-shopping-list-overlay,
+  .create-shopping-list-dialog {
+    animation: none;
+  }
+}
+
+.dialog-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.dialog-title {
+  margin: 0;
+  font-size: var(--yn-text-xl);
+  line-height: var(--yn-leading-tight);
+}
+
+.dialog-subtitle {
+  margin: 0;
+  font-size: var(--yn-text-md);
+  color: var(--yn-text-muted);
+}
+
+.dialog-preview {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
+  overflow: hidden;
+}
+
+.preview-heading {
+  margin: 0;
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--yn-text-muted);
+}
+
+.preview-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+  overflow-y: auto;
+
+  li {
+    display: flex;
+    gap: var(--yn-space-2);
+    align-items: baseline;
+    padding-block: var(--yn-space-1);
+    border-bottom: 1px solid var(--yn-glass-border-subtle);
+  }
+
+  li:last-child {
+    border-bottom: 0;
+  }
+}
+
+.preview-amount {
+  font-weight: var(--yn-font-medium);
+  color: var(--yn-text);
+}
+
+.preview-unit {
+  color: var(--yn-text-muted);
+}
+
+.preview-name {
+  flex: 1 1 auto;
+  color: var(--yn-text);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--yn-space-3);
+}

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
@@ -8,6 +8,7 @@ const en = {
       createShoppingList: {
         title: 'Create shopping list',
         preview: '{{count}} ingredients for {{servings}} servings',
+        previewNoServings: '{{count}} ingredients',
         confirm: 'Create list',
         creating: 'Creating...',
         cancel: 'Cancel',
@@ -106,5 +107,27 @@ describe('CreateShoppingListDialogComponent', () => {
     component.onEscapeKey();
 
     expect(emitted).toBe(1);
+  });
+
+  it('should drop the servings suffix when desiredServings is null', () => {
+    TestBed.configureTestingModule({
+      imports: [CreateShoppingListDialogComponent, setupTranslocoTesting(en)],
+    });
+    fixture = TestBed.createComponent(CreateShoppingListDialogComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('recipeTitle', 'Pasta Carbonara');
+    fixture.componentRef.setInput('desiredServings', null);
+    fixture.componentRef.setInput('ingredients', ingredients);
+    fixture.componentRef.setInput('isCreating', false);
+    fixture.detectChanges();
+
+    expect(component.suggestedTitle()).toBe('Pasta Carbonara');
+    const subtitle = fixture.nativeElement.querySelector(
+      '[data-testid="create-shopping-list-suggested-title"]',
+    );
+    expect(subtitle.textContent.trim()).toBe('Pasta Carbonara');
+    const heading = fixture.nativeElement.querySelector('.preview-heading');
+    expect(heading.textContent).toContain('3 ingredients');
+    expect(heading.textContent).not.toContain('servings');
   });
 });

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting, type ScalableIngredient } from '@yumney/shared/models';
+import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog.component';
+
+const en = {
+  recipes: {
+    detail: {
+      createShoppingList: {
+        title: 'Create shopping list',
+        preview: '{{count}} ingredients for {{servings}} servings',
+        confirm: 'Create list',
+        creating: 'Creating...',
+        cancel: 'Cancel',
+      },
+    },
+  },
+};
+
+const ingredients: ScalableIngredient[] = [
+  { name: 'Spaghetti', amount: 600, unit: 'g' },
+  { name: 'Eggs', amount: 6, unit: null },
+  { name: 'Parmesan', amount: null, unit: null },
+];
+
+describe('CreateShoppingListDialogComponent', () => {
+  let fixture: ComponentFixture<CreateShoppingListDialogComponent>;
+  let component: CreateShoppingListDialogComponent;
+
+  function setup(isCreating = false) {
+    TestBed.configureTestingModule({
+      imports: [CreateShoppingListDialogComponent, setupTranslocoTesting(en)],
+    });
+    fixture = TestBed.createComponent(CreateShoppingListDialogComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('recipeTitle', 'Pasta Carbonara');
+    fixture.componentRef.setInput('desiredServings', 6);
+    fixture.componentRef.setInput('ingredients', ingredients);
+    fixture.componentRef.setInput('isCreating', isCreating);
+    fixture.detectChanges();
+  }
+
+  it('should compose the suggested title from recipe title + desired servings', () => {
+    setup();
+    expect(component.suggestedTitle()).toBe('Pasta Carbonara (x6)');
+  });
+
+  it('should render every preview ingredient', () => {
+    setup();
+    const items = fixture.nativeElement.querySelectorAll('.preview-list li');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toContain('600');
+    expect(items[0].textContent).toContain('g');
+    expect(items[0].textContent).toContain('Spaghetti');
+    expect(items[2].textContent).toContain('Parmesan');
+  });
+
+  it('should emit confirmed when the confirm button is clicked', () => {
+    setup();
+    let emitted = 0;
+    component.confirmed.subscribe(() => emitted++);
+
+    fixture.nativeElement.querySelector('[data-testid="create-shopping-list-confirm"]').click();
+
+    expect(emitted).toBe(1);
+  });
+
+  it('should emit cancelled when the cancel button is clicked', () => {
+    setup();
+    let emitted = 0;
+    component.cancelled.subscribe(() => emitted++);
+
+    fixture.nativeElement.querySelector('[data-testid="create-shopping-list-cancel"]').click();
+
+    expect(emitted).toBe(1);
+  });
+
+  it('should disable buttons and show creating label while in flight', () => {
+    setup(true);
+
+    const confirm = fixture.nativeElement.querySelector(
+      '[data-testid="create-shopping-list-confirm"]',
+    );
+    const cancel = fixture.nativeElement.querySelector(
+      '[data-testid="create-shopping-list-cancel"]',
+    );
+    expect(confirm.disabled).toBe(true);
+    expect(cancel.disabled).toBe(true);
+    expect(confirm.textContent).toContain('Creating...');
+  });
+
+  it('should ignore Escape while a request is in flight', () => {
+    setup(true);
+    let emitted = 0;
+    component.cancelled.subscribe(() => emitted++);
+
+    component.onEscapeKey();
+
+    expect(emitted).toBe(0);
+  });
+
+  it('should emit cancelled on Escape when idle', () => {
+    setup();
+    let emitted = 0;
+    component.cancelled.subscribe(() => emitted++);
+
+    component.onEscapeKey();
+
+    expect(emitted).toBe(1);
+  });
+});

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
@@ -1,0 +1,50 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  HostListener,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import type { ScalableIngredient } from '@yumney/shared/models';
+
+@Component({
+  selector: 'yn-create-shopping-list-dialog',
+  imports: [TranslocoModule],
+  templateUrl: './create-shopping-list-dialog.component.html',
+  styleUrl: './create-shopping-list-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CreateShoppingListDialogComponent {
+  recipeTitle = input.required<string>();
+  desiredServings = input.required<number>();
+  ingredients = input.required<readonly ScalableIngredient[]>();
+  isCreating = input(false);
+
+  confirmed = output<void>();
+  cancelled = output<void>();
+
+  suggestedTitle = computed(() => `${this.recipeTitle()} (x${this.desiredServings()})`);
+
+  @HostListener('document:keydown.escape')
+  onEscapeKey(): void {
+    if (!this.isCreating()) {
+      this.cancelled.emit();
+    }
+  }
+
+  onConfirm(): void {
+    this.confirmed.emit();
+  }
+
+  onCancel(): void {
+    this.cancelled.emit();
+  }
+
+  onOverlayClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget && !this.isCreating()) {
+      this.cancelled.emit();
+    }
+  }
+}

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
@@ -18,14 +18,17 @@ import type { ScalableIngredient } from '@yumney/shared/models';
 })
 export class CreateShoppingListDialogComponent {
   recipeTitle = input.required<string>();
-  desiredServings = input.required<number>();
+  desiredServings = input.required<number | null>();
   ingredients = input.required<readonly ScalableIngredient[]>();
   isCreating = input(false);
 
   confirmed = output<void>();
   cancelled = output<void>();
 
-  suggestedTitle = computed(() => `${this.recipeTitle()} (x${this.desiredServings()})`);
+  suggestedTitle = computed(() => {
+    const servings = this.desiredServings();
+    return servings === null ? this.recipeTitle() : `${this.recipeTitle()} (x${servings})`;
+  });
 
   @HostListener('document:keydown.escape')
   onEscapeKey(): void {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -126,9 +126,15 @@
           isDeleting() ? t('recipes.detail.delete.deleting') : t('recipes.detail.actions.delete')
         }}
       </button>
-      <a class="btn-secondary" [routerLink]="ROUTES.shopping.create(recipe.identifier)">
+      <button
+        type="button"
+        class="btn-secondary"
+        data-testid="recipe-create-shopping-list-btn"
+        [disabled]="isCreatingShoppingList()"
+        (click)="onCreateShoppingList()"
+      >
         {{ t('recipes.detail.actions.shoppingList') }}
-      </a>
+      </button>
     </div>
 
     <section class="ingredients-section">
@@ -175,9 +181,15 @@
       <a class="btn-primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
       </a>
-      <a class="btn-secondary" [routerLink]="ROUTES.shopping.create(recipe.identifier)">
+      <button
+        type="button"
+        class="btn-secondary"
+        data-testid="recipe-create-shopping-list-btn"
+        [disabled]="isCreatingShoppingList()"
+        (click)="onCreateShoppingList()"
+      >
         {{ t('recipes.detail.actions.shoppingList') }}
-      </a>
+      </button>
     </div>
 
     @if (showDeleteConfirm()) {
@@ -187,6 +199,17 @@
         [cancelLabel]="t('recipes.detail.delete.cancelButton')"
         (confirmed)="onDeleteConfirmed()"
         (cancelled)="onDeleteCancelled()"
+      />
+    }
+
+    @if (showCreateShoppingListConfirm()) {
+      <yn-create-shopping-list-dialog
+        [recipeTitle]="recipe.title"
+        [desiredServings]="desiredServings() ?? recipe.servings ?? 1"
+        [ingredients]="scaledIngredients()"
+        [isCreating]="isCreatingShoppingList()"
+        (confirmed)="onCreateShoppingListConfirmed()"
+        (cancelled)="onCreateShoppingListCancelled()"
       />
     }
   }

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -205,7 +205,7 @@
     @if (showCreateShoppingListConfirm()) {
       <yn-create-shopping-list-dialog
         [recipeTitle]="recipe.title"
-        [desiredServings]="desiredServings() ?? recipe.servings ?? 1"
+        [desiredServings]="recipe.servings === null ? null : desiredServings()"
         [ingredients]="scaledIngredients()"
         [isCreating]="isCreatingShoppingList()"
         (confirmed)="onCreateShoppingListConfirmed()"

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter, ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError, EMPTY } from 'rxjs';
 import { RecipeDetailComponent } from './recipe-detail.component';
-import { RecipeApiService, RecipeDetail } from '../api';
+import { RecipeApiService, RecipeDetail, ShoppingApiService, ShoppingListDetail } from '../api';
 import { HttpErrorResponse } from '@angular/common/http';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 
@@ -62,6 +62,16 @@ const en = {
         },
       },
       resetServings: 'Reset',
+      createShoppingList: {
+        title: 'Create shopping list',
+        preview: '{{count}} ingredients for {{servings}} servings',
+        confirm: 'Create list',
+        creating: 'Creating...',
+        cancel: 'Cancel',
+        errors: {
+          generic: 'Failed to create shopping list. Please try again later.',
+        },
+      },
       a11y: {
         decreaseServings: 'Decrease servings',
         increaseServings: 'Increase servings',
@@ -80,6 +90,9 @@ describe('RecipeDetailComponent', () => {
     getRecipeById: ReturnType<typeof vi.fn>;
     deleteRecipe: ReturnType<typeof vi.fn>;
   };
+  let shoppingApiMock: {
+    createShoppingList: ReturnType<typeof vi.fn>;
+  };
 
   function setupTestBed(
     getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
@@ -89,6 +102,9 @@ describe('RecipeDetailComponent', () => {
       getRecipeById: getRecipeByIdReturn,
       deleteRecipe: vi.fn().mockReturnValue(EMPTY),
     };
+    shoppingApiMock = {
+      createShoppingList: vi.fn().mockReturnValue(EMPTY),
+    };
 
     TestBed.configureTestingModule({
       imports: [RecipeDetailComponent, setupTranslocoTesting(en)],
@@ -96,6 +112,7 @@ describe('RecipeDetailComponent', () => {
         provideYumneyIcons(),
         provideRouter([]),
         { provide: RecipeApiService, useValue: recipeApiMock },
+        { provide: ShoppingApiService, useValue: shoppingApiMock },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -305,17 +322,19 @@ describe('RecipeDetailComponent', () => {
     expect(editLink.textContent.trim()).toBe('Edit');
   }));
 
-  it('should render shopping list button as link', fakeAsync(() => {
+  it('should render shopping list trigger as a button', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
 
-    const shoppingLink = fixture.nativeElement.querySelector('.btn-secondary');
-    expect(shoppingLink).toBeTruthy();
-    expect(shoppingLink.tagName).toBe('A');
-    expect(shoppingLink.getAttribute('href')).toBe('/shopping/create/abc-123');
-    expect(shoppingLink.textContent).toContain('Shopping List');
+    const trigger = fixture.nativeElement.querySelector(
+      '[data-testid="recipe-create-shopping-list-btn"]',
+    );
+    expect(trigger).toBeTruthy();
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger.textContent).toContain('Shopping List');
+    expect(trigger.disabled).toBe(false);
   }));
 
   it('should call getRecipeById with correct identifier', fakeAsync(() => {
@@ -575,5 +594,168 @@ describe('RecipeDetailComponent', () => {
     component.desiredServings.set(6);
 
     expect(component.isScaled()).toBe(true);
+  }));
+
+  it('should open the create-shopping-list dialog on button click', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector(
+      '[data-testid="recipe-create-shopping-list-btn"]',
+    );
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(component.showCreateShoppingListConfirm()).toBe(true);
+    const dialog = fixture.nativeElement.querySelector(
+      '[data-testid="create-shopping-list-dialog"]',
+    );
+    expect(dialog).toBeTruthy();
+  }));
+
+  it('should preview scaled ingredients in the dialog', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.desiredServings.set(8);
+    component.onCreateShoppingList();
+    fixture.detectChanges();
+
+    const previewItems = fixture.nativeElement.querySelectorAll('.preview-list li');
+    expect(previewItems.length).toBe(3);
+    expect(previewItems[0].textContent).toContain('800');
+    expect(previewItems[1].textContent).toContain('8');
+  }));
+
+  it('should suggest auto-name "{title} (x{servings})" in the dialog', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.desiredServings.set(6);
+    component.onCreateShoppingList();
+    fixture.detectChanges();
+
+    const subtitle = fixture.nativeElement.querySelector(
+      '[data-testid="create-shopping-list-suggested-title"]',
+    );
+    expect(subtitle.textContent.trim()).toBe('Pasta Carbonara (x6)');
+  }));
+
+  it('should send scaled items + auto-title to the API on confirm', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.desiredServings.set(6);
+    component.onCreateShoppingList();
+
+    const created: ShoppingListDetail = {
+      identifier: 'list-1',
+      title: 'Pasta Carbonara (x6)',
+      items: [],
+      recipeIdentifier: 'abc-123',
+      createdAt: '2026-05-02T00:00:00Z',
+    } as unknown as ShoppingListDetail;
+    shoppingApiMock.createShoppingList.mockReturnValue(of(created));
+
+    component.onCreateShoppingListConfirmed();
+    tick();
+
+    expect(shoppingApiMock.createShoppingList).toHaveBeenCalledTimes(1);
+    const payload = shoppingApiMock.createShoppingList.mock.calls[0][0];
+    expect(payload.title).toBe('Pasta Carbonara (x6)');
+    expect(payload.recipeIdentifier).toBe('abc-123');
+    expect(payload.items[0]).toEqual({ name: 'Spaghetti', amount: 600, unit: 'g' });
+    expect(payload.items[1]).toEqual({ name: 'Eggs', amount: 6, unit: null });
+    expect(payload.items[2]).toEqual({ name: 'Parmesan', amount: null, unit: null });
+  }));
+
+  it('should send original amounts when servings are unchanged', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.onCreateShoppingList();
+
+    shoppingApiMock.createShoppingList.mockReturnValue(
+      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
+    );
+    component.onCreateShoppingListConfirmed();
+    tick();
+
+    const payload = shoppingApiMock.createShoppingList.mock.calls[0][0];
+    expect(payload.title).toBe('Pasta Carbonara (x4)');
+    expect(payload.items[0].amount).toBe(400);
+    expect(payload.items[1].amount).toBe(4);
+  }));
+
+  it('should send divided amounts when scaling down to 1', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.desiredServings.set(1);
+    component.onCreateShoppingList();
+
+    shoppingApiMock.createShoppingList.mockReturnValue(
+      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
+    );
+    component.onCreateShoppingListConfirmed();
+    tick();
+
+    const payload = shoppingApiMock.createShoppingList.mock.calls[0][0];
+    expect(payload.title).toBe('Pasta Carbonara (x1)');
+    expect(payload.items[0].amount).toBe(100);
+    expect(payload.items[1].amount).toBe(1);
+  }));
+
+  it('should navigate to the new list on success', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.onCreateShoppingList();
+
+    shoppingApiMock.createShoppingList.mockReturnValue(
+      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
+    );
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    component.onCreateShoppingListConfirmed();
+    tick();
+
+    expect(navigateSpy).toHaveBeenCalledWith('/shopping/lists/list-1');
+    navigateSpy.mockRestore();
+  }));
+
+  it('should NOT call createShoppingList on cancel', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.onCreateShoppingList();
+    expect(component.showCreateShoppingListConfirm()).toBe(true);
+
+    component.onCreateShoppingListCancelled();
+
+    expect(component.showCreateShoppingListConfirm()).toBe(false);
+    expect(shoppingApiMock.createShoppingList).not.toHaveBeenCalled();
+  }));
+
+  it('should surface a generic error when the API fails', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    component.onCreateShoppingList();
+
+    const httpError = new HttpErrorResponse({ status: 500 });
+    shoppingApiMock.createShoppingList.mockReturnValue(throwError(() => httpError));
+
+    component.onCreateShoppingListConfirmed();
+    tick();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('.error-banner');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Failed to create shopping list.');
+    expect(component.showCreateShoppingListConfirm()).toBe(false);
   }));
 });

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -65,6 +65,7 @@ const en = {
       createShoppingList: {
         title: 'Create shopping list',
         preview: '{{count}} ingredients for {{servings}} servings',
+        previewNoServings: '{{count}} ingredients',
         confirm: 'Create list',
         creating: 'Creating...',
         cancel: 'Cancel',
@@ -738,6 +739,26 @@ describe('RecipeDetailComponent', () => {
 
     expect(component.showCreateShoppingListConfirm()).toBe(false);
     expect(shoppingApiMock.createShoppingList).not.toHaveBeenCalled();
+  }));
+
+  it('should create a list without (xN) suffix when recipe has no servings', fakeAsync(() => {
+    const noServings: RecipeDetail = { ...mockRecipe, servings: null };
+    setupTestBed(vi.fn().mockReturnValue(of(noServings)));
+    fixture.detectChanges();
+    tick();
+    component.onCreateShoppingList();
+
+    shoppingApiMock.createShoppingList.mockReturnValue(
+      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
+    );
+
+    component.onCreateShoppingListConfirmed();
+    tick();
+
+    expect(shoppingApiMock.createShoppingList).toHaveBeenCalledTimes(1);
+    const payload = shoppingApiMock.createShoppingList.mock.calls[0][0];
+    expect(payload.title).toBe('Pasta Carbonara');
+    expect(payload.items[0].amount).toBe(400);
   }));
 
   it('should surface a generic error when the API fails', fakeAsync(() => {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -180,11 +180,11 @@ export class RecipeDetailComponent implements OnInit {
 
   onCreateShoppingListConfirmed(): void {
     const recipe = this.recipe();
-    const desired = this.desiredServings();
-    if (!recipe || desired === null) {
+    if (!recipe) {
       return;
     }
 
+    const desired = this.desiredServings();
     const items: CreateShoppingListItem[] = this.scaledIngredients().map(
       ({ name, amount, unit }) => ({
         name,
@@ -192,10 +192,12 @@ export class RecipeDetailComponent implements OnInit {
         unit,
       }),
     );
+    const title =
+      recipe.servings !== null && desired !== null ? `${recipe.title} (x${desired})` : recipe.title;
 
     this.createShoppingListState.execute(
       this.shoppingApi.createShoppingList({
-        title: `${recipe.title} (x${desired})`,
+        title,
         items,
         recipeIdentifier: recipe.identifier,
       }),

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { RecipeApiService, RecipeDetail } from '../api';
+import { CreateShoppingListItem, RecipeApiService, RecipeDetail, ShoppingApiService } from '../api';
 import {
   createAsyncState,
   scaleIngredients,
@@ -24,6 +24,7 @@ import {
   FavoriteButtonComponent,
   LoadingSpinnerComponent,
 } from '@yumney/ui';
+import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog/create-shopping-list-dialog.component';
 
 @Component({
   selector: 'yn-recipe-detail',
@@ -31,6 +32,7 @@ import {
     TranslocoModule,
     RouterLink,
     ConfirmDialogComponent,
+    CreateShoppingListDialogComponent,
     BackLinkComponent,
     LoadingSpinnerComponent,
     FavoriteButtonComponent,
@@ -43,18 +45,22 @@ export class RecipeDetailComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
 
   private recipeApi = inject(RecipeApiService);
+  private shoppingApi = inject(ShoppingApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private loadState = createAsyncState(this.destroyRef);
   private deleteState = createAsyncState(this.destroyRef);
+  private createShoppingListState = createAsyncState(this.destroyRef);
 
   recipe = signal<RecipeDetail | null>(null);
   isLoading = this.loadState.isLoading;
   isDeleting = this.deleteState.isLoading;
+  isCreatingShoppingList = this.createShoppingListState.isLoading;
   serverError = signal<string | null>(null);
   desiredServings = signal<number | null>(null);
   showDeleteConfirm = signal(false);
+  showCreateShoppingListConfirm = signal(false);
 
   scaledIngredients = computed(() => {
     const recipe = this.recipe();
@@ -155,5 +161,53 @@ export class RecipeDetailComponent implements OnInit {
 
   onToggleFavorite(): void {
     toggleFavoriteOnItem(this.recipe, this.destroyRef, (id) => this.recipeApi.toggleFavorite(id));
+  }
+
+  onCreateShoppingList(): void {
+    if (!this.recipe()) {
+      return;
+    }
+    this.serverError.set(null);
+    this.showCreateShoppingListConfirm.set(true);
+  }
+
+  onCreateShoppingListCancelled(): void {
+    if (this.isCreatingShoppingList()) {
+      return;
+    }
+    this.showCreateShoppingListConfirm.set(false);
+  }
+
+  onCreateShoppingListConfirmed(): void {
+    const recipe = this.recipe();
+    const desired = this.desiredServings();
+    if (!recipe || desired === null) {
+      return;
+    }
+
+    const items: CreateShoppingListItem[] = this.scaledIngredients().map(
+      ({ name, amount, unit }) => ({
+        name,
+        amount,
+        unit,
+      }),
+    );
+
+    this.createShoppingListState.execute(
+      this.shoppingApi.createShoppingList({
+        title: `${recipe.title} (x${desired})`,
+        items,
+        recipeIdentifier: recipe.identifier,
+      }),
+      ERROR_MAPS.recipes.createShoppingList,
+      (created) => {
+        this.showCreateShoppingListConfirm.set(false);
+        this.router.navigateByUrl(ROUTES.shopping.detail(created.identifier));
+      },
+      (error) => {
+        this.showCreateShoppingListConfirm.set(false);
+        this.serverError.set(error);
+      },
+    );
   }
 }

--- a/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
@@ -29,9 +29,9 @@ export class RecipeDetailPage {
     this.resetServingsButton = page.getByRole('button', { name: /reset/i });
     this.editButton = page.getByRole('link', { name: /edit/i });
     this.deleteButton = page.locator('.btn-danger');
-    // Action button on the recipe-detail page. Exact match to avoid colliding
-    // with the header nav link "Shopping Lists".
-    this.shoppingListButton = page.getByRole('link', { name: 'Shopping List', exact: true });
+    this.shoppingListButton = page
+      .locator('[data-testid="recipe-create-shopping-list-btn"]')
+      .first();
     this.sourceLink = page.locator('.source-link a');
     // Target the .confirm-overlay child rather than the host yn-confirm-dialog.
     // The host has 0x0 dimensions because its child is position:fixed, so

--- a/client/apps/shell-e2e/src/recipes/recipe-create-shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-create-shopping-list.spec.ts
@@ -34,9 +34,7 @@ test.describe('Create shopping list from recipe (US-080)', () => {
 
     await detail.shoppingListButton.click();
 
-    const confirmButton = authenticatedPage.locator(
-      '[data-testid="create-shopping-list-confirm"]',
-    );
+    const confirmButton = authenticatedPage.locator('[data-testid="create-shopping-list-confirm"]');
     await confirmButton.click();
 
     await expect(authenticatedPage).toHaveURL(/\/shopping\/lists\/[\w-]+/);

--- a/client/apps/shell-e2e/src/recipes/recipe-create-shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-create-shopping-list.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { RecipeDetailPage } from '../pages/recipe-detail.page';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
+
+test.describe('Create shopping list from recipe (US-080)', () => {
+  const recipe = setupSharedRecipe(test, 'E2E US080 Recipe', {
+    ingredient: 'Spaghetti',
+    servings: 4,
+  });
+
+  test('opens dialog with scaled preview and auto-name', async ({ authenticatedPage }) => {
+    const detail = new RecipeDetailPage(authenticatedPage);
+    await detail.goto(recipe().identifier);
+
+    await detail.increaseServingsButton.click();
+    await detail.increaseServingsButton.click();
+    await expect(detail.servingsValue).toHaveText('6');
+
+    await detail.shoppingListButton.click();
+
+    const dialog = authenticatedPage.locator('[data-testid="create-shopping-list-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    const suggestedTitle = dialog.locator('[data-testid="create-shopping-list-suggested-title"]');
+    await expect(suggestedTitle).toHaveText(`${recipe().title} (x6)`);
+
+    const previewItems = dialog.locator('.preview-list li');
+    await expect(previewItems).not.toHaveCount(0);
+  });
+
+  test('confirms and navigates to the new shopping list', async ({ authenticatedPage }) => {
+    const detail = new RecipeDetailPage(authenticatedPage);
+    await detail.goto(recipe().identifier);
+
+    await detail.shoppingListButton.click();
+
+    const confirmButton = authenticatedPage.locator(
+      '[data-testid="create-shopping-list-confirm"]',
+    );
+    await confirmButton.click();
+
+    await expect(authenticatedPage).toHaveURL(/\/shopping\/lists\/[\w-]+/);
+    await expect(authenticatedPage.getByRole('heading', { level: 1 })).toContainText(
+      `${recipe().title} (x4)`,
+    );
+  });
+});

--- a/client/apps/shell-e2e/src/shopping/shopping-detail.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-detail.spec.ts
@@ -5,7 +5,7 @@ test.describe('Shopping List Detail', () => {
   test('should navigate to shopping lists page', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/shopping/lists');
 
-    await expect(authenticatedPage.locator('.shopping-lists, .empty-state, .loading')).toBeVisible({
+    await expect(authenticatedPage.locator('.lists-grid, .empty-state, .loading')).toBeVisible({
       timeout: TIMEOUTS.default,
     });
   });

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -92,6 +92,7 @@
     "createShoppingList": {
       "title": "Einkaufsliste erstellen",
       "preview": "{{count}} Zutaten für {{servings}} Portionen",
+      "previewNoServings": "{{count}} Zutaten",
       "confirm": "Liste erstellen",
       "creating": "Wird erstellt...",
       "cancel": "Abbrechen",

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -89,6 +89,16 @@
         "generic": "Rezept konnte nicht gelöscht werden. Bitte versuche es später erneut."
       }
     },
+    "createShoppingList": {
+      "title": "Einkaufsliste erstellen",
+      "preview": "{{count}} Zutaten für {{servings}} Portionen",
+      "confirm": "Liste erstellen",
+      "creating": "Wird erstellt...",
+      "cancel": "Abbrechen",
+      "errors": {
+        "generic": "Einkaufsliste konnte nicht erstellt werden. Bitte versuche es später erneut."
+      }
+    },
     "resetServings": "Zurücksetzen",
     "a11y": {
       "decreaseServings": "Portionen verringern",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -89,6 +89,16 @@
         "generic": "Failed to delete recipe. Please try again later."
       }
     },
+    "createShoppingList": {
+      "title": "Create shopping list",
+      "preview": "{{count}} ingredients for {{servings}} servings",
+      "confirm": "Create list",
+      "creating": "Creating...",
+      "cancel": "Cancel",
+      "errors": {
+        "generic": "Failed to create shopping list. Please try again later."
+      }
+    },
     "resetServings": "Reset",
     "a11y": {
       "decreaseServings": "Decrease servings",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -92,6 +92,7 @@
     "createShoppingList": {
       "title": "Create shopping list",
       "preview": "{{count}} ingredients for {{servings}} servings",
+      "previewNoServings": "{{count}} ingredients",
       "confirm": "Create list",
       "creating": "Creating...",
       "cancel": "Cancel",

--- a/client/libs/shared/models/src/lib/error-maps.ts
+++ b/client/libs/shared/models/src/lib/error-maps.ts
@@ -29,6 +29,9 @@ export const ERROR_MAPS = {
     list: {
       default: 'recipes.list.errors.generic',
     } satisfies HttpErrorMap,
+    createShoppingList: {
+      default: 'recipes.detail.createShoppingList.errors.generic',
+    } satisfies HttpErrorMap,
   },
   shopping: {
     list: {


### PR DESCRIPTION
Closes #23.

## Summary
- "Shopping List" button on recipe-detail now opens an in-place glass-styled confirmation dialog instead of routing to `/shopping/create/{id}`. The dialog shows the scaled ingredient preview and an auto-generated title `{Recipe Title} (x{servings})`.
- Confirm posts the scaled items + `recipeIdentifier` to `POST /api/v1/shopping-lists`, then navigates to the new list. Cancel/Escape close the dialog. The existing create page is kept for the rare "deselect ingredients / rename" advanced flow.

## Notes
- No backend changes: `CreateShoppingListCommand` already accepts pre-scaled `Items` + optional `RecipeReference`. Frontend keeps the scaling (existing `scaleIngredients` from US-050) and sends the rounded amounts in the same shape it already used.
- Translations added in both `apps/recipes` and the shell's federated mirror (`apps/shell/public/assets/i18n/recipes/`) for EN + DE.
- E2E `RecipeDetailPage.shoppingListButton` switched to a `data-testid` locator since the trigger is now a `<button>` rather than an `<a>`.

## Test plan
- [x] `yarn nx test recipes` (140/140), `yarn nx test shared-models` (146/146)
- [x] `yarn nx lint recipes shared-models shared-api-client`
- [x] `yarn nx build recipes` and `yarn nx build shell`
- [ ] Manual smoke against running shell: scale to 6, click "Shopping List", verify dialog title `(x6)`, confirm, land on the new list with the scaled items.