### PR TITLE
feat(shopping): add multi-recipe shopping-list endpoint with merging (US-081 phase A)

### DIFF
--- a/src/Yumney.Shopping.Api/Requests/CreateFromRecipes.cs
+++ b/src/Yumney.Shopping.Api/Requests/CreateFromRecipes.cs
@@ -1,0 +1,15 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record CreateFromRecipes(string Title, List<RecipeForList> Recipes)
+{
+	public (ShoppingListTitle Title, IReadOnlyList<RecipeSelection> Recipes) ToValueObjects() =>
+	(
+		ShoppingListTitle.From(Title),
+		Recipes.Select(recipe => new RecipeSelection(
+			RecipeReference.From(recipe.RecipeIdentifier),
+			Servings.FromNullable(recipe.Servings)))
+			.ToList());
+}

--- a/src/Yumney.Shopping.Api/Requests/RecipeForList.cs
+++ b/src/Yumney.Shopping.Api/Requests/RecipeForList.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests;
+
+public sealed record RecipeForList(Guid RecipeIdentifier, int? Servings);

--- a/src/Yumney.Shopping.Api/Requests/Validator/CreateFromRecipesValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/CreateFromRecipesValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
+
+public sealed class CreateFromRecipesValidator : AbstractValidator<CreateFromRecipes>
+{
+	public CreateFromRecipesValidator()
+	{
+		RuleFor(request => request.Title)
+			.NotEmpty()
+			.MaximumLength(ShoppingListTitle.MaxLength);
+
+		RuleFor(request => request.Recipes)
+			.NotEmpty()
+			.WithMessage("At least one recipe is required.");
+
+		RuleForEach(request => request.Recipes).ChildRules(recipe =>
+		{
+			recipe.RuleFor(item => item.RecipeIdentifier).NotEmpty();
+			recipe.RuleFor(item => item.Servings)
+				.GreaterThan(0)
+				.When(item => item.Servings.HasValue);
+		});
+	}
+}

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -39,6 +39,28 @@ public static class ShoppingEndpoints
 			return result.ToCreated($"/api/v1/shopping-lists/{result.Value?.Identifier}");
 		}
 
+		group.MapPost("/from-recipes", CreateFromRecipes)
+			.WithName("CreateShoppingListFromRecipes")
+			.WithTags("Shopping")
+			.Produces<ShoppingListDetailDto>(StatusCodes.Status201Created)
+			.ProducesValidationProblem();
+
+		static async Task<IResult> CreateFromRecipes(
+			Requests.CreateFromRecipes request,
+			IValidator<Requests.CreateFromRecipes> validator,
+			ICommandHandler<CreateShoppingListFromRecipesCommand, Result<ShoppingListDetailDto>> handler,
+			CancellationToken cancellationToken)
+		{
+			var validation = await validator.ValidateAsync(request, cancellationToken);
+			if (validation.HasFailed()) return validation.ToValidationProblem();
+
+			var (title, recipes) = request.ToValueObjects();
+			var command = new CreateShoppingListFromRecipesCommand(title, recipes);
+
+			var result = await handler.HandleAsync(command, cancellationToken);
+			return result.ToCreated($"/api/v1/shopping-lists/{result.Value?.Identifier}");
+		}
+
 		group.MapGet("/", GetAll)
 			.WithName("GetShoppingLists")
 			.WithTags("Shopping")

--- a/src/Yumney.Shopping.Application/Commands/CreateShoppingListFromRecipesCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/CreateShoppingListFromRecipesCommand.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record CreateShoppingListFromRecipesCommand(
+	ShoppingListTitle Title,
+	IReadOnlyList<RecipeSelection> Recipes) : ICommand<Result<ShoppingListDetailDto>>;

