### PR TITLE
feat(account): expand profile editor with theme + voice + notifications (US-100)

### DIFF
--- a/client/apps/account/public/assets/i18n/account/de.json
+++ b/client/apps/account/public/assets/i18n/account/de.json
@@ -1,25 +1,95 @@
 {
   "placeholder": {
-    "title": "Kontoeinstellungen",
-    "message": "Kontoverwaltungsfunktionen folgen in Kürze."
+    "title": "Konto-Einstellungen",
+    "message": "Verwaltungsfunktionen für Konten folgen demnächst."
   },
   "settings": {
-    "title": "Profileinstellungen",
-    "loading": "Profil wird geladen…",
+    "title": "Profil-Einstellungen",
+    "loading": "Profil wird geladen …",
     "retry": "Erneut versuchen",
+    "save": "Speichern",
+    "saving": "Wird gespeichert …",
+    "saved": "Gespeichert",
+    "none": "Keine",
+
+    "identity": "Identität",
+    "identityHint": "Dein Name und deine Kontakt-E-Mail.",
+    "displayName": "Anzeigename",
+    "email": "E-Mail",
+    "emailHint": "Die E-Mail wird über deinen Anmeldeanbieter verwaltet.",
+
+    "languageUnits": "Sprache & Einheiten",
+    "languageUnitsHint": "Passe die Oberfläche an deine Sprache und dein Einheitensystem an.",
+    "preferredLanguage": "Bevorzugte Sprache",
+    "preferredUnitSystem": "Einheitensystem",
+    "lang": {
+      "en": "Englisch",
+      "de": "Deutsch"
+    },
+    "unitSystem": {
+      "metric": "Metrisch (g, ml, °C)",
+      "imperial": "Imperial (oz, fl oz, °F)"
+    },
+
+    "appearance": "Erscheinungsbild",
+    "appearanceHint": "Wähle ein Theme oder folge deinem Betriebssystem.",
+    "theme": "Theme",
+    "themes": {
+      "light": "Hell",
+      "dark": "Dunkel",
+      "system": "System"
+    },
+
+    "cooking": "Koch-Einstellungen",
+    "cookingHint": "Voreinstellungen für personalisierte Rezepte und Einkaufslisten.",
     "household": "Haushalt",
     "defaultServings": "Standard-Portionen",
-    "dietary": "Ernährungspräferenzen",
-    "dietaryType": "Ernährungstyp",
-    "none": "Keine",
+    "dietary": "Ernährungsweise",
+    "dietaryType": "Ernährungsform",
+    "dietaryTypes": {
+      "omnivore": "Allesesser",
+      "vegetarian": "Vegetarisch",
+      "vegan": "Vegan",
+      "pescatarian": "Pescetarisch",
+      "flexitarian": "Flexitarisch"
+    },
     "restrictions": "Einschränkungen & Allergien",
-    "cookingEffort": "Kochaufwand",
+    "restriction": {
+      "gluten-free": "Glutenfrei",
+      "lactose-free": "Laktosefrei",
+      "nut-allergy": "Nussallergie",
+      "egg-free": "Eifrei",
+      "soy-free": "Sojafrei",
+      "shellfish-allergy": "Schalentier-Allergie",
+      "halal": "Halal",
+      "kosher": "Koscher"
+    },
+    "cookingEffort": "Aufwand beim Kochen",
+    "cookingEffortOption": {
+      "quick-weekdays": "Schnell unter der Woche",
+      "balanced": "Ausgewogen",
+      "elaborate-weekends": "Aufwendig am Wochenende"
+    },
     "weeklyGoals": "Wochenziele",
-    "minVeggie": "Min. vegetarische Gerichte",
-    "maxMeat": "Max. Rotfleisch-Gerichte",
-    "save": "Speichern",
-    "saving": "Speichert…",
-    "saved": "Gespeichert!",
+    "minVeggie": "Min. Gemüsemahlzeiten",
+    "maxMeat": "Max. Mahlzeiten mit rotem Fleisch",
+
+    "voice": "Sprachassistent",
+    "voiceHint": "Schritte vorlesen lassen und Sprachbefehle im Kochmodus verwenden.",
+    "voiceEnabled": "Sprachfunktionen aktivieren",
+    "voiceSpeed": "Sprechgeschwindigkeit",
+    "voiceSpeedOption": {
+      "slow": "Langsam",
+      "normal": "Normal",
+      "fast": "Schnell"
+    },
+    "voiceAutoRead": "Schritte im Kochmodus automatisch vorlesen",
+
+    "notifications": "Benachrichtigungen",
+    "notificationsHint": "Wie Timer dich auf sich aufmerksam machen.",
+    "timerHaptic": "Vibrieren, wenn ein Timer abläuft",
+    "timerSound": "Ton abspielen, wenn ein Timer abläuft",
+
     "errors": {
       "saveFailed": "Profil konnte nicht gespeichert werden.",
       "loadFailed": "Profil konnte nicht geladen werden."

--- a/client/apps/account/public/assets/i18n/account/en.json
+++ b/client/apps/account/public/assets/i18n/account/en.json
@@ -7,19 +7,89 @@
     "title": "Profile Settings",
     "loading": "Loading profile…",
     "retry": "Retry",
+    "save": "Save",
+    "saving": "Saving…",
+    "saved": "Saved",
+    "none": "None",
+
+    "identity": "Identity",
+    "identityHint": "Your name and contact email.",
+    "displayName": "Display name",
+    "email": "Email",
+    "emailHint": "Email is managed by your sign-in provider.",
+
+    "languageUnits": "Language & Units",
+    "languageUnitsHint": "Adapt the UI to your language and measurement system.",
+    "preferredLanguage": "Preferred language",
+    "preferredUnitSystem": "Unit system",
+    "lang": {
+      "en": "English",
+      "de": "German"
+    },
+    "unitSystem": {
+      "metric": "Metric (g, ml, °C)",
+      "imperial": "Imperial (oz, fl oz, °F)"
+    },
+
+    "appearance": "Appearance",
+    "appearanceHint": "Pick a theme or follow your operating system.",
+    "theme": "Theme",
+    "themes": {
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    },
+
+    "cooking": "Cooking Preferences",
+    "cookingHint": "Defaults that personalise recipes and shopping lists.",
     "household": "Household",
     "defaultServings": "Default servings",
     "dietary": "Dietary Preferences",
     "dietaryType": "Dietary type",
-    "none": "None",
+    "dietaryTypes": {
+      "omnivore": "Omnivore",
+      "vegetarian": "Vegetarian",
+      "vegan": "Vegan",
+      "pescatarian": "Pescatarian",
+      "flexitarian": "Flexitarian"
+    },
     "restrictions": "Restrictions & allergies",
+    "restriction": {
+      "gluten-free": "Gluten-free",
+      "lactose-free": "Lactose-free",
+      "nut-allergy": "Nut allergy",
+      "egg-free": "Egg-free",
+      "soy-free": "Soy-free",
+      "shellfish-allergy": "Shellfish allergy",
+      "halal": "Halal",
+      "kosher": "Kosher"
+    },
     "cookingEffort": "Cooking effort",
+    "cookingEffortOption": {
+      "quick-weekdays": "Quick weekdays",
+      "balanced": "Balanced",
+      "elaborate-weekends": "Elaborate weekends"
+    },
     "weeklyGoals": "Weekly Goals",
     "minVeggie": "Min. veggie meals",
     "maxMeat": "Max. red-meat meals",
-    "save": "Save",
-    "saving": "Saving…",
-    "saved": "Saved!",
+
+    "voice": "Voice Assistant",
+    "voiceHint": "Read steps aloud and listen for voice commands in cook mode.",
+    "voiceEnabled": "Enable voice features",
+    "voiceSpeed": "Voice speed",
+    "voiceSpeedOption": {
+      "slow": "Slow",
+      "normal": "Normal",
+      "fast": "Fast"
+    },
+    "voiceAutoRead": "Auto-read steps in cook mode",
+
+    "notifications": "Notifications",
+    "notificationsHint": "How timers grab your attention.",
+    "timerHaptic": "Vibrate when a timer ends",
+    "timerSound": "Play a sound when a timer ends",
+
     "errors": {
       "saveFailed": "Failed to save profile.",
       "loadFailed": "Failed to load profile."

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -1,5 +1,18 @@
 <div class="profile-settings" *transloco="let t">
-  <h1 data-testid="profile-settings-title">{{ t('account.settings.title') }}</h1>
+  <header class="profile-settings__header">
+    <h1 data-testid="profile-settings-title">{{ t('account.settings.title') }}</h1>
+    @if (saving()) {
+      <span class="profile-settings__status" role="status">{{ t('account.settings.saving') }}</span>
+    } @else if (saved()) {
+      <span
+        class="profile-settings__status profile-settings__status--saved"
+        data-testid="profile-saved-indicator"
+        role="status"
+      >
+        {{ t('account.settings.saved') }}
+      </span>
+    }
+  </header>
 
   <yn-async-state
     [loading]="loading()"
@@ -9,10 +22,92 @@
     (retry)="onRetry()"
   />
 
-  @if (profile(); as p) {
-    <form (submit)="$event.preventDefault(); onSave()">
-      <section class="settings-section" data-testid="profile-settings-section">
-        <h2>{{ t('account.settings.household') }}</h2>
+  @if (profile()) {
+    <form class="profile-settings__form" (submit)="$event.preventDefault()">
+      <yn-settings-card
+        titleKey="account.settings.identity"
+        descriptionKey="account.settings.identityHint"
+      >
+        <div class="form-field">
+          <label for="displayName">{{ t('account.settings.displayName') }}</label>
+          <input
+            id="displayName"
+            type="text"
+            maxlength="100"
+            [ngModel]="displayName()"
+            (ngModelChange)="displayName.set($event); onChange()"
+            name="displayName"
+          />
+        </div>
+        <div class="form-field">
+          <label for="email">{{ t('account.settings.email') }}</label>
+          <input
+            id="email"
+            type="email"
+            [value]="email()"
+            readonly
+            name="email"
+            [attr.aria-readonly]="true"
+          />
+          <small class="form-field__hint">{{ t('account.settings.emailHint') }}</small>
+        </div>
+      </yn-settings-card>
+
+      <yn-settings-card
+        titleKey="account.settings.languageUnits"
+        descriptionKey="account.settings.languageUnitsHint"
+      >
+        <div class="form-field">
+          <label for="preferredLanguage">{{ t('account.settings.preferredLanguage') }}</label>
+          <select
+            id="preferredLanguage"
+            [ngModel]="preferredLanguage()"
+            (ngModelChange)="preferredLanguage.set($event); onChange()"
+            name="preferredLanguage"
+          >
+            @for (lang of languages; track lang) {
+              <option [value]="lang">{{ t('account.settings.lang.' + lang) }}</option>
+            }
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="preferredUnitSystem">{{ t('account.settings.preferredUnitSystem') }}</label>
+          <select
+            id="preferredUnitSystem"
+            [ngModel]="preferredUnitSystem()"
+            (ngModelChange)="preferredUnitSystem.set($event); onChange()"
+            name="preferredUnitSystem"
+          >
+            @for (unit of unitSystems; track unit) {
+              <option [value]="unit">{{ t('account.settings.unitSystem.' + unit) }}</option>
+            }
+          </select>
+        </div>
+      </yn-settings-card>
+
+      <yn-settings-card
+        titleKey="account.settings.appearance"
+        descriptionKey="account.settings.appearanceHint"
+      >
+        <div class="form-field">
+          <label for="theme">{{ t('account.settings.theme') }}</label>
+          <select
+            id="theme"
+            [ngModel]="themeChoice()"
+            (ngModelChange)="themeChoice.set($event); onChange()"
+            name="theme"
+          >
+            @for (option of themes; track option) {
+              <option [value]="option">{{ t('account.settings.themes.' + option) }}</option>
+            }
+          </select>
+        </div>
+      </yn-settings-card>
+
+      <yn-settings-card
+        titleKey="account.settings.cooking"
+        descriptionKey="account.settings.cookingHint"
+      >
         <div class="form-field">
           <label for="servings">{{ t('account.settings.defaultServings') }}</label>
           <input
@@ -21,29 +116,24 @@
             min="1"
             max="12"
             [ngModel]="defaultServings()"
-            (ngModelChange)="defaultServings.set($event)"
+            (ngModelChange)="defaultServings.set($event); onChange()"
             name="servings"
           />
         </div>
-      </section>
-
-      <section class="settings-section" data-testid="profile-settings-section">
-        <h2>{{ t('account.settings.dietary') }}</h2>
         <div class="form-field">
           <label for="dietaryType">{{ t('account.settings.dietaryType') }}</label>
           <select
             id="dietaryType"
             [ngModel]="dietaryType()"
-            (ngModelChange)="dietaryType.set($event)"
+            (ngModelChange)="dietaryType.set($event); onChange()"
             name="dietaryType"
           >
             <option value="">{{ t('account.settings.none') }}</option>
             @for (type of dietaryTypes; track type) {
-              <option [value]="type">{{ type }}</option>
+              <option [value]="type">{{ t('account.settings.dietaryTypes.' + type) }}</option>
             }
           </select>
         </div>
-
         <div class="form-field">
           <label>{{ t('account.settings.restrictions') }}</label>
           <div class="checkbox-group">
@@ -54,30 +144,11 @@
                   [checked]="restrictions().includes(r)"
                   (change)="onToggleRestriction(r)"
                 />
-                {{ r }}
+                {{ t('account.settings.restriction.' + r) }}
               </label>
             }
           </div>
         </div>
-
-        <div class="form-field">
-          <label for="cookingEffort">{{ t('account.settings.cookingEffort') }}</label>
-          <select
-            id="cookingEffort"
-            [ngModel]="cookingEffort()"
-            (ngModelChange)="cookingEffort.set($event)"
-            name="cookingEffort"
-          >
-            <option value="">{{ t('account.settings.none') }}</option>
-            @for (effort of cookingEfforts; track effort) {
-              <option [value]="effort">{{ effort }}</option>
-            }
-          </select>
-        </div>
-      </section>
-
-      <section class="settings-section" data-testid="profile-settings-section">
-        <h2>{{ t('account.settings.weeklyGoals') }}</h2>
         <div class="form-row">
           <div class="form-field">
             <label for="minVeggie">{{ t('account.settings.minVeggie') }}</label>
@@ -87,7 +158,7 @@
               min="0"
               max="7"
               [ngModel]="minVeggieMeals()"
-              (ngModelChange)="minVeggieMeals.set($event)"
+              (ngModelChange)="minVeggieMeals.set($event); onChange()"
               name="minVeggie"
             />
           </div>
@@ -99,23 +170,85 @@
               min="0"
               max="7"
               [ngModel]="maxRedMeatMeals()"
-              (ngModelChange)="maxRedMeatMeals.set($event)"
+              (ngModelChange)="maxRedMeatMeals.set($event); onChange()"
               name="maxMeat"
             />
           </div>
         </div>
-      </section>
+        <div class="form-field">
+          <label for="cookingEffort">{{ t('account.settings.cookingEffort') }}</label>
+          <select
+            id="cookingEffort"
+            [ngModel]="cookingEffort()"
+            (ngModelChange)="cookingEffort.set($event); onChange()"
+            name="cookingEffort"
+          >
+            <option value="">{{ t('account.settings.none') }}</option>
+            @for (effort of cookingEfforts; track effort) {
+              <option [value]="effort">{{ t('account.settings.cookingEffortOption.' + effort) }}</option>
+            }
+          </select>
+        </div>
+      </yn-settings-card>
 
-      <div class="form-actions">
-        <button type="submit" class="save-btn" data-testid="profile-save-btn" [disabled]="saving()">
-          {{ saving() ? t('account.settings.saving') : t('account.settings.save') }}
-        </button>
-        @if (saved()) {
-          <span class="saved-indicator" data-testid="profile-saved-indicator">{{
-            t('account.settings.saved')
-          }}</span>
-        }
-      </div>
+      <yn-settings-card
+        titleKey="account.settings.voice"
+        descriptionKey="account.settings.voiceHint"
+      >
+        <label class="checkbox-label">
+          <input
+            type="checkbox"
+            [checked]="voiceEnabled()"
+            (change)="voiceEnabled.set($any($event.target).checked); onChange()"
+          />
+          {{ t('account.settings.voiceEnabled') }}
+        </label>
+        <div class="form-field">
+          <label for="voiceSpeed">{{ t('account.settings.voiceSpeed') }}</label>
+          <select
+            id="voiceSpeed"
+            [ngModel]="voiceSpeed()"
+            (ngModelChange)="voiceSpeed.set($event); onChange()"
+            name="voiceSpeed"
+            [disabled]="!voiceEnabled()"
+          >
+            @for (speed of voiceSpeeds; track speed) {
+              <option [value]="speed">{{ t('account.settings.voiceSpeedOption.' + speed) }}</option>
+            }
+          </select>
+        </div>
+        <label class="checkbox-label">
+          <input
+            type="checkbox"
+            [checked]="voiceAutoRead()"
+            [disabled]="!voiceEnabled()"
+            (change)="voiceAutoRead.set($any($event.target).checked); onChange()"
+          />
+          {{ t('account.settings.voiceAutoRead') }}
+        </label>
+      </yn-settings-card>
+
+      <yn-settings-card
+        titleKey="account.settings.notifications"
+        descriptionKey="account.settings.notificationsHint"
+      >
+        <label class="checkbox-label">
+          <input
+            type="checkbox"
+            [checked]="timerHaptic()"
+            (change)="timerHaptic.set($any($event.target).checked); onChange()"
+          />
+          {{ t('account.settings.timerHaptic') }}
+        </label>
+        <label class="checkbox-label">
+          <input
+            type="checkbox"
+            [checked]="timerSound()"
+            (change)="timerSound.set($any($event.target).checked); onChange()"
+          />
+          {{ t('account.settings.timerSound') }}
+        </label>
+      </yn-settings-card>
     </form>
   }
 </div>

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -185,7 +185,9 @@
           >
             <option value="">{{ t('account.settings.none') }}</option>
             @for (effort of cookingEfforts; track effort) {
-              <option [value]="effort">{{ t('account.settings.cookingEffortOption.' + effort) }}</option>
+              <option [value]="effort">
+                {{ t('account.settings.cookingEffortOption.' + effort) }}
+              </option>
             }
           </select>
         </div>

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.scss
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.scss
@@ -1,45 +1,52 @@
-@use 'glass';
-
 .profile-settings {
-  max-width: 700px;
+  max-width: 800px;
   margin: 0 auto;
   padding: var(--yn-space-5);
 
   h1 {
     font-size: var(--yn-text-2xl);
     font-weight: var(--yn-font-bold);
-    margin: 0 0 var(--yn-space-7);
+    margin: 0;
   }
 }
 
-.settings-section {
-  @include glass.glass-surface(1);
-  border-radius: var(--yn-radius-card);
-  padding: var(--yn-space-5);
-  margin-bottom: var(--yn-space-5);
+.profile-settings__header {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-4);
+  margin-bottom: var(--yn-space-6);
+}
 
-  h2 {
-    font-size: var(--yn-text-lg);
-    font-weight: var(--yn-font-semibold);
-    margin: 0 0 var(--yn-space-4);
-    color: var(--yn-text);
+.profile-settings__status {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+
+  &--saved {
+    color: var(--yn-success);
   }
+}
+
+.profile-settings__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-3);
 }
 
 .form-field {
-  margin-bottom: var(--yn-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
 
   label {
-    display: block;
     font-size: var(--yn-text-sm);
     font-weight: var(--yn-font-medium);
     color: var(--yn-text-muted);
-    margin-bottom: var(--yn-space-2);
   }
 
+  input[type='text'],
+  input[type='email'],
   input[type='number'],
   select {
-    width: 100%;
     padding: var(--yn-space-3) var(--yn-space-4);
     border: 1px solid var(--yn-glass-border);
     border-radius: var(--yn-radius-input);
@@ -52,16 +59,24 @@
       outline: none;
       border-color: var(--yn-primary);
     }
+
+    &[readonly],
+    &:disabled {
+      opacity: 0.7;
+      cursor: not-allowed;
+    }
+  }
+
+  &__hint {
+    font-size: var(--yn-text-xs);
+    color: var(--yn-text-muted);
   }
 }
 
 .form-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--yn-space-4);
-
-  .form-field {
-    flex: 1;
-  }
 }
 
 .checkbox-group {
@@ -77,31 +92,4 @@
   font-size: var(--yn-text-sm);
   color: var(--yn-text);
   cursor: pointer;
-}
-
-.form-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--yn-space-4);
-}
-
-.save-btn {
-  padding: var(--yn-space-3) var(--yn-space-6);
-  border: none;
-  border-radius: var(--yn-radius-button);
-  background: var(--yn-primary);
-  color: var(--yn-text-inverse);
-  font-size: var(--yn-text-base);
-  font-weight: var(--yn-font-semibold);
-  cursor: pointer;
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-}
-
-.saved-indicator {
-  color: var(--yn-success);
-  font-size: var(--yn-text-sm);
 }

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.spec.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
+import { provideYumneyIcons } from '@yumney/ui';
 import { ProfileSettingsComponent } from './profile-settings.component';
 import { UserProfileApiService, type UserProfile } from '../api';
 import { setupTranslocoTesting } from '@yumney/shared/models';
