### PR TITLE
fix(infra): require GhcrToken alongside GhcrUser for ACA pull credentials

### DIFF
--- a/src/Yumney.AppHost/Options/AppHostOptions.cs
+++ b/src/Yumney.AppHost/Options/AppHostOptions.cs
@@ -16,7 +16,8 @@ internal sealed record AppHostOptions(
 
 	public bool UseGhcr => !string.IsNullOrWhiteSpace(RegistryEndpoint);
 
-	public bool UseGhcrPullCredentials => !string.IsNullOrWhiteSpace(GhcrUser);
+	public bool UseGhcrPullCredentials =>
+		!string.IsNullOrWhiteSpace(GhcrUser) && !string.IsNullOrWhiteSpace(GhcrToken);
 
 	public static AppHostOptions FromConfiguration(IConfiguration config)
 	{


### PR DESCRIPTION
## Summary

Tightens ${'`'}AppHostOptions.UseGhcrPullCredentials${'`'} to require **both** ${'`'}GhcrUser${'`'} **and** ${'`'}GhcrToken${'`'}. Previously only ${'`'}GhcrUser${'`'} was checked, so a missing or expired ${'`'}GHCR_PAT${'`'} silently produced a ${'`'}ContainerAppRegistryCredentials${'`'} with an empty password.

## Context

Recent staging deploys have failed at ${'`'}provision-*-containerapp${'`'} with:

~~~
"ghcr.io/smartsolutionslab/yumney/<svc>:<tag>": GET https://...?scope=...%3Apull&service=ghcr.io: DENIED: denied
~~~

Looks like a registry-side problem; is actually the AppHost embedding empty credentials into the Container App revision because ${'`'}GhcrUser${'`'} is set (from ${'`'}\${{ github.actor }}${'`'} — always non-empty in CI) while ${'`'}GhcrToken${'`'} is empty (likely an expired secret).

This PR doesn't fix the credential itself — that needs ${'`'}GHCR_PAT${'`'} to be rotated in repo settings. It eliminates the silent-broken-auth state so the failure mode is either (a) a clear no-credentials pull (if the package is public) or (b) a startup-time hint about which input is missing.

## Out of scope

- Rotating ${'`'}GHCR_PAT${'`'} (needs repo-settings access).
- Switching to ACR + managed identity (the long-term fix; bigger change).
- Validating ${'`'}UseGhcr${'`'} symmetrically (${'`'}RegistryRepository${'`'} not checked alongside ${'`'}RegistryEndpoint${'`'}) — same shape of latent bug, separate PR.

## Test plan

- [ ] ${'`'}dotnet build src/Yumney.AppHost${'`'} green
- [ ] CI Backend (Build + Test) green
- [ ] After ${'`'}GHCR_PAT${'`'} rotation, deploy reaches ${'`'}provision-*-containerapp ✓${'`'}