--- a/src/Yumney.Shopping.Application/Commands/CreateShoppingListFromRecipesErrors.cs
+++ b/src/Yumney.Shopping.Application/Commands/CreateShoppingListFromRecipesErrors.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public static class CreateShoppingListFromRecipesErrors
+{
+	public static readonly ApiError NoRecipesProvided = new(
+		"SHOPPING_LIST_FROM_RECIPES_EMPTY",
+		"At least one recipe must be provided.",
+		400);
+
+	public static readonly ApiError NoIngredientsResolved = new(
+		"SHOPPING_LIST_FROM_RECIPES_NO_INGREDIENTS",
+		"None of the supplied recipes returned ingredients.",
+		404);
+}

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
@@ -1,0 +1,51 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shopping.Application.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+
+public sealed class CreateShoppingListFromRecipesCommandHandler(
+	IRecipeIngredientLookup recipeLookup,
+	IShoppingListEventStore eventStore,
+	ICurrentUser currentUser)
+	: ICommandHandler<CreateShoppingListFromRecipesCommand, Result<ShoppingListDetailDto>>
+{
+	public async Task<Result<ShoppingListDetailDto>> HandleAsync(
+		CreateShoppingListFromRecipesCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var (title, recipes) = command;
+		if (recipes.Count == 0)
+		{
+			return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoRecipesProvided);
+		}
+
+		var inputs = new List<IngredientMergeInput>(recipes.Count);
+		foreach (var selection in recipes)
+		{
+			var ingredients = await recipeLookup.LookupAsync(selection.Recipe, cancellationToken);
+			if (ingredients.Count == 0) continue;
+			inputs.Add(new IngredientMergeInput(ingredients, selection.DesiredServings));
+		}
+
+		if (inputs.Count == 0)
+		{
+			return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoIngredientsResolved);
+		}
+
+		var merged = IngredientMerger.Merge(inputs);
+		var items = merged
+			.Select(merge => Domain.ShoppingList.ShoppingListItem.Create(merge.Name, merge.Quantity))
+			.ToList();
+
+		var owner = currentUser.AsOwner();
+		var shoppingList = ShoppingList.Create(title, owner, items, recipeReference: null);
+
+		await eventStore.SaveAsync(shoppingList, cancellationToken);
+
+		return shoppingList.ToDetailDto();
+	}
+}

--- a/src/Yumney.Shopping.Application/Commands/RecipeSelection.cs
+++ b/src/Yumney.Shopping.Application/Commands/RecipeSelection.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+
+public sealed record RecipeSelection(RecipeReference Recipe, Servings? DesiredServings);

--- a/src/Yumney.Shopping.Application/Common/IngredientMergeInput.cs
+++ b/src/Yumney.Shopping.Application/Common/IngredientMergeInput.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Common;
+
+public sealed record IngredientMergeInput(
+	IReadOnlyList<RecipeIngredientLookupResult> Ingredients,
+	Servings? DesiredServings);

--- a/src/Yumney.Shopping.Application/Common/IngredientMerger.cs
+++ b/src/Yumney.Shopping.Application/Common/IngredientMerger.cs
@@ -1,0 +1,76 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Common;
+
+public static class IngredientMerger
+{
+	public static IReadOnlyList<MergedIngredient> Merge(IEnumerable<IngredientMergeInput> inputs)
+	{
+		var scaled = inputs.SelectMany(Scale).ToList();
+
+		var groupedByKey = scaled
+			.GroupBy(scaledIngredient => new MergeKey(
+				scaledIngredient.Name.Trim(),
+				scaledIngredient.Unit?.Trim()))
+			.Select(BuildMerged)
+			.ToList();
+
+		return groupedByKey;
+	}
+
+	private static IEnumerable<ScaledIngredient> Scale(IngredientMergeInput input)
+	{
+		foreach (var ingredient in input.Ingredients)
+		{
+			yield return new ScaledIngredient(
+				ingredient.Name,
+				ScaleAmount(ingredient.Amount, ingredient.RecipeServings, input.DesiredServings),
+				ingredient.Unit);
+		}
+	}
+
+	private static decimal? ScaleAmount(decimal? amount, int? originalServings, Servings? desiredServings)
+	{
+		if (amount is null) return null;
+		if (desiredServings is null || originalServings is null or <= 0) return amount;
+		if (originalServings == desiredServings.Value) return amount;
+
+		var ratio = (decimal)desiredServings.Value / originalServings.Value;
+		var scaled = amount.Value * ratio;
+		return amount.Value % 1 == 0
+			? Math.Round(scaled)
+			: Math.Round(scaled, 2);
+	}
+
+	private static MergedIngredient BuildMerged(IGrouping<MergeKey, ScaledIngredient> group)
+	{
+		var first = group.First();
+		var name = ItemName.From(first.Name);
+		var unit = Unit.FromNullable(first.Unit);
+
+		var summed = group
+			.Select(item => item.Amount)
+			.Where(amount => amount.HasValue)
+			.Sum(amount => amount!.Value);
+		if (summed == 0 && group.All(item => item.Amount is null))
+		{
+			return new MergedIngredient(name, null);
+		}
+
+		return new MergedIngredient(name, Quantity.Of(Amount.From(summed), unit));
+	}
+
+	private sealed record ScaledIngredient(string Name, decimal? Amount, string? Unit);
+
+	private sealed record MergeKey(string Name, string? Unit)
+	{
+		public bool Equals(MergeKey? other) =>
+			other is not null
+			&& string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+			&& string.Equals(Unit, other.Unit, StringComparison.OrdinalIgnoreCase);
+
+		public override int GetHashCode() => HashCode.Combine(
+			Name.ToLowerInvariant(),
+			Unit?.ToLowerInvariant());
+	}
+}

