### PR TITLE
fix(shared): log when integration/module handler throws after inbox mark

### DIFF
--- a/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
@@ -34,7 +34,25 @@ public sealed partial class IntegrationEventConsumer<TEvent>(
 			}
 
 			LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
-			await handler.HandleAsync(message, cancellationToken);
+			try
+			{
+				await handler.HandleAsync(message, cancellationToken);
+			}
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				// The inbox row was committed before this handler ran, so on
+				// redelivery the (messageId, consumerName) pair will be
+				// recognised as already processed and the handler will be
+				// skipped. The side effects are effectively lost — the only
+				// signal that this happened is this log line. Tracking issue:
+				// https://github.com/smartsolutionslab/yumney/issues/571
+				LogHandlerFailedAfterMark(ex, typeof(TEvent).Name, consumerName, message.EventIdentifier);
+				throw;
+			}
 		}
 	}
 
@@ -43,4 +61,7 @@ public sealed partial class IntegrationEventConsumer<TEvent>(
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "Skipping duplicate integration event {EventType} for {ConsumerName} (id {MessageId})")]
 	private partial void LogSkippingDuplicate(string eventType, string consumerName, Guid messageId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Integration handler {ConsumerName} for {EventType} (id {MessageId}) threw after the inbox mark was committed; the handler will not be retried — manual reprocessing may be required")]
+	private partial void LogHandlerFailedAfterMark(Exception exception, string eventType, string consumerName, Guid messageId);
 }

--- a/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
@@ -36,7 +36,25 @@ public sealed partial class ModuleEventConsumer<TEvent>(
 			}
 
 			LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
-			await handler.HandleAsync(message, cancellationToken);
+			try
+			{
+				await handler.HandleAsync(message, cancellationToken);
+			}
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				// The inbox row was committed before this handler ran, so on
+				// redelivery the (messageId, consumerName) pair will be
+				// recognised as already processed and the handler will be
+				// skipped. The side effects are effectively lost — the only
+				// signal that this happened is this log line. Tracking issue:
+				// https://github.com/smartsolutionslab/yumney/issues/571
+				LogHandlerFailedAfterMark(ex, typeof(TEvent).Name, consumerName, message.EventIdentifier);
+				throw;
+			}
 		}
 	}
 
@@ -45,4 +63,7 @@ public sealed partial class ModuleEventConsumer<TEvent>(
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "Skipping duplicate module event {EventType} for {ConsumerName} (id {MessageId})")]
 	private partial void LogSkippingDuplicate(string eventType, string consumerName, Guid messageId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Module handler {ConsumerName} for {EventType} (id {MessageId}) threw after the inbox mark was committed; the handler will not be retried — manual reprocessing may be required")]
+	private partial void LogHandlerFailedAfterMark(Exception exception, string eventType, string consumerName, Guid messageId);
 }


### PR DESCRIPTION
## Summary

Wraps the handler call in ${'`'}IntegrationEventConsumer${'`'} and ${'`'}ModuleEventConsumer${'`'} so a handler that throws after the inbox mark surfaces as an ${'`'}Error${'`'} log line — today the failure is invisible because Wolverine retries are silently skipped by the existing inbox row.

Strict observability fix; the at-most-once-per-mark semantics in INBOX.md are intentional and not changed here. The bigger A/B/C design conversation about that tradeoff is tracked in #571.

## What changes

- Wrap ${'`'}handler.HandleAsync(...)${'`'} in ${'`'}try/catch${'`'}.
- ${'`'}OperationCanceledException${'`'} during shutdown propagates without being logged as an error (matches the pattern in ${'`'}InProcessEventBus${'`'}).
- Any other exception logs ${'`'}LogHandlerFailedAfterMark${'`'} with the event type, consumer name, message id, and exception, then rethrows so Wolverine still sees a failed delivery.

## What does *not* change

- Inbox row is still committed before the handler runs.
- Wolverine's retry policy still kicks in, but the next attempt still hits the existing inbox row and skips. That's the behavior tracked in #571.
- No public API or DI surface changes.

## Test plan

- [ ] CI Backend (Build + Test) green
- [ ] CI Architecture tests green (the new logger methods follow the existing source-generated pattern)
- [ ] Manual: trigger a handler exception in a dev environment and confirm the new ${'`'}Error${'`'} log line appears with the message id and consumer name

Refs #571