### PR TITLE
refactor(infra): adopt Apply* query-extensions pattern + codify in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,110 @@ return recipes.ToDtos();
 
 The single allowed exception is when the constructor call is the one statement in the mapper itself (the extension method body is the projection).
 
+## Repository Query Plumbing — Apply* Extensions
+
+Repositories that build paged read queries with **filter / search / sort**
+keep the query plumbing in dedicated `*Extensions` static classes, one per
+concern, sitting next to the repository in the same `Persistence/` folder.
+The repository is left as a one-liner orchestrator.
+
+### One concern → one file → one extension class
+
+```
+src/Yumney.{Module}.Infrastructure/Persistence/
+├── {Aggregate}Repository.cs
+├── FilterExtensions.cs       // ApplyFilter + per-axis ApplyTags / ApplyDifficulty / ...
+├── SearchExtensions.cs       // ApplySearch
+└── SortingExtensions.cs      // ApplySorting
+```
+
+### Multiple methods on one receiver → C# 14 `extension(T)` block
+
+When a class hosts more than one `Apply*` instance-style method with the
+same receiver type, group them inside an `extension(IQueryable<T> query)`
+block so the receiver is declared once.
+
+```csharp
+// ✅ Multiple Apply* on the same receiver
+public static class FilterExtensions
+{
+    extension(IQueryable<Recipe> query)
+    {
+        public IQueryable<Recipe> ApplyTags(IReadOnlyList<RecipeTag>? tags) { ... }
+        public IQueryable<Recipe> ApplyDifficulty(Difficulty? difficulty) { ... }
+        public IQueryable<Recipe> ApplyFavoritesOnly(bool? favoritesOnly, ...) { ... }
+
+        public IQueryable<Recipe> ApplyFilter(RecipeFilter? filter, ...)
+        {
+            if (filter is null || filter.IsEmpty) return query;
+            var (tags, difficulty, maxPrepTime, maxCookTime, favoritesOnly) = filter;
+            return query
+                .ApplyDifficulty(difficulty)
+                .ApplyMaxPrepTime(maxPrepTime)
+                .ApplyCookingTime(maxCookTime)
+                .ApplyTags(tags)
+                .ApplyFavoritesOnly(favoritesOnly, ...);
+        }
+    }
+}
+```
+
+### Single method → classic `this T receiver` form
+
+```csharp
+// ✅ One Apply* on the receiver
+public static class SearchExtensions
+{
+    public static IQueryable<Recipe> ApplySearch(this IQueryable<Recipe> query, SearchTerm? search)
+    {
+        if (search is null) return query;
+        var pattern = $"%{search.Value}%";
+        return query.Where(recipe => EF.Functions.ILike(recipe.Title, pattern) || ...);
+    }
+}
+```
+
+### Per-axis methods early-return when inactive
+
+Each `Apply*` checks the inactive case (null, empty, `!= true`) and returns
+the query unchanged. The orchestrator never has to know which axes are set.
+
+```csharp
+public IQueryable<Recipe> ApplyDifficulty(Difficulty? difficulty)
+{
+    if (difficulty is null) return query;
+    return query.Where(recipe => recipe.Difficulty == difficulty);
+}
+```
+
+### Cross-cutting subqueries are passed in, not embedded
+
+When an axis needs to reach into another DbSet (e.g. favorites), the
+repository builds the subquery and **passes it as a parameter**. The
+extension class stays free of `DbContext` and stays unit-testable.
+
+```csharp
+// ❌ FORBIDDEN — extension class reaches into DbContext
+public static IQueryable<Recipe> ApplyFavoritesOnly(this IQueryable<Recipe> query, bool? on, RecipesDbContext context) { ... }
+
+// ✅ REQUIRED — repository owns the subquery, passes it in
+private IQueryable<RecipeIdentifier> GetFavoriteRecipeIdsOfUserQuery(OwnerIdentifier owner) =>
+    context.RecipeFavorites.Where(f => f.Owner == owner).Select(f => f.RecipeIdentifier);
+
+// in repository:
+query = query
+    .ApplySearch(search)
+    .ApplyFilter(filter, GetFavoriteRecipeIdsOfUserQuery(owner))
+    .ApplySorting(sorting);
+```
+
+### Rules of thumb
+
+- Don't extract until there's at least one of: (a) a switch over `SortingOptions`, (b) a multi-axis filter VO, or (c) a search predicate beyond a single inline `Where`. Trivial single-axis sorts (`OrderByDescending(x => x.OccurredAt)`) stay inline.
+- The orchestrator (`ApplyFilter` / `ApplySorting`) returns `IQueryable<T>` so it composes with the rest of the chain.
+- Per-axis methods are named for the **field**, not the verb (`ApplyTags`, not `ApplyTagFilter`).
+- The orchestrator deconstructs the filter VO via record `Deconstruct` and forwards each piece to the matching `Apply*`.
+
 ## Error Handling
 
 ### Result Pattern for expected errors

