### PR TITLE
refactor(frontend): async-state consolidation and i18n drift tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Verify i18n in sync
+        run: yarn sync:i18n:check
+
       - name: Lint
         run: yarn nx run-many -t lint
 

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,4 +1,11 @@
-import { Component, ChangeDetectionStrategy, DestroyRef, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
@@ -62,15 +69,11 @@ export class ProfileSettingsComponent {
       cookingEffort: this.cookingEffort() || null,
     };
 
-    this.saveState.execute(
-      this.api.updateProfile(request),
-      ERROR_MAPS.account.save,
-      (updated) => {
-        this.profile.set(updated);
-        this.saved.set(true);
-        setTimeout(() => this.saved.set(false), UI.SAVED_INDICATOR_MS);
-      },
-    );
+    this.saveState.execute(this.api.updateProfile(request), ERROR_MAPS.account.save, (updated) => {
+      this.profile.set(updated);
+      this.saved.set(true);
+      setTimeout(() => this.saved.set(false), UI.SAVED_INDICATOR_MS);
+    });
   }
 
   protected onToggleRestriction(restriction: string): void {
@@ -87,18 +90,14 @@ export class ProfileSettingsComponent {
   }
 
   private loadProfile(): void {
-    this.loadState.execute(
-      this.api.getProfile(),
-      ERROR_MAPS.account.load,
-      (profile) => {
-        this.profile.set(profile);
-        this.defaultServings.set(profile.defaultServings);
-        this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
-        this.restrictions.set([...profile.dietaryProfile.restrictions]);
-        this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
-        this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
-        this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
-      },
-    );
+    this.loadState.execute(this.api.getProfile(), ERROR_MAPS.account.load, (profile) => {
+      this.profile.set(profile);
+      this.defaultServings.set(profile.defaultServings);
+      this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
+      this.restrictions.set([...profile.dietaryProfile.restrictions]);
+      this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
+      this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
+      this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
+    });
   }
 }

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,10 +1,9 @@
 import { Component, ChangeDetectionStrategy, DestroyRef, inject, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } from '../api';
