### PR TITLE
feat(recipes): wire meal_prep quick action to multi-select on recipe list (US-081 phase D)

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { RecipeApiService, ShoppingApiService } from '../api';
+import { MultiRecipeShoppingListService } from './multi-recipe-shopping-list.service';
+
+interface ParamSnapshot {
+  multiSelect?: string;
+  preselect?: string;
+}
+
+function createService(params: ParamSnapshot = {}): MultiRecipeShoppingListService {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [setupTranslocoTesting({})],
+    providers: [
+      MultiRecipeShoppingListService,
+      { provide: RecipeApiService, useValue: { getRecipeById: vi.fn() } },
+      { provide: ShoppingApiService, useValue: { createShoppingListFromRecipes: vi.fn() } },
+      { provide: Router, useValue: { navigateByUrl: vi.fn() } },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          snapshot: {
+            queryParamMap: {
+              get: (key: string) => (params as Record<string, string | undefined>)[key] ?? null,
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  return TestBed.inject(MultiRecipeShoppingListService);
+}
+
+describe('MultiRecipeShoppingListService.initFromRoute', () => {
+  it('does nothing when multiSelect is absent', () => {
+    const service = createService();
+
+    service.initFromRoute();
+
+    expect(service.multiSelectMode()).toBe(false);
+    expect(service.selectedRecipeIds().size).toBe(0);
+  });
+
+  it('does nothing when multiSelect is present but not "true"', () => {
+    const service = createService({ multiSelect: 'false' });
+
+    service.initFromRoute();
+
+    expect(service.multiSelectMode()).toBe(false);
+  });
+
+  it('enters multi-select mode when multiSelect=true', () => {
+    const service = createService({ multiSelect: 'true' });
+
+    service.initFromRoute();
+
+    expect(service.multiSelectMode()).toBe(true);
+    expect(service.selectedRecipeIds().size).toBe(0);
+  });
+
+  it('preselects the comma-separated identifiers from the preselect param', () => {
+    const service = createService({ multiSelect: 'true', preselect: 'abc,def,ghi' });
+
+    service.initFromRoute();
+
+    expect(service.multiSelectMode()).toBe(true);
+    expect([...service.selectedRecipeIds()]).toEqual(['abc', 'def', 'ghi']);
+  });
+
+  it('trims whitespace and drops empty entries in the preselect csv', () => {
+    const service = createService({ multiSelect: 'true', preselect: ' abc , , def ' });
+
+    service.initFromRoute();
+
+    expect([...service.selectedRecipeIds()]).toEqual(['abc', 'def']);
+  });
+
+  it('ignores the preselect param when multiSelect is not true', () => {
+    const service = createService({ preselect: 'abc,def' });
+
+    service.initFromRoute();
+
+    expect(service.selectedRecipeIds().size).toBe(0);
+  });
+});

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
@@ -1,5 +1,5 @@
 import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import { forkJoin, of } from 'rxjs';
 import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
@@ -13,6 +13,7 @@ export class MultiRecipeShoppingListService {
   private recipeApi = inject(RecipeApiService);
   private shoppingApi = inject(ShoppingApiService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private transloco = inject(TranslocoService);
   private destroyRef = inject(DestroyRef);
   private previewLoadState = createAsyncState(this.destroyRef);
@@ -31,6 +32,24 @@ export class MultiRecipeShoppingListService {
 
   isSelected(identifier: string): boolean {
     return this.selectedRecipeIds().has(identifier);
+  }
+
+  initFromRoute(): void {
+    const params = this.route.snapshot.queryParamMap;
+    if (params.get('multiSelect') !== 'true') return;
+
+    this.multiSelectMode.set(true);
+
+    const preselect = params.get('preselect');
+    if (!preselect) return;
+
+    const ids = preselect
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+    if (ids.length > 0) {
+      this.selectedRecipeIds.set(new Set(ids));
+    }
   }
 
   toggleMode(): void {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -135,6 +135,7 @@ export class RecipeListComponent implements OnInit {
 
   ngOnInit(): void {
     this.assignment.initFromRoute();
+    this.multiSelect.initFromRoute();
     this.loadRecipes(false);
 
     this.searchSubject

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -496,6 +496,43 @@ describe('DashboardComponent', () => {
     const btn = fixture.nativeElement.querySelector('.create-btn');
     expect(btn.disabled).toBe(true);
   });
+
+  it('should navigate to /recipes on cook_now quick action', () => {
+    component.onQuickAction('cook_now');
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/recipes']);
+  });
+
+  it('should navigate to /recipes with multiSelect on meal_prep quick action', () => {
+    component.onQuickAction('meal_prep');
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/recipes'], {
+      queryParams: { multiSelect: 'true' },
+    });
+  });
+
+  it('should preselect suggested recipe ids when meal_prep fires with suggestions', () => {
+    component.suggestions.set({
+      suggestions: [
+        { recipeIdentifier: 'abc', title: 'A', imageUrl: null, prepTimeMinutes: null, reason: '' },
+        { recipeIdentifier: 'def', title: 'B', imageUrl: null, prepTimeMinutes: null, reason: '' },
+      ],
+      quickActions: ['meal_prep'],
+    });
+
+    component.onQuickAction('meal_prep');
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/recipes'], {
+      queryParams: { multiSelect: 'true', preselect: 'abc,def' },
+    });
+  });
+
+  it('should expand the import section for any other quick action', () => {
+    component.onQuickAction('try_something_new');
+
+    expect(component.importSectionExpanded()).toBe(true);
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+  });
 });
 
 describe('DashboardComponent – Share Intent', () => {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -129,9 +129,16 @@ export class DashboardComponent implements OnInit {
   onQuickAction(actionKey: string): void {
     if (actionKey === 'cook_now') {
       this.router.navigate([ROUTES.recipes.list]);
-    } else {
-      this.importSectionExpanded.set(true);
+      return;
     }
+    if (actionKey === 'meal_prep') {
+      const ids = (this.suggestions()?.suggestions ?? []).map((item) => item.recipeIdentifier);
+      const queryParams: Record<string, string> = { multiSelect: 'true' };
+      if (ids.length > 0) queryParams['preselect'] = ids.join(',');
+      this.router.navigate([ROUTES.recipes.list], { queryParams });
+      return;
+    }
+    this.importSectionExpanded.set(true);
   }
 
   onUrlExtracted(payload: { recipe: ImportRecipeResponse; sourceUrl: string }): void {


### PR DESCRIPTION
Closes #24. Phase D — last AC bullet on US-081.

## Summary
- \`MultiRecipeShoppingListService\` gains \`initFromRoute()\` that reads \`?multiSelect=true\` (enters multi-select mode) and \`?preselect=id1,id2\` (populates the selection set, trim-and-drop-empty). Called from \`recipe-list.component.ngOnInit\` next to the existing \`assignment.initFromRoute()\`.
- \`dashboard.component.onQuickAction\` handles \`meal_prep\` by navigating to \`/recipes\` with \`multiSelect=true\` plus the dashboard's current \`suggestions\` identifiers as a CSV \`preselect\` param. The pre-existing \`cook_now\` branch is unchanged.
- Six new tests on the service for \`initFromRoute\`; four new tests on the dashboard for the quick-action branch.

## Today vs once US-220 lands
The backend's \`SuggestionsResponse.Suggestions\` is empty server-side pending US-220 (intent dashboard). Today the action navigates with an empty \`preselect\` and the user lands in multi-select mode with no preselection — already useful. Once US-220 starts emitting suggestions, the wiring lights up automatically.

## US-081 closeout
- A: backend endpoint + merger (#547)
- B: selection UI + FAB (#548)
- C: preview dialog with per-recipe servings (#549)
- D: dashboard quick action — this PR

## Test plan
- [x] \`yarn nx test recipes\` (180/180, 6 new on \`MultiRecipeShoppingListService\`)
- [x] \`yarn nx test shell\` (223/223, 4 new on \`onQuickAction\`)
- [x] \`yarn nx lint recipes shell\`
- [x] prettier