--- a/src/Yumney.Shopping.Application/Common/MergedIngredient.cs
+++ b/src/Yumney.Shopping.Application/Common/MergedIngredient.cs
@@ -1,0 +1,5 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Common;
+
+public sealed record MergedIngredient(ItemName Name, Quantity? Quantity);

--- a/src/Yumney.Shopping.Application/DTOs/RecipeIngredientLookupResult.cs
+++ b/src/Yumney.Shopping.Application/DTOs/RecipeIngredientLookupResult.cs
@@ -1,0 +1,7 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public sealed record RecipeIngredientLookupResult(
+	string Name,
+	decimal? Amount,
+	string? Unit,
+	int? RecipeServings);

--- a/src/Yumney.Shopping.Application/Interfaces/IRecipeIngredientLookup.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IRecipeIngredientLookup.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+public interface IRecipeIngredientLookup
+{
+	Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
+		RecipeReference recipe,
+		CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Domain/ShoppingList/Servings.cs
+++ b/src/Yumney.Shopping.Domain/ShoppingList/Servings.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+public sealed record Servings : IValueObject<int>
+{
+	public int Value { get; }
+
+	private Servings(int value)
+	{
+		Value = Ensure.That(value).IsPositive().AndReturn();
+	}
+
+	public static Servings From(int value) => new(value);
+
+	public static Servings? FromNullable(int? value) => value.HasValue ? new Servings(value.Value) : null;
+
+	public static implicit operator int(Servings obj) => obj.Value;
+
+	public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
@@ -1,0 +1,32 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
+
+public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFactory) : IRecipeIngredientLookup
+{
+	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
+		RecipeReference recipe,
+		CancellationToken cancellationToken = default)
+	{
+		var client = httpClientFactory.CreateClient("recipes-api");
+		var url = $"/api/v1/recipes/{recipe.Value}";
+		var response = await client.GetFromJsonAsync<RecipeWireResponse>(url, cancellationToken);
+
+		if (response is null) return [];
+
+		return response.Ingredients
+			.Select(ingredient => new RecipeIngredientLookupResult(
+				ingredient.Name,
+				ingredient.Amount,
+				ingredient.Unit,
+				response.Servings))
+			.ToList();
+	}
+
+	private sealed record RecipeWireResponse(int? Servings, IReadOnlyList<IngredientWireResponse> Ingredients);
+
+	private sealed record IngredientWireResponse(string Name, decimal? Amount, string? Unit);
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -31,6 +31,8 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 		services.AddScoped<IIngredientBalanceReadModelRepository, IngredientBalanceReadModelRepository>();
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
+		services.AddScoped<IRecipeIngredientLookup, HttpRecipeIngredientLookup>();
+		services.AddYumneyServiceClient("recipes-api");
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddIntegrationEventHandlersFromAssemblyContaining<ShoppingListProjection>();
 		services.AddYumneyServiceClient("users-api");

--- a/tests/Yumney.Shopping.Api.Tests/Requests/CreateFromRecipesValidatorTests.cs
+++ b/tests/Yumney.Shopping.Api.Tests/Requests/CreateFromRecipesValidatorTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Api.Tests.Requests;
+
+public class CreateFromRecipesValidatorTests
+{
+	private readonly Api.Requests.Validator.CreateFromRecipesValidator validator = new();
+
+	[Fact]
+	public void Validate_ValidRequest_IsValid()
+	{
+		var result = validator.Validate(ValidRequest());
+
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void Validate_EmptyTitle_IsInvalid(string? title)
+	{
+		var request = ValidRequest() with { Title = title! };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_NoRecipes_IsInvalid()
+	{
+		var request = ValidRequest() with { Recipes = [] };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_RecipeWithEmptyIdentifier_IsInvalid()
+	{
+		var request = ValidRequest() with
+		{
+			Recipes = [new Api.Requests.RecipeForList(Guid.Empty, 4)],
+		};
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Validate_RecipeServingsNotPositive_IsInvalid(int servings)
+	{
+		var request = ValidRequest() with
+		{
+			Recipes = [new Api.Requests.RecipeForList(Guid.NewGuid(), servings)],
+		};
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Validate_RecipeServingsNull_IsValid()
+	{
+		var request = ValidRequest() with
+		{
+			Recipes = [new Api.Requests.RecipeForList(Guid.NewGuid(), null)],
+		};
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeTrue();
+	}
+
+	private static Api.Requests.CreateFromRecipes ValidRequest() => new(
+		"Meal Prep",
+		[new Api.Requests.RecipeForList(Guid.NewGuid(), 4)]);
+}

--- a/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListFromRecipesCommandHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Commands/CreateShoppingListFromRecipesCommandHandlerTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
+using SmartSolutionsLab.Yumney.Shopping.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Commands;
+
+public class CreateShoppingListFromRecipesCommandHandlerTests
+{
+	private readonly IRecipeIngredientLookup recipeLookup = Substitute.For<IRecipeIngredientLookup>();
+	private readonly IShoppingListEventStore eventStore = Substitute.For<IShoppingListEventStore>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly CreateShoppingListFromRecipesCommandHandler handler;
+
+	public CreateShoppingListFromRecipesCommandHandlerTests()
+	{
+		currentUser.UserId.Returns("user-123");
+		handler = new CreateShoppingListFromRecipesCommandHandler(recipeLookup, eventStore, currentUser);
+	}
+
+	[Fact]
+	public async Task HandleAsync_NoRecipesProvided_ReturnsFailure()
+	{
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Empty"),
+			[]);
+
+		var result = await handler.HandleAsync(command);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(CreateShoppingListFromRecipesErrors.NoRecipesProvided);
+	}
+
+	[Fact]
+	public async Task HandleAsync_AllRecipesYieldNoIngredients_ReturnsFailure()
+	{
+		var recipe = RecipeReference.New();
+		recipeLookup.LookupAsync(recipe, Arg.Any<CancellationToken>()).Returns([]);
+
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Empty"),
+			[new RecipeSelection(recipe, Servings.From(4))]);
+
+		var result = await handler.HandleAsync(command);
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(CreateShoppingListFromRecipesErrors.NoIngredientsResolved);
+	}
+
+	[Fact]
+	public async Task HandleAsync_TwoRecipesWithSharedIngredient_MergesAndPersists()
+	{
+		var pasta = RecipeReference.New();
+		var risotto = RecipeReference.New();
+		recipeLookup.LookupAsync(pasta, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Onion", 1m, null, 4),
+			new RecipeIngredientLookupResult("Olive Oil", 2m, "tbsp", 4),
+		});
+		recipeLookup.LookupAsync(risotto, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Onion", 2m, null, 4),
+			new RecipeIngredientLookupResult("Rice", 300m, "g", 4),
+		});
+
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Meal Prep"),
+			[
+				new RecipeSelection(pasta, Servings.From(4)),
+				new RecipeSelection(risotto, Servings.From(4)),
+			]);
+
+		var result = await handler.HandleAsync(command);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Items.Should().HaveCount(3);
+		result.Value.Items.Should().ContainSingle(item => item.Name == "Onion" && item.Amount == 3);
+		result.Value.Items.Should().ContainSingle(item => item.Name == "Olive Oil" && item.Amount == 2 && item.Unit == "tbsp");
+		result.Value.Items.Should().ContainSingle(item => item.Name == "Rice" && item.Amount == 300 && item.Unit == "g");
+	}
+
+	[Fact]
+	public async Task HandleAsync_ScalesPerRecipeBeforeMerging()
+	{
+		var pasta = RecipeReference.New();
+		var risotto = RecipeReference.New();
+		recipeLookup.LookupAsync(pasta, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Onion", 1m, null, 4),
+		});
+		recipeLookup.LookupAsync(risotto, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Onion", 2m, null, 4),
+		});
+
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Meal Prep"),
+			[
+				new RecipeSelection(pasta, Servings.From(8)),
+				new RecipeSelection(risotto, Servings.From(2)),
+			]);
+
+		var result = await handler.HandleAsync(command);
+
+		result.Value.Items.Should().ContainSingle(item => item.Name == "Onion" && item.Amount == 3);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PersistsToEventStore()
+	{
+		var recipe = RecipeReference.New();
+		recipeLookup.LookupAsync(recipe, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Flour", 200m, "g", 4),
+		});
+
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Meal Prep"),
+			[new RecipeSelection(recipe, Servings.From(4))]);
+
+		await handler.HandleAsync(command);
+
+		await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingList>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_DoesNotAttachRecipeReference()
+	{
+		var recipe = RecipeReference.New();
+		recipeLookup.LookupAsync(recipe, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Flour", 200m, "g", 4),
+		});
+
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Meal Prep"),
+			[new RecipeSelection(recipe, Servings.From(4))]);
+
+		var result = await handler.HandleAsync(command);
+
+		result.Value.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCancellationTokenToLookupAndStore()
+	{
+		var recipe = RecipeReference.New();
+		recipeLookup.LookupAsync(recipe, Arg.Any<CancellationToken>()).Returns(new[]
+		{
+			new RecipeIngredientLookupResult("Flour", 200m, "g", 4),
+		});
+
+		using var cts = new CancellationTokenSource();
+		var command = new CreateShoppingListFromRecipesCommand(
+			ShoppingListTitle.From("Meal Prep"),
+			[new RecipeSelection(recipe, Servings.From(4))]);
+
+		await handler.HandleAsync(command, cts.Token);
+
+		await recipeLookup.Received(1).LookupAsync(recipe, cts.Token);
+		await eventStore.Received(1).SaveAsync(Arg.Any<ShoppingList>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/Common/IngredientMergerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Common/IngredientMergerTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shopping.Application.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.Common;
+
+public class IngredientMergerTests
+{
+	[Fact]
+	public void Merge_SameNameAndUnitAcrossRecipes_SumsAmounts()
+	{
+		var inputs = new[]
+		{
+			Input(servings: 4, ("Flour", 200m, "g")),
+			Input(servings: 4, ("Flour", 300m, "g")),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Name.Value.Should().Be("Flour");
+		merged[0].Quantity!.Amount.Value.Should().Be(500);
+		merged[0].Quantity!.Unit!.Value.Should().Be("g");
+	}
+
+	[Fact]
+	public void Merge_SameNameDifferentUnits_KeepsSeparate()
+	{
+		var inputs = new[]
+		{
+			Input(servings: 4, ("Milk", 2m, "cup")),
+			Input(servings: 4, ("Milk", 500m, "ml")),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().HaveCount(2);
+		merged.Should().ContainSingle(merge => merge.Quantity!.Unit!.Value == "cup" && merge.Quantity!.Amount.Value == 2);
+		merged.Should().ContainSingle(merge => merge.Quantity!.Unit!.Value == "ml" && merge.Quantity!.Amount.Value == 500);
+	}
+
+	[Fact]
+	public void Merge_DifferentCaseSameIngredient_TreatsAsDuplicate()
+	{
+		var inputs = new[]
+		{
+			Input(servings: 4, ("flour", 200m, "g")),
+			Input(servings: 4, ("FLOUR", 300m, "G")),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Quantity!.Amount.Value.Should().Be(500);
+	}
+
+	[Fact]
+	public void Merge_ScalesAmountsToDesiredServings()
+	{
+		var inputs = new[]
+		{
+			InputWithDesired(originalServings: 4, desiredServings: 6, ("Flour", 200m, "g")),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Quantity!.Amount.Value.Should().Be(300);
+	}
+
+	[Fact]
+	public void Merge_ScalesDownAndRoundsIntegersToInteger()
+	{
+		var inputs = new[]
+		{
+			InputWithDesired(originalServings: 4, desiredServings: 1, ("Eggs", 4m, null)),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Quantity!.Amount.Value.Should().Be(1);
+	}
+
+	[Fact]
+	public void Merge_ScalesNonIntegerAmountsToTwoDecimals()
+	{
+		var inputs = new[]
+		{
+			InputWithDesired(originalServings: 4, desiredServings: 6, ("Olive Oil", 1.5m, "tbsp")),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Quantity!.Amount.Value.Should().Be(2.25m);
+	}
+
+	[Fact]
+	public void Merge_NullAmountAcrossAllOccurrences_ProducesNullQuantity()
+	{
+		var inputs = new[]
+		{
+			Input(servings: 4, ("Salt", null, null)),
+			Input(servings: 4, ("Salt", null, null)),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().ContainSingle();
+		merged[0].Quantity.Should().BeNull();
+	}
+
+	[Fact]
+	public void Merge_MissingDesiredServings_DoesNotScale()
+	{
+		var inputs = new[]
+		{
+			new IngredientMergeInput(
+				new[] { new RecipeIngredientLookupResult("Flour", 200m, "g", 4) },
+				DesiredServings: null),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged[0].Quantity!.Amount.Value.Should().Be(200);
+	}
+
+	[Fact]
+	public void Merge_MissingOriginalServings_DoesNotScale()
+	{
+		var inputs = new[]
+		{
+			new IngredientMergeInput(
+				new[] { new RecipeIngredientLookupResult("Flour", 200m, "g", null) },
+				Servings.From(8)),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged[0].Quantity!.Amount.Value.Should().Be(200);
+	}
+
+	[Fact]
+	public void Merge_MultipleRecipesWithMixedOverlap_MergesCorrectly()
+	{
+		var inputs = new[]
+		{
+			InputWithDesired(originalServings: 4, desiredServings: 4, ("Flour", 200m, "g"), ("Eggs", 2m, null)),
+			InputWithDesired(originalServings: 4, desiredServings: 4, ("Flour", 300m, "g"), ("Milk", 250m, "ml")),
+			InputWithDesired(originalServings: 4, desiredServings: 4, ("Salt", null, null)),
+		};
+
+		var merged = IngredientMerger.Merge(inputs);
+
+		merged.Should().HaveCount(4);
+		merged.Should().ContainSingle(merge => merge.Name.Value == "Flour" && merge.Quantity!.Amount.Value == 500);
+		merged.Should().ContainSingle(merge => merge.Name.Value == "Eggs" && merge.Quantity!.Amount.Value == 2);
+		merged.Should().ContainSingle(merge => merge.Name.Value == "Milk" && merge.Quantity!.Amount.Value == 250);
+		merged.Should().ContainSingle(merge => merge.Name.Value == "Salt" && merge.Quantity == null);
+	}
+
+	private static IngredientMergeInput Input(int servings, params (string Name, decimal? Amount, string? Unit)[] ingredients)
+	{
+		return new IngredientMergeInput(
+			ingredients.Select(item => new RecipeIngredientLookupResult(item.Name, item.Amount, item.Unit, servings)).ToList(),
+			Servings.From(servings));
+	}
+
+	private static IngredientMergeInput InputWithDesired(
+		int originalServings,
+		int desiredServings,
+		params (string Name, decimal? Amount, string? Unit)[] ingredients)
+	{
+		return new IngredientMergeInput(
+			ingredients.Select(item => new RecipeIngredientLookupResult(item.Name, item.Amount, item.Unit, originalServings)).ToList(),
+			Servings.From(desiredServings));
+	}
+}


### PR DESCRIPTION
First slice of #24. Backend only — frontend lands in a follow-up.

## Summary
- New endpoint: \`POST /api/v1/shopping-lists/from-recipes\` accepting \`{ title, recipes: [{ recipeIdentifier, servings? }] }\`
- New \`IRecipeIngredientLookup\` contract owned by Shopping (mirrors the consumer-defined-contract pattern MealPlan already uses; no cross-module project reference). HTTP adapter calls \`GET /api/v1/recipes/{id}\` via the named \`recipes-api\` client.
- New pure helper \`IngredientMerger\` scales per-recipe amounts then merges duplicates (same name + same unit → sum; different units → separate; case-insensitive on both name and unit; rounding mirrors the FE \`scaleIngredients\`).
- New \`Servings\` value object on Shopping.Domain (positive int).

## Out of scope (next PRs)
- B: multi-select mode on the recipe list + FAB
- C: glass preview modal with per-recipe servings
- D: dashboard \"meal prep this week\" hook

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\`
- [x] \`dotnet format --verify-no-changes\`
- [x] \`dotnet test\` for Shopping.Application (140), Shopping.Api (29), Shopping.Domain (176), Architecture (131)
- [x] New tests: \`IngredientMergerTests\` (10), \`CreateShoppingListFromRecipesCommandHandlerTests\` (7), \`CreateFromRecipesValidatorTests\` (8) — covering AC TC-081-01/02/03/04