### PR TITLE
refactor(client): add index.ts barrels to feature folders

### DIFF
--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -11,9 +11,6 @@ export const accountRoutes: Route[] = [
     // root providers. Without this, keys like account.settings.title render
     // as their literal path.
     providers: [provideTranslocoScope('account')],
-    loadComponent: () =>
-      import('./profile-settings/profile-settings.component').then(
-        (m) => m.ProfileSettingsComponent,
-      ),
+    loadComponent: () => import('./profile-settings').then((m) => m.ProfileSettingsComponent),
   },
 ];

--- a/client/apps/account/src/app/profile-settings/index.ts
+++ b/client/apps/account/src/app/profile-settings/index.ts
@@ -1,0 +1,1 @@
+export { ProfileSettingsComponent } from './profile-settings.component';

--- a/client/apps/recipes/src/app/cook-mode/index.ts
+++ b/client/apps/recipes/src/app/cook-mode/index.ts
@@ -1,0 +1,1 @@
+export { CookModeComponent } from './cook-mode.component';

--- a/client/apps/recipes/src/app/recipe-detail/index.ts
+++ b/client/apps/recipes/src/app/recipe-detail/index.ts
@@ -1,0 +1,1 @@
+export { RecipeDetailComponent } from './recipe-detail.component';

--- a/client/apps/recipes/src/app/recipe-edit/index.ts
+++ b/client/apps/recipes/src/app/recipe-edit/index.ts
@@ -1,0 +1,1 @@
+export { RecipeEditComponent } from './recipe-edit.component';

--- a/client/apps/recipes/src/app/recipe-list/index.ts
+++ b/client/apps/recipes/src/app/recipe-list/index.ts
@@ -1,0 +1,1 @@
+export { RecipeListComponent } from './recipe-list.component';

