### PR TITLE
feat: GDPR account deletion across all modules (US-101)

### DIFF
--- a/client/apps/account/public/assets/i18n/account/de.json
+++ b/client/apps/account/public/assets/i18n/account/de.json
@@ -24,5 +24,22 @@
       "saveFailed": "Profil konnte nicht gespeichert werden.",
       "loadFailed": "Profil konnte nicht geladen werden."
     }
+  },
+  "danger": {
+    "title": "Gefahrenzone",
+    "lead": "Unumkehrbare Vorgänge an deinem Konto.",
+    "deleteAccount": "Konto löschen",
+    "deleteIntro": "Das Löschen deines Kontos ist endgültig. Folgende Daten werden sofort und unwiderruflich entfernt:",
+    "consequence": {
+      "recipes": "Alle gespeicherten und importierten Rezepte einschließlich Favoriten.",
+      "shoppingLists": "Jede angelegte Einkaufsliste und deine Kaufhistorie.",
+      "mealPlans": "Deine Wochenpläne und Kochhistorie.",
+      "profile": "Dein Profil, deine Präferenzen, Ernährungseinstellungen und das Aktivitätsprotokoll.",
+      "signIn": "Dein Anmeldekonto — du wirst abgemeldet und kannst dich nicht erneut anmelden."
+    },
+    "confirmInstruction": "Tippe {{token}} zum Bestätigen",
+    "confirmAria": "Bestätigungswort eingeben",
+    "deleting": "Wird gelöscht…",
+    "retry": "Erneut versuchen"
   }
 }

--- a/client/apps/account/public/assets/i18n/account/en.json
+++ b/client/apps/account/public/assets/i18n/account/en.json
@@ -24,5 +24,22 @@
       "saveFailed": "Failed to save profile.",
       "loadFailed": "Failed to load profile."
     }
+  },
+  "danger": {
+    "title": "Danger Zone",
+    "lead": "Irreversible operations on your account.",
+    "deleteAccount": "Delete account",
+    "deleteIntro": "Deleting your account is permanent. The following data will be erased immediately and cannot be recovered:",
+    "consequence": {
+      "recipes": "All saved and imported recipes, including favorites.",
+      "shoppingLists": "Every shopping list you created and your purchase history.",
+      "mealPlans": "Your weekly meal plans and cooking history.",
+      "profile": "Your profile, preferences, dietary settings, and activity log.",
+      "signIn": "Your sign-in account — you will be signed out and unable to log in again."
+    },
+    "confirmInstruction": "Type {{token}} to confirm",
+    "confirmAria": "Type the confirmation token",
+    "deleting": "Deleting…",
+    "retry": "Try again"
   }
 }

--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -13,4 +13,10 @@ export const accountRoutes: Route[] = [
     providers: [provideTranslocoScope('account')],
     loadComponent: () => import('./profile-settings').then((m) => m.ProfileSettingsComponent),
   },
