### PR TITLE
refactor(infra): publish container images to cae-acr instead of GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,10 @@ concurrency:
 permissions:
   id-token: write
   contents: read
-  packages: write
 
 env:
   DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '22'
-  REGISTRY: ghcr.io
 
 jobs:
   test:
@@ -120,13 +118,6 @@ jobs:
         run: |
           sed -i "s|__GATEWAY_URL__|${{ vars.GATEWAY_URL }}|g" src/Yumney.AppHost/Realms/yumney-realm.json
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Azure login
         uses: azure/login@v2
         with:
@@ -136,13 +127,7 @@ jobs:
 
       - name: Deploy to Azure
         working-directory: src/Yumney.AppHost
-        run: |
-          aspire deploy \
-            -- \
-            RegistryEndpoint=ghcr.io \
-            RegistryRepository=${{ github.repository }} \
-            GhcrUser=${{ github.actor }} \
-            GhcrToken=${{ secrets.GHCR_PAT }}
+        run: aspire deploy
         env:
           ASPNETCORE_ENVIRONMENT: ${{ needs.version.outputs.environment == 'production' && 'Production' || 'Staging' }}
           Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}

--- a/src/Yumney.AppHost/Options/AppHostOptions.cs
+++ b/src/Yumney.AppHost/Options/AppHostOptions.cs
@@ -6,18 +6,9 @@ internal sealed record AppHostOptions(
 	bool DatabaseOnly,
 	bool E2ETests,
 	LlmProvider LlmProvider,
-	string OpenAiModelId,
-	string? RegistryEndpoint,
-	string? RegistryRepository,
-	string? GhcrUser,
-	string? GhcrToken)
+	string OpenAiModelId)
 {
 	public bool UseOllama => LlmProvider == LlmProvider.Ollama;
-
-	public bool UseGhcr => !string.IsNullOrWhiteSpace(RegistryEndpoint);
-
-	public bool UseGhcrPullCredentials =>
-		!string.IsNullOrWhiteSpace(GhcrUser) && !string.IsNullOrWhiteSpace(GhcrToken);
 
 	public static AppHostOptions FromConfiguration(IConfiguration config)
 	{
@@ -30,10 +21,6 @@ internal sealed record AppHostOptions(
 			DatabaseOnly: config.GetValue<bool>("DatabaseOnly"),
 			E2ETests: config.GetValue<bool>("E2ETests"),
 			LlmProvider: provider,
-			OpenAiModelId: config.GetValue<string>("OpenAi:ModelId") ?? "gpt-5.4-mini",
-			RegistryEndpoint: config.GetValue<string>("RegistryEndpoint"),
-			RegistryRepository: config.GetValue<string>("RegistryRepository"),
-			GhcrUser: config.GetValue<string>("GhcrUser"),
-			GhcrToken: config.GetValue<string>("GhcrToken"));
+			OpenAiModelId: config.GetValue<string>("OpenAi:ModelId") ?? "gpt-5.4-mini");
 	}
 }

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -142,40 +142,11 @@ if (!options.DatabaseOnly)
 		.WithReference(shoppingApi)
 		.WithReference(usersApi);
 
