### PR TITLE
refactor(infra): hide CountAsync+Skip+Take in a paging helper

### DIFF
--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 
@@ -81,15 +82,10 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 		query = ApplyFilter(query, owner, filter);
 		query = ApplySorting(query, sorting);
 
-		var totalCount = await query.CountAsync(cancellationToken);
-		var items = await query
+		return await query
 			.Include(recipe => recipe.Tags)
 			.AsSplitQuery()
-			.Skip(paging.Skip)
-			.Take(paging.PageSize.Value)
-			.ToListAsync(cancellationToken);
-
-		return (items, ItemCount.From(totalCount));
+			.ToPagedListAsync(paging, cancellationToken);
 	}
 
 	private static IQueryable<Recipe> ApplySorting(IQueryable<Recipe> query, SortingOptions<RecipeSortField> sorting)

--- a/src/Yumney.Shared.Persistence/PagingExtensions.cs
+++ b/src/Yumney.Shared.Persistence/PagingExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Shared.Persistence;
+
+public static class PagingExtensions
+{
+	public static async Task<(IReadOnlyList<T> Items, ItemCount TotalCount)> ToPagedListAsync<T>(
+		this IQueryable<T> query,
+		PagingOptions paging,
+		CancellationToken cancellationToken = default)
+	{
+		var totalCount = await query.CountAsync(cancellationToken);
+		var items = await query
+			.Skip(paging.Skip)
+			.Take(paging.PageSize.Value)
+			.ToListAsync(cancellationToken);
+		return (items, ItemCount.From(totalCount));
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -19,18 +20,13 @@ public sealed class EfCoreShoppingListProjectionRepository(ShoppingReadDbContext
 
 		query = ApplySorting(query, sorting);
 
-		var totalCount = await query.CountAsync(cancellationToken);
-		var items = await query
-			.Skip(paging.Skip)
-			.Take(paging.PageSize.Value)
+		return await query
 			.Select(summary => new ShoppingListSummary(
 				ShoppingListIdentifier.From(summary.Id),
 				ShoppingListTitle.From(summary.Title),
 				ItemCount.From(summary.ItemCount),
 				summary.CreatedAt))
-			.ToListAsync(cancellationToken);
-
-		return (items, ItemCount.From(totalCount));
+			.ToPagedListAsync(paging, cancellationToken);
 	}
 
 	public async Task<ShoppingListProjectedDetail> GetByIdAsync(


### PR DESCRIPTION
## Summary
- New \`PagingExtensions.ToPagedListAsync\` on \`IQueryable<T>\` (in \`Yumney.Shared.Persistence\`) that counts the query, skips, takes, materialises, and returns the existing \`(IReadOnlyList<T>, ItemCount)\` tuple repositories already expose.
- \`RecipeRepository.GetByOwnerAsync\` and \`EfCoreShoppingListProjectionRepository.GetByOwnerAsync\` switch to it and drop the manual 5-line count + skip + take + ToListAsync dance.

## Out of scope
Repository signatures and handler shapes stay as-is — the helper only hides the boilerplate, no surface change. Returning \`PagedResult<T>\` directly + a \`Map\` extension is the bigger reshape that was deliberately not chosen here.

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\`
- [x] \`dotnet format --verify-no-changes\`
- [x] Recipes.Infrastructure (100), Shopping.Infrastructure (23), Architecture (131), Integration (241) all green