+  {
+    path: 'danger-zone',
+    title: 'Danger Zone — Yumney',
+    providers: [provideTranslocoScope('account')],
+    loadComponent: () => import('./danger-zone').then((m) => m.DangerZoneComponent),
+  },
 ];

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.html
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.html
@@ -1,0 +1,48 @@
+<section class="danger-zone" *transloco="let t">
+  <header>
+    <h2>{{ t('account.danger.title') }}</h2>
+    <p class="danger-zone__lead">{{ t('account.danger.lead') }}</p>
+  </header>
+
+  <div class="danger-zone__card">
+    <h3>{{ t('account.danger.deleteAccount') }}</h3>
+    <p>{{ t('account.danger.deleteIntro') }}</p>
+    <ul class="danger-zone__consequences">
+      <li>{{ t('account.danger.consequence.recipes') }}</li>
+      <li>{{ t('account.danger.consequence.shoppingLists') }}</li>
+      <li>{{ t('account.danger.consequence.mealPlans') }}</li>
+      <li>{{ t('account.danger.consequence.profile') }}</li>
+      <li>{{ t('account.danger.consequence.signIn') }}</li>
+    </ul>
+
+    <label class="danger-zone__field">
+      <span>{{ t('account.danger.confirmInstruction', { token: confirmationToken }) }}</span>
+      <input
+        type="text"
+        [ngModel]="confirmationInput()"
+        (ngModelChange)="confirmationInput.set($event)"
+        [attr.aria-label]="t('account.danger.confirmAria')"
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </label>
+
+    <yn-async-state
+      [loading]="false"
+      [error]="error()"
+      loadingKey="account.danger.deleting"
+      retryKey="account.danger.retry"
+      (retry)="onDelete()"
+    />
+
+    <button
+      type="button"
+      class="danger-zone__btn"
+      [disabled]="!canDelete()"
+      (click)="onDelete()"
+      data-testid="delete-account-btn"
+    >
+      {{ deleting() ? t('account.danger.deleting') : t('account.danger.deleteAccount') }}
+    </button>
+  </div>
+</section>

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.scss
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.scss
@@ -1,0 +1,82 @@
+.danger-zone {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--yn-space-5);
+
+  h2 {
+    margin: 0 0 var(--yn-space-2);
+    color: var(--yn-color-danger, #b00020);
+  }
+}
+
+.danger-zone__lead {
+  color: var(--yn-text-muted);
+  margin-bottom: var(--yn-space-5);
+}
+
+.danger-zone__card {
+  border-radius: var(--yn-radius-card);
+  border: 1px solid var(--yn-color-danger, #b00020);
+  background: var(--yn-glass-bg);
+  padding: var(--yn-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-4);
+
+  h3 {
+    margin: 0;
+    color: var(--yn-color-danger, #b00020);
+  }
+}
+
+.danger-zone__consequences {
+  margin: 0;
+  padding-left: var(--yn-space-5);
+  color: var(--yn-text);
+
+  li {
+    margin-bottom: var(--yn-space-2);
+  }
+}
+
+.danger-zone__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+
+  span {
+    font-size: var(--yn-text-sm);
+    color: var(--yn-text-muted);
+  }
+
+  input {
+    padding: var(--yn-space-3) var(--yn-space-4);
+    border: 1px solid var(--yn-glass-border);
+    border-radius: var(--yn-radius-input);
+    background: var(--yn-glass-bg);
+    font: inherit;
+    letter-spacing: 0.1em;
+
+    &:focus {
+      outline: none;
+      border-color: var(--yn-color-danger, #b00020);
+    }
+  }
+}
+
+.danger-zone__btn {
+  padding: var(--yn-space-3) var(--yn-space-5);
+  border: 0;
+  border-radius: var(--yn-radius-button);
+  background: var(--yn-color-danger, #b00020);
+  color: white;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.spec.ts
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '@yumney/shared/auth';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { DangerZoneComponent } from './danger-zone.component';
+import { UserProfileApiService } from '../api';
+
+const en = {
+  account: {
+    danger: {
+      title: 'Danger Zone',
+      lead: 'Lead',
+      deleteAccount: 'Delete account',
+      deleteIntro: 'Intro',
+      consequence: {
+        recipes: 'Recipes go',
+        shoppingLists: 'Lists go',
+        mealPlans: 'Plans go',
+        profile: 'Profile goes',
+        signIn: 'Sign-in goes',
+      },
+      confirmInstruction: 'Type {{token}} to confirm',
+      confirmAria: 'Type the confirmation token',
+      deleting: 'Deleting…',
+      retry: 'Try again',
+    },
+  },
+};
+
+describe('DangerZoneComponent', () => {
+  let fixture: ComponentFixture<DangerZoneComponent>;
+  let apiMock: { deleteAccount: ReturnType<typeof vi.fn> };
+  let authMock: { logout: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    apiMock = { deleteAccount: vi.fn().mockReturnValue(of(undefined)) };
+    authMock = { logout: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [DangerZoneComponent, setupTranslocoTesting(en)],
+      providers: [
+        { provide: UserProfileApiService, useValue: apiMock },
+        { provide: AuthService, useValue: authMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DangerZoneComponent);
+    fixture.detectChanges();
+  });
+
+  function getButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="delete-account-btn"]');
+  }
+
+  function getInput(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input[type="text"]');
+  }
+
+  function typeConfirmation(value: string): void {
+    fixture.componentInstance['confirmationInput'].set(value);
+    fixture.detectChanges();
+  }
+
+  it('should disable the delete button until DELETE is typed exactly', () => {
+    expect(getButton().disabled).toBe(true);
+
+    typeConfirmation('delete');
+    expect(getButton().disabled).toBe(true);
+
+    typeConfirmation('DELETO');
+    expect(getButton().disabled).toBe(true);
+
+    typeConfirmation('DELETE');
+    expect(getButton().disabled).toBe(false);
+  });
+
+  it('should call deleteAccount when the button is clicked with valid confirmation', () => {
+    typeConfirmation('DELETE');
+
+    getButton().click();
+
+    expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call deleteAccount when the confirmation is wrong', () => {
+    typeConfirmation('cancel');
+
+    fixture.componentInstance['onDelete']();
+
+    expect(apiMock.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('should sign the user out after a successful deletion', () => {
+    typeConfirmation('DELETE');
+
+    getButton().click();
+
+    expect(authMock.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not sign out when deletion fails', () => {
+    apiMock.deleteAccount.mockReturnValue(throwError(() => new Error('boom')));
+    typeConfirmation('DELETE');
+
+    getButton().click();
+
+    expect(authMock.logout).not.toHaveBeenCalled();
+  });
+
+  it('should accept text input via the confirmation field', () => {
+    const input = getInput();
+    expect(input).toBeTruthy();
+    expect(input.getAttribute('autocomplete')).toBe('off');
+  });
+});

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.ts
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.ts
@@ -1,0 +1,52 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AuthService } from '@yumney/shared/auth';
+import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
+import { AsyncStateComponent } from '@yumney/ui';
+import { UserProfileApiService } from '../api';
+
+const CONFIRMATION_TOKEN = 'DELETE';
+
+@Component({
+  selector: 'yn-danger-zone',
+  standalone: true,
+  imports: [FormsModule, TranslocoModule, AsyncStateComponent],
+  templateUrl: './danger-zone.component.html',
+  styleUrl: './danger-zone.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DangerZoneComponent {
+  protected readonly confirmationToken = CONFIRMATION_TOKEN;
+
+  private api = inject(UserProfileApiService);
+  private auth = inject(AuthService);
+  private destroyRef = inject(DestroyRef);
+  private deleteState = createAsyncState(this.destroyRef);
+
+  protected confirmationInput = signal('');
+  protected deleting = this.deleteState.isLoading;
+  protected error = this.deleteState.serverError;
+
+  protected canDelete = computed(
+    () => this.confirmationInput().trim() === CONFIRMATION_TOKEN && !this.deleting(),
+  );
+
+  protected onDelete(): void {
+    if (!this.canDelete()) return;
+
+    this.deleteState.execute(this.api.deleteAccount(), ERROR_MAPS.account.save, () => {
+      // Wipe the local session and bounce the user back to the IdP login page.
+      // The Keycloak account is already gone, so the redirect lands on a fresh
+      // sign-in screen.
+      this.auth.logout();
+    });
+  }
+}

--- a/client/apps/account/src/app/danger-zone/index.ts
+++ b/client/apps/account/src/app/danger-zone/index.ts
@@ -1,0 +1,1 @@
+export { DangerZoneComponent } from './danger-zone.component';

--- a/client/apps/shell/public/assets/i18n/account/de.json
+++ b/client/apps/shell/public/assets/i18n/account/de.json
@@ -24,5 +24,22 @@
       "saveFailed": "Profil konnte nicht gespeichert werden.",
       "loadFailed": "Profil konnte nicht geladen werden."
     }
+  },
+  "danger": {
+    "title": "Gefahrenzone",
+    "lead": "Unumkehrbare Vorgänge an deinem Konto.",
+    "deleteAccount": "Konto löschen",
+    "deleteIntro": "Das Löschen deines Kontos ist endgültig. Folgende Daten werden sofort und unwiderruflich entfernt:",
+    "consequence": {
+      "recipes": "Alle gespeicherten und importierten Rezepte einschließlich Favoriten.",
+      "shoppingLists": "Jede angelegte Einkaufsliste und deine Kaufhistorie.",
+      "mealPlans": "Deine Wochenpläne und Kochhistorie.",
+      "profile": "Dein Profil, deine Präferenzen, Ernährungseinstellungen und das Aktivitätsprotokoll.",
+      "signIn": "Dein Anmeldekonto — du wirst abgemeldet und kannst dich nicht erneut anmelden."
+    },
+    "confirmInstruction": "Tippe {{token}} zum Bestätigen",
+    "confirmAria": "Bestätigungswort eingeben",
+    "deleting": "Wird gelöscht…",
+    "retry": "Erneut versuchen"
   }
 }

--- a/client/apps/shell/public/assets/i18n/account/en.json
+++ b/client/apps/shell/public/assets/i18n/account/en.json
@@ -24,5 +24,22 @@
       "saveFailed": "Failed to save profile.",
       "loadFailed": "Failed to load profile."
     }
+  },
+  "danger": {
+    "title": "Danger Zone",
+    "lead": "Irreversible operations on your account.",
+    "deleteAccount": "Delete account",
+    "deleteIntro": "Deleting your account is permanent. The following data will be erased immediately and cannot be recovered:",
+    "consequence": {
+      "recipes": "All saved and imported recipes, including favorites.",
+      "shoppingLists": "Every shopping list you created and your purchase history.",
+      "mealPlans": "Your weekly meal plans and cooking history.",
+      "profile": "Your profile, preferences, dietary settings, and activity log.",
+      "signIn": "Your sign-in account — you will be signed out and unable to log in again."
+    },
+    "confirmInstruction": "Type {{token}} to confirm",
+    "confirmAria": "Type the confirmation token",
+    "deleting": "Deleting…",
+    "retry": "Try again"
   }
 }

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -53,5 +53,6 @@ export const API_ENDPOINTS = {
     activity: `${API_BASE}/users/me/activity`,
     suggestions: `${API_BASE}/users/me/suggestions`,
     profile: `${API_BASE}/users/me/profile`,
+    me: `${API_BASE}/users/me`,
   },
 } as const;