-	// ── Container Registry (GHCR for CI/CD) ──
-#pragma warning disable ASPIRECOMPUTE003
-	var registry = options.UseGhcr
-		? builder.AddContainerRegistry("ghcr", options.RegistryEndpoint!, options.RegistryRepository!)
-		: null;
-
-	if (registry is not null)
-	{
-		migrationRunner.WithContainerRegistry(registry);
-		recipesApi.WithContainerRegistry(registry);
-		shoppingApi.WithContainerRegistry(registry);
-		usersApi.WithContainerRegistry(registry);
-		mealplanApi.WithContainerRegistry(registry);
-	}
-#pragma warning restore ASPIRECOMPUTE003
-
-	// ── ACA Scaling + GHCR pull credentials ──
+	// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
+	// ACA pulls them via the environment's managed identity, so no registry credentials
+	// are baked into the container app revisions.
 	void ConfigureContainerApp(AzureResourceInfrastructure infra, ContainerApp app, int minReplicas, int maxReplicas, int? concurrentRequests = null)
 	{
-		if (options.UseGhcrPullCredentials)
-		{
-			app.Configuration.Registries.Add(new ContainerAppRegistryCredentials
-			{
-				Server = "ghcr.io",
-				Username = options.GhcrUser!,
-				PasswordSecretRef = "ghcr-token",
-			});
-			app.Configuration.Secrets.Add(new ContainerAppWritableSecret
-			{
-				Name = "ghcr-token",
-				Value = options.GhcrToken!,
-			});
-		}
-
 		app.Template.Scale.MinReplicas = minReplicas;
 		app.Template.Scale.MaxReplicas = maxReplicas;
 
@@ -248,13 +219,6 @@ if (!options.DatabaseOnly)
 		var frontend = builder
 			.AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
 			.WithHttpEndpoint(targetPort: 80);
-
-#pragma warning disable ASPIRECOMPUTE003
-		if (registry is not null)
-		{
-			frontend.WithContainerRegistry(registry);
-		}
-#pragma warning restore ASPIRECOMPUTE003
 
 		builder
 			.AddYarp("yumney-gateway")


### PR DESCRIPTION
## Summary

Drops the GHCR push/pull plumbing and lets Aspire publish images to the ACR provisioned alongside the Container Apps Environment (${'`'}cae-acr${'`'}, already created by ${'`'}AddAzureContainerAppEnvironment${'`'}). ACA pulls via the environment's managed identity, so no PAT is rotated, no ${'`'}ContainerAppRegistryCredentials${'`'} is baked into revisions, and a missing secret can no longer manifest as ${'`'}DENIED: denied${'`'} at provision time.

## Why now

Recent staging deploys failed with ${'`'}DENIED: denied${'`'} on ${'`'}ghcr.io${'`'} during ${'`'}provision-*-containerapp${'`'}. PR #562 tightened the credentials guard so the failure mode is at least diagnosable, but the root cause (expired ${'`'}GHCR_PAT${'`'} + private GHCR package) recurs at every PAT rotation. ${'`'}cae-acr${'`'} is already provisioned and demonstrably works — ${'`'}provision-yumney-gateway-containerapp ✓${'`'} in every recent deploy log uses it.

## Diff

- ${'`'}Program.cs${'`'}: drop ${'`'}AddContainerRegistry(\"ghcr\", ...)${'`'}, the five ${'`'}WithContainerRegistry(registry)${'`'} attachments, the frontend's ${'`'}WithContainerRegistry${'`'}, and the GHCR credential block inside ${'`'}ConfigureContainerApp${'`'}. The ${'`'}ASPIRECOMPUTE003${'`'} pragma goes with them.
- ${'`'}AppHostOptions${'`'}: remove ${'`'}RegistryEndpoint${'`'}, ${'`'}RegistryRepository${'`'}, ${'`'}GhcrUser${'`'}, ${'`'}GhcrToken${'`'}, ${'`'}UseGhcr${'`'}, ${'`'}UseGhcrPullCredentials${'`'}.
- ${'`'}deploy.yml${'`'}: remove the ${'`'}ghcr.io REGISTRY${'`'} env, the *Log in to GitHub Container Registry* step, the four ${'`'}Ghcr*${'`'} parameters passed to ${'`'}aspire deploy${'`'}, and the now-unused ${'`'}packages: write${'`'} permission.

## Follow-ups (out of scope)

- Retire the ${'`'}GHCR_PAT${'`'} repo secret once this lands.
- Optionally clean up old ${'`'}aspire-deploy-*${'`'} image tags from GHCR.

## Test plan

- [ ] ${'`'}dotnet build src/Yumney.AppHost${'`'} green
- [ ] CI Backend (Build + Test) green
- [ ] After merge, watch the Deploy run on develop: ${'`'}push-*${'`'} steps target ACR; ${'`'}provision-*-containerapp${'`'} succeeds without a registry credential