-import { UI } from '@yumney/shared/models';
+import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
+import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } from '../api';
 
 @Component({
   selector: 'yn-profile-settings',
@@ -18,10 +17,12 @@ export class ProfileSettingsComponent {
   private api = inject(UserProfileApiService);
   private destroyRef = inject(DestroyRef);
   private transloco = inject(TranslocoService);
+  private loadState = createAsyncState(this.destroyRef);
+  private saveState = createAsyncState(this.destroyRef);
 
   protected profile = signal<UserProfile | null>(null);
-  protected loading = signal(false);
-  protected saving = signal(false);
+  protected loading = this.loadState.isLoading;
+  protected saving = this.saveState.isLoading;
   protected error = signal<string | null>(null);
   protected saved = signal(false);
 
@@ -51,7 +52,6 @@ export class ProfileSettingsComponent {
 
   protected onSave(): void {
     if (this.saving()) return;
-    this.saving.set(true);
     this.saved.set(false);
     this.error.set(null);
 
@@ -64,27 +64,22 @@ export class ProfileSettingsComponent {
       cookingEffort: this.cookingEffort() || null,
     };
 
-    this.api
-      .updateProfile(request)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (updated) => {
-          this.profile.set(updated);
-          this.saving.set(false);
-          this.saved.set(true);
-          setTimeout(() => this.saved.set(false), UI.SAVED_INDICATOR_MS);
-        },
-        error: () => {
-          this.error.set(this.transloco.translate('account.settings.errors.saveFailed'));
-          this.saving.set(false);
-        },
-      });
+    this.saveState.execute(
+      this.api.updateProfile(request),
+      ERROR_MAPS.account.save,
+      (updated) => {
+        this.profile.set(updated);
+        this.saved.set(true);
+        setTimeout(() => this.saved.set(false), UI.SAVED_INDICATOR_MS);
+      },
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   protected onToggleRestriction(restriction: string): void {
     const current = this.restrictions();
     if (current.includes(restriction)) {
-      this.restrictions.set(current.filter((r) => r !== restriction));
+      this.restrictions.set(current.filter((entry) => entry !== restriction));
     } else {
       this.restrictions.set([...current, restriction]);
     }
@@ -95,26 +90,20 @@ export class ProfileSettingsComponent {
   }
 
   private loadProfile(): void {
-    this.loading.set(true);
     this.error.set(null);
-    this.api
-      .getProfile()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (profile) => {
-          this.profile.set(profile);
-          this.defaultServings.set(profile.defaultServings);
-          this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
-          this.restrictions.set([...profile.dietaryProfile.restrictions]);
-          this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
-          this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
-          this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
-          this.loading.set(false);
-        },
-        error: () => {
-          this.error.set(this.transloco.translate('account.settings.errors.loadFailed'));
-          this.loading.set(false);
-        },
-      });
+    this.loadState.execute(
+      this.api.getProfile(),
+      ERROR_MAPS.account.load,
+      (profile) => {
+        this.profile.set(profile);
+        this.defaultServings.set(profile.defaultServings);
+        this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
+        this.restrictions.set([...profile.dietaryProfile.restrictions]);
+        this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
+        this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
+        this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
+      },
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 }

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,6 +1,6 @@
-import { Component, ChangeDetectionStrategy, DestroyRef, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { TranslocoModule } from '@jsverse/transloco';
 import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } from '../api';
@@ -16,14 +16,13 @@ import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } fr
 export class ProfileSettingsComponent {
   private api = inject(UserProfileApiService);
   private destroyRef = inject(DestroyRef);
-  private transloco = inject(TranslocoService);
   private loadState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
 
   protected profile = signal<UserProfile | null>(null);
   protected loading = this.loadState.isLoading;
   protected saving = this.saveState.isLoading;
-  protected error = signal<string | null>(null);
+  protected error = computed(() => this.loadState.serverError() ?? this.saveState.serverError());
   protected saved = signal(false);
 
   protected defaultServings = signal(4);
@@ -53,7 +52,6 @@ export class ProfileSettingsComponent {
   protected onSave(): void {
     if (this.saving()) return;
     this.saved.set(false);
-    this.error.set(null);
 
     const request: UpdateProfileRequest = {
       defaultServings: this.defaultServings(),
@@ -72,7 +70,6 @@ export class ProfileSettingsComponent {
         this.saved.set(true);
         setTimeout(() => this.saved.set(false), UI.SAVED_INDICATOR_MS);
       },
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
     );
   }
 
@@ -90,7 +87,6 @@ export class ProfileSettingsComponent {
   }
 
   private loadProfile(): void {
-    this.error.set(null);
     this.loadState.execute(
       this.api.getProfile(),
       ERROR_MAPS.account.load,
@@ -103,7 +99,6 @@ export class ProfileSettingsComponent {
         this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
         this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
       },
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
     );
   }
 }

--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -77,6 +77,8 @@
     "loading": "Rezept wird geladen...",
     "success": "Rezept \"{{title}}\" erfolgreich aktualisiert!",
     "discardConfirm": "Du hast ungespeicherte Änderungen. Verwerfen?",
+    "discardConfirmButton": "Verwerfen",
+    "discardCancelButton": "Weiter bearbeiten",
     "errors": {
       "notFound": "Rezept nicht gefunden.",
       "generic": "Rezept konnte nicht aktualisiert werden. Bitte versuche es später erneut."

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -77,6 +77,8 @@
     "loading": "Loading recipe...",
     "success": "Recipe \"{{title}}\" updated successfully!",
     "discardConfirm": "You have unsaved changes. Discard them?",
+    "discardConfirmButton": "Discard",
+    "discardCancelButton": "Keep editing",
     "errors": {
       "notFound": "Recipe not found.",
       "generic": "Failed to update recipe. Please try again later."

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.html
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.html
@@ -18,4 +18,14 @@
       (discard)="onDiscard()"
     />
   }
+
+  @if (showDiscardConfirm()) {
+    <yn-confirm-dialog
+      [message]="t('recipes.edit.discardConfirm')"
+      [confirmLabel]="t('recipes.edit.discardConfirmButton')"
+      [cancelLabel]="t('recipes.edit.discardCancelButton')"
+      (confirmed)="onDiscardConfirmed()"
+      (cancelled)="onDiscardCancelled()"
+    />
+  }
 </div>

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.spec.ts
@@ -230,15 +230,29 @@ describe('RecipeEditComponent', () => {
     expect((data as Record<string, unknown>)['createdAt']).toBeUndefined();
   }));
 
-  it('should navigate to detail on discard', fakeAsync(() => {
+  it('should open discard confirm dialog and navigate on confirm', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
     fixture.detectChanges();
     tick();
 
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     component.onDiscard();
+    expect(component.showDiscardConfirm()).toBe(true);
 
+    component.onDiscardConfirmed();
+    expect(component.showDiscardConfirm()).toBe(false);
     expect(router.navigate).toHaveBeenCalledWith(['/recipes', 'abc-123']);
+  }));
+
+  it('should not navigate when discard is cancelled', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)));
+    fixture.detectChanges();
+    tick();
+
+    component.onDiscard();
+    component.onDiscardCancelled();
+
+    expect(component.showDiscardConfirm()).toBe(false);
+    expect(router.navigate).not.toHaveBeenCalled();
   }));
 
   it('should call updateRecipe on save', fakeAsync(() => {

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '../api';
 import {
   createAsyncState,
@@ -16,11 +16,22 @@ import {
   ERROR_MAPS,
   ROUTES,
 } from '@yumney/shared/models';
-import { BackLinkComponent, LoadingSpinnerComponent, RecipePreviewComponent } from '@yumney/ui';
+import {
+  BackLinkComponent,
+  ConfirmDialogComponent,
+  LoadingSpinnerComponent,
+  RecipePreviewComponent,
+} from '@yumney/ui';
 
 @Component({
   selector: 'yn-recipe-edit',
-  imports: [TranslocoModule, BackLinkComponent, LoadingSpinnerComponent, RecipePreviewComponent],
+  imports: [
+    TranslocoModule,
+    BackLinkComponent,
+    ConfirmDialogComponent,
+    LoadingSpinnerComponent,
+    RecipePreviewComponent,
+  ],
   templateUrl: './recipe-edit.component.html',
   styleUrl: './recipe-edit.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,12 +42,12 @@ export class RecipeEditComponent implements OnInit {
   private router = inject(Router);
   private loadState = createAsyncState(inject(DestroyRef));
   private saveState = createAsyncState(inject(DestroyRef));
-  private transloco = inject(TranslocoService);
 
   recipeData = signal<ImportRecipeResponse | null>(null);
   isLoading = this.loadState.isLoading;
   isSaving = this.saveState.isLoading;
   serverError = signal<string | null>(null);
+  showDiscardConfirm = signal(false);
 
   identifier = signal('');
 
@@ -69,8 +80,16 @@ export class RecipeEditComponent implements OnInit {
   }
 
   onDiscard(): void {
-    if (window.confirm(this.transloco.translate('recipes.edit.discardConfirm'))) {
-      this.router.navigate([ROUTES.recipes.list, this.identifier()]);
-    }
+    if (this.isSaving()) return;
+    this.showDiscardConfirm.set(true);
+  }
+
+  onDiscardConfirmed(): void {
+    this.showDiscardConfirm.set(false);
+    this.router.navigate([ROUTES.recipes.list, this.identifier()]);
+  }
+
+  onDiscardCancelled(): void {
+    this.showDiscardConfirm.set(false);
   }
 }

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  computed,
   inject,
   OnInit,
   DestroyRef,
@@ -46,15 +47,19 @@ export class RecipeEditComponent implements OnInit {
   recipeData = signal<ImportRecipeResponse | null>(null);
   isLoading = this.loadState.isLoading;
   isSaving = this.saveState.isLoading;
-  serverError = signal<string | null>(null);
   showDiscardConfirm = signal(false);
+
+  private notFoundError = signal<string | null>(null);
+  serverError = computed(
+    () => this.notFoundError() ?? this.loadState.serverError() ?? this.saveState.serverError(),
+  );
 
   identifier = signal('');
 
   ngOnInit(): void {
     this.identifier.set(this.route.snapshot.paramMap.get('identifier') ?? '');
     if (!this.identifier()) {
-      this.serverError.set('recipes.edit.errors.notFound');
+      this.notFoundError.set('recipes.edit.errors.notFound');
       return;
     }
 
@@ -62,20 +67,16 @@ export class RecipeEditComponent implements OnInit {
       this.recipeApi.getRecipeById(this.identifier()),
       ERROR_MAPS.recipes.edit,
       (recipe) => this.recipeData.set(mapDetailToImportResponse(recipe)),
-      (error) => this.serverError.set(error),
     );
   }
 
   onSave(recipe: ImportRecipeResponse): void {
     const request = mapToUpdateRecipeRequest(recipe);
 
-    this.serverError.set(null);
-
     this.saveState.execute(
       this.recipeApi.updateRecipe(this.identifier(), request),
       ERROR_MAPS.recipes.edit,
       () => this.router.navigate([ROUTES.recipes.list, this.identifier()]),
-      (error) => this.serverError.set(error),
     );
   }
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { NEVER, of, throwError } from 'rxjs';
 import { MealPlanApiService, RecipeListItem } from '../api';
 import { RecipeAssignmentService } from './recipe-assignment.service';
 
@@ -92,8 +92,7 @@ describe('RecipeAssignmentService', () => {
   });
 
   it('should set assigning true while the request is in flight', () => {
-    assignRecipe = vi.fn().mockReturnValue(of({}));
-    const service = setup('2026-W1-tuesday');
+    const service = setup('2026-W1-tuesday', NEVER);
     service.initFromRoute();
 
     service.assign(recipe);

--- a/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.ts
@@ -1,8 +1,7 @@
 import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
+import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
 import { MealPlanApiService, RecipeListItem } from '../api';
-import { ROUTES } from '@yumney/shared/models';
 
 const ASSIGN_TO_PATTERN = /^(\d{4})-W(\d{1,2})-(\w+)$/;
 
@@ -12,10 +11,12 @@ export class RecipeAssignmentService {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
+  private assignState = createAsyncState(this.destroyRef);
 
   readonly assignTo = signal<string | null>(null);
   readonly assignMode = computed(() => this.assignTo() !== null);
-  readonly assigning = signal(false);
+  readonly assigning = this.assignState.isLoading;
+  readonly serverError = this.assignState.serverError;
 
   initFromRoute(): void {
     this.assignTo.set(this.route.snapshot.queryParamMap.get('assignTo'));
@@ -29,19 +30,16 @@ export class RecipeAssignmentService {
     if (!match) return;
 
     const [, yearStr, weekStr, day] = match;
-    this.assigning.set(true);
 
-    this.mealPlanApi
-      .assignRecipe(Number(yearStr), Number(weekStr), {
+    this.assignState.execute(
+      this.mealPlanApi.assignRecipe(Number(yearStr), Number(weekStr), {
         day,
         recipeIdentifier: recipe.identifier,
         recipeTitle: recipe.title,
-      })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => this.router.navigate([ROUTES.mealPlanner]),
-        error: () => this.assigning.set(false),
-      });
+      }),
+      ERROR_MAPS.mealPlanner.assign,
+      () => this.router.navigate([ROUTES.mealPlanner]),
+    );
   }
 
   cancel(): void {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -103,10 +103,9 @@
   }
 
   @if (recipes().length > 0) {
-    <div class="recipe-grid">
+    <div class="recipe-grid" ynStaggerNewItems>
       @for (recipe of recipes(); track recipe.identifier) {
         <yn-recipe-card
-          #recipeCard
           [recipe]="recipe"
           [assignMode]="assignment.assignMode()"
           [multiSelectMode]="multiSelect.multiSelectMode()"

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -2,13 +2,10 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
-  effect,
-  ElementRef,
   inject,
   OnInit,
   DestroyRef,
   signal,
-  viewChildren,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, debounceTime } from 'rxjs';
@@ -27,9 +24,8 @@ import {
   EMPTY_FILTER,
   FilterPanelComponent,
   InfiniteScrollDirective,
-  prefersReducedMotion,
   type RecipeFilterValue,
-  staggerFadeIn,
+  StaggerNewItemsDirective,
 } from '@yumney/ui';
 import { RecipeCardComponent } from './recipe-card/recipe-card.component';
 import { SortMenuComponent, SortMenuOption } from './sort-menu/sort-menu.component';
@@ -49,6 +45,7 @@ interface SortOption extends SortMenuOption {
     RouterLink,
     LucideAngularModule,
     InfiniteScrollDirective,
+    StaggerNewItemsDirective,
     FilterPanelComponent,
     RecipeCardComponent,
     SortMenuComponent,
@@ -74,8 +71,6 @@ export class RecipeListComponent implements OnInit {
   private asyncState = createAsyncState(this.destroyRef);
   private searchSubject = new Subject<string>();
   private loadRequestId = 0;
-  private previousCardCount = 0;
-  private recipeCards = viewChildren<ElementRef>('recipeCard');
 
   protected assignment = inject(RecipeAssignmentService);
   protected multiSelect = inject(MultiRecipeShoppingListService);
@@ -113,25 +108,6 @@ export class RecipeListComponent implements OnInit {
     if (f.favoritesOnly) count += 1;
     return count;
   });
-
-  constructor() {
-    effect(() => {
-      const count = this.recipes().length;
-      if (count > this.previousCardCount && !prefersReducedMotion()) {
-        const prev = this.previousCardCount;
-        this.previousCardCount = count;
-        requestAnimationFrame(() => {
-          const cards = this.recipeCards();
-          const newCards = cards.slice(prev).map((ref) => ref.nativeElement);
-          if (newCards.length > 0) {
-            staggerFadeIn(newCards as Element[]);
-          }
-        });
-      } else {
-        this.previousCardCount = count;
-      }
-    });
-  }
 
   ngOnInit(): void {
     this.assignment.initFromRoute();

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -313,7 +313,8 @@
     "errors": {
       "loadFailed": "Essensplan konnte nicht geladen werden.",
       "clearFailed": "Slot konnte nicht geleert werden.",
-      "generateFailed": "Einkaufsliste konnte nicht erstellt werden."
+      "generateFailed": "Einkaufsliste konnte nicht erstellt werden.",
+      "assignFailed": "Rezept konnte nicht zum Essensplan hinzugefügt werden."
     }
   },
   "common": {

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -84,8 +84,8 @@
       "languageDe": "Deutsch",
       "languageEn": "English",
       "openChat": "Rezept-Chat öffnen",
-      "switchToDark": "Heller Modus",
-      "switchToLight": "Dunkler Modus"
+      "switchToDark": "Zu dunklem Modus wechseln",
+      "switchToLight": "Zu hellem Modus wechseln"
     },
     "offlineIndicator": {
       "offline": "Du bist offline. Einige Funktionen sind nicht verfügbar.",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -313,7 +313,8 @@
     "errors": {
       "loadFailed": "Failed to load meal plan.",
       "clearFailed": "Failed to clear slot.",
-      "generateFailed": "Failed to generate shopping list."
+      "generateFailed": "Failed to generate shopping list.",
+      "assignFailed": "Failed to assign recipe to meal plan."
     }
   },
   "common": {

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -77,6 +77,8 @@
     "loading": "Rezept wird geladen...",
     "success": "Rezept \"{{title}}\" erfolgreich aktualisiert!",
     "discardConfirm": "Du hast ungespeicherte Änderungen. Verwerfen?",
+    "discardConfirmButton": "Verwerfen",
+    "discardCancelButton": "Weiter bearbeiten",
     "errors": {
       "notFound": "Rezept nicht gefunden.",
       "generic": "Rezept konnte nicht aktualisiert werden. Bitte versuche es später erneut."

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -77,6 +77,8 @@
     "loading": "Loading recipe...",
     "success": "Recipe \"{{title}}\" updated successfully!",
     "discardConfirm": "You have unsaved changes. Discard them?",
+    "discardConfirmButton": "Discard",
+    "discardCancelButton": "Keep editing",
     "errors": {
       "notFound": "Recipe not found.",
       "generic": "Failed to update recipe. Please try again later."

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -52,9 +52,9 @@ export class RegisterComponent {
         [
           Validators.required,
           Validators.minLength(VALIDATION.USERS.PASSWORD.MIN_LENGTH),
-          Validators.pattern(/[A-Z]/),
-          Validators.pattern(/[a-z]/),
-          Validators.pattern(/[0-9]/),
+          Validators.pattern(new RegExp(VALIDATION.USERS.PASSWORD.UPPERCASE_PATTERN)),
+          Validators.pattern(new RegExp(VALIDATION.USERS.PASSWORD.LOWERCASE_PATTERN)),
+          Validators.pattern(new RegExp(VALIDATION.USERS.PASSWORD.DIGIT_PATTERN)),
         ],
       ],
       confirmPassword: ['', [Validators.required]],

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -9,7 +9,7 @@ import {
   computed,
 } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import {
   MealPlanApiService,
@@ -38,7 +38,6 @@ const JS_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'F
 export class MealPlannerComponent {
   private api = inject(MealPlanApiService);
   private destroyRef = inject(DestroyRef);
-  private transloco = inject(TranslocoService);
   private router = inject(Router);
   private host = inject(ElementRef<HTMLElement>);
   private loadState = createAsyncState(this.destroyRef);
@@ -49,7 +48,12 @@ export class MealPlannerComponent {
   protected weekNumber = signal(this.getCurrentWeek());
   protected plan = signal<WeeklyPlan | null>(null);
   protected loading = this.loadState.isLoading;
-  protected error = signal<string | null>(null);
+  protected error = computed(
+    () =>
+      this.loadState.serverError() ??
+      this.generateState.serverError() ??
+      this.clearSlotState.serverError(),
+  );
   protected generatingList = this.generateState.isLoading;
   protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
@@ -98,7 +102,6 @@ export class MealPlannerComponent {
 
   protected onGenerateShoppingList(): void {
     this.shoppingResult.set(null);
-    this.error.set(null);
 
     this.generateState.execute(
       this.api.generateShoppingList(this.year(), this.weekNumber()),
@@ -107,7 +110,6 @@ export class MealPlannerComponent {
         this.shoppingResult.set(result);
         setTimeout(() => this.shoppingResult.set(null), UI.RESULT_DISPLAY_MS);
       },
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
     );
   }
 
@@ -124,12 +126,10 @@ export class MealPlannerComponent {
       this.api.clearSlot(this.year(), this.weekNumber(), { day }),
       ERROR_MAPS.mealPlanner.clearSlot,
       (plan) => this.plan.set(plan),
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
     );
   }
 
   private loadPlan(): void {
-    this.error.set(null);
     this.loadState.execute(
       this.api.getWeeklyPlan(this.year(), this.weekNumber()),
       ERROR_MAPS.mealPlanner.load,
@@ -137,7 +137,6 @@ export class MealPlannerComponent {
         this.plan.set(plan);
         queueMicrotask(() => this.scrollTodayIntoView());
       },
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
     );
   }
 

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -8,7 +8,6 @@ import {
   signal,
   computed,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
@@ -18,7 +17,7 @@ import {
   type MealSlot,
   type GenerateShoppingListResult,
 } from '@yumney/shared/api-client';
-import { UI } from '@yumney/shared/models';
+import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
 const WEEKS_PER_YEAR = 52;
@@ -42,13 +41,16 @@ export class MealPlannerComponent {
   private transloco = inject(TranslocoService);
   private router = inject(Router);
   private host = inject(ElementRef<HTMLElement>);
+  private loadState = createAsyncState(this.destroyRef);
+  private generateState = createAsyncState(this.destroyRef);
+  private clearSlotState = createAsyncState(this.destroyRef);
 
   protected year = signal(new Date().getFullYear());
   protected weekNumber = signal(this.getCurrentWeek());
   protected plan = signal<WeeklyPlan | null>(null);
-  protected loading = signal(false);
+  protected loading = this.loadState.isLoading;
   protected error = signal<string | null>(null);
-  protected generatingList = signal(false);
+  protected generatingList = this.generateState.isLoading;
   protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
   protected weekLabel = computed(
@@ -95,24 +97,18 @@ export class MealPlannerComponent {
   );
 
   protected onGenerateShoppingList(): void {
-    this.generatingList.set(true);
     this.shoppingResult.set(null);
     this.error.set(null);
 
-    this.api
-      .generateShoppingList(this.year(), this.weekNumber())
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          this.shoppingResult.set(result);
-          this.generatingList.set(false);
-          setTimeout(() => this.shoppingResult.set(null), UI.RESULT_DISPLAY_MS);
-        },
-        error: () => {
-          this.error.set(this.transloco.translate('mealPlanner.errors.generateFailed'));
-          this.generatingList.set(false);
-        },
-      });
+    this.generateState.execute(
+      this.api.generateShoppingList(this.year(), this.weekNumber()),
+      ERROR_MAPS.mealPlanner.generateShoppingList,
+      (result) => {
+        this.shoppingResult.set(result);
+        setTimeout(() => this.shoppingResult.set(null), UI.RESULT_DISPLAY_MS);
+      },
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   protected onSelectSlot(day: string): void {
@@ -124,32 +120,25 @@ export class MealPlannerComponent {
   }
 
   protected onClearSlot(day: string): void {
-    this.api
-      .clearSlot(this.year(), this.weekNumber(), { day })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (plan) => this.plan.set(plan),
-        error: () => this.error.set(this.transloco.translate('mealPlanner.errors.clearFailed')),
-      });
+    this.clearSlotState.execute(
+      this.api.clearSlot(this.year(), this.weekNumber(), { day }),
+      ERROR_MAPS.mealPlanner.clearSlot,
+      (plan) => this.plan.set(plan),
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   private loadPlan(): void {
-    this.loading.set(true);
     this.error.set(null);
-    this.api
-      .getWeeklyPlan(this.year(), this.weekNumber())
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (plan) => {
-          this.plan.set(plan);
-          this.loading.set(false);
-          queueMicrotask(() => this.scrollTodayIntoView());
-        },
-        error: () => {
-          this.error.set(this.transloco.translate('mealPlanner.errors.loadFailed'));
-          this.loading.set(false);
-        },
-      });
+    this.loadState.execute(
+      this.api.getWeeklyPlan(this.year(), this.weekNumber()),
+      ERROR_MAPS.mealPlanner.load,
+      (plan) => {
+        this.plan.set(plan);
+        queueMicrotask(() => this.scrollTodayIntoView());
+      },
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   private scrollTodayIntoView(): void {

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -88,7 +88,7 @@ export class MergedListComponent {
       this.api.addItem({ name }),
       ERROR_MAPS.shopping.merged.add,
       () => this.loadList(),
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+      (errorKey) => this.error.set(errorKey),
     );
   }
 
@@ -97,7 +97,7 @@ export class MergedListComponent {
       this.api.removeItem({ name: itemName }),
       ERROR_MAPS.shopping.merged.remove,
       () => this.loadList(),
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+      (errorKey) => this.error.set(errorKey),
     );
   }
 
@@ -124,7 +124,7 @@ export class MergedListComponent {
           this.copyToClipboard(text);
         }
       },
-      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+      (errorKey) => this.error.set(errorKey),
     );
   }
 
@@ -158,7 +158,7 @@ export class MergedListComponent {
         },
         error: () => {
           if (requestId !== this.loadRequestId) return;
-          this.error.set(this.transloco.translate('shopping.errors.loadFailed'));
+          this.error.set('shopping.errors.loadFailed');
           this.loading.set(false);
         },
       });
@@ -168,8 +168,6 @@ export class MergedListComponent {
     navigator.clipboard
       .writeText(text)
       .then(() => this.toasts.success('shopping.export.copied'))
-      .catch(() => {
-        this.error.set(this.transloco.translate('shopping.errors.exportFailed'));
-      });
+      .catch(() => this.error.set('shopping.errors.exportFailed'));
   }
 }

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -8,11 +8,10 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { TranslocoModule } from '@jsverse/transloco';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem } from '../api';
-import { TranslocoService } from '@jsverse/transloco';
-import { ToastService } from '@yumney/shared/models';
+import { createAsyncState, ERROR_MAPS, ToastService } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
 interface CategoryGroup {
@@ -34,6 +33,7 @@ export class MergedListComponent {
   private destroyRef = inject(DestroyRef);
   private transloco = inject(TranslocoService);
   private toasts = inject(ToastService);
+  private mutationState = createAsyncState(this.destroyRef);
 
   protected list = signal<MergedShoppingList | null>(null);
   protected loading = signal(false);
@@ -84,51 +84,48 @@ export class MergedListComponent {
     if (!name) return;
 
     this.newItemName.set('');
-    this.api
-      .addItem({ name })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => this.loadList(),
-        error: () => this.error.set(this.transloco.translate('shopping.errors.addFailed')),
-      });
+    this.mutationState.execute(
+      this.api.addItem({ name }),
+      ERROR_MAPS.shopping.merged.add,
+      () => this.loadList(),
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   protected onRemoveItem(itemName: string): void {
-    this.api
-      .removeItem({ name: itemName })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => this.loadList(),
-        error: () => this.error.set(this.transloco.translate('shopping.errors.removeFailed')),
-      });
+    this.mutationState.execute(
+      this.api.removeItem({ name: itemName }),
+      ERROR_MAPS.shopping.merged.remove,
+      () => this.loadList(),
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   protected onExport(): void {
-    this.api
-      .exportList()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (text) => {
-          if (text.trim().length === 0) {
-            this.toasts.info('shopping.export.nothing');
-            return;
-          }
+    this.mutationState.execute(
+      this.api.exportList(),
+      ERROR_MAPS.shopping.merged.export,
+      (text) => {
+        if (text.trim().length === 0) {
+          this.toasts.info('shopping.export.nothing');
+          return;
+        }
 
-          if (navigator.share) {
-            navigator
-              .share({ text })
-              .then(() => this.toasts.success('shopping.export.shared'))
-              .catch((err: unknown) => {
-                // AbortError = user dismissed share sheet; do not fall back.
-                if (err instanceof DOMException && err.name === 'AbortError') return;
-                this.copyToClipboard(text);
-              });
-          } else {
-            this.copyToClipboard(text);
-          }
-        },
-        error: () => this.error.set(this.transloco.translate('shopping.errors.exportFailed')),
-      });
+        if (navigator.share) {
+          navigator
+            .share({ text })
+            .then(() => this.toasts.success('shopping.export.shared'))
+            .catch((shareError: unknown) => {
+              // AbortError = user dismissed share sheet; do not fall back.
+              if (shareError instanceof DOMException && shareError.name === 'AbortError') return;
+              this.copyToClipboard(text);
+            });
+        } else {
+          this.copyToClipboard(text);
+        }
+      },
+      (errorKey) => this.error.set(this.transloco.translate(errorKey)),
+    );
   }
 
   protected onKeydown(event: KeyboardEvent): void {

--- a/client/libs/shared/models/src/lib/error-maps.ts
+++ b/client/libs/shared/models/src/lib/error-maps.ts
@@ -49,6 +49,19 @@ export const ERROR_MAPS = {
       default: 'shopping.create.errors.createFailed',
     } satisfies HttpErrorMap,
   },
+  mealPlanner: {
+    assign: {
+      default: 'mealPlanner.errors.assignFailed',
+    } satisfies HttpErrorMap,
+  },
+  account: {
+    load: {
+      default: 'account.settings.errors.loadFailed',
+    } satisfies HttpErrorMap,
+    save: {
+      default: 'account.settings.errors.saveFailed',
+    } satisfies HttpErrorMap,
+  },
   auth: {
     register: {
       409: 'auth.register.errors.emailAlreadyExists',

--- a/client/libs/shared/models/src/lib/error-maps.ts
+++ b/client/libs/shared/models/src/lib/error-maps.ts
@@ -48,10 +48,30 @@ export const ERROR_MAPS = {
     create: {
       default: 'shopping.create.errors.createFailed',
     } satisfies HttpErrorMap,
+    merged: {
+      add: {
+        default: 'shopping.errors.addFailed',
+      } satisfies HttpErrorMap,
+      remove: {
+        default: 'shopping.errors.removeFailed',
+      } satisfies HttpErrorMap,
+      export: {
+        default: 'shopping.errors.exportFailed',
+      } satisfies HttpErrorMap,
+    },
   },
   mealPlanner: {
     assign: {
       default: 'mealPlanner.errors.assignFailed',
+    } satisfies HttpErrorMap,
+    load: {
+      default: 'mealPlanner.errors.loadFailed',
+    } satisfies HttpErrorMap,
+    clearSlot: {
+      default: 'mealPlanner.errors.clearFailed',
+    } satisfies HttpErrorMap,
+    generateShoppingList: {
+      default: 'mealPlanner.errors.generateFailed',
     } satisfies HttpErrorMap,
   },
   account: {

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -44,3 +44,4 @@ export { provideYumneyIcons } from './lib/icons/provide-icons';
 
 // Directives
 export { InfiniteScrollDirective } from './lib/directives/infinite-scroll.directive';
+export { StaggerNewItemsDirective } from './lib/directives/stagger-new-items.directive';

--- a/client/libs/ui/src/lib/async-state/async-state.component.ts
+++ b/client/libs/ui/src/lib/async-state/async-state.component.ts
@@ -11,7 +11,7 @@ import { TranslocoModule } from '@jsverse/transloco';
     }
     @if (error(); as err) {
       <div class="error" role="alert">
-        {{ err }}
+        {{ err | transloco }}
         <button class="retry-btn" (click)="retry.emit()">
           {{ retryKey() | transloco }}
         </button>

--- a/client/libs/ui/src/lib/directives/stagger-new-items.directive.ts
+++ b/client/libs/ui/src/lib/directives/stagger-new-items.directive.ts
@@ -1,0 +1,35 @@
+import { AfterViewInit, Directive, ElementRef, OnDestroy, inject } from '@angular/core';
+import { prefersReducedMotion, staggerFadeIn } from '../animation/gsap-utils';
+
+@Directive({
+  selector: '[ynStaggerNewItems]',
+  standalone: true,
+})
+export class StaggerNewItemsDirective implements AfterViewInit, OnDestroy {
+  private host = inject(ElementRef<HTMLElement>);
+  private observer: MutationObserver | null = null;
+
+  ngAfterViewInit(): void {
+    this.observer = new MutationObserver((records) => this.onMutation(records));
+    this.observer.observe(this.host.nativeElement, { childList: true });
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+    this.observer = null;
+  }
+
+  private onMutation(records: MutationRecord[]): void {
+    if (prefersReducedMotion()) return;
+
+    const added: Element[] = [];
+    for (const record of records) {
+      record.addedNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) added.push(node as Element);
+      });
+    }
+    if (added.length === 0) return;
+
+    requestAnimationFrame(() => staggerFadeIn(added));
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
     "serve:shell:dist": "node scripts/serve-shell-dist.mjs",
     "generate:validation": "node scripts/generate-validation-constants.mjs",
     "generate:api-types": "node scripts/generate-api-types.mjs",
+    "sync:i18n": "node scripts/sync-i18n.mjs",
+    "sync:i18n:check": "node scripts/sync-i18n.mjs --check",
     "build:all": "node scripts/generate-validation-constants.mjs && nx run-many --target=build --projects=shell,recipes,shopping,account --parallel=4 && node scripts/copy-remotes.mjs",
     "storybook": "nx storybook ui --compodoc=false",
     "storybook:build": "nx build-storybook ui --compodoc=false"

--- a/client/scripts/sync-i18n.mjs
+++ b/client/scripts/sync-i18n.mjs
@@ -1,0 +1,112 @@
+/**
+ * Mirrors scoped i18n files from each MFE into the shell.
+ *
+ * Each MFE owns its translations under apps/{mfe}/public/assets/i18n/{scope}/{lang}.json.
+ * When the shell loads an MFE via federation, the HTTP request for translations resolves
+ * against the shell's origin, so the shell needs an identical copy at
+ * apps/shell/public/assets/i18n/{scope}/{lang}.json. This script keeps both sides in sync.
+ *
+ * Usage:
+ *   node scripts/sync-i18n.mjs           # copy MFE → shell
+ *   node scripts/sync-i18n.mjs --check   # exit 1 if any pair differs (CI mode)
+ */
+import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const clientRoot = resolve(__dirname, '..');
+const appsDir = join(clientRoot, 'apps');
+const shellI18nRoot = join(appsDir, 'shell', 'public', 'assets', 'i18n');
+
+const checkMode = process.argv.includes('--check');
+
+async function discoverScopedFiles() {
+  const apps = await readdir(appsDir, { withFileTypes: true });
+  const sources = [];
+
+  for (const app of apps) {
+    if (!app.isDirectory() || app.name === 'shell' || app.name.endsWith('-e2e')) continue;
+
+    const i18nDir = join(appsDir, app.name, 'public', 'assets', 'i18n');
+    if (!existsSync(i18nDir)) continue;
+
+    const entries = await readdir(i18nDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const scopeDir = join(i18nDir, entry.name);
+      const files = await readdir(scopeDir);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        sources.push({
+          scope: entry.name,
+          source: join(scopeDir, file),
+          target: join(shellI18nRoot, entry.name, file),
+        });
+      }
+    }
+  }
+
+  return sources;
+}
+
+async function readOrNull(path) {
+  if (!existsSync(path)) return null;
+  return readFile(path, 'utf8');
+}
+
+async function main() {
+  const pairs = await discoverScopedFiles();
+  if (pairs.length === 0) {
+    console.log('No scoped i18n files found.');
+    return;
+  }
+
+  const drifted = [];
+  const copied = [];
+
+  for (const { source, target } of pairs) {
+    const [sourceContent, targetContent] = await Promise.all([
+      readFile(source, 'utf8'),
+      readOrNull(target),
+    ]);
+
+    if (sourceContent === targetContent) continue;
+
+    drifted.push({ source, target });
+    if (!checkMode) {
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, sourceContent);
+      copied.push(target);
+    }
+  }
+
+  if (checkMode) {
+    if (drifted.length === 0) {
+      console.log(`✔ All ${pairs.length} scoped i18n file(s) in sync.`);
+      return;
+    }
+    console.error(`✖ ${drifted.length} scoped i18n file(s) out of sync with shell:`);
+    for (const { source, target } of drifted) {
+      console.error(`  - ${relative(clientRoot, source)} → ${relative(clientRoot, target)}`);
+    }
+    console.error('\nRun `yarn sync:i18n` to update the shell copies.');
+    process.exit(1);
+  }
+
+  if (copied.length === 0) {
+    console.log(`✔ All ${pairs.length} scoped i18n file(s) already in sync.`);
+    return;
+  }
+  console.log(`✔ Synced ${copied.length} of ${pairs.length} scoped i18n file(s):`);
+  for (const target of copied) {
+    console.log(`  - ${relative(clientRoot, target)}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/client/scripts/sync-i18n.mjs
+++ b/client/scripts/sync-i18n.mjs
@@ -1,14 +1,20 @@
 /**
- * Mirrors scoped i18n files from each MFE into the shell.
+ * Mirrors scoped i18n files from each MFE into the shell, and (in --check mode)
+ * verifies that top-level i18n keys shared across apps agree on their values.
  *
  * Each MFE owns its translations under apps/{mfe}/public/assets/i18n/{scope}/{lang}.json.
  * When the shell loads an MFE via federation, the HTTP request for translations resolves
  * against the shell's origin, so the shell needs an identical copy at
  * apps/shell/public/assets/i18n/{scope}/{lang}.json. This script keeps both sides in sync.
  *
+ * Each app also has top-level apps/{app}/public/assets/i18n/{lang}.json files for strings
+ * served when the app runs standalone. These overlap (shared layout/header, common toast,
+ * etc.) but have no single source of truth — so --check reports any value drift on shared
+ * keys for human resolution. Sync mode does not auto-copy these.
+ *
  * Usage:
- *   node scripts/sync-i18n.mjs           # copy MFE → shell
- *   node scripts/sync-i18n.mjs --check   # exit 1 if any pair differs (CI mode)
+ *   node scripts/sync-i18n.mjs           # copy scoped MFE → shell
+ *   node scripts/sync-i18n.mjs --check   # exit 1 if any scoped pair or top-level shared key differs
  */
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -57,6 +63,70 @@ async function readOrNull(path) {
   return readFile(path, 'utf8');
 }
 
+function flatten(obj, prefix = '') {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flatten(v, key));
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+async function discoverTopLevelFiles() {
+  const apps = await readdir(appsDir, { withFileTypes: true });
+  const byLang = new Map();
+
+  for (const app of apps) {
+    if (!app.isDirectory() || app.name.endsWith('-e2e')) continue;
+    const i18nDir = join(appsDir, app.name, 'public', 'assets', 'i18n');
+    if (!existsSync(i18nDir)) continue;
+
+    const entries = await readdir(i18nDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() || !entry.name.endsWith('.json')) continue;
+      const lang = entry.name.replace(/\.json$/, '');
+      if (!byLang.has(lang)) byLang.set(lang, []);
+      byLang.get(lang).push({ app: app.name, path: join(i18nDir, entry.name) });
+    }
+  }
+
+  return byLang;
+}
+
+async function findTopLevelDrifts() {
+  const byLang = await discoverTopLevelFiles();
+  const drifts = [];
+
+  for (const [lang, files] of byLang) {
+    const flatByApp = {};
+    for (const { app, path } of files) {
+      flatByApp[app] = flatten(JSON.parse(await readFile(path, 'utf8')));
+    }
+
+    const allKeys = new Set();
+    for (const flat of Object.values(flatByApp)) {
+      for (const key of Object.keys(flat)) allKeys.add(key);
+    }
+
+    for (const key of allKeys) {
+      const valuesByApp = {};
+      for (const [app, flat] of Object.entries(flatByApp)) {
+        if (key in flat) valuesByApp[app] = flat[key];
+      }
+      const distinctValues = new Set(Object.values(valuesByApp));
+      if (Object.keys(valuesByApp).length > 1 && distinctValues.size > 1) {
+        drifts.push({ lang, key, valuesByApp });
+      }
+    }
+  }
+
+  return drifts;
+}
+
 async function main() {
   const pairs = await discoverScopedFiles();
   if (pairs.length === 0) {
@@ -84,16 +154,35 @@ async function main() {
   }
 
   if (checkMode) {
-    if (drifted.length === 0) {
-      console.log(`✔ All ${pairs.length} scoped i18n file(s) in sync.`);
-      return;
+    const topLevelDrifts = await findTopLevelDrifts();
+    let failed = false;
+
+    if (drifted.length > 0) {
+      failed = true;
+      console.error(`✖ ${drifted.length} scoped i18n file(s) out of sync with shell:`);
+      for (const { source, target } of drifted) {
+        console.error(`  - ${relative(clientRoot, source)} → ${relative(clientRoot, target)}`);
+      }
+      console.error('\nRun `yarn sync:i18n` to update the shell copies.');
     }
-    console.error(`✖ ${drifted.length} scoped i18n file(s) out of sync with shell:`);
-    for (const { source, target } of drifted) {
-      console.error(`  - ${relative(clientRoot, source)} → ${relative(clientRoot, target)}`);
+
+    if (topLevelDrifts.length > 0) {
+      failed = true;
+      if (drifted.length > 0) console.error('');
+      console.error(
+        `✖ ${topLevelDrifts.length} top-level i18n key(s) drift between apps (no auto-fix; resolve manually):`,
+      );
+      for (const { lang, key, valuesByApp } of topLevelDrifts) {
+        console.error(`  - [${lang}] ${key}`);
+        for (const [app, value] of Object.entries(valuesByApp)) {
+          console.error(`      ${app}: ${JSON.stringify(value)}`);
+        }
+      }
     }
-    console.error('\nRun `yarn sync:i18n` to update the shell copies.');
-    process.exit(1);
+
+    if (failed) process.exit(1);
+    console.log(`✔ All ${pairs.length} scoped i18n file(s) in sync; no top-level drift.`);
+    return;
   }
 
   if (copied.length === 0) {


### PR DESCRIPTION
## Summary

Frontend cleanup pass driven by a survey of the Angular workspace. Four focused commits:

- **`createAsyncState` migration** — `RecipeAssignmentService`, `ProfileSettingsComponent`, `meal-planner`, and `merged-list` mutations move off raw `subscribe()` + `takeUntilDestroyed` to the shared helper. New `ERROR_MAPS` entries for `mealPlanner.{assign,load,clearSlot,generateShoppingList}`, `account.{load,save}`, `shopping.merged.{add,remove,export}`. `merged-list.loadList` deliberately stays manual — its request-ID guard is incompatible with the helper's loading-state lifecycle (see commit body).
- **i18n sync tooling** — new `scripts/sync-i18n.mjs` mirrors MFE-owned scoped translations (`apps/{mfe}/.../i18n/{scope}/`) into `apps/shell/.../i18n/{scope}/` (MFE is source of truth). `--check` mode also flattens top-level i18n files and reports value drift on shared keys (no auto-fix; manual resolution). Wired to CI as a new step.
- **i18n drift caught** — German `switchToDark`/`switchToLight` in `apps/shell/.../i18n/de.json` described the target mode (\"Heller Modus\") instead of the action (\"Zu dunklem Modus wechseln\"). All three MFEs already had the correct strings; shell was the outlier. Fixed.
- **Other frontend cleanups**:
  - `register.component.ts` — wired to auto-generated `VALIDATION.USERS.PASSWORD.*_PATTERN` constants (wrapped in `new RegExp(...)` because `Validators.pattern(string)` anchors as `^...$`).
  - `recipe-edit.component.ts` — replaced `window.confirm()` with the existing `<yn-confirm-dialog>` (i18n-compliant, keyboard-accessible, in-flight save guard).
  - `recipe-list.component.ts` — extracted the stagger-fade-in constructor effect into a reusable `StaggerNewItemsDirective` in `libs/ui` (MutationObserver-driven).
  - `AsyncStateComponent` — pipes the `error` input through `| transloco`, matching what it already did for `loadingKey`/`retryKey`. Components can now hand it a translation key directly; pre-translated strings still work via the missing-key passthrough.

## Test plan

- [x] `yarn nx run-many -t test --projects=ui,account,shopping,shell,recipes` — all green
- [x] `yarn nx run-many -t lint --projects=ui,account,shopping,shell,recipes` — clean (only pre-existing warnings in unrelated files)
- [x] `yarn sync:i18n:check` — passes; drift detection verified by injecting and healing a deliberate drift round-trip
- [x] Stale-response test in `merged-list` (rapid past-purchases toggle) still passes — confirms the loadList request-ID guard is intact
- [ ] Smoke-test in browser: load merged list, toggle past purchases rapidly, trigger an add/remove, generate shopping list from meal planner, edit a recipe and discard