### PR TITLE
test(recipes): close US-080 coverage gaps (overlay click + inflight disabled)

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
@@ -109,6 +109,28 @@ describe('CreateShoppingListDialogComponent', () => {
     expect(emitted).toBe(1);
   });
 
+  it('should emit cancelled when the overlay is clicked', () => {
+    setup();
+    let emitted = 0;
+    component.cancelled.subscribe(() => emitted++);
+
+    const overlay = fixture.nativeElement.querySelector('.create-shopping-list-overlay');
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(emitted).toBe(1);
+  });
+
+  it('should ignore overlay clicks while a request is in flight', () => {
+    setup(true);
+    let emitted = 0;
+    component.cancelled.subscribe(() => emitted++);
+
+    const overlay = fixture.nativeElement.querySelector('.create-shopping-list-overlay');
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(emitted).toBe(0);
+  });
+
   it('should drop the servings suffix when desiredServings is null', () => {
     TestBed.configureTestingModule({
       imports: [CreateShoppingListDialogComponent, setupTranslocoTesting(en)],

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -741,6 +741,31 @@ describe('RecipeDetailComponent', () => {
     expect(shoppingApiMock.createShoppingList).not.toHaveBeenCalled();
   }));
 
+  it('should disable the shopping-list trigger while a request is in flight', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const inflight = new Subject<ShoppingListDetail>();
+    shoppingApiMock.createShoppingList.mockReturnValue(inflight);
+
+    component.onCreateShoppingList();
+    component.onCreateShoppingListConfirmed();
+    fixture.detectChanges();
+
+    const triggers = fixture.nativeElement.querySelectorAll(
+      '[data-testid="recipe-create-shopping-list-btn"]',
+    );
+    expect(triggers.length).toBeGreaterThan(0);
+    triggers.forEach((trigger: HTMLButtonElement) => {
+      expect(trigger.disabled).toBe(true);
+    });
+
+    inflight.complete();
+    tick();
+  }));
+
   it('should create a list without (xN) suffix when recipe has no servings', fakeAsync(() => {
     const noServings: RecipeDetail = { ...mockRecipe, servings: null };
     setupTestBed(vi.fn().mockReturnValue(of(noServings)));


### PR DESCRIPTION
Follow-up to #545. Three gaps surfaced in the post-merge re-review:

- dialog: overlay click emits \`cancelled\` (the \`onOverlayClick\` handler had no test)
- dialog: overlay click is ignored while a request is in flight (the \`!isCreating()\` guard)
- recipe-detail: both shopping-list trigger buttons are disabled while a create request is in flight (\`[disabled]="isCreatingShoppingList()"\` markup contract)

No production code changes — tests only.

## Test plan
- [x] \`yarn nx test recipes\` (145/145)
- [x] \`yarn nx lint recipes\`
- [x] prettier