--- a/client/libs/shared/api-client/src/lib/user-profile-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/user-profile-api.service.ts
@@ -15,4 +15,13 @@ export class UserProfileApiService {
   updateProfile(request: UpdateProfileRequest): Observable<UserProfile> {
     return this.http.put<UserProfile>(API_ENDPOINTS.users.profile, request);
   }
+
+  // Permanently erases the current user's account (GDPR Art. 17, US-101).
+  // Returns 204 on success or 503 if Keycloak deletion fails after local data
+  // is already erased — in that case the user is already logged-out for all
+  // practical purposes; their PII is gone but support may need to clean up
+  // the dangling Keycloak account.
+  deleteAccount(): Observable<void> {
+    return this.http.delete<void>(API_ENDPOINTS.users.me);
+  }
 }

--- a/src/Yumney.MealPlan.Api/Program.cs
+++ b/src/Yumney.MealPlan.Api/Program.cs
@@ -1,12 +1,15 @@
 using SmartSolutionsLab.Yumney.MealPlan.Api;
 using SmartSolutionsLab.Yumney.MealPlan.Application;
+using SmartSolutionsLab.Yumney.MealPlan.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddYumneyDefaults(typeof(MealPlanInfrastructureServiceCollectionExtensions).Assembly);
+builder.AddYumneyDefaults(
+	typeof(MealPlanInfrastructureServiceCollectionExtensions).Assembly,
+	typeof(UserAccountDeletedHandler).Assembly);
 
 builder.Services
 	.AddMealPlanApi()