--- a/src/Yumney.Recipes.Infrastructure/Persistence/FilterExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/FilterExtensions.cs
@@ -1,0 +1,79 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+
+public static class FilterExtensions
+{
+	extension(IQueryable<Recipe> query)
+	{
+		public IQueryable<Recipe> ApplyTags(IReadOnlyList<RecipeTag>? tags)
+		{
+			if (tags is null || tags.Count <= 0) return query;
+
+			// AND logic: every requested tag must be present on the recipe.
+			foreach (var requiredTag in tags)
+			{
+				var tagValue = requiredTag.Value;
+				query = query.Where(recipe => recipe.Tags.Any(tag => tag.Value == tagValue));
+			}
+
+			return query;
+		}
+
+		public IQueryable<Recipe> ApplyCookingTime(CookingTime? maxCookTime)
+		{
+			if (maxCookTime is null) return query;
+
+			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Cooking != null && recipe.Timing.Cooking <= maxCookTime);
+
+			return query;
+		}
+
+		public IQueryable<Recipe> ApplyMaxPrepTime(PreparationTime? maxPrepTime)
+		{
+			if (maxPrepTime is null) return query;
+
+			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Preparation != null && recipe.Timing.Preparation <= maxPrepTime);
+
+			return query;
+		}
+
+		public IQueryable<Recipe> ApplyDifficulty(Difficulty? difficulty)
+		{
+			if (difficulty is null) return query;
+
+			query = query.Where(recipe => recipe.Difficulty == difficulty);
+
+			return query;
+		}
+
+		public IQueryable<Recipe> ApplyFavoritesOnly(
+			bool? favoritesOnly,
+			IQueryable<RecipeIdentifier> favoritesRecipesOfUserQuery)
+		{
+			if (favoritesOnly != true) return query;
+
+			query = query.Where(recipe => favoritesRecipesOfUserQuery.Contains(recipe.Id));
+
+			return query;
+		}
+
+		public IQueryable<Recipe> ApplyFilter(
+			RecipeFilter? filter,
+			IQueryable<RecipeIdentifier> favoriteRecipesOfUserQuery)
+		{
+			if (filter is null || filter.IsEmpty) return query;
+
+			var (tags, difficulty, maxPrepTime, maxCookTime, favoritesOnly) = filter;
+
+			query = query
+				.ApplyDifficulty(difficulty)
+				.ApplyMaxPrepTime(maxPrepTime)
+				.ApplyCookingTime(maxCookTime)
+				.ApplyTags(tags)
+				.ApplyFavoritesOnly(favoritesOnly, favoriteRecipesOfUserQuery);
+
+			return query;
+		}
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
@@ -8,11 +8,16 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 {
 	private readonly DbSet<RecipeFavorite> favorites = context.RecipeFavorites;
 
-	public async Task<bool> IsFavoritedAsync(OwnerIdentifier owner, RecipeIdentifier recipe, CancellationToken cancellationToken = default)
+	public async Task<bool> IsFavoritedAsync(
+		OwnerIdentifier owner,
+		RecipeIdentifier recipe,
+		CancellationToken cancellationToken = default)
 	{
 		return await favorites
 			.AsNoTracking()
-			.AnyAsync(favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe, cancellationToken);
+			.AnyAsync(
+				favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe,
+				cancellationToken);
 	}
 
 	public async Task<IReadOnlySet<Guid>> GetFavoritedIdsAsync(

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -69,18 +69,10 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 	{
 		var query = recipes.AsNoTracking().Where(recipe => recipe.Owner == owner);
 
-		if (search is not null)
-		{
-			var pattern = $"%{search.Value}%";
-
-			query = query.Where(recipe =>
-				EF.Functions.ILike(recipe.Title, pattern) ||
-				(recipe.Description != null && EF.Functions.ILike(recipe.Description, pattern)) ||
-				recipe.Ingredients.Any(ingredient => EF.Functions.ILike(ingredient.Name, pattern)));
-		}
-
-		query = ApplyFilter(query, owner, filter);
-		query = ApplySorting(query, sorting);
+		query = query
+			.ApplySearch(search)
+			.ApplyFilter(filter, GetFavoriteRecipeIdsOfUserQuery(owner))
+			.ApplySorting(sorting);
 
 		return await query
 			.Include(recipe => recipe.Tags)
@@ -88,57 +80,11 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 			.ToPagedListAsync(paging, cancellationToken);
 	}
 
-	private static IQueryable<Recipe> ApplySorting(IQueryable<Recipe> query, SortingOptions<RecipeSortField> sorting)
+	private IQueryable<RecipeIdentifier> GetFavoriteRecipeIdsOfUserQuery(OwnerIdentifier owner)
 	{
-		return (sorting.SortBy, sorting.Direction) switch
-		{
-			(RecipeSortField.Name, SortDirection.Ascending) => query.OrderBy(recipe => recipe.Title),
-			(RecipeSortField.Name, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.Title),
-			(RecipeSortField.Date, SortDirection.Ascending) => query.OrderBy(recipe => recipe.CreatedAt),
-			(RecipeSortField.Date, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.CreatedAt),
-			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
-		};
-	}
-
-	private IQueryable<Recipe> ApplyFilter(IQueryable<Recipe> query, OwnerIdentifier owner, RecipeFilter? filter)
-	{
-		if (filter is null || filter.IsEmpty) return query;
-
-		if (filter.Difficulty is not null)
-		{
-			query = query.Where(recipe => recipe.Difficulty == filter.Difficulty);
-		}
-
-		if (filter.MaxPrepTime is not null)
-		{
-			var maxPrep = filter.MaxPrepTime;
-			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Preparation != null && recipe.Timing.Preparation <= maxPrep);
-		}
-
-		if (filter.MaxCookTime is not null)
-		{
-			var maxCook = filter.MaxCookTime;
-			query = query.Where(recipe => recipe.Timing != null && recipe.Timing.Cooking != null && recipe.Timing.Cooking <= maxCook);
-		}
-
-		if (filter.Tags is not null && filter.Tags.Count > 0)
-		{
-			// AND logic: every requested tag must be present on the recipe.
-			foreach (var requiredTag in filter.Tags)
-			{
-				var tagValue = requiredTag.Value;
-				query = query.Where(recipe => recipe.Tags.Any(tag => tag.Value == tagValue));
-			}
-		}
-
-		if (filter.FavoritesOnly == true)
-		{
-			var favoriteRecipeIds = context.RecipeFavorites
-				.Where(favorite => favorite.Owner == owner)
-				.Select(favorite => favorite.RecipeIdentifier);
-			query = query.Where(recipe => favoriteRecipeIds.Contains(recipe.Id));
-		}
-
-		return query;
+		var favoriteRecipeIds = context.RecipeFavorites
+			.Where(favorite => favorite.Owner == owner)
+			.Select(favorite => favorite.RecipeIdentifier);
+		return favoriteRecipeIds;
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/SearchExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/SearchExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+
+public static class SearchExtensions
+{
+	public static IQueryable<Recipe> ApplySearch(this IQueryable<Recipe> query, SearchTerm? search)
+	{
+		if (search is null) return query;
+
+		var pattern = $"%{search.Value}%";
+
+		query = query.Where(recipe =>
+			EF.Functions.ILike(recipe.Title, pattern) ||
+			(recipe.Description != null && EF.Functions.ILike(recipe.Description, pattern)) ||
+			recipe.Ingredients.Any(ingredient => EF.Functions.ILike(ingredient.Name, pattern)));
+
+		return query;
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/Persistence/SortingExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/SortingExtensions.cs
@@ -1,0 +1,19 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+
+public static class SortingExtensions
+{
+	public static IQueryable<Recipe> ApplySorting(this IQueryable<Recipe> query, SortingOptions<RecipeSortField> sorting)
+	{
+		return (sorting.SortBy, sorting.Direction) switch
+		{
+			(RecipeSortField.Name, SortDirection.Ascending) => query.OrderBy(recipe => recipe.Title),
+			(RecipeSortField.Name, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.Title),
+			(RecipeSortField.Date, SortDirection.Ascending) => query.OrderBy(recipe => recipe.CreatedAt),
+			(RecipeSortField.Date, SortDirection.Descending) => query.OrderByDescending(recipe => recipe.CreatedAt),
+			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
+		};
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -16,9 +16,9 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 		SortingOptions<ShoppingListSortField> sorting,
 		CancellationToken cancellationToken = default)
 	{
-		var query = context.ShoppingListSummaryReadItems.Where(summary => summary.OwnerId == owner.Value);
-
-		query = ApplySorting(query, sorting);
+		var query = context.ShoppingListSummaryReadItems
+			.Where(summary => summary.OwnerId == owner.Value)
+			.ApplySorting(sorting);
 
 		return await query
 			.Select(summary => new ShoppingListSummary(
@@ -57,19 +57,5 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 			.Select(summary => summary.Id)
 			.ToListAsync(cancellationToken);
 		return ids.Select(ShoppingListIdentifier.From).ToList();
-	}
-
-	private static IQueryable<ShoppingListSummaryReadItem> ApplySorting(
-		IQueryable<ShoppingListSummaryReadItem> query,
-		SortingOptions<ShoppingListSortField> sorting)
-	{
-		return (sorting.SortBy, sorting.Direction) switch
-		{
-			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(summary => summary.Title),
-			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(summary => summary.Title),
-			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(summary => summary.CreatedAt),
-			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(summary => summary.CreatedAt),
-			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
-		};
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSortingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListSortingExtensions.cs
@@ -1,0 +1,21 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+public static class ShoppingListSortingExtensions
+{
+	public static IQueryable<ShoppingListSummaryReadItem> ApplySorting(
+		this IQueryable<ShoppingListSummaryReadItem> query,
+		SortingOptions<ShoppingListSortField> sorting)
+	{
+		return (sorting.SortBy, sorting.Direction) switch
+		{
+			(ShoppingListSortField.Title, SortDirection.Ascending) => query.OrderBy(summary => summary.Title),
+			(ShoppingListSortField.Title, SortDirection.Descending) => query.OrderByDescending(summary => summary.Title),
+			(ShoppingListSortField.Date, SortDirection.Ascending) => query.OrderBy(summary => summary.CreatedAt),
+			(ShoppingListSortField.Date, SortDirection.Descending) => query.OrderByDescending(summary => summary.CreatedAt),
+			_ => throw new InvalidOperationException($"Unsupported sort combination: {sorting.SortBy}, {sorting.Direction}"),
+		};
+	}
+}


### PR DESCRIPTION
Picks up the local \`RecipeRepository\` refactor and rolls the same pattern across the rest of the project plus a new CLAUDE.md rule.

## Pattern detected
\`RecipeRepository\` was rewritten so query plumbing (filter / search / sort) lives in dedicated \`*Extensions\` static classes next to the repo. The repository becomes a one-liner orchestrator:

\`\`\`csharp
query = query
    .ApplySearch(search)
    .ApplyFilter(filter, GetFavoriteRecipeIdsOfUserQuery(owner))
    .ApplySorting(sorting);
\`\`\`

Multiple \`Apply*\` methods on the same receiver use the C# 14 \`extension(IQueryable<T> query) { ... }\` block; single methods stay on the classic \`this T receiver\` form. Cross-cutting subqueries (e.g. favorites) are passed in as parameters so the extensions stay free of \`DbContext\`.

## What this PR does
- Carries the local refactor (\`FilterExtensions.cs\`, \`SearchExtensions.cs\`, \`SortingExtensions.cs\`, \`RecipeRepository.cs\`, \`RecipeFavoriteRepository.cs\` formatting).
- **Drive-by fixes** in \`FilterExtensions\`: \`ApplyDificulty\` → \`ApplyDifficulty\`; \`ApplyFavoritesOnly\` guard tightened from \`favoritesOnly is false\` to \`favoritesOnly != true\` to match the original semantics (\"only fires on true\", not \"fires unless explicitly false\").
- **Shopping**: pulls \`EfCoreShoppingListProjectionRepository\`'s private \`ApplySorting\` into \`ShoppingListSortingExtensions\` so the repo follows the same shape.
- **CLAUDE.md**: new \`Repository Query Plumbing — Apply* Extensions\` section spelling out file layout, the \`extension(T)\` block vs \`this\`-form choice, early-return per-axis convention, and the cross-cutting subquery rule. Includes a \"don't extract until\" guideline so trivial single-axis sorts stay inline.

## What this PR does NOT do
- Doesn't touch the meal-plan / user-activity repos: their queries are single-axis and don't yet warrant extraction (the new rule explicitly says so).

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\`
- [x] \`dotnet format --verify-no-changes\`
- [x] Recipes.Infrastructure (100), Shopping.Infrastructure (23), Recipes.Application (165), Shopping.Application (140), Architecture (131), Integration (241) all green