### PR TITLE
feat(recipes): add multi-recipe preview dialog with per-recipe servings (US-081 phase C)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -54,7 +54,21 @@
       "creating": "Wird erstellt...",
       "autoTitle": "Meal Prep ({{count}} Rezepte)",
       "selectAriaLabel": "Rezept auswählen",
-      "deselectAriaLabel": "Auswahl entfernen"
+      "deselectAriaLabel": "Auswahl entfernen",
+      "preview": {
+        "title": "Einkaufsliste prüfen",
+        "subtitle": "{{count}} Rezepte ausgewählt",
+        "loading": "Rezeptdetails werden geladen...",
+        "fallbackTitle": "Rezept",
+        "recipesHeading": "Rezepte & Portionen",
+        "mergedHeading": "{{count}} zusammengeführte Zutaten",
+        "servings": "{{count}} Portionen",
+        "decreaseAriaLabel": "Portionen für {{title}} verringern",
+        "increaseAriaLabel": "Portionen für {{title}} erhöhen",
+        "confirm": "Liste erstellen",
+        "creating": "Wird erstellt...",
+        "cancel": "Abbrechen"
+      }
     }
   },
   "edit": {

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -54,7 +54,21 @@
       "creating": "Creating...",
       "autoTitle": "Meal Prep ({{count}} recipes)",
       "selectAriaLabel": "Select recipe",
-      "deselectAriaLabel": "Deselect recipe"
+      "deselectAriaLabel": "Deselect recipe",
+      "preview": {
+        "title": "Review shopping list",
+        "subtitle": "{{count}} recipes selected",
+        "loading": "Loading recipe details...",
+        "fallbackTitle": "Recipe",
+        "recipesHeading": "Recipes & servings",
+        "mergedHeading": "{{count}} merged ingredients",
+        "servings": "{{count}} servings",
+        "decreaseAriaLabel": "Decrease servings for {{title}}",
+        "increaseAriaLabel": "Increase servings for {{title}}",
+        "confirm": "Create list",
+        "creating": "Creating...",
+        "cancel": "Cancel"
+      }
     }
   },
   "edit": {

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
@@ -1,0 +1,132 @@
+<div class="multi-preview-overlay" (click)="onOverlayClick($event)" *transloco="let t">
+  <div
+    class="multi-preview-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="multi-preview-title"
+    data-testid="multi-recipe-preview-dialog"
+  >
+    <header class="dialog-header">
+      <h2 id="multi-preview-title" class="dialog-title">
+        {{ t('recipes.list.multiSelect.preview.title') }}
+      </h2>
+      <p class="dialog-subtitle">
+        {{ t('recipes.list.multiSelect.preview.subtitle', { count: recipes().length }) }}
+      </p>
+    </header>
+
+    @if (isLoading()) {
+      <div class="dialog-loading">
+        <yn-loading-spinner label="recipes.list.multiSelect.preview.loading" />
+      </div>
+    } @else {
+      <section
+        class="dialog-recipes"
+        aria-labelledby="multi-preview-recipes-heading"
+        data-testid="multi-recipe-preview-recipes"
+      >
+        <h3 id="multi-preview-recipes-heading" class="section-heading">
+          {{ t('recipes.list.multiSelect.preview.recipesHeading') }}
+        </h3>
+        <ul class="recipe-list">
+          @for (recipe of recipes(); track recipe.identifier) {
+            <li class="recipe-row">
+              <span class="recipe-row-title">{{ recipe.title }}</span>
+              <div class="servings-control">
+                <button
+                  type="button"
+                  class="servings-button"
+                  data-testid="multi-recipe-decrease-servings"
+                  [disabled]="recipe.desiredServings <= 1"
+                  [attr.aria-label]="
+                    t('recipes.list.multiSelect.preview.decreaseAriaLabel', {
+                      title: recipe.title,
+                    })
+                  "
+                  (click)="onDecrease(recipe.identifier)"
+                >
+                  &minus;
+                </button>
+                <span class="servings-value" aria-live="polite">
+                  {{
+                    t('recipes.list.multiSelect.preview.servings', {
+                      count: recipe.desiredServings,
+                    })
+                  }}
+                </span>
+                <button
+                  type="button"
+                  class="servings-button"
+                  data-testid="multi-recipe-increase-servings"
+                  [attr.aria-label]="
+                    t('recipes.list.multiSelect.preview.increaseAriaLabel', {
+                      title: recipe.title,
+                    })
+                  "
+                  (click)="onIncrease(recipe.identifier)"
+                >
+                  +
+                </button>
+              </div>
+            </li>
+          }
+        </ul>
+      </section>
+
+      <section
+        class="dialog-merged"
+        aria-labelledby="multi-preview-merged-heading"
+        data-testid="multi-recipe-preview-merged"
+      >
+        <h3 id="multi-preview-merged-heading" class="section-heading">
+          {{
+            t('recipes.list.multiSelect.preview.mergedHeading', {
+              count: mergedIngredients().length,
+            })
+          }}
+        </h3>
+        <ul class="merged-list">
+          @for (
+            ingredient of mergedIngredients();
+            track ingredient.name + (ingredient.unit ?? '')
+          ) {
+            <li>
+              @if (ingredient.amount !== null) {
+                <span class="merged-amount">{{ ingredient.amount }}</span>
+              }
+              @if (ingredient.unit) {
+                <span class="merged-unit">{{ ingredient.unit }}</span>
+              }
+              <span class="merged-name">{{ ingredient.name }}</span>
+            </li>
+          }
+        </ul>
+      </section>
+    }
+
+    <div class="dialog-actions">
+      <button
+        type="button"
+        class="btn-secondary"
+        [disabled]="isCreating()"
+        (click)="onCancel()"
+        data-testid="multi-recipe-preview-cancel"
+      >
+        {{ t('recipes.list.multiSelect.preview.cancel') }}
+      </button>
+      <button
+        type="button"
+        class="btn-primary"
+        [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0"
+        (click)="onConfirm()"
+        data-testid="multi-recipe-preview-confirm"
+      >
+        {{
+          isCreating()
+            ? t('recipes.list.multiSelect.preview.creating')
+            : t('recipes.list.multiSelect.preview.confirm')
+        }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.scss
@@ -1,0 +1,181 @@
+@use 'buttons';
+@use 'glass';
+
+.multi-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--yn-z-modal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--yn-space-5);
+  background: var(--yn-overlay);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+}
+
+.multi-preview-dialog {
+  @include glass.glass-dialog;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-6);
+  padding: var(--yn-space-7);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .multi-preview-overlay,
+  .multi-preview-dialog {
+    animation: none;
+  }
+}
+
+.dialog-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.dialog-title {
+  margin: 0;
+  font-size: var(--yn-text-xl);
+  line-height: var(--yn-leading-tight);
+}
+
+.dialog-subtitle {
+  margin: 0;
+  font-size: var(--yn-text-md);
+  color: var(--yn-text-muted);
+}
+
+.dialog-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--yn-space-7) 0;
+}
+
+.dialog-recipes,
+.dialog-merged {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
+  min-height: 0;
+}
+
+.dialog-merged {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.section-heading {
+  margin: 0;
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--yn-text-muted);
+}
+
+.recipe-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
+}
+
+.recipe-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--yn-space-4);
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border-subtle);
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+}
+
+.recipe-row-title {
+  font-weight: var(--yn-font-medium);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.servings-control {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  flex-shrink: 0;
+}
+
+.servings-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid var(--yn-glass-border-subtle);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  cursor: pointer;
+  font-size: var(--yn-text-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.servings-value {
+  min-width: 84px;
+  text-align: center;
+  font-size: var(--yn-text-sm);
+}
+
+.merged-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+  overflow-y: auto;
+
+  li {
+    display: flex;
+    gap: var(--yn-space-2);
+    align-items: baseline;
+    padding-block: var(--yn-space-1);
+    border-bottom: 1px solid var(--yn-glass-border-subtle);
+  }
+
+  li:last-child {
+    border-bottom: 0;
+  }
+}
+
+.merged-amount {
+  font-weight: var(--yn-font-medium);
+}
+
+.merged-unit {
+  color: var(--yn-text-muted);
+}
+
+.merged-name {
+  flex: 1 1 auto;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--yn-space-3);
+}

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
@@ -1,0 +1,201 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import {
+  MultiRecipePreviewDialogComponent,
+  type MultiRecipeSelection,
+} from './multi-recipe-preview-dialog.component';
+
+const en = {
+  recipes: {
+    list: {
+      multiSelect: {
+        preview: {
+          title: 'Review shopping list',
+          subtitle: '{{count}} recipes selected',
+          loading: 'Loading recipe details...',
+          fallbackTitle: 'Recipe',
+          recipesHeading: 'Recipes & servings',
+          mergedHeading: '{{count}} merged ingredients',
+          servings: '{{count}} servings',
+          decreaseAriaLabel: 'Decrease servings for {{title}}',
+          increaseAriaLabel: 'Increase servings for {{title}}',
+          confirm: 'Create list',
+          creating: 'Creating...',
+          cancel: 'Cancel',
+        },
+      },
+    },
+  },
+};
+
+const sampleRecipes: MultiRecipeSelection[] = [
+  {
+    identifier: 'abc-123',
+    title: 'Pasta',
+    originalServings: 4,
+    desiredServings: 4,
+    ingredients: [
+      { name: 'Flour', amount: 200, unit: 'g' },
+      { name: 'Eggs', amount: 2, unit: null },
+    ],
+  },
+  {
+    identifier: 'def-456',
+    title: 'Cake',
+    originalServings: 4,
+    desiredServings: 4,
+    ingredients: [
+      { name: 'Flour', amount: 300, unit: 'g' },
+      { name: 'Milk', amount: 250, unit: 'ml' },
+    ],
+  },
+];
+
+describe('MultiRecipePreviewDialogComponent', () => {
+  let fixture: ComponentFixture<MultiRecipePreviewDialogComponent>;
+  let component: MultiRecipePreviewDialogComponent;
+
+  function setup(
+    overrides: Partial<{
+      recipes: MultiRecipeSelection[];
+      isLoading: boolean;
+      isCreating: boolean;
+    }> = {},
+  ) {
+    TestBed.configureTestingModule({
+      imports: [MultiRecipePreviewDialogComponent, setupTranslocoTesting(en)],
+    });
+    fixture = TestBed.createComponent(MultiRecipePreviewDialogComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('recipes', overrides.recipes ?? sampleRecipes);
+    fixture.componentRef.setInput('isLoading', overrides.isLoading ?? false);
+    fixture.componentRef.setInput('isCreating', overrides.isCreating ?? false);
+    fixture.detectChanges();
+  }
+
+  it('should render a row per recipe with the current desired servings', () => {
+    setup();
+    const rows = fixture.nativeElement.querySelectorAll('.recipe-row');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('Pasta');
+    expect(rows[0].textContent).toContain('4 servings');
+  });
+
+  it('should compute merged ingredients with case-insensitive name+unit matching', () => {
+    setup();
+    const merged = component.mergedIngredients();
+    expect(merged).toHaveLength(3);
+    expect(merged.find((entry) => entry.name === 'Flour')?.amount).toBe(500);
+    expect(merged.find((entry) => entry.name === 'Eggs')?.amount).toBe(2);
+    expect(merged.find((entry) => entry.name === 'Milk')?.amount).toBe(250);
+  });
+
+  it('should show a loading state and skip the merged section', () => {
+    setup({ isLoading: true });
+    expect(fixture.nativeElement.querySelector('.dialog-loading')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-merged"]'),
+    ).toBeNull();
+    expect(component.mergedIngredients()).toHaveLength(0);
+  });
+
+  it('should emit servingsChanged on increase / decrease', () => {
+    setup();
+    let lastChange: { identifier: string; servings: number } | null = null;
+    component.servingsChanged.subscribe((event) => (lastChange = event));
+
+    component.onIncrease('abc-123');
+    expect(lastChange).toEqual({ identifier: 'abc-123', servings: 5 });
+
+    component.onDecrease('abc-123');
+    expect(lastChange).toEqual({ identifier: 'abc-123', servings: 3 });
+  });
+
+  it('should not emit a decrease below 1', () => {
+    const recipes: MultiRecipeSelection[] = [{ ...sampleRecipes[0], desiredServings: 1 }];
+    setup({ recipes });
+    let count = 0;
+    component.servingsChanged.subscribe(() => count++);
+
+    component.onDecrease('abc-123');
+
+    expect(count).toBe(0);
+  });
+
+  it('should emit confirmed when the confirm button is clicked', () => {
+    setup();
+    let count = 0;
+    component.confirmed.subscribe(() => count++);
+
+    fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-confirm"]').click();
+
+    expect(count).toBe(1);
+  });
+
+  it('should emit cancelled when the cancel button is clicked', () => {
+    setup();
+    let count = 0;
+    component.cancelled.subscribe(() => count++);
+
+    fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-cancel"]').click();
+
+    expect(count).toBe(1);
+  });
+
+  it('should disable the confirm button while creating', () => {
+    setup({ isCreating: true });
+    const confirm = fixture.nativeElement.querySelector(
+      '[data-testid="multi-recipe-preview-confirm"]',
+    );
+    expect(confirm.disabled).toBe(true);
+    expect(confirm.textContent).toContain('Creating...');
+  });
+
+  it('should disable the confirm button while loading', () => {
+    setup({ isLoading: true });
+    const confirm = fixture.nativeElement.querySelector(
+      '[data-testid="multi-recipe-preview-confirm"]',
+    );
+    expect(confirm.disabled).toBe(true);
+  });
+
+  it('should disable the confirm button when there are no merged ingredients', () => {
+    setup({ recipes: [{ ...sampleRecipes[0], ingredients: [] }] });
+    const confirm = fixture.nativeElement.querySelector(
+      '[data-testid="multi-recipe-preview-confirm"]',
+    );
+    expect(confirm.disabled).toBe(true);
+  });
+
+  it('should ignore Escape while creating', () => {
+    setup({ isCreating: true });
+    let count = 0;
+    component.cancelled.subscribe(() => count++);
+
+    component.onEscapeKey();
+
+    expect(count).toBe(0);
+  });
+
+  it('should emit cancelled on Escape when idle', () => {
+    setup();
+    let count = 0;
+    component.cancelled.subscribe(() => count++);
+
+    component.onEscapeKey();
+
+    expect(count).toBe(1);
+  });
+
+  it('should emit cancelled on overlay click', () => {
+    setup();
+    let count = 0;
+    component.cancelled.subscribe(() => count++);
+
+    fixture.nativeElement
+      .querySelector('.multi-preview-overlay')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(count).toBe(1);
+  });
+});

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
@@ -1,0 +1,85 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  HostListener,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  mergeRecipeIngredients,
+  type MergedIngredient,
+  type RecipeForMerge,
+  type ScalableIngredient,
+} from '@yumney/shared/models';
+import { LoadingSpinnerComponent } from '@yumney/ui';
+
+export interface MultiRecipeSelection {
+  identifier: string;
+  title: string;
+  originalServings: number | null;
+  desiredServings: number;
+  ingredients: readonly ScalableIngredient[];
+}
+
+@Component({
+  selector: 'yn-multi-recipe-preview-dialog',
+  imports: [TranslocoModule, LoadingSpinnerComponent],
+  templateUrl: './multi-recipe-preview-dialog.component.html',
+  styleUrl: './multi-recipe-preview-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MultiRecipePreviewDialogComponent {
+  recipes = input.required<readonly MultiRecipeSelection[]>();
+  isLoading = input(false);
+  isCreating = input(false);
+  defaultServings = input(4);
+
+  confirmed = output<void>();
+  cancelled = output<void>();
+  servingsChanged = output<{ identifier: string; servings: number }>();
+
+  mergedIngredients = computed<MergedIngredient[]>(() => {
+    if (this.isLoading()) return [];
+    const recipes: RecipeForMerge[] = this.recipes().map((recipe) => ({
+      ingredients: recipe.ingredients,
+      originalServings: recipe.originalServings,
+      desiredServings: recipe.desiredServings,
+    }));
+    return mergeRecipeIngredients(recipes);
+  });
+
+  @HostListener('document:keydown.escape')
+  onEscapeKey(): void {
+    if (!this.isCreating()) {
+      this.cancelled.emit();
+    }
+  }
+
+  onConfirm(): void {
+    this.confirmed.emit();
+  }
+
+  onCancel(): void {
+    this.cancelled.emit();
+  }
+
+  onOverlayClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget && !this.isCreating()) {
+      this.cancelled.emit();
+    }
+  }
+
+  onIncrease(identifier: string): void {
+    const recipe = this.recipes().find((entry) => entry.identifier === identifier);
+    if (!recipe) return;
+    this.servingsChanged.emit({ identifier, servings: recipe.desiredServings + 1 });
+  }
+
+  onDecrease(identifier: string): void {
+    const recipe = this.recipes().find((entry) => entry.identifier === identifier);
+    if (!recipe || recipe.desiredServings <= 1) return;
+    this.servingsChanged.emit({ identifier, servings: recipe.desiredServings - 1 });
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
@@ -1,0 +1,128 @@
+import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { TranslocoService } from '@jsverse/transloco';
+import { forkJoin, of } from 'rxjs';
+import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
+import { RecipeApiService, RecipeDetail, ShoppingApiService } from '../api';
+import type { MultiRecipeSelection } from './multi-recipe-preview-dialog/multi-recipe-preview-dialog.component';
+
+const FALLBACK_SERVINGS = 4;
+
+@Injectable()
+export class MultiRecipeShoppingListService {
+  private recipeApi = inject(RecipeApiService);
+  private shoppingApi = inject(ShoppingApiService);
+  private router = inject(Router);
+  private transloco = inject(TranslocoService);
+  private destroyRef = inject(DestroyRef);
+  private previewLoadState = createAsyncState(this.destroyRef);
+  private createState = createAsyncState(this.destroyRef);
+
+  readonly multiSelectMode = signal(false);
+  readonly selectedRecipeIds = signal<ReadonlySet<string>>(new Set<string>());
+  readonly showPreviewDialog = signal(false);
+  readonly previewSelections = signal<readonly MultiRecipeSelection[]>([]);
+  readonly isLoadingPreview = this.previewLoadState.isLoading;
+  readonly isCreating = this.createState.isLoading;
+
+  readonly selectedCount = computed(() => this.selectedRecipeIds().size);
+  readonly hasSelection = computed(() => this.selectedCount() > 0);
+  readonly serverError = signal<string | null>(null);
+
+  isSelected(identifier: string): boolean {
+    return this.selectedRecipeIds().has(identifier);
+  }
+
+  toggleMode(): void {
+    const next = !this.multiSelectMode();
+    this.multiSelectMode.set(next);
+    if (!next) this.selectedRecipeIds.set(new Set<string>());
+  }
+
+  toggleSelection(identifier: string): void {
+    const next = new Set(this.selectedRecipeIds());
+    if (next.has(identifier)) next.delete(identifier);
+    else next.add(identifier);
+    this.selectedRecipeIds.set(next);
+  }
+
+  clearSelection(): void {
+    if (this.selectedRecipeIds().size > 0) {
+      this.selectedRecipeIds.set(new Set<string>());
+    }
+  }
+
+  openPreview(): void {
+    if (!this.hasSelection()) return;
+    const ids = [...this.selectedRecipeIds()];
+    this.serverError.set(null);
+    this.showPreviewDialog.set(true);
+    this.previewSelections.set([]);
+
+    const fetches = ids.map((identifier) => this.recipeApi.getRecipeById(identifier));
+    this.previewLoadState.execute(
+      forkJoin(fetches.length > 0 ? fetches : [of(null as unknown as RecipeDetail)]),
+      ERROR_MAPS.recipes.createShoppingList,
+      (results) => {
+        const fallback = this.transloco.translate('recipes.list.multiSelect.preview.fallbackTitle');
+        this.previewSelections.set(
+          (results as RecipeDetail[]).map((recipe) => ({
+            identifier: recipe.identifier,
+            title: recipe.title || fallback,
+            originalServings: recipe.servings,
+            desiredServings: recipe.servings ?? FALLBACK_SERVINGS,
+            ingredients: recipe.ingredients,
+          })),
+        );
+      },
+      (error) => {
+        this.showPreviewDialog.set(false);
+        this.serverError.set(error);
+      },
+    );
+  }
+
+  changeServings(identifier: string, servings: number): void {
+    this.previewSelections.update((selections) =>
+      selections.map((entry) =>
+        entry.identifier === identifier ? { ...entry, desiredServings: servings } : entry,
+      ),
+    );
+  }
+
+  cancelPreview(): void {
+    if (this.isCreating()) return;
+    this.showPreviewDialog.set(false);
+    this.previewSelections.set([]);
+  }
+
+  confirmPreview(): void {
+    const selections = this.previewSelections();
+    if (selections.length === 0) return;
+
+    const title = this.transloco.translate('recipes.list.multiSelect.autoTitle', {
+      count: selections.length,
+    });
+    const recipes = selections.map((entry) => ({
+      recipeIdentifier: entry.identifier,
+      servings: entry.desiredServings,
+    }));
+
+    this.serverError.set(null);
+    this.createState.execute(
+      this.shoppingApi.createShoppingListFromRecipes({ title, recipes }),
+      ERROR_MAPS.recipes.createShoppingList,
+      (created) => {
+        this.showPreviewDialog.set(false);
+        this.previewSelections.set([]);
+        this.multiSelectMode.set(false);
+        this.selectedRecipeIds.set(new Set<string>());
+        this.router.navigateByUrl(ROUTES.shopping.detail(created.identifier));
+      },
+      (error) => {
+        this.showPreviewDialog.set(false);
+        this.serverError.set(error);
+      },
+    );
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -60,11 +60,11 @@
         type="button"
         class="filter-toggle"
         data-testid="recipe-list-multi-select-toggle"
-        [attr.aria-pressed]="multiSelectMode()"
-        (click)="onToggleMultiSelectMode()"
+        [attr.aria-pressed]="multiSelect.multiSelectMode()"
+        (click)="multiSelect.toggleMode()"
       >
         {{
-          multiSelectMode()
+          multiSelect.multiSelectMode()
             ? t('recipes.list.multiSelect.exit')
             : t('recipes.list.multiSelect.enter')
         }}
@@ -109,30 +109,39 @@
           #recipeCard
           [recipe]="recipe"
           [assignMode]="assignment.assignMode()"
-          [multiSelectMode]="multiSelectMode()"
-          [selected]="isRecipeSelected(recipe.identifier)"
+          [multiSelectMode]="multiSelect.multiSelectMode()"
+          [selected]="multiSelect.isSelected(recipe.identifier)"
           (toggleFavorite)="onToggleFavorite($event)"
           (assign)="assignment.assign($event)"
-          (toggleSelect)="onToggleRecipeSelection($event)"
+          (toggleSelect)="multiSelect.toggleSelection($event)"
         />
       }
     </div>
   }
 
-  @if (multiSelectMode() && hasSelection()) {
+  @if (
+    multiSelect.multiSelectMode() && multiSelect.hasSelection() && !multiSelect.showPreviewDialog()
+  ) {
     <button
       type="button"
       class="multi-select-fab"
       data-testid="recipe-list-multi-select-fab"
-      [disabled]="isCreatingMultiShoppingList()"
-      (click)="onCreateMultiShoppingList()"
+      [disabled]="multiSelect.isCreating()"
+      (click)="multiSelect.openPreview()"
     >
-      @if (isCreatingMultiShoppingList()) {
-        {{ t('recipes.list.multiSelect.creating') }}
-      } @else {
-        {{ t('recipes.list.multiSelect.fab', { count: selectedCount() }) }}
-      }
+      {{ t('recipes.list.multiSelect.fab', { count: multiSelect.selectedCount() }) }}
     </button>
+  }
+
+  @if (multiSelect.showPreviewDialog()) {
+    <yn-multi-recipe-preview-dialog
+      [recipes]="multiSelect.previewSelections()"
+      [isLoading]="multiSelect.isLoadingPreview()"
+      [isCreating]="multiSelect.isCreating()"
+      (servingsChanged)="multiSelect.changeServings($event.identifier, $event.servings)"
+      (confirmed)="multiSelect.confirmPreview()"
+      (cancelled)="multiSelect.cancelPreview()"
+    />
   }
 
   <div

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
@@ -137,6 +137,7 @@ describe('RecipeListComponent', () => {
   let fixture: ComponentFixture<RecipeListComponent>;
   let recipeApiMock: {
     getRecipes: ReturnType<typeof vi.fn>;
+    getRecipeById: ReturnType<typeof vi.fn>;
     toggleFavorite: ReturnType<typeof vi.fn>;
   };
   let shoppingApiMock: {
@@ -154,6 +155,7 @@ describe('RecipeListComponent', () => {
   function setupTestBed(getRecipesReturn: ReturnType<typeof vi.fn> = vi.fn()) {
     recipeApiMock = {
       getRecipes: getRecipesReturn,
+      getRecipeById: vi.fn(),
       toggleFavorite: vi.fn(),
     };
     shoppingApiMock = {
@@ -706,7 +708,7 @@ describe('RecipeListComponent', () => {
     tick();
     fixture.detectChanges();
 
-    component.onToggleMultiSelectMode();
+    component.multiSelect.toggleMode();
     fixture.detectChanges();
 
     expect(
@@ -720,9 +722,9 @@ describe('RecipeListComponent', () => {
     tick();
     fixture.detectChanges();
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    component.onToggleRecipeSelection('def-456');
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.toggleSelection('def-456');
     fixture.detectChanges();
 
     const fab = fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-fab"]');
@@ -735,12 +737,12 @@ describe('RecipeListComponent', () => {
     fixture.detectChanges();
     tick();
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    expect(component.selectedRecipeIds().has('abc-123')).toBe(true);
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    expect(component.multiSelect.selectedRecipeIds().has('abc-123')).toBe(true);
 
-    component.onToggleRecipeSelection('abc-123');
-    expect(component.selectedRecipeIds().has('abc-123')).toBe(false);
+    component.multiSelect.toggleSelection('abc-123');
+    expect(component.multiSelect.selectedRecipeIds().has('abc-123')).toBe(false);
   }));
 
   it('should clear selection when leaving multi-select mode', fakeAsync(() => {
@@ -748,60 +750,105 @@ describe('RecipeListComponent', () => {
     fixture.detectChanges();
     tick();
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    expect(component.selectedRecipeIds().size).toBe(1);
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    expect(component.multiSelect.selectedRecipeIds().size).toBe(1);
 
-    component.onToggleMultiSelectMode();
+    component.multiSelect.toggleMode();
 
-    expect(component.multiSelectMode()).toBe(false);
-    expect(component.selectedRecipeIds().size).toBe(0);
+    expect(component.multiSelect.multiSelectMode()).toBe(false);
+    expect(component.multiSelect.selectedRecipeIds().size).toBe(0);
   }));
 
-  it('should POST selected recipes with their servings on FAB click', fakeAsync(() => {
+  it('should open the preview dialog and load each selected recipe', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
 
-    shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
+    recipeApiMock.getRecipeById.mockImplementation((identifier: string) =>
+      of({
+        identifier,
+        title: identifier === 'abc-123' ? 'Pasta' : 'Salad',
+        servings: identifier === 'abc-123' ? 4 : 2,
+        ingredients: [{ name: 'Flour', amount: 200, unit: 'g' }],
+      }),
     );
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    component.onToggleRecipeSelection('def-456');
-    component.onCreateMultiShoppingList();
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.toggleSelection('def-456');
+    component.multiSelect.openPreview();
     tick();
 
-    expect(shoppingApiMock.createShoppingListFromRecipes).toHaveBeenCalledTimes(1);
-    const payload = shoppingApiMock.createShoppingListFromRecipes.mock.calls[0][0];
-    expect(payload.title).toBe('Meal Prep (2 recipes)');
-    expect(payload.recipes).toEqual([
-      { recipeIdentifier: 'abc-123', servings: 4 },
-      { recipeIdentifier: 'def-456', servings: 2 },
-    ]);
+    expect(component.multiSelect.showPreviewDialog()).toBe(true);
+    expect(recipeApiMock.getRecipeById).toHaveBeenCalledTimes(2);
+    expect(component.multiSelect.previewSelections()).toHaveLength(2);
+    expect(component.multiSelect.previewSelections()[0].desiredServings).toBe(4);
+    expect(component.multiSelect.previewSelections()[1].desiredServings).toBe(2);
+    expect(shoppingApiMock.createShoppingListFromRecipes).not.toHaveBeenCalled();
   }));
 
-  it('should navigate to the new list and exit multi-select mode on success', fakeAsync(() => {
+  it('should POST adjusted servings and navigate when the preview is confirmed', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
 
+    recipeApiMock.getRecipeById.mockImplementation((identifier: string) =>
+      of({
+        identifier,
+        title: 'Pasta',
+        servings: 4,
+        ingredients: [{ name: 'Flour', amount: 200, unit: 'g' }],
+      }),
+    );
     shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(
       of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
     );
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    component.onCreateMultiShoppingList();
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.openPreview();
+    tick();
+    component.multiSelect.changeServings('abc-123', 6);
+    component.multiSelect.confirmPreview();
     tick();
 
+    expect(shoppingApiMock.createShoppingListFromRecipes).toHaveBeenCalledTimes(1);
+    const payload = shoppingApiMock.createShoppingListFromRecipes.mock.calls[0][0];
+    expect(payload.title).toBe('Meal Prep (1 recipes)');
+    expect(payload.recipes).toEqual([{ recipeIdentifier: 'abc-123', servings: 6 }]);
     expect(navigateSpy).toHaveBeenCalledWith('/shopping/lists/list-1');
-    expect(component.multiSelectMode()).toBe(false);
-    expect(component.selectedRecipeIds().size).toBe(0);
+    expect(component.multiSelect.showPreviewDialog()).toBe(false);
+    expect(component.multiSelect.multiSelectMode()).toBe(false);
     navigateSpy.mockRestore();
+  }));
+
+  it('should close the preview without posting when cancelled', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
+    fixture.detectChanges();
+    tick();
+
+    recipeApiMock.getRecipeById.mockReturnValue(
+      of({
+        identifier: 'abc-123',
+        title: 'Pasta',
+        servings: 4,
+        ingredients: [],
+      }),
+    );
+
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.openPreview();
+    tick();
+    component.multiSelect.cancelPreview();
+
+    expect(component.multiSelect.showPreviewDialog()).toBe(false);
+    expect(component.multiSelect.multiSelectMode()).toBe(true);
+    expect(component.multiSelect.selectedRecipeIds().has('abc-123')).toBe(true);
+    expect(shoppingApiMock.createShoppingListFromRecipes).not.toHaveBeenCalled();
   }));
 
   it('should not call the API when no recipes are selected', fakeAsync(() => {
@@ -809,8 +856,8 @@ describe('RecipeListComponent', () => {
     fixture.detectChanges();
     tick();
 
-    component.onToggleMultiSelectMode();
-    component.onCreateMultiShoppingList();
+    component.multiSelect.toggleMode();
+    component.multiSelect.openPreview();
     tick();
 
     expect(shoppingApiMock.createShoppingListFromRecipes).not.toHaveBeenCalled();
@@ -821,19 +868,47 @@ describe('RecipeListComponent', () => {
     fixture.detectChanges();
     tick();
 
+    recipeApiMock.getRecipeById.mockReturnValue(
+      of({
+        identifier: 'abc-123',
+        title: 'Pasta',
+        servings: 4,
+        ingredients: [],
+      }),
+    );
     shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(
       throwError(() => ({ status: 500 })),
     );
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    component.onCreateMultiShoppingList();
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.openPreview();
+    tick();
+    component.multiSelect.confirmPreview();
     tick();
     fixture.detectChanges();
 
     expect(component.serverError()).toBeTruthy();
-    expect(component.multiSelectMode()).toBe(true);
-    expect(component.selectedRecipeIds().has('abc-123')).toBe(true);
+    expect(component.multiSelect.multiSelectMode()).toBe(true);
+    expect(component.multiSelect.selectedRecipeIds().has('abc-123')).toBe(true);
+  }));
+
+  it('should surface a server error if the recipe detail fetch fails', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
+    fixture.detectChanges();
+    tick();
+
+    recipeApiMock.getRecipeById.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.openPreview();
+    tick();
+    fixture.detectChanges();
+
+    expect(component.multiSelect.showPreviewDialog()).toBe(false);
+    expect(component.serverError()).toBeTruthy();
+    expect(shoppingApiMock.createShoppingListFromRecipes).not.toHaveBeenCalled();
   }));
 
   it('should clear the selection when search/sort/filter triggers a reload', fakeAsync(() => {
@@ -841,16 +916,16 @@ describe('RecipeListComponent', () => {
     fixture.detectChanges();
     tick();
 
-    component.onToggleMultiSelectMode();
-    component.onToggleRecipeSelection('abc-123');
-    component.onToggleRecipeSelection('def-456');
-    expect(component.selectedRecipeIds().size).toBe(2);
+    component.multiSelect.toggleMode();
+    component.multiSelect.toggleSelection('abc-123');
+    component.multiSelect.toggleSelection('def-456');
+    expect(component.multiSelect.selectedRecipeIds().size).toBe(2);
 
     component.onSortSelect('name-asc');
     tick();
 
-    expect(component.selectedRecipeIds().size).toBe(0);
-    expect(component.multiSelectMode()).toBe(true);
+    expect(component.multiSelect.selectedRecipeIds().size).toBe(0);
+    expect(component.multiSelect.multiSelectMode()).toBe(true);
   }));
 
   it('should hide the multi-select toggle while in assign mode', fakeAsync(() => {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -12,9 +12,9 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, debounceTime } from 'rxjs';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { RecipeApiService, RecipeListItem, GetRecipesParams, ShoppingApiService } from '../api';
+import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
 import {
   createAsyncState,
   ERROR_MAPS,
@@ -22,7 +22,7 @@ import {
   UI,
   toggleFavoriteInList,
 } from '@yumney/shared/models';
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import {
   EMPTY_FILTER,
   FilterPanelComponent,
@@ -34,6 +34,8 @@ import {
 import { RecipeCardComponent } from './recipe-card/recipe-card.component';
 import { SortMenuComponent, SortMenuOption } from './sort-menu/sort-menu.component';
 import { RecipeAssignmentService } from './recipe-assignment.service';
+import { MultiRecipePreviewDialogComponent } from './multi-recipe-preview-dialog/multi-recipe-preview-dialog.component';
+import { MultiRecipeShoppingListService } from './multi-recipe-shopping-list.service';
 
 interface SortOption extends SortMenuOption {
   by: 'Name' | 'Date';
@@ -50,8 +52,9 @@ interface SortOption extends SortMenuOption {
     FilterPanelComponent,
     RecipeCardComponent,
     SortMenuComponent,
+    MultiRecipePreviewDialogComponent,
   ],
-  providers: [RecipeAssignmentService],
+  providers: [RecipeAssignmentService, MultiRecipeShoppingListService],
   templateUrl: './recipe-list.component.html',
   styleUrl: './recipe-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -67,18 +70,15 @@ export class RecipeListComponent implements OnInit {
   ];
 
   private recipeApi = inject(RecipeApiService);
-  private shoppingApi = inject(ShoppingApiService);
-  private router = inject(Router);
-  private transloco = inject(TranslocoService);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
-  private createShoppingListState = createAsyncState(this.destroyRef);
   private searchSubject = new Subject<string>();
   private loadRequestId = 0;
   private previousCardCount = 0;
   private recipeCards = viewChildren<ElementRef>('recipeCard');
 
   protected assignment = inject(RecipeAssignmentService);
+  protected multiSelect = inject(MultiRecipeShoppingListService);
 
   recipes = signal<RecipeListItem[]>([]);
   totalCount = signal(0);
@@ -87,21 +87,12 @@ export class RecipeListComponent implements OnInit {
   sortBy = signal<'Name' | 'Date'>('Date');
   sortDirection = signal<'Ascending' | 'Descending'>('Descending');
   isLoading = this.asyncState.isLoading;
-  serverError = computed(
-    () => this.createShoppingListState.serverError() ?? this.asyncState.serverError(),
-  );
-  isCreatingMultiShoppingList = this.createShoppingListState.isLoading;
+  serverError = computed(() => this.multiSelect.serverError() ?? this.asyncState.serverError());
   searchQuery = signal('');
   activeSearch = signal('');
   filter = signal<RecipeFilterValue>({ ...EMPTY_FILTER });
   filterPanelOpen = signal(false);
   availableTags = signal<string[]>([]);
-  multiSelectMode = signal(false);
-  selectedRecipeIds = signal<ReadonlySet<string>>(new Set<string>());
-
-  selectedCount = computed(() => this.selectedRecipeIds().size);
-  hasSelection = computed(() => this.selectedCount() > 0);
-  isRecipeSelected = (identifier: string): boolean => this.selectedRecipeIds().has(identifier);
 
   hasMore = computed(() => this.recipes().length < this.totalCount());
 
@@ -194,57 +185,11 @@ export class RecipeListComponent implements OnInit {
     this.resetAndReload();
   }
 
-  onToggleMultiSelectMode(): void {
-    const next = !this.multiSelectMode();
-    this.multiSelectMode.set(next);
-    if (!next) {
-      this.selectedRecipeIds.set(new Set<string>());
-    }
-  }
-
-  onToggleRecipeSelection(identifier: string): void {
-    const next = new Set(this.selectedRecipeIds());
-    if (next.has(identifier)) {
-      next.delete(identifier);
-    } else {
-      next.add(identifier);
-    }
-    this.selectedRecipeIds.set(next);
-  }
-
-  onCreateMultiShoppingList(): void {
-    if (!this.hasSelection()) return;
-
-    const ids = [...this.selectedRecipeIds()];
-    const recipesByIdentifier = new Map(
-      this.recipes().map((recipe) => [recipe.identifier, recipe]),
-    );
-    const title = this.transloco.translate('recipes.list.multiSelect.autoTitle', {
-      count: ids.length,
-    });
-    const recipes = ids.map((identifier) => ({
-      recipeIdentifier: identifier,
-      servings: recipesByIdentifier.get(identifier)?.servings ?? null,
-    }));
-
-    this.createShoppingListState.execute(
-      this.shoppingApi.createShoppingListFromRecipes({ title, recipes }),
-      ERROR_MAPS.recipes.createShoppingList,
-      (created) => {
-        this.multiSelectMode.set(false);
-        this.selectedRecipeIds.set(new Set<string>());
-        this.router.navigateByUrl(ROUTES.shopping.detail(created.identifier));
-      },
-    );
-  }
-
   private resetAndReload(): void {
     this.currentPage.set(1);
     this.recipes.set([]);
     this.totalCount.set(0);
-    if (this.selectedRecipeIds().size > 0) {
-      this.selectedRecipeIds.set(new Set<string>());
-    }
+    this.multiSelect.clearSelection();
     this.loadRecipes(false);
   }
 

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -54,7 +54,21 @@
       "creating": "Wird erstellt...",
       "autoTitle": "Meal Prep ({{count}} Rezepte)",
       "selectAriaLabel": "Rezept auswählen",
-      "deselectAriaLabel": "Auswahl entfernen"
+      "deselectAriaLabel": "Auswahl entfernen",
+      "preview": {
+        "title": "Einkaufsliste prüfen",
+        "subtitle": "{{count}} Rezepte ausgewählt",
+        "loading": "Rezeptdetails werden geladen...",
+        "fallbackTitle": "Rezept",
+        "recipesHeading": "Rezepte & Portionen",
+        "mergedHeading": "{{count}} zusammengeführte Zutaten",
+        "servings": "{{count}} Portionen",
+        "decreaseAriaLabel": "Portionen für {{title}} verringern",
+        "increaseAriaLabel": "Portionen für {{title}} erhöhen",
+        "confirm": "Liste erstellen",
+        "creating": "Wird erstellt...",
+        "cancel": "Abbrechen"
+      }
     }
   },
   "edit": {

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -54,7 +54,21 @@
       "creating": "Creating...",
       "autoTitle": "Meal Prep ({{count}} recipes)",
       "selectAriaLabel": "Select recipe",
-      "deselectAriaLabel": "Deselect recipe"
+      "deselectAriaLabel": "Deselect recipe",
+      "preview": {
+        "title": "Review shopping list",
+        "subtitle": "{{count}} recipes selected",
+        "loading": "Loading recipe details...",
+        "fallbackTitle": "Recipe",
+        "recipesHeading": "Recipes & servings",
+        "mergedHeading": "{{count}} merged ingredients",
+        "servings": "{{count}} servings",
+        "decreaseAriaLabel": "Decrease servings for {{title}}",
+        "increaseAriaLabel": "Increase servings for {{title}}",
+        "confirm": "Create list",
+        "creating": "Creating...",
+        "cancel": "Cancel"
+      }
     }
   },
   "edit": {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -5,6 +5,11 @@ export { type PaginationParams } from './lib/pagination-params';
 export { urlValidator, passwordsMatchValidator } from './lib/validators';
 export { VALIDATION } from './lib/validation-constants';
 export { scaleIngredients, type ScalableIngredient } from './lib/scale-ingredients';
+export {
+  mergeRecipeIngredients,
+  type RecipeForMerge,
+  type MergedIngredient,
+} from './lib/merge-recipe-ingredients';
 export { UI } from './lib/ui-constants';
 export { createAsyncState, type AsyncState } from './lib/async-state';
 export { ensureFormValid } from './lib/form-helpers';

--- a/client/libs/shared/models/src/lib/merge-recipe-ingredients.spec.ts
+++ b/client/libs/shared/models/src/lib/merge-recipe-ingredients.spec.ts
@@ -1,0 +1,108 @@
+import { mergeRecipeIngredients, type RecipeForMerge } from './merge-recipe-ingredients';
+
+describe('mergeRecipeIngredients', () => {
+  it('sums amounts when name and unit match', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'Flour', amount: 200, unit: 'g' }], 4, 4),
+      recipe([{ name: 'Flour', amount: 300, unit: 'g' }], 4, 4),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ name: 'Flour', amount: 500, unit: 'g' });
+  });
+
+  it('keeps separate entries when units differ', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'Milk', amount: 2, unit: 'cup' }], 4, 4),
+      recipe([{ name: 'Milk', amount: 500, unit: 'ml' }], 4, 4),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.find((entry) => entry.unit === 'cup')?.amount).toBe(2);
+    expect(result.find((entry) => entry.unit === 'ml')?.amount).toBe(500);
+  });
+
+  it('treats name and unit casing as equivalent', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'flour', amount: 200, unit: 'g' }], 4, 4),
+      recipe([{ name: 'FLOUR', amount: 300, unit: 'G' }], 4, 4),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe(500);
+  });
+
+  it('scales each recipe before merging', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'Onion', amount: 1, unit: null }], 4, 8),
+      recipe([{ name: 'Onion', amount: 2, unit: null }], 4, 2),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe(3);
+  });
+
+  it('rounds non-integer scaled amounts to two decimals', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'Olive Oil', amount: 1.5, unit: 'tbsp' }], 4, 6),
+    ]);
+
+    expect(result[0].amount).toBe(2.25);
+  });
+
+  it('keeps amount-less ingredients with a null amount', () => {
+    const result = mergeRecipeIngredients([
+      recipe([{ name: 'Salt', amount: null, unit: null }], 4, 4),
+      recipe([{ name: 'Salt', amount: null, unit: null }], 4, 4),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBeNull();
+  });
+
+  it('drops scaling when servings are missing', () => {
+    const result = mergeRecipeIngredients([
+      {
+        ingredients: [{ name: 'Flour', amount: 200, unit: 'g' }],
+        originalServings: null,
+        desiredServings: 8,
+      },
+    ]);
+
+    expect(result[0].amount).toBe(200);
+  });
+
+  it('combines mixed cases of overlap and separate items', () => {
+    const result = mergeRecipeIngredients([
+      recipe(
+        [
+          { name: 'Flour', amount: 200, unit: 'g' },
+          { name: 'Eggs', amount: 2, unit: null },
+        ],
+        4,
+        4,
+      ),
+      recipe(
+        [
+          { name: 'Flour', amount: 300, unit: 'g' },
+          { name: 'Milk', amount: 250, unit: 'ml' },
+        ],
+        4,
+        4,
+      ),
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result.find((entry) => entry.name === 'Flour')?.amount).toBe(500);
+    expect(result.find((entry) => entry.name === 'Eggs')?.amount).toBe(2);
+    expect(result.find((entry) => entry.name === 'Milk')?.amount).toBe(250);
+  });
+});
+
+function recipe(
+  ingredients: { name: string; amount: number | null; unit: string | null }[],
+  originalServings: number,
+  desiredServings: number,
+): RecipeForMerge {
+  return { ingredients, originalServings, desiredServings };
+}

--- a/client/libs/shared/models/src/lib/merge-recipe-ingredients.ts
+++ b/client/libs/shared/models/src/lib/merge-recipe-ingredients.ts
@@ -1,0 +1,42 @@
+import { scaleIngredients, type ScalableIngredient } from './scale-ingredients';
+
+export interface RecipeForMerge {
+  ingredients: readonly ScalableIngredient[];
+  originalServings: number | null;
+  desiredServings: number | null;
+}
+
+export interface MergedIngredient {
+  name: string;
+  amount: number | null;
+  unit: string | null;
+}
+
+export function mergeRecipeIngredients(recipes: readonly RecipeForMerge[]): MergedIngredient[] {
+  const buckets = new Map<string, MergedIngredient>();
+
+  for (const recipe of recipes) {
+    const scaled =
+      recipe.originalServings !== null && recipe.desiredServings !== null
+        ? scaleIngredients([...recipe.ingredients], recipe.originalServings, recipe.desiredServings)
+        : recipe.ingredients;
+
+    for (const ingredient of scaled) {
+      const key = `${ingredient.name.trim().toLowerCase()}|${(ingredient.unit ?? '').trim().toLowerCase()}`;
+      const existing = buckets.get(key);
+      if (existing) {
+        if (ingredient.amount !== null) {
+          existing.amount = (existing.amount ?? 0) + ingredient.amount;
+        }
+      } else {
+        buckets.set(key, {
+          name: ingredient.name.trim(),
+          unit: ingredient.unit?.trim() || null,
+          amount: ingredient.amount,
+        });
+      }
+    }
+  }
+
+  return [...buckets.values()];
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
@@ -18,7 +18,8 @@ public sealed class HttpIngredientBalanceProvider(IHttpClientFactory httpClientF
 	public async Task<IReadOnlyDictionary<string, Freshness>> GetAvailableIngredientsAsync(CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("shopping-api");
-		var dto = await client.GetFromJsonAsync<BalanceDto>("/api/v1/shopping-lists/balance", jsonOptions, cancellationToken);
+		var url = "/api/v1/shopping-lists/balance";
+		var dto = await client.GetFromJsonAsync<BalanceDto>(url, jsonOptions, cancellationToken);
 
 		var result = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
 		if (dto?.Items is null) return result;


### PR DESCRIPTION
Phase C of #24. Frontend on top of Phase A's endpoint and Phase B's selection UI.

## Summary
- New \`mergeRecipeIngredients\` helper in \`@yumney/shared/models\` that mirrors the backend \`IngredientMerger\` (case-insensitive name+unit grouping, scales each recipe before summing). 8 tests cover AC TC-081-01/02/03/04.
- New \`MultiRecipePreviewDialogComponent\` — glass-styled modal with a per-recipe servings stepper and a live merged-ingredients list that recomputes as servings change. Escape + overlay cancel, confirm disabled while loading/creating or when no merged items. 13 component tests.
- Extracted the whole multi-select shopping-list flow (selection state, preview load, POST, navigation) into \`MultiRecipeShoppingListService\`. \`RecipeListComponent\` is back under the 300-line limit and the template just calls service methods.
- Recipe-list FAB now opens the preview instead of POSTing. After Confirm, the request lands at \`POST /api/v1/shopping-lists/from-recipes\` with each recipe's adjusted servings.

## Out of scope
- Phase D: dashboard \"meal prep this week\" quick action.

## Test plan
- [x] \`yarn nx test recipes\` (174/174, 13 new in dialog spec, 8 new in shared-models)
- [x] \`yarn nx test shared-models\`
- [x] \`yarn nx lint recipes shared-models\`
- [x] \`yarn nx build recipes\`
- [x] prettier