--- a/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// GDPR Art. 17 reaction (US-101). Wipes every WeeklyPlan (events + metadata
+/// + read models) owned by the deleted user.
+/// </summary>
+public sealed class UserAccountDeletedHandler(IMealPlanUserDataPurger purger)
+	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
+{
+	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
+		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+}

--- a/src/Yumney.MealPlan.Application/Interfaces/IMealPlanUserDataPurger.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IMealPlanUserDataPurger.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+
+/// <summary>
+/// Hard-deletes every MealPlan-module row owned by the given user — both event
+/// store (events + aggregate metadata) and read models. Used by the GDPR
+/// account-deletion flow (US-101). Implementations MUST be idempotent.
+/// </summary>
+public interface IMealPlanUserDataPurger
+{
+	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.MealPlan.Application/MealPlanApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Application/MealPlanApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application;
 
@@ -8,6 +9,7 @@ public static class MealPlanApplicationServiceCollectionExtensions
 	public static IServiceCollection AddMealPlanApplication(this IServiceCollection services)
 	{
 		services.AddHandlersFromAssemblyContaining<Queries.Handlers.GetWeeklyPlanQueryHandler>();
+		services.AddBusEventHandlersFromAssemblyContaining<Queries.Handlers.GetWeeklyPlanQueryHandler>();
 
 		return services;
 	}

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 
 		services.AddScoped<IMealPlanEventStore, EfCoreMealPlanEventStore>();
 		services.AddScoped<IMealPlanReadModelRepository, MealPlanReadModelRepository>();
+		services.AddScoped<IMealPlanUserDataPurger, EfCoreMealPlanUserDataPurger>();
 		services.AddBusEventHandlersFromAssemblyContaining<MealPlanProjectionHandler>();
 
 		services.AddScoped<IRecipeIngredientLookup, HttpRecipeIngredientLookup>();

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EfCoreMealPlanUserDataPurger.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EfCoreMealPlanUserDataPurger.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IMealPlanUserDataPurger"/>. Resolves
+/// the owner's aggregate IDs from the metadata table, deletes their event
+/// streams, then drops the metadata rows and the owner-scoped read models.
+/// </summary>
+public sealed class EfCoreMealPlanUserDataPurger(MealPlanDbContext writeContext, MealPlanReadDbContext readContext)
+	: IMealPlanUserDataPurger
+{
+	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		var aggregateIds = await writeContext.MealPlanAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Select(aggregate => aggregate.AggregateId)
+			.ToListAsync(cancellationToken);
+
+		if (aggregateIds.Count > 0)
+		{
+			await writeContext.MealPlanEvents
+				.Where(stored => aggregateIds.Contains(stored.AggregateId))
+				.ExecuteDeleteAsync(cancellationToken);
+		}
+
+		await writeContext.MealPlanAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<MealPlanSlotReadItem>()
+			.Where(slot => slot.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<MealPlanWeekReadItem>()
+			.Where(week => week.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// GDPR Art. 17 reaction (US-101). Wipes every Recipe and RecipeFavorite owned
+/// by the deleted user.
+/// </summary>
+public sealed class UserAccountDeletedHandler(IRecipesUserDataPurger purger)
+	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
+{
+	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
+		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+}

--- a/src/Yumney.Recipes.Application/Interfaces/IRecipesUserDataPurger.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IRecipesUserDataPurger.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Hard-deletes every Recipes-module row owned by the given user. Used by the
+/// GDPR account-deletion flow (US-101). Implementations MUST be idempotent —
+/// the integration event that drives this may be re-delivered.
+/// </summary>
+public interface IRecipesUserDataPurger
+{
+	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Infrastructure/Persistence/EfCoreRecipesUserDataPurger.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/EfCoreRecipesUserDataPurger.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IRecipesUserDataPurger"/>. Bulk-deletes
+/// every Recipe and RecipeFavorite scoped to the given Keycloak user id.
+/// </summary>
+public sealed class EfCoreRecipesUserDataPurger(RecipesDbContext context) : IRecipesUserDataPurger
+{
+	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		var owner = OwnerIdentifier.From(keycloakUserId);
+
+		await context.RecipeFavorites
+			.Where(favorite => favorite.Owner == owner)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await context.Recipes
+			.Where(recipe => recipe.Owner == owner)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipeRepository, RecipeRepository>();
 		services.AddScoped<IRecipeFavoriteRepository, RecipeFavoriteRepository>();
 		services.AddScoped<IRecipesUnitOfWork, RecipesUnitOfWork>();
+		services.AddScoped<IRecipesUserDataPurger, EfCoreRecipesUserDataPurger>();
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
 		services.AddYumneyServiceClient("shopping-api");

--- a/src/Yumney.Shared.Events/CrossModule/UserAccountDeletedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/UserAccountDeletedIntegrationEvent.cs
@@ -1,0 +1,10 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Users module when a user erases their account (US-101 / GDPR Art. 17).
+/// Carries the Keycloak user identifier as a primitive so subscribers in every module
+/// can wipe owner-scoped data without taking a Users.Domain dependency.
+/// Handlers MUST be idempotent: this event may be re-delivered, and repeated handling
+/// must not throw if the data is already gone.
+/// </summary>
+public sealed record UserAccountDeletedIntegrationEvent(string KeycloakUserId) : IntegrationEvent;

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// GDPR Art. 17 reaction (US-101). Wipes every shopping list (events + metadata
+/// + read models) and every ledger / balance row owned by the deleted user.
+/// </summary>
+public sealed class UserAccountDeletedHandler(IShoppingUserDataPurger purger)
+	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
+{
+	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
+		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+}

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingUserDataPurger.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingUserDataPurger.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+
+/// <summary>
+/// Hard-deletes every Shopping-module row owned by the given user — both event
+/// store (events + aggregate metadata) and read models. Used by the GDPR
+/// account-deletion flow (US-101). Implementations MUST be idempotent.
+/// </summary>
+public interface IShoppingUserDataPurger
+{
+	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EfCoreShoppingUserDataPurger.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EfCoreShoppingUserDataPurger.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IShoppingUserDataPurger"/>. Resolves
+/// the owner's aggregate IDs from the metadata tables, deletes their event
+/// streams, then drops the metadata rows and every owner-scoped read-model row.
+/// </summary>
+public sealed class EfCoreShoppingUserDataPurger(ShoppingDbContext writeContext, ShoppingReadDbContext readContext)
+	: IShoppingUserDataPurger
+{
+	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		var shoppingListAggregateIds = await writeContext.ShoppingListAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Select(aggregate => aggregate.AggregateId)
+			.ToListAsync(cancellationToken);
+
+		if (shoppingListAggregateIds.Count > 0)
+		{
+			await writeContext.ShoppingListEvents
+				.Where(stored => shoppingListAggregateIds.Contains(stored.AggregateId))
+				.ExecuteDeleteAsync(cancellationToken);
+		}
+
+		await writeContext.ShoppingListAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		var shoppingAggregateIds = await writeContext.ShoppingAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Select(aggregate => aggregate.AggregateId)
+			.ToListAsync(cancellationToken);
+
+		if (shoppingAggregateIds.Count > 0)
+		{
+			await writeContext.ShoppingEvents
+				.Where(stored => shoppingAggregateIds.Contains(stored.AggregateId))
+				.ExecuteDeleteAsync(cancellationToken);
+		}
+
+		await writeContext.ShoppingAggregates
+			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<ShoppingListItemReadItem>()
+			.Where(item => item.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<ShoppingListSummaryReadItem>()
+			.Where(summary => summary.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<IngredientBalanceReadItem>()
+			.Where(balance => balance.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await readContext.Set<ShoppingLedgerReadItem>()
+			.Where(ledger => ledger.OwnerId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddBusEventHandlersFromAssemblyContaining<ShoppingListProjection>();
 		services.AddYumneyServiceClient("users-api");
+		services.AddScoped<IShoppingUserDataPurger, EfCoreShoppingUserDataPurger>();
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
 		return services;

--- a/src/Yumney.Users.Api/DangerZoneEndpoints.cs
+++ b/src/Yumney.Users.Api/DangerZoneEndpoints.cs
@@ -1,5 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Web;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 

--- a/src/Yumney.Users.Api/DangerZoneEndpoints.cs
+++ b/src/Yumney.Users.Api/DangerZoneEndpoints.cs
@@ -1,0 +1,34 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+
+namespace SmartSolutionsLab.Yumney.Users.Api;
+
+/// <summary>
+/// Irreversible operations on the current user's account (US-101 / GDPR Art. 17).
+/// Kept in its own endpoint group so the destructive surface is easy to audit.
+/// </summary>
+public static class DangerZoneEndpoints
+{
+	public static IEndpointRouteBuilder MapDangerZoneEndpoints(this IEndpointRouteBuilder app)
+	{
+		var group = app.MapGroup("/users/me");
+
+		group.MapDelete("/", DeleteAccount)
+			.WithName("DeleteAccount")
+			.WithTags("Users")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status503ServiceUnavailable);
+
+		static async Task<IResult> DeleteAccount(
+			ICommandHandler<DeleteAccountCommand, Result> handler,
+			CancellationToken cancellationToken)
+		{
+			var result = await handler.HandleAsync(new DeleteAccountCommand(), cancellationToken);
+			return result.ToNoContent();
+		}
+
+		return app;
+	}
+}

--- a/src/Yumney.Users.Api/UsersEndpoints.cs
+++ b/src/Yumney.Users.Api/UsersEndpoints.cs
@@ -10,6 +10,7 @@ public static class UsersEndpoints
 		app.MapUserActivityEndpoints();
 		app.MapProfileEndpoints();
 		app.MapStaplesEndpoints();
+		app.MapDangerZoneEndpoints();
 
 		return app;
 	}

--- a/src/Yumney.Users.Application/Commands/DeleteAccountCommand.cs
+++ b/src/Yumney.Users.Application/Commands/DeleteAccountCommand.cs
@@ -1,5 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
 

--- a/src/Yumney.Users.Application/Commands/DeleteAccountCommand.cs
+++ b/src/Yumney.Users.Application/Commands/DeleteAccountCommand.cs
@@ -1,0 +1,12 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
+
+/// <summary>
+/// Permanently erases the current user's account (US-101 / GDPR Art. 17).
+/// The handler resolves the user from <see cref="ICurrentUser"/>; the command
+/// itself is parameterless to prevent accidental cross-user deletion from a
+/// crafted request.
+/// </summary>
+public sealed record DeleteAccountCommand : ICommand<Result>;

--- a/src/Yumney.Users.Application/Commands/DeleteAccountErrors.cs
+++ b/src/Yumney.Users.Application/Commands/DeleteAccountErrors.cs
@@ -1,4 +1,4 @@
-using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
 

--- a/src/Yumney.Users.Application/Commands/DeleteAccountErrors.cs
+++ b/src/Yumney.Users.Application/Commands/DeleteAccountErrors.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
+
+public static class DeleteAccountErrors
+{
+	public static readonly ApiError IdentityProviderUnavailable = new(
+		"DELETE_ACCOUNT_IDP_UNAVAILABLE",
+		"Local data was erased but the identity provider could not be reached. Please try again or contact support.",
+		503);
+}

--- a/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
@@ -3,6 +3,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;

--- a/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using ActivityOwner = SmartSolutionsLab.Yumney.Users.Domain.UserActivity.OwnerIdentifier;
+using StaplesOwner = SmartSolutionsLab.Yumney.Users.Domain.StaplesList.OwnerIdentifier;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+
+#pragma warning disable SA1601
+public sealed partial class DeleteAccountCommandHandler(
+	IAppUserProfileRepository profiles,
+	IUserActivityRepository activities,
+	IStaplesListRepository staplesLists,
+	IKeycloakAdminService keycloak,
+	IEventBus eventBus,
+	ICurrentUser currentUser,
+	ILogger<DeleteAccountCommandHandler> logger)
+	: ICommandHandler<DeleteAccountCommand, Result>
+{
+	public async Task<Result> HandleAsync(DeleteAccountCommand command, CancellationToken cancellationToken = default)
+	{
+		var keycloakId = KeycloakUserId.From(currentUser.UserId);
+		LogDeletionRequested(keycloakId.Value);
+
+		// 1. Tell every other module to wipe owner-scoped data first. Subscribers
+		// must be idempotent — see UserAccountDeletedIntegrationEvent docstring.
+		await eventBus.PublishAsync(new UserAccountDeletedIntegrationEvent(keycloakId.Value), cancellationToken);
+
+		// 2. Erase Users-module-owned data (profile, activity, staples).
+		await activities.DeleteAllByOwnerAsync(ActivityOwner.From(keycloakId.Value), cancellationToken);
+		await staplesLists.DeleteByOwnerAsync(StaplesOwner.From(keycloakId.Value), cancellationToken);
+		await profiles.DeleteByKeycloakUserIdAsync(keycloakId, cancellationToken);
+
+		// 3. Finally, drop the Keycloak account. If this fails the user is locked
+		// out (no profile, no Keycloak user) but their PII is already gone, which
+		// satisfies GDPR — surface the failure so support can finish manually.
+		var keycloakResult = await keycloak.DeleteUserAsync(keycloakId, cancellationToken);
+		if (keycloakResult.IsFailure)
+		{
+			LogKeycloakDeletionFailed(keycloakId.Value);
+			return Result.Failure(DeleteAccountErrors.IdentityProviderUnavailable);
+		}
+
+		LogDeletionCompleted(keycloakId.Value);
+		return Result.Success();
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "GDPR: account deletion requested for {KeycloakUserId}")]
+	private partial void LogDeletionRequested(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "GDPR: account deletion completed for {KeycloakUserId}")]
+	private partial void LogDeletionCompleted(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "GDPR: local data erased but Keycloak deletion failed for {KeycloakUserId}")]
+	private partial void LogKeycloakDeletionFailed(string keycloakUserId);
+}

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -10,4 +10,11 @@ public interface IKeycloakAdminService
 	Task<Result<KeycloakUserId>> FindUserByEmailAsync(Email email, CancellationToken cancellationToken = default);
 
 	Task<Result> SendVerificationEmailAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Permanently removes the user from the Keycloak realm. Treats a 404 from Keycloak
+	/// as success so the call is idempotent — the caller can retry safely after a
+	/// partial failure.
+	/// </summary>
+	Task<Result> DeleteUserAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -16,5 +16,8 @@ public interface IKeycloakAdminService
 	/// as success so the call is idempotent — the caller can retry safely after a
 	/// partial failure.
 	/// </summary>
+	/// <param name="keycloakUserId">The Keycloak user identifier to delete.</param>
+	/// <param name="cancellationToken">Token to cancel the in-flight request.</param>
+	/// <returns>Success on deletion (or 404); failure when Keycloak is unreachable.</returns>
 	Task<Result> DeleteUserAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Application/Yumney.Users.Application.csproj
+++ b/src/Yumney.Users.Application/Yumney.Users.Application.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Users.Domain\Yumney.Users.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/IAppUserProfileRepository.cs
@@ -8,4 +8,8 @@ public interface IAppUserProfileRepository
 	Task<AppUserProfile> GetByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 
 	Task AddAsync(AppUserProfile profile, CancellationToken cancellationToken = default);
+
+	// Idempotent: returns the number of rows removed (0 if already gone).
+	// Used by the GDPR account-deletion flow (US-101).
+	Task<int> DeleteByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Domain/StaplesList/IStaplesListRepository.cs
+++ b/src/Yumney.Users.Domain/StaplesList/IStaplesListRepository.cs
@@ -8,4 +8,7 @@ public interface IStaplesListRepository
 	Task<StaplesList> GetByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 
 	Task AddAsync(StaplesList staplesList, CancellationToken cancellationToken = default);
+
+	// Idempotent. Returns the number of rows removed.
+	Task<int> DeleteByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
+++ b/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
@@ -5,4 +5,7 @@ public interface IUserActivityRepository
 	Task AddAsync(UserActivity activity, CancellationToken cancellationToken = default);
 
 	Task<IReadOnlyList<UserActivity>> GetRecentAsync(OwnerIdentifier owner, ActivityLimit limit, CancellationToken cancellationToken = default);
+
+	// Idempotent. Returns the number of rows removed.
+	Task<int> DeleteAllByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -23,4 +23,11 @@ public sealed class AppUserProfileRepository(UsersDbContext context) : IAppUserP
 	{
 		await profiles.AddAsync(profile, cancellationToken);
 	}
+
+	public async Task<int> DeleteByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		return await profiles
+			.Where(profile => profile.KeycloakUserId == keycloakUserId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/StaplesListRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/StaplesListRepository.cs
@@ -28,4 +28,9 @@ public sealed class StaplesListRepository(UsersDbContext context) : IStaplesList
 	{
 		await staplesLists.AddAsync(staplesList, cancellationToken);
 	}
+
+	public async Task<int> DeleteByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
+	{
+		return await staplesLists.Where(list => list.Owner == owner).ExecuteDeleteAsync(cancellationToken);
+	}
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
@@ -24,4 +24,9 @@ public sealed class UserActivityRepository(UsersDbContext context) : IUserActivi
 			.Take(limit.Value)
 			.ToListAsync(cancellationToken);
 	}
+
+	public async Task<int> DeleteAllByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
+	{
+		return await activities.Where(activity => activity.Owner == owner).ExecuteDeleteAsync(cancellationToken);
+	}
 }

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+#pragma warning disable SA1601
+public sealed partial class KeycloakAdminService
+{
+	public async Task<Result> DeleteUserAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		using var activity = UsersDiagnostics.ActivitySource.StartActivity("keycloak.delete_user");
+		activity?.SetTag("keycloak.user_id", keycloakUserId.Value);
+
+		var token = await GetServiceAccountTokenAsync(cancellationToken);
+		if (token.IsFailure)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, "Token acquisition failed");
+			return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+
+		var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}";
+		using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+
+		try
+		{
+			var response = await httpClient.SendAsync(request, cancellationToken);
+
+			// 404 means the user is already gone — treat as success so the call is idempotent.
+			if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
+			{
+				activity?.SetStatus(ActivityStatusCode.Ok);
+				return Result.Success();
+			}
+
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			activity?.SetStatus(ActivityStatusCode.Error, $"HTTP {response.StatusCode}");
+			LogDeleteUserFailed(response.StatusCode, body);
+			return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+		catch (HttpRequestException ex)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+			LogDeleteUserHttpError(ex);
+			return Result.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+	}
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Failed to delete Keycloak user. Status: {StatusCode}, Body: {Body}")]
+	private partial void LogDeleteUserFailed(HttpStatusCode statusCode, string body);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "HTTP error while deleting Keycloak user")]
+	private partial void LogDeleteUserHttpError(Exception ex);
+}

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 

--- a/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+using ActivityOwner = SmartSolutionsLab.Yumney.Users.Domain.UserActivity.OwnerIdentifier;
+using StaplesOwner = SmartSolutionsLab.Yumney.Users.Domain.StaplesList.OwnerIdentifier;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.Commands;
+
+public class DeleteAccountCommandHandlerTests
+{
+	private const string KeycloakId = "kc-user-123";
+
+	private readonly IAppUserProfileRepository profiles = Substitute.For<IAppUserProfileRepository>();
+	private readonly IUserActivityRepository activities = Substitute.For<IUserActivityRepository>();
+	private readonly IStaplesListRepository staplesLists = Substitute.For<IStaplesListRepository>();
+	private readonly IKeycloakAdminService keycloak = Substitute.For<IKeycloakAdminService>();
+	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly DeleteAccountCommandHandler handler;
+
+	public DeleteAccountCommandHandlerTests()
+	{
+		currentUser.UserId.Returns(KeycloakId);
+		keycloak.DeleteUserAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Success());
+		handler = new DeleteAccountCommandHandler(
+			profiles, activities, staplesLists, keycloak, eventBus, currentUser, NullLogger<DeleteAccountCommandHandler>.Instance);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PublishesIntegrationEventBeforeLocalDelete()
+	{
+		Received.InOrder(() => { });
+
+		await handler.HandleAsync(new DeleteAccountCommand());
+
+		await eventBus.Received(1).PublishAsync(
+			Arg.Is<UserAccountDeletedIntegrationEvent>(e => e.KeycloakUserId == KeycloakId),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_DeletesUsersModuleData()
+	{
+		await handler.HandleAsync(new DeleteAccountCommand());
+
+		await activities.Received(1).DeleteAllByOwnerAsync(
+			Arg.Is<ActivityOwner>(owner => owner.Value == KeycloakId),
+			Arg.Any<CancellationToken>());
+		await staplesLists.Received(1).DeleteByOwnerAsync(
+			Arg.Is<StaplesOwner>(owner => owner.Value == KeycloakId),
+			Arg.Any<CancellationToken>());
+		await profiles.Received(1).DeleteByKeycloakUserIdAsync(
+			Arg.Is<KeycloakUserId>(id => id.Value == KeycloakId),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_DeletesKeycloakUserLast()
+	{
+		await handler.HandleAsync(new DeleteAccountCommand());
+
+		await keycloak.Received(1).DeleteUserAsync(
+			Arg.Is<KeycloakUserId>(id => id.Value == KeycloakId),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_AllStepsSucceed_ReturnsSuccess()
+	{
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task HandleAsync_KeycloakFails_StillDeletedLocalDataAndReturnsIdpUnavailable()
+	{
+		keycloak.DeleteUserAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Failure(new ApiError("KC_DOWN", "Keycloak unavailable", 503)));
+
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeFalse();
+		result.Error.Should().Be(DeleteAccountErrors.IdentityProviderUnavailable);
+
+		// Local data was still erased — that's the GDPR-correct behaviour.
+		await profiles.Received(1).DeleteByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCancellationToken()
+	{
+		var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(new DeleteAccountCommand(), cts.Token);
+
+		await eventBus.Received(1).PublishAsync(
+			Arg.Any<UserAccountDeletedIntegrationEvent>(),
+			cts.Token);
+		await keycloak.Received(1).DeleteUserAsync(Arg.Any<KeycloakUserId>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;


### PR DESCRIPTION
## Summary
Implements **GDPR Art. 17 / Right to Erasure** end-to-end.

**Orchestration** — `DELETE /api/v1/users/me` runs `DeleteAccountCommandHandler`, which:
1. Publishes `UserAccountDeletedIntegrationEvent` so every other module wipes owner-scoped data first.
2. Hard-deletes Users-module rows (`AppUserProfile`, `UserActivity`, `StaplesList`).
3. Calls `IKeycloakAdminService.DeleteUserAsync` last — a 404 there is treated as success so the call is idempotent. If Keycloak fails after local erasure, returns 503 (PII is already gone, support can finish manually).

**Per-module purgers** — each module gets an `IXxxUserDataPurger` interface (Application) + EF-backed implementation (Infrastructure) wired into a per-module `IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>`:
- **Recipes**: hard-deletes `Recipe` + `RecipeFavorite` by owner.
- **Shopping**: walks `ShoppingListAggregateMetadata` / `ShoppingAggregateMetadata` to find aggregate IDs, deletes their event streams, drops metadata rows, then wipes every read model (lists, items, ledger, balance).
- **MealPlan**: same pattern for `WeeklyPlan` event stream + slot/week read models.

All purgers use `ExecuteDeleteAsync` and are idempotent — re-delivery of the integration event is safe.

**Frontend** — new `yn-danger-zone` glass card behind `/account/danger-zone` route. Lists the five things that will be erased, gates the destructive button on typing the literal token `DELETE`, calls `UserProfileApiService.deleteAccount()`, and on success runs `AuthService.logout()` to wipe the local session and bounce to the IdP login page. Full DE+EN i18n.

Closes #29

## Trade-offs
- **Confirmation email** is intentionally not implemented yet — see follow-up below. Keycloak's user-deletion path doesn't auto-send one and standing up SMTP / template wiring belongs in its own PR.
- **Recipes/Chat module data** — wipes \`Recipe\` and \`RecipeFavorite\` (the owner-scoped Recipes data). Chat history is not currently owner-scoped at the persistence level so it isn't covered here.

## Test plan
- [x] `dotnet test` — Users.Domain 219, **Users.Application 41 (+6 new for `DeleteAccountCommandHandler`)**, Users.Infrastructure 19, Users.Api 24, Architecture 134 — all green.
- [x] `nx test account` — **20 (+6 new for `DangerZoneComponent`)** — all green.
- [x] `dotnet build Yumney.slnx` — 0 warnings, 0 errors.
- [x] `nx run-many --target=build --projects=account,ui,shared-api-client` — clean.
- [ ] Manual end-to-end: create test user → import a recipe + create a shopping list + a meal plan → visit `/account/danger-zone` → wrong typed → button disabled → type `DELETE` → click → redirect to login → attempt re-login → IdP rejects → DB rows gone for that owner across all four modules.

## Follow-ups to file
- Send a confirmation email once the account is erased (currently silent).
- Audit `Chat` module for owner-scoping and add it to the purger if applicable.