### PR TITLE
refactor(application): extract overlong handler methods

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -24,9 +24,19 @@ public sealed class GenerateShoppingListCommandHandler(
 		var planned = await readModel.GetPlannedRecipesAsync(owner, week, cancellationToken);
 		if (planned.Recipes.Count == 0) return GenerateShoppingListErrors.NoRecipes;
 
+		var merged = await MergeIngredientsAsync(planned.Recipes, cancellationToken);
+		(int staplesSkipped, List<ShoppingItemRequest> itemsToAdd) = await FilterOutStaplesAsync(owner, merged, cancellationToken);
+
+		return new GenerateShoppingListResultDto(itemsToAdd.Count, staplesSkipped);
+	}
+
+	private async Task<Dictionary<string, MergedItem>> MergeIngredientsAsync(
+		IReadOnlyList<PlannedRecipeDto> recipes,
+		CancellationToken cancellationToken)
+	{
 		Dictionary<string, MergedItem> merged = new(StringComparer.OrdinalIgnoreCase);
 
-		foreach (var recipe in planned.Recipes)
+		foreach (var recipe in recipes)
 		{
 			var recipeRef = SlotRecipeIdentifier.From(recipe.RecipeIdentifier);
 			var ingredients = await recipeIngredients.LookupAsync(recipeRef, cancellationToken);
@@ -51,9 +61,7 @@ public sealed class GenerateShoppingListCommandHandler(
 			}
 		}
 
-		(int staplesSkipped, List<ShoppingItemRequest> itemsToAdd) = await FilterOutStaplesAsync(owner, merged, cancellationToken);
-
-		return new GenerateShoppingListResultDto(itemsToAdd.Count, staplesSkipped);
+		return merged;
 	}
 
 	private async Task<(int StaplesSkipped, List<ShoppingItemRequest> ItemsToAdd)> FilterOutStaplesAsync(

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -38,47 +38,13 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
 		activity?.SetTag("chat.history_length", history.Count);
 
 		var userRecipes = await LoadUserRecipeContextAsync(owner, cancellationToken);
+		var chatHistory = BuildChatHistory(message, history, userRecipes);
 
-		var chatHistory = new ChatHistory();
-		chatHistory.AddSystemMessage(BuildSystemPrompt(userRecipes));
+		var replyResult = await GetChatReplyAsync(chatHistory, activity, cancellationToken);
+		if (replyResult.IsFailure) return replyResult.Error!;
 
-		foreach (var (role, content) in history)
-		{
-			if (role == ChatRole.User)
-			{
-				chatHistory.AddUserMessage(content.Value);
-			}
-			else if (role == ChatRole.Assistant)
-			{
-				chatHistory.AddAssistantMessage(content.Value);
-			}
-		}
-
-		chatHistory.AddUserMessage(message.Value);
-
-		var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
-
-		string reply;
-		try
-		{
-			var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
-			reply = result.Content ?? string.Empty;
-			activity?.SetTag("llm.response_length", reply.Length);
-		}
-		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-		{
-			throw;
-		}
-		catch (Exception ex)
-		{
-			activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-			LogChatFailed(ex.Message);
-			return ImportRecipeErrors.ExtractionFailed;
-		}
-
-		var suggestions = MatchRecipesByMention(reply, userRecipes);
-
-		return new ChatResponseDto(reply, suggestions);
+		var suggestions = MatchRecipesByMention(replyResult.Value, userRecipes);
+		return new ChatResponseDto(replyResult.Value, suggestions);
 	}
 
 	internal static List<ChatRecipeSuggestionDto> MatchRecipesByMention(string reply, IReadOnlyList<Recipe> userRecipes)
@@ -100,6 +66,56 @@ public sealed partial class SemanticKernelChatService(Kernel kernel, IRecipeRepo
 		}
 
 		return suggestions;
+	}
+
+	private static ChatHistory BuildChatHistory(
+		ChatMessageContent message,
+		IReadOnlyList<DomainChatHistoryEntry> history,
+		IReadOnlyList<Recipe> userRecipes)
+	{
+		var chatHistory = new ChatHistory();
+		chatHistory.AddSystemMessage(BuildSystemPrompt(userRecipes));
+
+		foreach (var (role, content) in history)
+		{
+			if (role == ChatRole.User)
+			{
+				chatHistory.AddUserMessage(content.Value);
+			}
+			else if (role == ChatRole.Assistant)
+			{
+				chatHistory.AddAssistantMessage(content.Value);
+			}
+		}
+
+		chatHistory.AddUserMessage(message.Value);
+		return chatHistory;
+	}
+
+	private async Task<Result<string>> GetChatReplyAsync(
+		ChatHistory chatHistory,
+		Activity? activity,
+		CancellationToken cancellationToken)
+	{
+		var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+		try
+		{
+			var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, cancellationToken: cancellationToken);
+			var reply = result.Content ?? string.Empty;
+			activity?.SetTag("llm.response_length", reply.Length);
+			return reply;
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			throw;
+		}
+		catch (Exception ex)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+			LogChatFailed(ex.Message);
+			return ImportRecipeErrors.ExtractionFailed;
+		}
 	}
 
 	private static string BuildSystemPrompt(IReadOnlyList<Recipe> userRecipes)


### PR DESCRIPTION
## Summary

Two long-method extractions to satisfy CLAUDE.md's 30-line method body limit. Both surfaced from a backend audit pass.

- **`GenerateShoppingListCommandHandler.HandleAsync`** (38 → 12 lines body) — pull the per-recipe ingredient-merging double-foreach into `MergeIngredientsAsync`.
- **`SemanticKernelChatService.ChatAsync`** (48 → 13 lines body) — split into `BuildChatHistory` (static) and `GetChatReplyAsync`. New helpers sit after `MatchRecipesByMention` so SA1202 member-ordering (internal before private) is preserved; `MatchRecipesByMention` stays internal because tests in `Yumney.Recipes.Infrastructure.Tests` reach in.

No behavior changes. No new tests added — the existing test suites cover the extracted paths.

## Test plan

- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format Yumney.slnx --verify-no-changes` — clean
- [x] MealPlan.Application.Tests (46), MealPlan.Domain.Tests (127), Recipes.Application.Tests (165), Recipes.Domain.Tests (243), Recipes.Infrastructure.Tests (100) — all green
- [ ] Smoke-test `generateShoppingList` and chat in browser