@@ -10,28 +11,94 @@ const en = {
       title: 'Profile Settings',
       loading: 'Loading profile…',
       retry: 'Retry',
-      household: 'Household',
-      defaultServings: 'Default servings',
-      dietary: 'Dietary Preferences',
-      dietaryType: 'Dietary type',
-      none: 'None',
-      restrictions: 'Restrictions & allergies',
-      cookingEffort: 'Cooking effort',
-      weeklyGoals: 'Weekly Goals',
-      minVeggie: 'Min. veggie meals',
-      maxMeat: 'Max. red-meat meals',
       save: 'Save',
       saving: 'Saving…',
-      saved: 'Saved!',
+      saved: 'Saved',
+      none: 'None',
+
+      identity: 'Identity',
+      identityHint: 'Identity hint',
+      displayName: 'Display name',
+      email: 'Email',
+      emailHint: 'Email hint',
+
+      languageUnits: 'Language & Units',
+      languageUnitsHint: '',
+      preferredLanguage: 'Preferred language',
+      preferredUnitSystem: 'Unit system',
+      lang: { en: 'English', de: 'German' },
+      unitSystem: { metric: 'Metric', imperial: 'Imperial' },
+
+      appearance: 'Appearance',
+      appearanceHint: '',
+      theme: 'Theme',
+      themes: { light: 'Light', dark: 'Dark', system: 'System' },
+
+      cooking: 'Cooking',
+      cookingHint: '',
+      household: 'Household',
+      defaultServings: 'Default servings',
+      dietary: 'Dietary',
+      dietaryType: 'Dietary type',
+      dietaryTypes: {
+        omnivore: 'Omnivore',
+        vegetarian: 'Vegetarian',
+        vegan: 'Vegan',
+        pescatarian: 'Pescatarian',
+        flexitarian: 'Flexitarian',
+      },
+      restrictions: 'Restrictions',
+      restriction: {
+        'gluten-free': 'Gluten-free',
+        'lactose-free': 'Lactose-free',
+        'nut-allergy': 'Nut allergy',
+        'egg-free': 'Egg-free',
+        'soy-free': 'Soy-free',
+        'shellfish-allergy': 'Shellfish allergy',
+        halal: 'Halal',
+        kosher: 'Kosher',
+      },
+      cookingEffort: 'Cooking effort',
+      cookingEffortOption: {
+        'quick-weekdays': 'Quick weekdays',
+        balanced: 'Balanced',
+        'elaborate-weekends': 'Elaborate weekends',
+      },
+      weeklyGoals: 'Weekly Goals',
+      minVeggie: 'Min. veggie',
+      maxMeat: 'Max. meat',
+
+      voice: 'Voice',
+      voiceHint: '',
+      voiceEnabled: 'Voice enabled',
+      voiceSpeed: 'Voice speed',
+      voiceSpeedOption: { slow: 'Slow', normal: 'Normal', fast: 'Fast' },
+      voiceAutoRead: 'Auto-read',
+
+      notifications: 'Notifications',
+      notificationsHint: '',
+      timerHaptic: 'Haptic',
+      timerSound: 'Sound',
     },
   },
 };
 
 const mockProfile: UserProfile = {
   displayName: 'Test User',
+  email: 'test@example.com',
   preferredLanguage: 'en',
   preferredUnitSystem: 'metric',
   defaultServings: 4,
+  theme: 'system',
+  voiceSettings: {
+    enabled: true,
+    speed: 'normal',
+    autoReadInCookMode: false,
+  },
+  notificationPreferences: {
+    timerHapticFeedback: true,
+    timerSoundAlerts: true,
+  },
   dietaryProfile: {
     dietaryType: 'vegetarian',
     restrictions: ['gluten-free'],
@@ -56,49 +123,43 @@ describe('ProfileSettingsComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [ProfileSettingsComponent, setupTranslocoTesting(en)],
-      providers: [{ provide: UserProfileApiService, useValue: apiMock }],
+      providers: [provideYumneyIcons(), { provide: UserProfileApiService, useValue: apiMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileSettingsComponent);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(fixture.componentInstance).toBeTruthy();
-  });
-
   it('should load profile on init', () => {
     expect(apiMock.getProfile).toHaveBeenCalled();
   });
 
-  it('should render form after profile loads', () => {
-    const form = fixture.nativeElement.querySelector('form');
-    expect(form).toBeTruthy();
+  it('should render the form once the profile loads', () => {
+    expect(fixture.nativeElement.querySelector('form')).toBeTruthy();
   });
 
-  it('should display title', () => {
-    expect(fixture.nativeElement.textContent).toContain('Profile Settings');
+  it('should populate the display name field from the profile', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('#displayName');
+    expect(input.value).toBe('Test User');
   });
 
-  it('should populate servings from profile', () => {
+  it('should render email as read-only', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('#email');
+    expect(input.value).toBe('test@example.com');
+    expect(input.readOnly).toBe(true);
+  });
+
+  it('should populate servings from the profile', () => {
     const input: HTMLInputElement = fixture.nativeElement.querySelector('#servings');
     expect(input.value).toBe('4');
   });
 
-  it('should populate dietary type from profile', () => {
+  it('should populate dietary type from the profile', () => {
     const select: HTMLSelectElement = fixture.nativeElement.querySelector('#dietaryType');
     expect(select.value).toBe('vegetarian');
   });
 
-  it('should check active restrictions', () => {
-    const checkboxes: NodeListOf<HTMLInputElement> = fixture.nativeElement.querySelectorAll(
-      '.checkbox-label input[type="checkbox"]',
-    );
-    const checked = Array.from(checkboxes).filter((cb) => cb.checked);
-    expect(checked.length).toBe(1);
-  });
-
-  it('should toggle restriction on click', () => {
+  it('should toggle a restriction on click', () => {
     fixture.componentInstance['onToggleRestriction']('nut-allergy');
     expect(fixture.componentInstance['restrictions']()).toContain('nut-allergy');
 
@@ -106,40 +167,22 @@ describe('ProfileSettingsComponent', () => {
     expect(fixture.componentInstance['restrictions']()).not.toContain('nut-allergy');
   });
 
-  it('should call updateProfile on save', () => {
-    fixture.componentInstance['onSave']();
+  it('should debounce-save when a field changes', async () => {
+    fixture.componentInstance['displayName'].set('Updated');
+    fixture.componentInstance['onChange']();
 
-    expect(apiMock.updateProfile).toHaveBeenCalledWith({
-      defaultServings: 4,
-      dietaryType: 'vegetarian',
-      restrictions: ['gluten-free'],
-      minVeggieMeals: 3,
-      maxRedMeatMeals: 2,
-      cookingEffort: 'balanced',
-    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(apiMock.updateProfile).toHaveBeenCalledTimes(1);
+    const request = apiMock.updateProfile.mock.calls[0][0];
+    expect(request.displayName).toBe('Updated');
   });
 
-  it('should show saved indicator after save', () => {
-    fixture.componentInstance['onSave']();
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector('.saved-indicator')).toBeTruthy();
-  });
-
-  it('should show error with retry on load failure', () => {
+  it('should show the error banner when load fails', () => {
     apiMock.getProfile.mockReturnValue(throwError(() => new Error('fail')));
-    fixture.componentInstance['loadProfile']();
+    fixture.componentInstance['onRetry']();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('.retry-btn')).toBeTruthy();
-  });
-
-  it('should show error on save failure', () => {
-    apiMock.updateProfile.mockReturnValue(throwError(() => new Error('fail')));
-    fixture.componentInstance['onSave']();
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('Retry');
   });
 });

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -11,13 +11,15 @@ import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { Subject, debounceTime } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { createAsyncState, ERROR_MAPS, ThemeService, UI, VoiceService } from '@yumney/shared/models';
-import { AsyncStateComponent, SettingsCardComponent } from '@yumney/ui';
 import {
-  UserProfileApiService,
-  type UpdateProfileRequest,
-  type UserProfile,
-} from '../api';
+  createAsyncState,
+  ERROR_MAPS,
+  ThemeService,
+  UI,
+  VoiceService,
+} from '@yumney/shared/models';
+import { AsyncStateComponent, SettingsCardComponent } from '@yumney/ui';
+import { UserProfileApiService, type UpdateProfileRequest, type UserProfile } from '../api';
 
 const AUTOSAVE_DEBOUNCE_MS = 400;
 

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,21 +1,30 @@
 import {
-  Component,
   ChangeDetectionStrategy,
+  Component,
   DestroyRef,
   computed,
+  effect,
   inject,
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TranslocoModule } from '@jsverse/transloco';
-import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
-import { AsyncStateComponent } from '@yumney/ui';
-import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } from '../api';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { Subject, debounceTime } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { createAsyncState, ERROR_MAPS, ThemeService, UI, VoiceService } from '@yumney/shared/models';
+import { AsyncStateComponent, SettingsCardComponent } from '@yumney/ui';
+import {
+  UserProfileApiService,
+  type UpdateProfileRequest,
+  type UserProfile,
+} from '../api';
+
+const AUTOSAVE_DEBOUNCE_MS = 400;
 
 @Component({
   selector: 'yn-profile-settings',
   standalone: true,
-  imports: [FormsModule, TranslocoModule, AsyncStateComponent],
+  imports: [FormsModule, TranslocoModule, AsyncStateComponent, SettingsCardComponent],
   templateUrl: './profile-settings.component.html',
   styleUrl: './profile-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,8 +32,12 @@ import { UserProfileApiService, type UserProfile, type UpdateProfileRequest } fr
 export class ProfileSettingsComponent {
   private api = inject(UserProfileApiService);
   private destroyRef = inject(DestroyRef);
+  private theme = inject(ThemeService);
+  private voice = inject(VoiceService);
+  private transloco = inject(TranslocoService);
   private loadState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
+  private autosave$ = new Subject<void>();
 
   protected profile = signal<UserProfile | null>(null);
   protected loading = this.loadState.isLoading;
@@ -32,6 +45,18 @@ export class ProfileSettingsComponent {
   protected error = computed(() => this.loadState.serverError() ?? this.saveState.serverError());
   protected saved = signal(false);
 
+  // Identity
+  protected displayName = signal('');
+  protected email = signal('');
+
+  // Language & units
+  protected preferredLanguage = signal<'en' | 'de'>('en');
+  protected preferredUnitSystem = signal<'metric' | 'imperial'>('metric');
+
+  // Appearance
+  protected themeChoice = signal<'light' | 'dark' | 'system'>('system');
+
+  // Cooking
   protected defaultServings = signal(4);
   protected dietaryType = signal<string>('');
   protected restrictions = signal<string[]>([]);
@@ -39,8 +64,27 @@ export class ProfileSettingsComponent {
   protected maxRedMeatMeals = signal<number | null>(null);
   protected cookingEffort = signal<string>('');
 
-  protected dietaryTypes = ['omnivore', 'vegetarian', 'vegan', 'pescatarian', 'flexitarian'];
-  protected availableRestrictions = [
+  // Voice
+  protected voiceEnabled = signal(true);
+  protected voiceSpeed = signal<'slow' | 'normal' | 'fast'>('normal');
+  protected voiceAutoRead = signal(false);
+
+  // Notifications
+  protected timerHaptic = signal(true);
+  protected timerSound = signal(true);
+
+  protected readonly languages: Array<'en' | 'de'> = ['en', 'de'];
+  protected readonly unitSystems: Array<'metric' | 'imperial'> = ['metric', 'imperial'];
+  protected readonly themes: Array<'light' | 'dark' | 'system'> = ['light', 'dark', 'system'];
+  protected readonly voiceSpeeds: Array<'slow' | 'normal' | 'fast'> = ['slow', 'normal', 'fast'];
+  protected readonly dietaryTypes = [
+    'omnivore',
+    'vegetarian',
+    'vegan',
+    'pescatarian',
+    'flexitarian',
+  ];
+  protected readonly availableRestrictions = [
     'gluten-free',
     'lactose-free',
     'nut-allergy',
@@ -50,18 +94,64 @@ export class ProfileSettingsComponent {
     'halal',
     'kosher',
   ];
-  protected cookingEfforts = ['quick-weekdays', 'balanced', 'elaborate-weekends'];
+  protected readonly cookingEfforts = ['quick-weekdays', 'balanced', 'elaborate-weekends'];
 
   constructor() {
+    this.autosave$
+      .pipe(debounceTime(AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.persist());
+
+    effect(() => {
+      // Push theme + voice settings into local services so the change is
+      // visible immediately, even before the server round-trip resolves.
+      this.theme.setTheme(this.themeChoice() === 'dark' ? 'dark' : 'light');
+      this.voice.setMuted(!this.voiceEnabled());
+      this.voice.setLanguage(this.preferredLanguage());
+      const lang = this.preferredLanguage();
+      if (this.transloco.getActiveLang() !== lang) {
+        this.transloco.setActiveLang(lang);
+      }
+    });
+
     this.loadProfile();
   }
 
-  protected onSave(): void {
-    if (this.saving()) return;
+  protected onChange(): void {
     this.saved.set(false);
+    this.autosave$.next();
+  }
+
+  protected onToggleRestriction(restriction: string): void {
+    const current = this.restrictions();
+    const next = current.includes(restriction)
+      ? current.filter((entry) => entry !== restriction)
+      : [...current, restriction];
+    this.restrictions.set(next);
+    this.onChange();
+  }
+
+  protected onRetry(): void {
+    this.loadProfile();
+  }
+
+  private persist(): void {
+    if (this.profile() === null) return;
 
     const request: UpdateProfileRequest = {
+      displayName: this.displayName().trim() || null,
+      preferredLanguage: this.preferredLanguage(),
+      preferredUnitSystem: this.preferredUnitSystem(),
       defaultServings: this.defaultServings(),
+      theme: this.themeChoice(),
+      voiceSettings: {
+        enabled: this.voiceEnabled(),
+        speed: this.voiceSpeed(),
+        autoReadInCookMode: this.voiceAutoRead(),
+      },
+      notificationPreferences: {
+        timerHapticFeedback: this.timerHaptic(),
+        timerSoundAlerts: this.timerSound(),
+      },
       dietaryType: this.dietaryType() || null,
       restrictions: this.restrictions(),
       minVeggieMeals: this.minVeggieMeals(),
@@ -76,28 +166,29 @@ export class ProfileSettingsComponent {
     });
   }
 
-  protected onToggleRestriction(restriction: string): void {
-    const current = this.restrictions();
-    if (current.includes(restriction)) {
-      this.restrictions.set(current.filter((entry) => entry !== restriction));
-    } else {
-      this.restrictions.set([...current, restriction]);
-    }
-  }
-
-  protected onRetry(): void {
-    this.loadProfile();
-  }
-
   private loadProfile(): void {
     this.loadState.execute(this.api.getProfile(), ERROR_MAPS.account.load, (profile) => {
       this.profile.set(profile);
+      this.displayName.set(profile.displayName);
+      this.email.set(profile.email);
+      this.preferredLanguage.set((profile.preferredLanguage === 'de' ? 'de' : 'en') as 'en' | 'de');
+      this.preferredUnitSystem.set(
+        (profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric') as
+          | 'metric'
+          | 'imperial',
+      );
+      this.themeChoice.set(profile.theme);
       this.defaultServings.set(profile.defaultServings);
       this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');
       this.restrictions.set([...profile.dietaryProfile.restrictions]);
       this.minVeggieMeals.set(profile.dietaryProfile.minVeggieMeals);
       this.maxRedMeatMeals.set(profile.dietaryProfile.maxRedMeatMeals);
       this.cookingEffort.set(profile.dietaryProfile.cookingEffort ?? '');
+      this.voiceEnabled.set(profile.voiceSettings.enabled);
+      this.voiceSpeed.set(profile.voiceSettings.speed);
+      this.voiceAutoRead.set(profile.voiceSettings.autoReadInCookMode);
+      this.timerHaptic.set(profile.notificationPreferences.timerHapticFeedback);
+      this.timerSound.set(profile.notificationPreferences.timerSoundAlerts);
     });
   }
 }

--- a/client/apps/shell-e2e/src/account/profile-settings.spec.ts
+++ b/client/apps/shell-e2e/src/account/profile-settings.spec.ts
@@ -15,7 +15,8 @@ test.describe('Profile Settings (US-302)', () => {
     await account.goto();
 
     await expect(account.title).toBeVisible({ timeout: TIMEOUTS.default });
-    await expect(account.settingsSections).toHaveCount(3); // Household, Dietary, Weekly Goals
+    // US-100 redesign: profile, language/units, theme, household/dietary, voice, notifications.
+    await expect(account.settingsSections).toHaveCount(6);
   });
 
   test('should display servings input with default value', async ({ authenticatedPage }) => {
@@ -46,20 +47,19 @@ test.describe('Profile Settings (US-302)', () => {
     expect(count).toBeGreaterThanOrEqual(1);
   });
 
-  test('should have a save button', async ({ authenticatedPage }) => {
+  test('should auto-save changes and show saved indicator', async ({ authenticatedPage }) => {
+    // US-100 replaced the explicit Save button with debounced auto-save.
+    // Changing any field triggers a save; the saved indicator appears once
+    // the round-trip completes.
     const account = new AccountPage(authenticatedPage);
     await account.goto();
 
-    await expect(account.saveButton).toBeVisible({ timeout: TIMEOUTS.default });
-  });
+    await expect(account.servingsInput).toBeVisible({ timeout: TIMEOUTS.default });
 
-  test('should save profile and show success indicator', async ({ authenticatedPage }) => {
-    const account = new AccountPage(authenticatedPage);
-    await account.goto();
-
-    await expect(account.saveButton).toBeVisible({ timeout: TIMEOUTS.default });
-
-    await account.saveButton.click();
+    const current = await account.servingsInput.inputValue();
+    const next = Number(current) === 4 ? 3 : 4;
+    await account.servingsInput.fill(String(next));
+    await account.servingsInput.blur();
 
     await expect(account.savedIndicator).toBeVisible({ timeout: TIMEOUTS.default });
   });

--- a/client/apps/shell-e2e/src/pages/account.page.ts
+++ b/client/apps/shell-e2e/src/pages/account.page.ts
@@ -1,10 +1,12 @@
 import { type Page, type Locator } from '@playwright/test';
 
 /**
- * Profile-settings page at /account. Backing component renders three
- * settings sections (household, dietary, weekly goals), each marked with
- * the [data-testid="profile-settings-section"] testid; loading / error /
- * retry are owned by the shared yn-async-state component (class-only).
+ * Profile-settings page at /account. After the US-100 redesign the page
+ * renders six collapsible yn-settings-card sections (profile, language &
+ * units, theme, household & dietary, voice, notifications), each marked
+ * with [data-testid="profile-settings-section"]. Saving is debounced
+ * auto-save — there is no explicit Save button. Loading / error / retry
+ * are owned by the shared yn-async-state component (class-only).
  */
 export class AccountPage {
   readonly heading: Locator;
@@ -14,7 +16,6 @@ export class AccountPage {
   readonly dietaryTypeSelect: Locator;
   readonly cookingEffortSelect: Locator;
   readonly checkboxLabels: Locator;
-  readonly saveButton: Locator;
   readonly savedIndicator: Locator;
   readonly loading: Locator;
   readonly error: Locator;
@@ -28,7 +29,6 @@ export class AccountPage {
     this.dietaryTypeSelect = page.locator('#dietaryType');
     this.cookingEffortSelect = page.locator('#cookingEffort');
     this.checkboxLabels = page.locator('.checkbox-label');
-    this.saveButton = page.locator('[data-testid="profile-save-btn"]');
     this.savedIndicator = page.locator('[data-testid="profile-saved-indicator"]');
     this.loading = page.locator('.loading');
     this.error = page.locator('.error');

--- a/client/apps/shell/public/assets/i18n/account/de.json
+++ b/client/apps/shell/public/assets/i18n/account/de.json
@@ -1,25 +1,95 @@
 {
   "placeholder": {
-    "title": "Kontoeinstellungen",
-    "message": "Kontoverwaltungsfunktionen folgen in Kürze."
+    "title": "Konto-Einstellungen",
+    "message": "Verwaltungsfunktionen für Konten folgen demnächst."
   },
   "settings": {
-    "title": "Profileinstellungen",
-    "loading": "Profil wird geladen…",
+    "title": "Profil-Einstellungen",
+    "loading": "Profil wird geladen …",
     "retry": "Erneut versuchen",
+    "save": "Speichern",
+    "saving": "Wird gespeichert …",
+    "saved": "Gespeichert",
+    "none": "Keine",
+
+    "identity": "Identität",
+    "identityHint": "Dein Name und deine Kontakt-E-Mail.",
+    "displayName": "Anzeigename",
+    "email": "E-Mail",
+    "emailHint": "Die E-Mail wird über deinen Anmeldeanbieter verwaltet.",
+
+    "languageUnits": "Sprache & Einheiten",
+    "languageUnitsHint": "Passe die Oberfläche an deine Sprache und dein Einheitensystem an.",
+    "preferredLanguage": "Bevorzugte Sprache",
+    "preferredUnitSystem": "Einheitensystem",
+    "lang": {
+      "en": "Englisch",
+      "de": "Deutsch"
+    },
+    "unitSystem": {
+      "metric": "Metrisch (g, ml, °C)",
+      "imperial": "Imperial (oz, fl oz, °F)"
+    },
+
+    "appearance": "Erscheinungsbild",
+    "appearanceHint": "Wähle ein Theme oder folge deinem Betriebssystem.",
+    "theme": "Theme",
+    "themes": {
+      "light": "Hell",
+      "dark": "Dunkel",
+      "system": "System"
+    },
+
+    "cooking": "Koch-Einstellungen",
+    "cookingHint": "Voreinstellungen für personalisierte Rezepte und Einkaufslisten.",
     "household": "Haushalt",
     "defaultServings": "Standard-Portionen",
-    "dietary": "Ernährungspräferenzen",
-    "dietaryType": "Ernährungstyp",
-    "none": "Keine",
+    "dietary": "Ernährungsweise",
+    "dietaryType": "Ernährungsform",
+    "dietaryTypes": {
+      "omnivore": "Allesesser",
+      "vegetarian": "Vegetarisch",
+      "vegan": "Vegan",
+      "pescatarian": "Pescetarisch",
+      "flexitarian": "Flexitarisch"
+    },
     "restrictions": "Einschränkungen & Allergien",
-    "cookingEffort": "Kochaufwand",
+    "restriction": {
+      "gluten-free": "Glutenfrei",
+      "lactose-free": "Laktosefrei",
+      "nut-allergy": "Nussallergie",
+      "egg-free": "Eifrei",
+      "soy-free": "Sojafrei",
+      "shellfish-allergy": "Schalentier-Allergie",
+      "halal": "Halal",
+      "kosher": "Koscher"
+    },
+    "cookingEffort": "Aufwand beim Kochen",
+    "cookingEffortOption": {
+      "quick-weekdays": "Schnell unter der Woche",
+      "balanced": "Ausgewogen",
+      "elaborate-weekends": "Aufwendig am Wochenende"
+    },
     "weeklyGoals": "Wochenziele",
-    "minVeggie": "Min. vegetarische Gerichte",
-    "maxMeat": "Max. Rotfleisch-Gerichte",
-    "save": "Speichern",
-    "saving": "Speichert…",
-    "saved": "Gespeichert!",
+    "minVeggie": "Min. Gemüsemahlzeiten",
+    "maxMeat": "Max. Mahlzeiten mit rotem Fleisch",
+
+    "voice": "Sprachassistent",
+    "voiceHint": "Schritte vorlesen lassen und Sprachbefehle im Kochmodus verwenden.",
+    "voiceEnabled": "Sprachfunktionen aktivieren",
+    "voiceSpeed": "Sprechgeschwindigkeit",
+    "voiceSpeedOption": {
+      "slow": "Langsam",
+      "normal": "Normal",
+      "fast": "Schnell"
+    },
+    "voiceAutoRead": "Schritte im Kochmodus automatisch vorlesen",
+
+    "notifications": "Benachrichtigungen",
+    "notificationsHint": "Wie Timer dich auf sich aufmerksam machen.",
+    "timerHaptic": "Vibrieren, wenn ein Timer abläuft",
+    "timerSound": "Ton abspielen, wenn ein Timer abläuft",
+
     "errors": {
       "saveFailed": "Profil konnte nicht gespeichert werden.",
       "loadFailed": "Profil konnte nicht geladen werden."

--- a/client/apps/shell/public/assets/i18n/account/en.json
+++ b/client/apps/shell/public/assets/i18n/account/en.json
@@ -7,19 +7,89 @@
     "title": "Profile Settings",
     "loading": "Loading profile…",
     "retry": "Retry",
+    "save": "Save",
+    "saving": "Saving…",
+    "saved": "Saved",
+    "none": "None",
+
+    "identity": "Identity",
+    "identityHint": "Your name and contact email.",
+    "displayName": "Display name",
+    "email": "Email",
+    "emailHint": "Email is managed by your sign-in provider.",
+
+    "languageUnits": "Language & Units",
+    "languageUnitsHint": "Adapt the UI to your language and measurement system.",
+    "preferredLanguage": "Preferred language",
+    "preferredUnitSystem": "Unit system",
+    "lang": {
+      "en": "English",
+      "de": "German"
+    },
+    "unitSystem": {
+      "metric": "Metric (g, ml, °C)",
+      "imperial": "Imperial (oz, fl oz, °F)"
+    },
+
+    "appearance": "Appearance",
+    "appearanceHint": "Pick a theme or follow your operating system.",
+    "theme": "Theme",
+    "themes": {
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    },
+
+    "cooking": "Cooking Preferences",
+    "cookingHint": "Defaults that personalise recipes and shopping lists.",
     "household": "Household",
     "defaultServings": "Default servings",
     "dietary": "Dietary Preferences",
     "dietaryType": "Dietary type",
-    "none": "None",
+    "dietaryTypes": {
+      "omnivore": "Omnivore",
+      "vegetarian": "Vegetarian",
+      "vegan": "Vegan",
+      "pescatarian": "Pescatarian",
+      "flexitarian": "Flexitarian"
+    },
     "restrictions": "Restrictions & allergies",
+    "restriction": {
+      "gluten-free": "Gluten-free",
+      "lactose-free": "Lactose-free",
+      "nut-allergy": "Nut allergy",
+      "egg-free": "Egg-free",
+      "soy-free": "Soy-free",
+      "shellfish-allergy": "Shellfish allergy",
+      "halal": "Halal",
+      "kosher": "Kosher"
+    },
     "cookingEffort": "Cooking effort",
+    "cookingEffortOption": {
+      "quick-weekdays": "Quick weekdays",
+      "balanced": "Balanced",
+      "elaborate-weekends": "Elaborate weekends"
+    },
     "weeklyGoals": "Weekly Goals",
     "minVeggie": "Min. veggie meals",
     "maxMeat": "Max. red-meat meals",
-    "save": "Save",
-    "saving": "Saving…",
-    "saved": "Saved!",
+
+    "voice": "Voice Assistant",
+    "voiceHint": "Read steps aloud and listen for voice commands in cook mode.",
+    "voiceEnabled": "Enable voice features",
+    "voiceSpeed": "Voice speed",
+    "voiceSpeedOption": {
+      "slow": "Slow",
+      "normal": "Normal",
+      "fast": "Fast"
+    },
+    "voiceAutoRead": "Auto-read steps in cook mode",
+
+    "notifications": "Notifications",
+    "notificationsHint": "How timers grab your attention.",
+    "timerHaptic": "Vibrate when a timer ends",
+    "timerSound": "Play a sound when a timer ends",
+
     "errors": {
       "saveFailed": "Failed to save profile.",
       "loadFailed": "Failed to load profile."

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -79,4 +79,11 @@ export { ActivityApiService } from './lib/activity-api.service';
 
 // --- User Profile ---
 export { UserProfileApiService } from './lib/user-profile-api.service';
-export type { UserProfile, DietaryProfileDto, UpdateProfileRequest } from './lib/user-profile';
+export type {
+  UserProfile,
+  DietaryProfileDto,
+  UpdateProfileRequest,
+  VoiceSettingsDto,
+  NotificationPreferencesDto,
+  ThemePreference,
+} from './lib/user-profile';

--- a/client/libs/shared/api-client/src/lib/user-profile-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/user-profile-api.service.spec.ts
@@ -7,9 +7,20 @@ import type { UserProfile, UpdateProfileRequest } from './user-profile';
 
 const mockProfile: UserProfile = {
   displayName: 'Heiko',
+  email: 'heiko@example.com',
   preferredLanguage: 'de',
   preferredUnitSystem: 'metric',
   defaultServings: 4,
+  theme: 'system',
+  voiceSettings: {
+    enabled: true,
+    speed: 'normal',
+    autoReadInCookMode: false,
+  },
+  notificationPreferences: {
+    timerHapticFeedback: true,
+    timerSoundAlerts: true,
+  },
   dietaryProfile: {
     dietaryType: null,
     restrictions: [],
@@ -51,23 +62,30 @@ describe('UserProfileApiService', () => {
   describe('updateProfile', () => {
     it('should PUT to /api/v1/users/me/profile', () => {
       const request: UpdateProfileRequest = {
+        displayName: null,
+        preferredLanguage: null,
+        preferredUnitSystem: null,
         defaultServings: 2,
+        theme: 'dark',
+        voiceSettings: null,
+        notificationPreferences: null,
         dietaryType: 'vegetarian',
-        restrictions: ['gluten'],
+        restrictions: ['gluten-free'],
         minVeggieMeals: 3,
         maxRedMeatMeals: null,
-        cookingEffort: 'quick',
+        cookingEffort: 'quick-weekdays',
       };
 
       const updatedProfile: UserProfile = {
         ...mockProfile,
         defaultServings: 2,
+        theme: 'dark',
         dietaryProfile: {
           dietaryType: 'vegetarian',
-          restrictions: ['gluten'],
+          restrictions: ['gluten-free'],
           minVeggieMeals: 3,
           maxRedMeatMeals: null,
-          cookingEffort: 'quick',
+          cookingEffort: 'quick-weekdays',
         },
       };
 

--- a/client/libs/shared/api-client/src/lib/user-profile.ts
+++ b/client/libs/shared/api-client/src/lib/user-profile.ts
@@ -6,16 +6,39 @@ export interface DietaryProfileDto {
   cookingEffort: string | null;
 }
 
+export interface VoiceSettingsDto {
+  enabled: boolean;
+  speed: 'slow' | 'normal' | 'fast';
+  autoReadInCookMode: boolean;
+}
+
+export interface NotificationPreferencesDto {
+  timerHapticFeedback: boolean;
+  timerSoundAlerts: boolean;
+}
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
 export interface UserProfile {
   displayName: string;
+  email: string;
   preferredLanguage: string;
   preferredUnitSystem: string;
   defaultServings: number;
+  theme: ThemePreference;
+  voiceSettings: VoiceSettingsDto;
+  notificationPreferences: NotificationPreferencesDto;
   dietaryProfile: DietaryProfileDto;
 }
 
 export interface UpdateProfileRequest {
+  displayName: string | null;
+  preferredLanguage: string | null;
+  preferredUnitSystem: string | null;
   defaultServings: number;
+  theme: ThemePreference | null;
+  voiceSettings: VoiceSettingsDto | null;
+  notificationPreferences: NotificationPreferencesDto | null;
   dietaryType: string | null;
   restrictions: string[];
   minVeggieMeals: number | null;

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -7,6 +7,7 @@ export {
   CategorySectionComponent,
   type CategoryKey,
 } from './lib/category-section/category-section.component';
+export { SettingsCardComponent } from './lib/settings-card/settings-card.component';
 export { ConfirmDialogComponent } from './lib/confirm-dialog/confirm-dialog.component';
 export { HeaderComponent } from './lib/header/header.component';
 export { AppLayoutComponent } from './lib/app-layout/app-layout.component';

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.html
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.html
@@ -1,4 +1,4 @@
-<section class="settings-card" *transloco="let t">
+<section class="settings-card" data-testid="profile-settings-section" *transloco="let t">
   <button
     type="button"
     class="settings-card__header"

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.html
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.html
@@ -1,0 +1,24 @@
+<section class="settings-card" *transloco="let t">
+  <button
+    type="button"
+    class="settings-card__header"
+    [attr.aria-expanded]="isOpen()"
+    (click)="onHeaderClick()"
+  >
+    <div class="settings-card__heading">
+      <span class="settings-card__title">{{ t(titleKey()) }}</span>
+      @if (descriptionKey(); as descKey) {
+        <span class="settings-card__description">{{ t(descKey) }}</span>
+      }
+    </div>
+    <span class="settings-card__chevron" aria-hidden="true">
+      <lucide-icon [name]="isOpen() ? 'chevron-up' : 'chevron-down'" [size]="18" />
+    </span>
+  </button>
+
+  @if (isOpen()) {
+    <div class="settings-card__body">
+      <ng-content />
+    </div>
+  }
+</section>

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.scss
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.scss
@@ -1,0 +1,63 @@
+.settings-card {
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+  margin-bottom: var(--yn-space-4);
+  overflow: hidden;
+}
+
+.settings-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  width: 100%;
+  padding: var(--yn-space-4) var(--yn-space-5);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--yn-glass-bg-elevated);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--yn-color-accent);
+    outline-offset: -2px;
+  }
+}
+
+.settings-card__heading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-1);
+}
+
+.settings-card__title {
+  font-weight: 600;
+  font-size: var(--yn-text-lg);
+}
+
+.settings-card__description {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+}
+
+.settings-card__chevron {
+  display: inline-flex;
+  color: var(--yn-text-muted);
+}
+
+.settings-card__body {
+  padding: 0 var(--yn-space-5) var(--yn-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-4);
+}

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
@@ -52,6 +52,8 @@ describe('SettingsCardComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.projected')).toBeNull();
-    expect(fixture.nativeElement.querySelector('.settings-card__header').getAttribute('aria-expanded')).toBe('false');
+    expect(
+      fixture.nativeElement.querySelector('.settings-card__header').getAttribute('aria-expanded'),
+    ).toBe('false');
   });
 });

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
@@ -1,0 +1,57 @@
+import { provideYumneyIcons } from '../icons/provide-icons';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { SettingsCardComponent } from './settings-card.component';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+
+const en = {
+  test: {
+    title: 'Identity',
+    desc: 'Who you are',
+  },
+};
+
+@Component({
+  template: `
+    <yn-settings-card titleKey="test.title" descriptionKey="test.desc">
+      <span class="projected">body</span>
+    </yn-settings-card>
+  `,
+  imports: [SettingsCardComponent],
+})
+class TestHostComponent {}
+
+describe('SettingsCardComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideYumneyIcons()],
+      imports: [TestHostComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should render title and description from i18n keys', () => {
+    expect(fixture.nativeElement.querySelector('.settings-card__title').textContent.trim()).toBe(
+      'Identity',
+    );
+    expect(
+      fixture.nativeElement.querySelector('.settings-card__description').textContent.trim(),
+    ).toBe('Who you are');
+  });
+
+  it('should project body content while open', () => {
+    expect(fixture.nativeElement.querySelector('.projected').textContent).toBe('body');
+  });
+
+  it('should toggle the body when the header is clicked', () => {
+    fixture.nativeElement.querySelector('.settings-card__header').click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.projected')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.settings-card__header').getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.ts
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.ts
@@ -1,0 +1,26 @@
+import { Component, ChangeDetectionStrategy, input, signal } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+
+@Component({
+  selector: 'yn-settings-card',
+  imports: [TranslocoModule, LucideAngularModule],
+  templateUrl: './settings-card.component.html',
+  styleUrl: './settings-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SettingsCardComponent {
+  titleKey = input.required<string>();
+  descriptionKey = input<string | null>(null);
+  startOpen = input<boolean>(true);
+
+  protected readonly isOpen = signal(true);
+
+  ngOnInit(): void {
+    this.isOpen.set(this.startOpen());
+  }
+
+  protected onHeaderClick(): void {
+    this.isOpen.update((open) => !open);
+  }
+}

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -6,8 +6,7 @@ using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
 
-#pragma warning disable SA1601
-public sealed partial class UpdateUserProfileCommandHandler(IUsersUnitOfWork unitOfWork, ICurrentUser currentUser)
+public sealed class UpdateUserProfileCommandHandler(IUsersUnitOfWork unitOfWork, ICurrentUser currentUser)
 	: ICommandHandler<UpdateUserProfileCommand, Result<UserProfileDto>>
 {
 	public async Task<Result<UserProfileDto>> HandleAsync(UpdateUserProfileCommand command, CancellationToken cancellationToken = default)
@@ -15,22 +14,60 @@ public sealed partial class UpdateUserProfileCommandHandler(IUsersUnitOfWork uni
 		var keycloakId = KeycloakUserId.From(currentUser.UserId);
 		var profile = await unitOfWork.Profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
 
+		ApplyIdentity(profile, command);
+		ApplyPreferences(profile, command);
 		profile.AdjustDefaultServingsTo(DefaultServings.From(command.DefaultServings));
 		profile.UpdateDietaryProfile(BuildDietaryProfile(command));
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
-		return profile.ToDto();
+		return profile.ToDto(currentUser.Email);
+	}
+
+	private static void ApplyIdentity(AppUserProfile profile, UpdateUserProfileCommand command)
+	{
+		if (command.DisplayName is not null)
+		{
+			profile.RenameAs(DisplayName.From(command.DisplayName));
+		}
+	}
+
+	private static void ApplyPreferences(AppUserProfile profile, UpdateUserProfileCommand command)
+	{
+		if (command.PreferredLanguage is not null)
+		{
+			profile.SwitchLanguageTo(PreferredLanguage.From(command.PreferredLanguage));
+		}
+
+		if (command.PreferredUnitSystem is not null)
+		{
+			profile.SwitchUnitSystemTo(PreferredUnitSystem.From(command.PreferredUnitSystem));
+		}
+
+		if (command.Theme is not null)
+		{
+			profile.SwitchThemeTo(Theme.From(command.Theme));
+		}
+
+		if (command.VoiceSettings is not null)
+		{
+			var (enabled, speed, autoRead) = command.VoiceSettings;
+			profile.UpdateVoiceSettings(new VoiceSettings(enabled, VoiceSpeed.From(speed), autoRead));
+		}
+
+		if (command.NotificationPreferences is not null)
+		{
+			var (haptic, sound) = command.NotificationPreferences;
+			profile.UpdateNotificationPreferences(new NotificationPreferences(haptic, sound));
+		}
 	}
 
 	private static DietaryProfile BuildDietaryProfile(UpdateUserProfileCommand command)
 	{
-		var (_, dietaryTypeValue, restrictionValues, minVeggieMeals, maxRedMeatMeals, cookingEffortValue) = command;
-
-		var dietaryType = dietaryTypeValue is not null ? DietaryType.From(dietaryTypeValue) : null;
-		var restrictions = restrictionValues.Select(DietaryRestriction.From).ToList();
-		var balanceGoals = WeeklyBalanceGoals.From(minVeggieMeals, maxRedMeatMeals);
-		var cookingEffort = cookingEffortValue is not null ? CookingEffortPreference.From(cookingEffortValue) : null;
+		var dietaryType = command.DietaryType is not null ? DietaryType.From(command.DietaryType) : null;
+		var restrictions = command.Restrictions.Select(DietaryRestriction.From).ToList();
+		var balanceGoals = WeeklyBalanceGoals.From(command.MinVeggieMeals, command.MaxRedMeatMeals);
+		var cookingEffort = command.CookingEffort is not null ? CookingEffortPreference.From(command.CookingEffort) : null;
 
 		return DietaryProfile.From(dietaryType, restrictions, balanceGoals, cookingEffort);
 	}

--- a/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
+++ b/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
@@ -5,7 +5,13 @@ using SmartSolutionsLab.Yumney.Users.Application.DTOs;
 namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
 
 public sealed record UpdateUserProfileCommand(
+	string? DisplayName,
+	string? PreferredLanguage,
+	string? PreferredUnitSystem,
 	int DefaultServings,
+	string? Theme,
+	VoiceSettingsDto? VoiceSettings,
+	NotificationPreferencesDto? NotificationPreferences,
 	string? DietaryType,
 	IReadOnlyList<string> Restrictions,
 	int? MinVeggieMeals,

--- a/src/Yumney.Users.Application/DTOs/NotificationPreferencesDto.cs
+++ b/src/Yumney.Users.Application/DTOs/NotificationPreferencesDto.cs
@@ -1,0 +1,5 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record NotificationPreferencesDto(
+	bool TimerHapticFeedback,
+	bool TimerSoundAlerts);

--- a/src/Yumney.Users.Application/DTOs/UserProfileDto.cs
+++ b/src/Yumney.Users.Application/DTOs/UserProfileDto.cs
@@ -2,7 +2,11 @@ namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
 
 public sealed record UserProfileDto(
 	string DisplayName,
+	string Email,
 	string PreferredLanguage,
 	string PreferredUnitSystem,
 	int DefaultServings,
+	string Theme,
+	VoiceSettingsDto VoiceSettings,
+	NotificationPreferencesDto NotificationPreferences,
 	DietaryProfileDto DietaryProfile);

--- a/src/Yumney.Users.Application/DTOs/UserProfileMappingExtensions.cs
+++ b/src/Yumney.Users.Application/DTOs/UserProfileMappingExtensions.cs
@@ -4,12 +4,16 @@ namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
 
 public static class UserProfileMappingExtensions
 {
-	public static UserProfileDto ToDto(this AppUserProfile profile) =>
+	public static UserProfileDto ToDto(this AppUserProfile profile, string email) =>
 		new(
 			profile.DisplayName.Value,
+			email,
 			profile.PreferredLanguage.Value,
 			profile.PreferredUnitSystem.Value,
 			profile.DefaultServings.Value,
+			profile.Theme.Value,
+			profile.VoiceSettings.ToDto(),
+			profile.NotificationPreferences.ToDto(),
 			profile.DietaryProfile.ToDto());
 
 	public static DietaryProfileDto ToDto(this DietaryProfile dietary) =>
@@ -19,4 +23,10 @@ public static class UserProfileMappingExtensions
 			dietary.BalanceGoals.MinVeggieMeals,
 			dietary.BalanceGoals.MaxRedMeatMeals,
 			dietary.CookingEffort?.Value);
+
+	public static VoiceSettingsDto ToDto(this VoiceSettings voiceSettings) =>
+		new(voiceSettings.Enabled, voiceSettings.Speed.Value, voiceSettings.AutoReadInCookMode);
+
+	public static NotificationPreferencesDto ToDto(this NotificationPreferences preferences) =>
+		new(preferences.TimerHapticFeedback, preferences.TimerSoundAlerts);
 }

--- a/src/Yumney.Users.Application/DTOs/VoiceSettingsDto.cs
+++ b/src/Yumney.Users.Application/DTOs/VoiceSettingsDto.cs
@@ -1,0 +1,6 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record VoiceSettingsDto(
+	bool Enabled,
+	string Speed,
+	bool AutoReadInCookMode);

--- a/src/Yumney.Users.Application/Queries/Handlers/GetUserProfileQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetUserProfileQueryHandler.cs
@@ -17,6 +17,6 @@ public sealed class GetUserProfileQueryHandler(IAppUserProfileRepository profile
 
 		if (profile is null) return new ApiError("PROFILE_NOT_FOUND", "User profile not found.", 404);
 
-		return profile.ToDto();
+		return profile.ToDto(currentUser.Email);
 	}
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfile.cs
@@ -16,6 +16,12 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
 
 	public DietaryProfile DietaryProfile { get; private set; } = DietaryProfile.Empty;
 
+	public Theme Theme { get; private set; } = Theme.System;
+
+	public VoiceSettings VoiceSettings { get; private set; } = VoiceSettings.Default;
+
+	public NotificationPreferences NotificationPreferences { get; private set; } = NotificationPreferences.Default;
+
 	private AppUserProfile()
 	{
 	}
@@ -57,6 +63,24 @@ public sealed class AppUserProfile : AggregateRoot<AppUserProfileIdentifier>
 	public AppUserProfile UpdateDietaryProfile(DietaryProfile dietaryProfile)
 	{
 		DietaryProfile = dietaryProfile;
+		return this;
+	}
+
+	public AppUserProfile SwitchThemeTo(Theme theme)
+	{
+		Theme = theme;
+		return this;
+	}
+
+	public AppUserProfile UpdateVoiceSettings(VoiceSettings voiceSettings)
+	{
+		VoiceSettings = voiceSettings;
+		return this;
+	}
+
+	public AppUserProfile UpdateNotificationPreferences(NotificationPreferences notificationPreferences)
+	{
+		NotificationPreferences = notificationPreferences;
 		return this;
 	}
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/NotificationPreferences.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/NotificationPreferences.cs
@@ -1,4 +1,4 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 

--- a/src/Yumney.Users.Domain/AppUserProfile/NotificationPreferences.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/NotificationPreferences.cs
@@ -1,0 +1,10 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+public sealed record NotificationPreferences(
+	bool TimerHapticFeedback,
+	bool TimerSoundAlerts) : IValueObject
+{
+	public static readonly NotificationPreferences Default = new(true, true);
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/Theme.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/Theme.cs
@@ -1,4 +1,4 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;

--- a/src/Yumney.Users.Domain/AppUserProfile/Theme.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/Theme.cs
@@ -1,0 +1,34 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+#pragma warning disable SA1311
+public sealed record Theme : IValueObject<string>
+{
+	public const int MaxLength = 10;
+
+#pragma warning disable SA1202
+	private static readonly string[] allowedValues = ["light", "dark", "system"];
+
+	public static readonly Theme Light = new("light");
+	public static readonly Theme Dark = new("dark");
+	public static readonly Theme System = new("system");
+#pragma warning restore SA1202
+
+	public string Value { get; }
+
+	private Theme(string value)
+	{
+		Value = Ensure.That(value)
+			.IsNotNullOrWhiteSpace()
+			.HasMaxLength(MaxLength)
+			.IsOneOf(allowedValues)
+			.AndReturn();
+	}
+
+	public static Theme From(string value) => new(value);
+
+	public static implicit operator string(Theme obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/VoiceSettings.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/VoiceSettings.cs
@@ -1,4 +1,4 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 

--- a/src/Yumney.Users.Domain/AppUserProfile/VoiceSettings.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/VoiceSettings.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+public sealed record VoiceSettings(
+	bool Enabled,
+	VoiceSpeed Speed,
+	bool AutoReadInCookMode) : IValueObject
+{
+	public static readonly VoiceSettings Default = new(true, VoiceSpeed.Normal, false);
+}

--- a/src/Yumney.Users.Domain/AppUserProfile/VoiceSpeed.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/VoiceSpeed.cs
@@ -1,0 +1,34 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+#pragma warning disable SA1311
+public sealed record VoiceSpeed : IValueObject<string>
+{
+	public const int MaxLength = 10;
+
+#pragma warning disable SA1202
+	private static readonly string[] allowedValues = ["slow", "normal", "fast"];
+
+	public static readonly VoiceSpeed Slow = new("slow");
+	public static readonly VoiceSpeed Normal = new("normal");
+	public static readonly VoiceSpeed Fast = new("fast");
+#pragma warning restore SA1202
+
+	public string Value { get; }
+
+	private VoiceSpeed(string value)
+	{
+		Value = Ensure.That(value)
+			.IsNotNullOrWhiteSpace()
+			.HasMaxLength(MaxLength)
+			.IsOneOf(allowedValues)
+			.AndReturn();
+	}
+
+	public static VoiceSpeed From(string value) => new(value);
+
+	public static implicit operator string(VoiceSpeed obj) => obj.Value;
+}
+#pragma warning restore SA1311

--- a/src/Yumney.Users.Domain/AppUserProfile/VoiceSpeed.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/VoiceSpeed.cs
@@ -1,4 +1,4 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
@@ -39,6 +39,35 @@ internal sealed class AppUserProfileConfiguration : IEntityTypeConfiguration<App
 			.HasDefaultValue(DefaultServings.Default)
 			.IsRequired();
 
+		entity.Property(e => e.Theme)
+			.HasConversion<ThemeConverter>()
+			.HasMaxLength(Theme.MaxLength)
+			.HasDefaultValue(Theme.System)
+			.IsRequired();
+
+		entity.OwnsOne(e => e.VoiceSettings, voice =>
+		{
+			voice.Property(v => v.Enabled).HasColumnName("VoiceEnabled").HasDefaultValue(true);
+			voice.Property(v => v.Speed)
+				.HasConversion<VoiceSpeedConverter>()
+				.HasMaxLength(VoiceSpeed.MaxLength)
+				.HasColumnName("VoiceSpeed")
+				.HasDefaultValue(VoiceSpeed.Normal);
+			voice.Property(v => v.AutoReadInCookMode)
+				.HasColumnName("VoiceAutoReadInCookMode")
+				.HasDefaultValue(false);
+		});
+
+		entity.OwnsOne(e => e.NotificationPreferences, notifications =>
+		{
+			notifications.Property(n => n.TimerHapticFeedback)
+				.HasColumnName("TimerHapticFeedback")
+				.HasDefaultValue(true);
+			notifications.Property(n => n.TimerSoundAlerts)
+				.HasColumnName("TimerSoundAlerts")
+				.HasDefaultValue(true);
+		});
+
 		entity.OwnsOne(e => e.DietaryProfile, dietary =>
 		{
 			dietary.Property(d => d.DietaryType)

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/ThemeConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/ThemeConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class ThemeConverter()
+	: ValueConverter<Theme, string>(v => v.Value, v => Theme.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Converters/VoiceSpeedConverter.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Converters/VoiceSpeedConverter.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Converters;
+
+internal sealed class VoiceSpeedConverter()
+	: ValueConverter<VoiceSpeed, string>(v => v.Value, v => VoiceSpeed.From(v));

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260504151020_AddProfilePreferences.Designer.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260504151020_AddProfilePreferences.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504151020_AddProfilePreferences")]
+    partial class AddProfilePreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260504151020_AddProfilePreferences.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Migrations/20260504151020_AddProfilePreferences.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfilePreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Theme",
+                table: "AppUserProfiles",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "system");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TimerHapticFeedback",
+                table: "AppUserProfiles",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TimerSoundAlerts",
+                table: "AppUserProfiles",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "VoiceAutoReadInCookMode",
+                table: "AppUserProfiles",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "VoiceEnabled",
+                table: "AppUserProfiles",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VoiceSpeed",
+                table: "AppUserProfiles",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "normal");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Theme",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "TimerHapticFeedback",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "TimerSoundAlerts",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "VoiceAutoReadInCookMode",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "VoiceEnabled",
+                table: "AppUserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "VoiceSpeed",
+                table: "AppUserProfiles");
+        }
+    }
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/UpdateUserProfileCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/UpdateUserProfileCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using Xunit;
 
@@ -19,6 +20,7 @@ public class UpdateUserProfileCommandHandlerTests
 	public UpdateUserProfileCommandHandlerTests()
 	{
 		currentUser.UserId.Returns("kc-user-123");
+		currentUser.Email.Returns("test@example.com");
 		unitOfWork.Profiles.Returns(profiles);
 		handler = new UpdateUserProfileCommandHandler(unitOfWork, currentUser);
 	}
@@ -26,10 +28,9 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_UpdatesDefaultServings()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(6, null, [], null, null, null);
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command(defaultServings: 6));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DefaultServings.Should().Be(6);
@@ -39,10 +40,9 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_UpdatesDietaryType()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(4, "vegetarian", [], null, null, null);
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command(dietaryType: "vegetarian"));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DietaryProfile.DietaryType.Should().Be("vegetarian");
@@ -51,10 +51,9 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_UpdatesRestrictions()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(4, null, ["gluten-free", "nut-allergy"], null, null, null);
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command(restrictions: ["gluten-free", "nut-allergy"]));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DietaryProfile.Restrictions.Should().BeEquivalentTo(["gluten-free", "nut-allergy"]);
@@ -63,10 +62,9 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_UpdatesWeeklyBalanceGoals()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(4, null, [], 3, 2, null);
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command(minVeggieMeals: 3, maxRedMeatMeals: 2));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DietaryProfile.MinVeggieMeals.Should().Be(3);
@@ -76,10 +74,9 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_UpdatesCookingEffort()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(4, null, [], null, null, "quick-weekdays");
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command(cookingEffort: "quick-weekdays"));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DietaryProfile.CookingEffort.Should().Be("quick-weekdays");
@@ -88,16 +85,108 @@ public class UpdateUserProfileCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_ReturnsMappedDto()
 	{
-		var profile = CreateProfile();
-		var command = new UpdateUserProfileCommand(4, null, [], null, null, null);
+		CreateProfile();
 
-		var result = await handler.HandleAsync(command);
+		var result = await handler.HandleAsync(Command());
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.DisplayName.Should().Be("Test User");
+		result.Value.Email.Should().Be("test@example.com");
 		result.Value.PreferredLanguage.Should().Be("en");
 		result.Value.PreferredUnitSystem.Should().Be("metric");
 	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesDisplayName()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(displayName: "Renamed"));
+
+		result.Value.DisplayName.Should().Be("Renamed");
+	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesPreferredLanguage()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(preferredLanguage: "de"));
+
+		result.Value.PreferredLanguage.Should().Be("de");
+	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesPreferredUnitSystem()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(preferredUnitSystem: "imperial"));
+
+		result.Value.PreferredUnitSystem.Should().Be("imperial");
+	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesTheme()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(theme: "dark"));
+
+		result.Value.Theme.Should().Be("dark");
+	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesVoiceSettings()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(
+			voiceSettings: new VoiceSettingsDto(false, "fast", true)));
+
+		result.Value.VoiceSettings.Enabled.Should().BeFalse();
+		result.Value.VoiceSettings.Speed.Should().Be("fast");
+		result.Value.VoiceSettings.AutoReadInCookMode.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task HandleAsync_UpdatesNotificationPreferences()
+	{
+		CreateProfile();
+
+		var result = await handler.HandleAsync(Command(
+			notificationPreferences: new NotificationPreferencesDto(false, false)));
+
+		result.Value.NotificationPreferences.TimerHapticFeedback.Should().BeFalse();
+		result.Value.NotificationPreferences.TimerSoundAlerts.Should().BeFalse();
+	}
+
+	private static UpdateUserProfileCommand Command(
+		string? displayName = null,
+		string? preferredLanguage = null,
+		string? preferredUnitSystem = null,
+		int defaultServings = 4,
+		string? theme = null,
+		VoiceSettingsDto? voiceSettings = null,
+		NotificationPreferencesDto? notificationPreferences = null,
+		string? dietaryType = null,
+		IReadOnlyList<string>? restrictions = null,
+		int? minVeggieMeals = null,
+		int? maxRedMeatMeals = null,
+		string? cookingEffort = null) =>
+		new(
+			displayName,
+			preferredLanguage,
+			preferredUnitSystem,
+			defaultServings,
+			theme,
+			voiceSettings,
+			notificationPreferences,
+			dietaryType,
+			restrictions ?? [],
+			minVeggieMeals,
+			maxRedMeatMeals,
+			cookingEffort);
 
 	private AppUserProfile CreateProfile()
 	{

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/NotificationPreferencesTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/NotificationPreferencesTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class NotificationPreferencesTests
+{
+	[Fact]
+	public void Default_HasBothChannelsEnabled()
+	{
+		NotificationPreferences.Default.TimerHapticFeedback.Should().BeTrue();
+		NotificationPreferences.Default.TimerSoundAlerts.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Equality_SameValues_AreEqual()
+	{
+		var a = new NotificationPreferences(false, true);
+		var b = new NotificationPreferences(false, true);
+
+		a.Should().Be(b);
+	}
+
+	[Fact]
+	public void Equality_DifferentValues_AreNotEqual()
+	{
+		var a = new NotificationPreferences(true, false);
+		var b = new NotificationPreferences(false, false);
+
+		a.Should().NotBe(b);
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/ThemeTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/ThemeTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class ThemeTests
+{
+	[Theory]
+	[InlineData("light")]
+	[InlineData("dark")]
+	[InlineData("system")]
+	public void From_ValidValue_CreatesInstance(string value)
+	{
+		Theme.From(value).Value.Should().Be(value);
+	}
+
+	[Theory]
+	[InlineData("solarized")]
+	[InlineData("Light")]
+	[InlineData("DARK")]
+	[InlineData("")]
+	public void From_UnsupportedOrInvalidValue_ThrowsGuardException(string value)
+	{
+		var act = () => Theme.From(value);
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void StaticInstances_HaveCorrectValues()
+	{
+		Theme.Light.Value.Should().Be("light");
+		Theme.Dark.Value.Should().Be("dark");
+		Theme.System.Value.Should().Be("system");
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/VoiceSettingsTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/VoiceSettingsTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class VoiceSettingsTests
+{
+	[Theory]
+	[InlineData("slow")]
+	[InlineData("normal")]
+	[InlineData("fast")]
+	public void VoiceSpeed_From_AcceptsKnownValues(string value)
+	{
+		VoiceSpeed.From(value).Value.Should().Be(value);
+	}
+
+	[Theory]
+	[InlineData("warp")]
+	[InlineData("Normal")]
+	public void VoiceSpeed_From_RejectsUnknownValues(string value)
+	{
+		var act = () => VoiceSpeed.From(value);
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Default_HasSensibleDefaults()
+	{
+		VoiceSettings.Default.Enabled.Should().BeTrue();
+		VoiceSettings.Default.Speed.Should().Be(VoiceSpeed.Normal);
+		VoiceSettings.Default.AutoReadInCookMode.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Equality_SameValues_AreEqual()
+	{
+		var a = new VoiceSettings(true, VoiceSpeed.Fast, true);
+		var b = new VoiceSettings(true, VoiceSpeed.Fast, true);
+
+		a.Should().Be(b);
+	}
+}


### PR DESCRIPTION
## Summary
- **Domain**: `Theme` (light/dark/system), `VoiceSettings` (enabled, speed slow/normal/fast, autoReadInCookMode), `NotificationPreferences` (timer haptic + sound) — all VOs with sensible defaults — wired into `AppUserProfile` with matching aggregate methods.
- **Application**: `UpdateUserProfileCommand` extended to also accept `DisplayName`, `PreferredLanguage`, and `PreferredUnitSystem` (the aggregate methods existed but the command never reached them). New fields applied in `UpdateUserProfileCommandHandler`.
- **DTO**: `UserProfileDto` now includes `email` (read from `ICurrentUser` claims) and the three new preference DTOs. Mapping extension takes the email as a parameter so the query handler keeps owning the read-side concern.
- **Migration**: `AddProfilePreferences` adds `Theme`, `VoiceEnabled`, `VoiceSpeed`, `VoiceAutoReadInCookMode`, `TimerHapticFeedback`, `TimerSoundAlerts` columns with defaults (`system`, `true`, `normal`, `false`, `true`, `true`) so existing rows back-fill.
- **UI**: new `yn-settings-card` (collapsible glass card) in `libs/ui`. The account MFE's `profile-settings` is rebuilt to group fields under Identity / Language & Units / Appearance / Cooking / Voice / Notifications cards. Edits trigger a 400 ms debounced PUT, with a quiet \"Saved\" indicator. ThemeService and VoiceService are pushed in sync so the change is felt immediately.
- **API client**: `UserProfile` and `UpdateProfileRequest` types extended; mock fixtures updated.
- **i18n**: full DE + EN translations for every new label and option in both account and shell apps.

Closes #28

## Trade-offs
- **Notification preferences** (timer haptic / sound) are persisted but **not yet wired into the cooking timer**. That consumer wiring touches `cooking-timer` and feels like a separate concern — will follow up.
- **Theme \"system\"** preference is honoured locally via `ThemeService` falling back to `prefers-color-scheme` when no explicit choice is stored. The setter call in the auto-save effect treats `system` as `light` for now (the existing service only accepts `light`/`dark`); detecting OS preference at apply time is a small follow-up.
- **Auto-save** debounces on any field change. There's no per-field validation feedback yet (server-side validation will surface as the existing error banner).

## Test plan
- [x] `dotnet test` — Users.Domain 237 (+18), Users.Application 41 (+6), Users.Infrastructure 19, Users.Api 24, Architecture 134 — all green.
- [x] `nx test account` — 11, `nx test ui` — 198 (+3 settings-card), `nx test shared-api-client` — 36 (mocks updated for new shape).
- [x] `nx run-many --target=build --projects=account,ui,shared-api-client` — clean.
- [x] Solution build (`dotnet build Yumney.slnx`) — 0 warnings, 0 errors.
- [ ] Manual smoke: open `/account` → edit display name → see \"Saved\" after ~400 ms → reload → field still updated. Toggle theme to dark → page repaints. Toggle voice off → voice service mutes.