--- a/client/apps/recipes/src/app/recipes.routes.ts
+++ b/client/apps/recipes/src/app/recipes.routes.ts
@@ -12,27 +12,24 @@ export const recipesRoutes: Route[] = [
     path: ':identifier/edit',
     title: 'Edit Recipe — Yumney',
     providers: RECIPES_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./recipe-edit/recipe-edit.component').then((m) => m.RecipeEditComponent),
+    loadComponent: () => import('./recipe-edit').then((m) => m.RecipeEditComponent),
   },
   {
     path: ':identifier/cook',
     title: 'Cook Mode — Yumney',
     providers: RECIPES_SCOPE_PROVIDERS,
-    loadComponent: () => import('./cook-mode/cook-mode.component').then((m) => m.CookModeComponent),
+    loadComponent: () => import('./cook-mode').then((m) => m.CookModeComponent),
   },
   {
     path: ':identifier',
     title: 'Recipe — Yumney',
     providers: RECIPES_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./recipe-detail/recipe-detail.component').then((m) => m.RecipeDetailComponent),
+    loadComponent: () => import('./recipe-detail').then((m) => m.RecipeDetailComponent),
   },
   {
     path: '',
     title: 'My Recipes — Yumney',
     providers: RECIPES_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./recipe-list/recipe-list.component').then((m) => m.RecipeListComponent),
+    loadComponent: () => import('./recipe-list').then((m) => m.RecipeListComponent),
   },
 ];

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -11,8 +11,7 @@ export const appRoutes: Route[] = [
     path: 'dashboard',
     title: 'Dashboard — Yumney',
     canActivate: [authGuard],
-    loadComponent: () =>
-      import('./dashboard/dashboard.component').then((m) => m.DashboardComponent),
+    loadComponent: () => import('./dashboard').then((m) => m.DashboardComponent),
   },
   {
     path: 'recipes',
@@ -30,8 +29,7 @@ export const appRoutes: Route[] = [
     path: 'meal-planner',
     title: 'Meal Planner — Yumney',
     canActivate: [authGuard],
-    loadComponent: () =>
-      import('./meal-planner/meal-planner.component').then((m) => m.MealPlannerComponent),
+    loadComponent: () => import('./meal-planner').then((m) => m.MealPlannerComponent),
   },
   {
     path: 'account',

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -8,7 +8,7 @@ import {
   ToastHostComponent,
 } from '@yumney/ui';
 import { ChatStateService } from '@yumney/shared/models';
-import { OfflineIndicatorComponent } from './layout/offline-indicator/offline-indicator.component';
+import { OfflineIndicatorComponent } from './layout/offline-indicator';
 import { filter } from 'rxjs';
 
 @Component({

--- a/client/apps/shell/src/app/auth/auth.routes.ts
+++ b/client/apps/shell/src/app/auth/auth.routes.ts
@@ -6,20 +6,17 @@ export const authRoutes: Route[] = [
     path: 'login',
     title: 'Sign In — Yumney',
     canActivate: [guestGuard],
-    loadComponent: () => import('./login/login.component').then((m) => m.LoginComponent),
+    loadComponent: () => import('./login').then((m) => m.LoginComponent),
   },
   {
     path: 'register',
     title: 'Register — Yumney',
     canActivate: [guestGuard],
-    loadComponent: () => import('./register/register.component').then((m) => m.RegisterComponent),
+    loadComponent: () => import('./register').then((m) => m.RegisterComponent),
   },
   {
     path: 'resend-verification',
     title: 'Resend Verification — Yumney',
-    loadComponent: () =>
-      import('./resend-verification/resend-verification.component').then(
-        (m) => m.ResendVerificationComponent,
-      ),
+    loadComponent: () => import('./resend-verification').then((m) => m.ResendVerificationComponent),
   },
 ];

--- a/client/apps/shell/src/app/auth/login/index.ts
+++ b/client/apps/shell/src/app/auth/login/index.ts
@@ -1,0 +1,1 @@
+export { LoginComponent } from './login.component';

--- a/client/apps/shell/src/app/auth/register/index.ts
+++ b/client/apps/shell/src/app/auth/register/index.ts
@@ -1,0 +1,1 @@
+export { RegisterComponent } from './register.component';

--- a/client/apps/shell/src/app/auth/resend-verification/index.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/index.ts
@@ -1,0 +1,1 @@
+export { ResendVerificationComponent } from './resend-verification.component';

--- a/client/apps/shell/src/app/dashboard/index.ts
+++ b/client/apps/shell/src/app/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { DashboardComponent } from './dashboard.component';

--- a/client/apps/shell/src/app/layout/offline-indicator/index.ts
+++ b/client/apps/shell/src/app/layout/offline-indicator/index.ts
@@ -1,0 +1,1 @@
+export { OfflineIndicatorComponent } from './offline-indicator.component';

--- a/client/apps/shell/src/app/meal-planner/index.ts
+++ b/client/apps/shell/src/app/meal-planner/index.ts
@@ -1,0 +1,1 @@
+export { MealPlannerComponent } from './meal-planner.component';

--- a/client/apps/shopping/src/app/merged-list/index.ts
+++ b/client/apps/shopping/src/app/merged-list/index.ts
@@ -1,0 +1,1 @@
+export { MergedListComponent } from './merged-list.component';

--- a/client/apps/shopping/src/app/shopping-create/index.ts
+++ b/client/apps/shopping/src/app/shopping-create/index.ts
@@ -1,0 +1,1 @@
+export { ShoppingCreateComponent } from './shopping-create.component';

--- a/client/apps/shopping/src/app/shopping-detail/index.ts
+++ b/client/apps/shopping/src/app/shopping-detail/index.ts
@@ -1,0 +1,1 @@
+export { ShoppingDetailComponent } from './shopping-detail.component';

--- a/client/apps/shopping/src/app/shopping-list/index.ts
+++ b/client/apps/shopping/src/app/shopping-list/index.ts
@@ -1,0 +1,1 @@
+export { ShoppingListComponent } from './shopping-list.component';

--- a/client/apps/shopping/src/app/shopping.routes.ts
+++ b/client/apps/shopping/src/app/shopping.routes.ts
@@ -12,28 +12,24 @@ export const shoppingRoutes: Route[] = [
     path: 'create/:recipeIdentifier',
     title: 'Create Shopping List — Yumney',
     providers: SHOPPING_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./shopping-create/shopping-create.component').then((m) => m.ShoppingCreateComponent),
+    loadComponent: () => import('./shopping-create').then((m) => m.ShoppingCreateComponent),
   },
   {
     path: 'lists/:identifier',
     title: 'Shopping List — Yumney',
     providers: SHOPPING_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./shopping-detail/shopping-detail.component').then((m) => m.ShoppingDetailComponent),
+    loadComponent: () => import('./shopping-detail').then((m) => m.ShoppingDetailComponent),
   },
   {
     path: 'lists',
     title: 'Shopping Lists — Yumney',
     providers: SHOPPING_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./shopping-list/shopping-list.component').then((m) => m.ShoppingListComponent),
+    loadComponent: () => import('./shopping-list').then((m) => m.ShoppingListComponent),
   },
   {
     path: '',
     title: 'Shopping — Yumney',
     providers: SHOPPING_SCOPE_PROVIDERS,
-    loadComponent: () =>
-      import('./merged-list/merged-list.component').then((m) => m.MergedListComponent),
+    loadComponent: () => import('./merged-list').then((m) => m.MergedListComponent),
   },
 ];


### PR DESCRIPTION
## Summary

Adds an `index.ts` barrel to each app feature folder. Route lazy-loaders and the shell's static `OfflineIndicatorComponent` import now reference the folder instead of the inner `.component` file.

Before:
~~~ts
loadComponent: () => import('./recipe-edit/recipe-edit.component').then((m) => m.RecipeEditComponent),
~~~

After:
~~~ts
loadComponent: () => import('./recipe-edit').then((m) => m.RecipeEditComponent),
~~~

15 new barrels, 6 files updated (5 route files + ${'`'}app.ts${'`'}). No behavioral change. Net +30 / -28 lines.

## Coverage

| App | Barrels added |
|---|---|
| shell | auth/{login,register,resend-verification}, dashboard, meal-planner, layout/offline-indicator |
| recipes | recipe-{detail,edit,list}, cook-mode |
| shopping | shopping-{create,detail,list}, merged-list |
| account | profile-settings |

## Out of scope

- ${'`'}libs/ui${'`'} barrel kept flat (existing pattern; 30+ components).
- No changes to ${'`'}createAsyncState${'`'}, ${'`'}ensureFormValid${'`'}, or any component logic.
- ${'`'}account-placeholder${'`'} folder skipped — no longer routed.

## Test plan

- [ ] ${'`'}yarn nx run-many -t lint --parallel${'`'} green
- [ ] ${'`'}yarn nx run-many -t typecheck --parallel${'`'} green
- [ ] ${'`'}yarn nx run-many -t test --parallel${'`'} green
- [ ] Manual: navigate to each route in the running app; lazy chunks load