### PR TITLE
chore(shopping): drop unused DTOs using in projection repository

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
-using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 


### PR DESCRIPTION
Tiny follow-up to #550. The \`Yumney.Shopping.Application.DTOs\` import on \`EfCoreShoppingListProjectionRepository\` became dead the moment the inline \`ApplySorting\` was extracted in #550 — the projection's own DTOs aren't referenced inside this file. \`dotnet format\` flagged it on the next run.

Stacked on \`refactor/repo-query-extensions\` so it merges cleanly once #550 lands; flip the base to \`develop\` after #550 merges if you want it to ship as a standalone PR.

## Test plan
- [x] \`dotnet build src/Yumney.Shopping.Infrastructure/...csproj -p:TreatWarningsAsErrors=true\`