### PR TITLE
chore(shopping): drop unused DTOs using in projection repository

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/EfCoreShoppingListProjectionRepository.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
-using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 


### PR DESCRIPTION
Re-opens #551 (the original was auto-closed when its #550 parent merged).

Tiny one-line follow-up: the \`Yumney.Shopping.Application.DTOs\` import on \`EfCoreShoppingListProjectionRepository\` is dead — the projection's own DTOs aren't referenced inside this file. \`dotnet format\` flagged it after the prior refactors landed.

## Test plan
- [x] \`dotnet build src/Yumney.Shopping.Infrastructure/...csproj -p:TreatWarningsAsErrors=true\`