### PR TITLE
fix(shared): atomic inbox + handler transaction (#571)

### DIFF
--- a/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
@@ -6,8 +6,9 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 
 /// <summary>
 /// Generic Wolverine handler that delegates to IIntegrationEventHandler&lt;TEvent&gt; implementations.
-/// Each handler invocation is gated by the registered <see cref="IInboxStore"/> so redelivered
-/// or duplicate messages do not replay side effects.
+/// Each invocation runs inside an <see cref="IInboxScope"/> so the inbox row and the handler's
+/// writes share a single transaction: the row only commits on handler success, and a thrown
+/// handler rolls the row back so a redelivery can retry the work.
 /// </summary>
 /// <typeparam name="TEvent">The integration event type to handle.</typeparam>
 #pragma warning disable SA1601
@@ -24,35 +25,41 @@ public sealed partial class IntegrationEventConsumer<TEvent>(
 		foreach (var handler in handlers)
 		{
 			var consumerName = handler.GetType().FullName ?? handler.GetType().Name;
-			var shouldProcess = await inboxStore.TryMarkProcessedAsync(
-				message.EventIdentifier, consumerName, cancellationToken);
+			await InvokeWithInboxAsync(handler, message, consumerName, cancellationToken);
+		}
+	}
 
-			if (!shouldProcess)
-			{
-				LogSkippingDuplicate(typeof(TEvent).Name, consumerName, message.EventIdentifier);
-				continue;
-			}
+	private async Task InvokeWithInboxAsync(
+		IIntegrationEventHandler<TEvent> handler,
+		TEvent message,
+		string consumerName,
+		CancellationToken cancellationToken)
+	{
+		await using var scope = await inboxStore.BeginAsync(message.EventIdentifier, consumerName, cancellationToken);
 
-			LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
-			try
-			{
-				await handler.HandleAsync(message, cancellationToken);
-			}
-			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-			{
-				throw;
-			}
-			catch (Exception ex)
-			{
-				// The inbox row was committed before this handler ran, so on
-				// redelivery the (messageId, consumerName) pair will be
-				// recognised as already processed and the handler will be
-				// skipped. The side effects are effectively lost — the only
-				// signal that this happened is this log line. Tracking issue:
-				// https://github.com/smartsolutionslab/yumney/issues/571
-				LogHandlerFailedAfterMark(ex, typeof(TEvent).Name, consumerName, message.EventIdentifier);
-				throw;
-			}
+		if (!scope.ShouldProcess)
+		{
+			LogSkippingDuplicate(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+			return;
+		}
+
+		LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
+
+		try
+		{
+			await handler.HandleAsync(message, cancellationToken);
+			await scope.CommitAsync(cancellationToken);
+		}
+		catch (Exception exception) when (scope.IsDuplicateInboxViolation(exception))
+		{
+			await scope.RollbackAsync(cancellationToken);
+			LogSkippingDuplicateRace(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+		}
+		catch (Exception exception)
+		{
+			await scope.RollbackAsync(cancellationToken);
+			LogHandlerFailed(exception, typeof(TEvent).Name, handler.GetType().Name, message.EventIdentifier);
+			throw;
 		}
 	}
 
@@ -62,6 +69,9 @@ public sealed partial class IntegrationEventConsumer<TEvent>(
 	[LoggerMessage(Level = LogLevel.Information, Message = "Skipping duplicate integration event {EventType} for {ConsumerName} (id {MessageId})")]
 	private partial void LogSkippingDuplicate(string eventType, string consumerName, Guid messageId);
 
-	[LoggerMessage(Level = LogLevel.Error, Message = "Integration handler {ConsumerName} for {EventType} (id {MessageId}) threw after the inbox mark was committed; the handler will not be retried — manual reprocessing may be required")]
-	private partial void LogHandlerFailedAfterMark(Exception exception, string eventType, string consumerName, Guid messageId);
+	[LoggerMessage(Level = LogLevel.Information, Message = "Concurrent peer already recorded integration event {EventType} for {ConsumerName} (id {MessageId}); rolling back and skipping")]
+	private partial void LogSkippingDuplicateRace(string eventType, string consumerName, Guid messageId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Handler {HandlerType} for integration event {EventType} (id {MessageId}) threw — inbox row rolled back, message will be retried")]
+	private partial void LogHandlerFailed(Exception exception, string eventType, string handlerType, Guid messageId);
 }

--- a/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
@@ -7,9 +7,8 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 /// <summary>
 /// Generic Wolverine handler that delegates to <see cref="IModuleEventHandler{TEvent}"/>
 /// implementations. Counterpart to <see cref="IntegrationEventConsumer{TEvent}"/> for
-/// in-module bus envelopes. Each handler invocation is gated by the registered
-/// <see cref="IInboxStore"/> so redelivered or duplicate messages do not replay
-/// side effects.
+/// in-module bus envelopes. Each invocation runs inside an <see cref="IInboxScope"/>
+/// so the inbox row and the handler's writes share a single transaction.
 /// </summary>
 /// <typeparam name="TEvent">The module event type to handle.</typeparam>
 #pragma warning disable SA1601
@@ -26,35 +25,41 @@ public sealed partial class ModuleEventConsumer<TEvent>(
 		foreach (var handler in handlers)
 		{
 			var consumerName = handler.GetType().FullName ?? handler.GetType().Name;
-			var shouldProcess = await inboxStore.TryMarkProcessedAsync(
-				message.EventIdentifier, consumerName, cancellationToken);
+			await InvokeWithInboxAsync(handler, message, consumerName, cancellationToken);
+		}
+	}
 
-			if (!shouldProcess)
-			{
-				LogSkippingDuplicate(typeof(TEvent).Name, consumerName, message.EventIdentifier);
-				continue;
-			}
+	private async Task InvokeWithInboxAsync(
+		IModuleEventHandler<TEvent> handler,
+		TEvent message,
+		string consumerName,
+		CancellationToken cancellationToken)
+	{
+		await using var scope = await inboxStore.BeginAsync(message.EventIdentifier, consumerName, cancellationToken);
 
-			LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
-			try
-			{
-				await handler.HandleAsync(message, cancellationToken);
-			}
-			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-			{
-				throw;
-			}
-			catch (Exception ex)
-			{
-				// The inbox row was committed before this handler ran, so on
-				// redelivery the (messageId, consumerName) pair will be
-				// recognised as already processed and the handler will be
-				// skipped. The side effects are effectively lost — the only
-				// signal that this happened is this log line. Tracking issue:
-				// https://github.com/smartsolutionslab/yumney/issues/571
-				LogHandlerFailedAfterMark(ex, typeof(TEvent).Name, consumerName, message.EventIdentifier);
-				throw;
-			}
+		if (!scope.ShouldProcess)
+		{
+			LogSkippingDuplicate(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+			return;
+		}
+
+		LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
+
+		try
+		{
+			await handler.HandleAsync(message, cancellationToken);
+			await scope.CommitAsync(cancellationToken);
+		}
+		catch (Exception exception) when (scope.IsDuplicateInboxViolation(exception))
+		{
+			await scope.RollbackAsync(cancellationToken);
+			LogSkippingDuplicateRace(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+		}
+		catch (Exception exception)
+		{
+			await scope.RollbackAsync(cancellationToken);
+			LogHandlerFailed(exception, typeof(TEvent).Name, handler.GetType().Name, message.EventIdentifier);
+			throw;
 		}
 	}
 
@@ -64,6 +69,9 @@ public sealed partial class ModuleEventConsumer<TEvent>(
 	[LoggerMessage(Level = LogLevel.Information, Message = "Skipping duplicate module event {EventType} for {ConsumerName} (id {MessageId})")]
 	private partial void LogSkippingDuplicate(string eventType, string consumerName, Guid messageId);
 
-	[LoggerMessage(Level = LogLevel.Error, Message = "Module handler {ConsumerName} for {EventType} (id {MessageId}) threw after the inbox mark was committed; the handler will not be retried — manual reprocessing may be required")]
-	private partial void LogHandlerFailedAfterMark(Exception exception, string eventType, string consumerName, Guid messageId);
+	[LoggerMessage(Level = LogLevel.Information, Message = "Concurrent peer already recorded module event {EventType} for {ConsumerName} (id {MessageId}); rolling back and skipping")]
+	private partial void LogSkippingDuplicateRace(string eventType, string consumerName, Guid messageId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Handler {HandlerType} for module event {EventType} (id {MessageId}) threw — inbox row rolled back, message will be retried")]
+	private partial void LogHandlerFailed(Exception exception, string eventType, string handlerType, Guid messageId);
 }

--- a/src/Yumney.Shared.Events/IInboxScope.cs
+++ b/src/Yumney.Shared.Events/IInboxScope.cs
@@ -1,0 +1,21 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events;
+
+/// <summary>
+/// Per-handler invocation scope returned by <see cref="IInboxStore.BeginAsync"/>.
+/// Owns the underlying transaction (if any) and decides whether the handler
+/// should run. Callers must dispose the scope; on a successful handler run
+/// they call <see cref="CommitAsync"/> to persist the inbox row together
+/// with the handler's writes, otherwise <see cref="RollbackAsync"/> to
+/// release the transaction so a retry can pick the message up again.
+/// A <see cref="DisposeAsync"/> without prior commit rolls back implicitly.
+/// </summary>
+public interface IInboxScope : IAsyncDisposable
+{
+	bool ShouldProcess { get; }
+
+	Task CommitAsync(CancellationToken cancellationToken = default);
+
+	Task RollbackAsync(CancellationToken cancellationToken = default);
+
+	bool IsDuplicateInboxViolation(Exception exception);
+}

--- a/src/Yumney.Shared.Events/IInboxStore.cs
+++ b/src/Yumney.Shared.Events/IInboxStore.cs
@@ -1,12 +1,14 @@
 namespace SmartSolutionsLab.Yumney.Shared.Events;
 
 /// <summary>
-/// Deduplication store for integration-event consumers. Implementations are
-/// expected to persist a (messageId, consumerName) pair atomically and return
-/// <c>true</c> only when the pair was not already present. Consumers that
-/// receive <c>false</c> must skip the handler to avoid replaying side effects.
+/// Deduplication store for integration- and module-event consumers.
+/// Implementations open a scope that gates the handler invocation: if the
+/// (messageId, consumerName) row is already present the scope reports
+/// <see cref="IInboxScope.ShouldProcess"/> = <c>false</c>; otherwise the
+/// scope stages the row so it commits atomically with the handler's own
+/// writes when <see cref="IInboxScope.CommitAsync"/> is called.
 /// </summary>
 public interface IInboxStore
 {
-	Task<bool> TryMarkProcessedAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default);
+	Task<IInboxScope> BeginAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shared.Events/INBOX.md
+++ b/src/Yumney.Shared.Events/INBOX.md
@@ -1,18 +1,18 @@
 # Integration-event inbox
 
-Every `IIntegrationEventHandler<T>` invocation goes through an `IInboxStore`
-before the handler runs. The store's `TryMarkProcessedAsync(messageId,
-consumerName)` is expected to persist the pair atomically and return
-`true` only when the pair was not already present. On `false`, the
-generic consumer skips the handler, preventing redelivered or duplicate
-messages from replaying side effects.
+Every `IIntegrationEventHandler<T>` (and `IModuleEventHandler<T>`)
+invocation runs inside an `IInboxScope` opened by the registered
+`IInboxStore`. The scope owns a transaction wrapping both the inbox
+`(messageId, consumerName)` row and the handler's own writes — the row
+only commits if the handler succeeds, and a thrown handler rolls the row
+back so a redelivery can retry the work cleanly.
 
 ## Default: `NoOpInboxStore`
 
-The Wolverine bus registers `NoOpInboxStore` by default — every call
-returns `true`, matching pre-inbox behaviour. No schema change is
-required to adopt the abstraction; modules opt in to real deduplication
-on their own timeline.
+The Wolverine bus registers `NoOpInboxStore` by default. Its scope
+always reports `ShouldProcess = true` and commit / rollback are no-ops,
+matching pre-inbox behaviour. No schema change is required to adopt the
+abstraction; modules opt in to real deduplication on their own timeline.
 
 ## Activating the EF Core store per module
 
@@ -36,7 +36,28 @@ on their own timeline.
    services.AddScoped<IInboxStore, EfCoreInboxStore<MyDbContext>>();
    ```
 
-`EfCoreInboxStore<TContext>` relies on the composite unique key
-`(MessageId, ConsumerName)` defined by `InboxMessageConfiguration`. A
-duplicate insert raises `DbUpdateException`, which the store translates
-into the `false` return the consumer uses to skip the handler.
+## Atomicity contract
+
+`EfCoreInboxStore<TContext>` opens a database transaction on the supplied
+context inside `BeginAsync`. While that transaction is open it pre-checks
+the inbox; if the row is already present the scope reports
+`ShouldProcess = false` and the consumer skips the handler.
+
+If the row is absent the scope stages the `InboxMessage` add and hands
+control to the consumer, which invokes the handler and calls
+`scope.CommitAsync()`. Commit flushes pending changes on the same
+context (handler writes + the staged inbox row) and commits the
+transaction in one shot. Handler exceptions cause `scope.RollbackAsync()`,
+which discards the staged row alongside any partial handler writes — the
+next delivery sees a clean inbox and retries.
+
+For this to work the handler must use the same `DbContext` the inbox
+store was registered with. In Yumney every module's projection /
+event-store handlers resolve the same `Scoped` DbContext as the inbox
+store, so the transaction wraps both writes naturally.
+
+A concurrent peer that commits the same `(messageId, consumerName)` row
+between our pre-check and our commit shows up as a unique-constraint
+violation. The consumer detects this via `scope.IsDuplicateInboxViolation`
+and treats it as a duplicate — rollback, log, skip, no rethrow — so
+Wolverine does not retry an already-completed message.

--- a/src/Yumney.Shared.Events/NoOpInboxStore.cs
+++ b/src/Yumney.Shared.Events/NoOpInboxStore.cs
@@ -8,6 +8,21 @@ namespace SmartSolutionsLab.Yumney.Shared.Events;
 /// </summary>
 public sealed class NoOpInboxStore : IInboxStore
 {
-	public Task<bool> TryMarkProcessedAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default)
-		=> Task.FromResult(true);
+	public Task<IInboxScope> BeginAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default)
+		=> Task.FromResult<IInboxScope>(NoOpInboxScope.Instance);
+}
+
+internal sealed class NoOpInboxScope : IInboxScope
+{
+	public static readonly NoOpInboxScope Instance = new();
+
+	public bool ShouldProcess => true;
+
+	public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+	public Task RollbackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+	public bool IsDuplicateInboxViolation(Exception exception) => false;
+
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/Yumney.Shared.Persistence/EfCoreInboxStore.cs
+++ b/src/Yumney.Shared.Persistence/EfCoreInboxStore.cs
@@ -1,41 +1,101 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shared.Persistence;
 
 /// <summary>
-/// EF Core-backed <see cref="IInboxStore"/>. Relies on a composite unique
-/// constraint on (MessageId, ConsumerName) in the target context: an
-/// insert that violates the constraint is translated into a <c>false</c>
-/// return so the caller can skip the handler.
+/// EF Core-backed <see cref="IInboxStore"/>. Each <see cref="BeginAsync"/>
+/// call opens a database transaction on the supplied context and stages an
+/// <see cref="InboxMessage"/> row when the (messageId, consumerName) pair
+/// is not already present. The caller (event consumer) commits the scope
+/// only after the handler succeeds, so the inbox row and the handler's
+/// writes share a single transactional fate. On handler failure the scope
+/// rolls back, leaving the inbox empty for the next delivery to retry.
 /// </summary>
 /// <typeparam name="TContext">The DbContext that holds the InboxMessages set.</typeparam>
 public sealed class EfCoreInboxStore<TContext>(TContext context) : IInboxStore
 	where TContext : DbContext
 {
-	public async Task<bool> TryMarkProcessedAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default)
+	public async Task<IInboxScope> BeginAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default)
 	{
-		var set = context.Set<InboxMessage>();
-		set.Add(new InboxMessage { MessageId = messageId, ConsumerName = consumerName });
+		var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
 
-		try
+		var alreadyProcessed = await context.Set<InboxMessage>()
+			.AsNoTracking()
+			.AnyAsync(message => message.MessageId == messageId && message.ConsumerName == consumerName, cancellationToken);
+
+		if (alreadyProcessed)
 		{
-			await context.SaveChangesAsync(cancellationToken);
-			return true;
+			return new EfCoreInboxScope(context, transaction, shouldProcess: false, stagedEntry: null);
 		}
-		catch (DbUpdateException)
+
+		var entry = context.Set<InboxMessage>().Add(new InboxMessage
 		{
-			// Likely a unique-constraint violation because the pair is already present.
-			// Detach the failed entity so subsequent saves on this context are not affected.
-			foreach (var entry in context.ChangeTracker.Entries<InboxMessage>().ToList())
+			MessageId = messageId,
+			ConsumerName = consumerName,
+		});
+
+		return new EfCoreInboxScope(context, transaction, shouldProcess: true, stagedEntry: entry.Entity);
+	}
+
+	private sealed class EfCoreInboxScope(
+		TContext context,
+		IDbContextTransaction transaction,
+		bool shouldProcess,
+		InboxMessage? stagedEntry) : IInboxScope
+	{
+		private bool finalized;
+
+		public bool ShouldProcess => shouldProcess;
+
+		public async Task CommitAsync(CancellationToken cancellationToken = default)
+		{
+			if (finalized) return;
+			finalized = true;
+
+			await context.SaveChangesAsync(cancellationToken);
+			await transaction.CommitAsync(cancellationToken);
+		}
+
+		public async Task RollbackAsync(CancellationToken cancellationToken = default)
+		{
+			if (finalized) return;
+			finalized = true;
+
+			DetachStagedEntry();
+			await transaction.RollbackAsync(cancellationToken);
+		}
+
+		public bool IsDuplicateInboxViolation(Exception exception)
+		{
+			return exception is DbUpdateException dbUpdate && dbUpdate.IsUniqueViolation();
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			if (!finalized)
 			{
-				if (entry.Entity.MessageId == messageId && entry.Entity.ConsumerName == consumerName)
-				{
-					entry.State = EntityState.Detached;
-				}
+				finalized = true;
+				DetachStagedEntry();
+				await transaction.RollbackAsync();
 			}
 
-			return false;
+			await transaction.DisposeAsync();
+		}
+
+		private void DetachStagedEntry()
+		{
+			if (stagedEntry is null) return;
+
+			var tracked = context.ChangeTracker.Entries<InboxMessage>()
+				.FirstOrDefault(entry => ReferenceEquals(entry.Entity, stagedEntry));
+
+			if (tracked is { } trackedEntry)
+			{
+				trackedEntry.State = EntityState.Detached;
+			}
 		}
 	}
 }

--- a/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests.cs
@@ -13,9 +13,9 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Shared;
 
 /// <summary>
 /// Integration tests for <see cref="EfCoreInboxStore{TContext}"/> using the
-/// Shopping module's DbContext (the first module to activate the inbox
-/// per #280). Real PostgreSQL is required so the unique constraint on
-/// (MessageId, ConsumerName) fires for the duplicate-insert path.
+/// Shopping module's DbContext. Exercises the scope-based atomic contract:
+/// commit persists the inbox row, rollback discards it (and any handler
+/// writes), and a duplicate pre-check is observed without inserting.
 /// </summary>
 [Collection(AspireCollection.Name)]
 public class EfCoreInboxStoreTests(AspireFixture fixture) : IAsyncLifetime
@@ -42,25 +42,67 @@ public class EfCoreInboxStoreTests(AspireFixture fixture) : IAsyncLifetime
 	}
 
 	[Fact]
-	public async Task TryMarkProcessedAsync_NewPair_ReturnsTrueAndPersists()
+	public async Task BeginAsync_NewPair_AllowsProcessAndPersistsOnCommit()
 	{
 		var messageId = Guid.NewGuid();
 		var consumerName = $"consumer-{Guid.NewGuid():N}";
 		recorded.Add((messageId, consumerName));
 
-		await using var context = await fixture.CreateShoppingDbContextAsync();
-		var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+			await using var scope = await store.BeginAsync(messageId, consumerName);
 
-		var result = await store.TryMarkProcessedAsync(messageId, consumerName);
+			scope.ShouldProcess.Should().BeTrue();
+			await scope.CommitAsync();
+		}
 
-		result.Should().BeTrue();
 		await using var verify = await fixture.CreateShoppingDbContextAsync();
 		(await verify.InboxMessages.AnyAsync(m => m.MessageId == messageId && m.ConsumerName == consumerName))
 			.Should().BeTrue();
 	}
 
 	[Fact]
-	public async Task TryMarkProcessedAsync_DuplicatePair_ReturnsFalse()
+	public async Task BeginAsync_RollbackBeforeCommit_DropsTheRow()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerName = $"consumer-{Guid.NewGuid():N}";
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+			await using var scope = await store.BeginAsync(messageId, consumerName);
+
+			scope.ShouldProcess.Should().BeTrue();
+			await scope.RollbackAsync();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		(await verify.InboxMessages.AnyAsync(m => m.MessageId == messageId && m.ConsumerName == consumerName))
+			.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task BeginAsync_DisposeWithoutCommit_RollsBack()
+	{
+		var messageId = Guid.NewGuid();
+		var consumerName = $"consumer-{Guid.NewGuid():N}";
+
+		await using (var context = await fixture.CreateShoppingDbContextAsync())
+		{
+			var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+			await using var scope = await store.BeginAsync(messageId, consumerName);
+
+			scope.ShouldProcess.Should().BeTrue();
+		}
+
+		await using var verify = await fixture.CreateShoppingDbContextAsync();
+		(await verify.InboxMessages.AnyAsync(m => m.MessageId == messageId && m.ConsumerName == consumerName))
+			.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task BeginAsync_DuplicatePair_ReportsAlreadyProcessed()
 	{
 		var messageId = Guid.NewGuid();
 		var consumerName = $"consumer-{Guid.NewGuid():N}";
@@ -69,36 +111,19 @@ public class EfCoreInboxStoreTests(AspireFixture fixture) : IAsyncLifetime
 		await using (var firstContext = await fixture.CreateShoppingDbContextAsync())
 		{
 			var first = new EfCoreInboxStore<ShoppingDbContext>(firstContext);
-			(await first.TryMarkProcessedAsync(messageId, consumerName)).Should().BeTrue();
+			await using var scope = await first.BeginAsync(messageId, consumerName);
+			await scope.CommitAsync();
 		}
 
 		await using var secondContext = await fixture.CreateShoppingDbContextAsync();
 		var second = new EfCoreInboxStore<ShoppingDbContext>(secondContext);
-		var duplicateResult = await second.TryMarkProcessedAsync(messageId, consumerName);
+		await using var duplicateScope = await second.BeginAsync(messageId, consumerName);
 
-		duplicateResult.Should().BeFalse();
+		duplicateScope.ShouldProcess.Should().BeFalse();
 	}
 
 	[Fact]
-	public async Task TryMarkProcessedAsync_DuplicatePair_DetachesFailedEntity()
-	{
-		var messageId = Guid.NewGuid();
-		var consumerName = $"consumer-{Guid.NewGuid():N}";
-		recorded.Add((messageId, consumerName));
-
-		await using (var first = await fixture.CreateShoppingDbContextAsync())
-		{
-			await new EfCoreInboxStore<ShoppingDbContext>(first).TryMarkProcessedAsync(messageId, consumerName);
-		}
-
-		await using var context = await fixture.CreateShoppingDbContextAsync();
-		await new EfCoreInboxStore<ShoppingDbContext>(context).TryMarkProcessedAsync(messageId, consumerName);
-
-		context.ChangeTracker.Entries<InboxMessage>().Should().BeEmpty();
-	}
-
-	[Fact]
-	public async Task TryMarkProcessedAsync_SameMessageDifferentConsumer_ReturnsTrueForBoth()
+	public async Task BeginAsync_SameMessageDifferentConsumer_AllowsBoth()
 	{
 		var messageId = Guid.NewGuid();
 		var consumerA = $"consumer-a-{Guid.NewGuid():N}";
@@ -106,10 +131,18 @@ public class EfCoreInboxStoreTests(AspireFixture fixture) : IAsyncLifetime
 		recorded.Add((messageId, consumerA));
 		recorded.Add((messageId, consumerB));
 
-		await using var context = await fixture.CreateShoppingDbContextAsync();
-		var store = new EfCoreInboxStore<ShoppingDbContext>(context);
+		await using (var contextA = await fixture.CreateShoppingDbContextAsync())
+		{
+			var storeA = new EfCoreInboxStore<ShoppingDbContext>(contextA);
+			await using var scopeA = await storeA.BeginAsync(messageId, consumerA);
+			scopeA.ShouldProcess.Should().BeTrue();
+			await scopeA.CommitAsync();
+		}
 
-		(await store.TryMarkProcessedAsync(messageId, consumerA)).Should().BeTrue();
-		(await store.TryMarkProcessedAsync(messageId, consumerB)).Should().BeTrue();
+		await using var contextB = await fixture.CreateShoppingDbContextAsync();
+		var storeB = new EfCoreInboxStore<ShoppingDbContext>(contextB);
+		await using var scopeB = await storeB.BeginAsync(messageId, consumerB);
+		scopeB.ShouldProcess.Should().BeTrue();
+		await scopeB.CommitAsync();
 	}
 }

--- a/tests/Yumney.Shared.Events.Tests/IntegrationEventConsumerTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/IntegrationEventConsumerTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using Xunit;
@@ -11,32 +10,61 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
 public class IntegrationEventConsumerTests
 {
 	[Fact]
-	public async Task HandleAsync_NewMessage_InvokesHandlerOnce()
+	public async Task HandleAsync_NewMessage_InvokesHandlerAndCommitsScope()
 	{
-		var handler = Substitute.For<IIntegrationEventHandler<TestEvent>>();
-		var inbox = new NoOpInboxStore();
+		var handler = new RecordingHandler();
+		var inbox = new TestInboxStore();
 		var consumer = CreateConsumer(handler, inbox);
 		var message = new TestEvent();
 
 		await consumer.HandleAsync(message, CancellationToken.None);
 
-		await handler.Received(1).HandleAsync(message, Arg.Any<CancellationToken>());
+		handler.CallCount.Should().Be(1);
+		inbox.Scopes.Should().HaveCount(1);
+		inbox.Scopes[0].Committed.Should().BeTrue();
+		inbox.Scopes[0].RolledBack.Should().BeFalse();
 	}
 
 	[Fact]
-	public async Task HandleAsync_DuplicateMessage_SkipsHandler()
+	public async Task HandleAsync_DuplicateMessage_SkipsHandlerWithoutCommit()
 	{
-		var handler = Substitute.For<IIntegrationEventHandler<TestEvent>>();
-		var inbox = Substitute.For<IInboxStore>();
-		inbox.TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns(false);
-
+		var handler = new RecordingHandler();
+		var inbox = new TestInboxStore(shouldProcessSequence: [false]);
 		var consumer = CreateConsumer(handler, inbox);
-		var message = new TestEvent();
 
-		await consumer.HandleAsync(message, CancellationToken.None);
+		await consumer.HandleAsync(new TestEvent(), CancellationToken.None);
 
-		await handler.DidNotReceive().HandleAsync(Arg.Any<TestEvent>(), Arg.Any<CancellationToken>());
+		handler.CallCount.Should().Be(0);
+		inbox.Scopes[0].Committed.Should().BeFalse();
+		inbox.Scopes[0].RolledBack.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task HandleAsync_HandlerThrows_RollsBackAndPropagates()
+	{
+		var handler = new RecordingHandler { ThrowOnCall = new InvalidOperationException("boom") };
+		var inbox = new TestInboxStore();
+		var consumer = CreateConsumer(handler, inbox);
+
+		var act = async () => await consumer.HandleAsync(new TestEvent(), CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+		inbox.Scopes[0].Committed.Should().BeFalse();
+		inbox.Scopes[0].RolledBack.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task HandleAsync_DuplicateRaceOnCommit_RollsBackAndSwallows()
+	{
+		var raceException = new InvalidOperationException("unique violation");
+		var handler = new RecordingHandler { ThrowOnCall = raceException };
+		var inbox = new TestInboxStore(isDuplicate: ex => ReferenceEquals(ex, raceException));
+		var consumer = CreateConsumer(handler, inbox);
+
+		await consumer.HandleAsync(new TestEvent(), CancellationToken.None);
+
+		inbox.Scopes[0].Committed.Should().BeFalse();
+		inbox.Scopes[0].RolledBack.Should().BeTrue();
 	}
 
 	[Fact]
@@ -44,10 +72,7 @@ public class IntegrationEventConsumerTests
 	{
 		var handlerA = new RecordingHandler();
 		var handlerB = new RecordingHandler();
-
-		var inbox = Substitute.For<IInboxStore>();
-		inbox.TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Is<string>(n => n.Contains(nameof(RecordingHandler))), Arg.Any<CancellationToken>())
-			.Returns(true, false);
+		var inbox = new TestInboxStore(shouldProcessSequence: [true, false]);
 
 		var services = new ServiceCollection();
 		services.AddSingleton<IIntegrationEventHandler<TestEvent>>(handlerA);
@@ -61,25 +86,15 @@ public class IntegrationEventConsumerTests
 
 		await consumer.HandleAsync(new TestEvent(), CancellationToken.None);
 
-		var totalCalls = handlerA.CallCount + handlerB.CallCount;
-		totalCalls.Should().Be(1, "exactly one handler runs when the inbox allows one and blocks the other");
-	}
-
-	private sealed class RecordingHandler : IIntegrationEventHandler<TestEvent>
-	{
-		public int CallCount { get; private set; }
-
-		public Task HandleAsync(TestEvent integrationEvent, CancellationToken cancellationToken = default)
-		{
-			CallCount++;
-			return Task.CompletedTask;
-		}
+		(handlerA.CallCount + handlerB.CallCount).Should().Be(1);
+		inbox.Scopes.Should().HaveCount(2);
+		inbox.Scopes.Count(scope => scope.Committed).Should().Be(1);
 	}
 
 	[Fact]
 	public async Task HandleAsync_NoRegisteredHandlers_DoesNothing()
 	{
-		var inbox = Substitute.For<IInboxStore>();
+		var inbox = new TestInboxStore();
 		var provider = new ServiceCollection().BuildServiceProvider();
 
 		var consumer = new IntegrationEventConsumer<TestEvent>(
@@ -89,19 +104,33 @@ public class IntegrationEventConsumerTests
 
 		await consumer.HandleAsync(new TestEvent(), CancellationToken.None);
 
-		await inbox.DidNotReceive().TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		inbox.Scopes.Should().BeEmpty();
 	}
 
 	[Fact]
-	public async Task NoOpInboxStore_AlwaysReturnsTrue()
+	public async Task NoOpInboxStore_AlwaysReturnsProcessableScope()
 	{
 		var inbox = new NoOpInboxStore();
 
-		var first = await inbox.TryMarkProcessedAsync(Guid.NewGuid(), "consumer");
-		var second = await inbox.TryMarkProcessedAsync(Guid.NewGuid(), "consumer");
+		await using var first = await inbox.BeginAsync(Guid.NewGuid(), "consumer");
+		await using var second = await inbox.BeginAsync(Guid.NewGuid(), "consumer");
 
-		first.Should().BeTrue();
-		second.Should().BeTrue();
+		first.ShouldProcess.Should().BeTrue();
+		second.ShouldProcess.Should().BeTrue();
+	}
+
+	private sealed class RecordingHandler : IIntegrationEventHandler<TestEvent>
+	{
+		public int CallCount { get; private set; }
+
+		public Exception? ThrowOnCall { get; init; }
+
+		public Task HandleAsync(TestEvent integrationEvent, CancellationToken cancellationToken = default)
+		{
+			CallCount++;
+			if (ThrowOnCall is not null) throw ThrowOnCall;
+			return Task.CompletedTask;
+		}
 	}
 
 	private static IntegrationEventConsumer<TestEvent> CreateConsumer(

--- a/tests/Yumney.Shared.Events.Tests/ModuleEventConsumerTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/ModuleEventConsumerTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using Xunit;
@@ -11,32 +10,44 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
 public class ModuleEventConsumerTests
 {
 	[Fact]
-	public async Task HandleAsync_NewMessage_InvokesHandlerOnce()
+	public async Task HandleAsync_NewMessage_InvokesHandlerAndCommitsScope()
 	{
-		var handler = Substitute.For<IModuleEventHandler<TestModuleEvent>>();
-		var inbox = new NoOpInboxStore();
+		var handler = new RecordingHandler();
+		var inbox = new TestInboxStore();
 		var consumer = CreateConsumer(handler, inbox);
 		var message = new TestModuleEvent("owner-1");
 
 		await consumer.HandleAsync(message, CancellationToken.None);
 
-		await handler.Received(1).HandleAsync(message, Arg.Any<CancellationToken>());
+		handler.CallCount.Should().Be(1);
+		inbox.Scopes[0].Committed.Should().BeTrue();
 	}
 
 	[Fact]
 	public async Task HandleAsync_DuplicateMessage_SkipsHandler()
 	{
-		var handler = Substitute.For<IModuleEventHandler<TestModuleEvent>>();
-		var inbox = Substitute.For<IInboxStore>();
-		inbox.TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-			.Returns(false);
-
+		var handler = new RecordingHandler();
+		var inbox = new TestInboxStore(shouldProcessSequence: [false]);
 		var consumer = CreateConsumer(handler, inbox);
-		var message = new TestModuleEvent("owner-1");
 
-		await consumer.HandleAsync(message, CancellationToken.None);
+		await consumer.HandleAsync(new TestModuleEvent("owner-1"), CancellationToken.None);
 
-		await handler.DidNotReceive().HandleAsync(Arg.Any<TestModuleEvent>(), Arg.Any<CancellationToken>());
+		handler.CallCount.Should().Be(0);
+		inbox.Scopes[0].Committed.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task HandleAsync_HandlerThrows_RollsBackAndPropagates()
+	{
+		var handler = new RecordingHandler { ThrowOnCall = new InvalidOperationException("boom") };
+		var inbox = new TestInboxStore();
+		var consumer = CreateConsumer(handler, inbox);
+
+		var act = async () => await consumer.HandleAsync(new TestModuleEvent("owner-1"), CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+		inbox.Scopes[0].RolledBack.Should().BeTrue();
+		inbox.Scopes[0].Committed.Should().BeFalse();
 	}
 
 	[Fact]
@@ -44,10 +55,7 @@ public class ModuleEventConsumerTests
 	{
 		var handlerA = new RecordingHandler();
 		var handlerB = new RecordingHandler();
-
-		var inbox = Substitute.For<IInboxStore>();
-		inbox.TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Is<string>(n => n.Contains(nameof(RecordingHandler))), Arg.Any<CancellationToken>())
-			.Returns(true, false);
+		var inbox = new TestInboxStore(shouldProcessSequence: [true, false]);
 
 		var services = new ServiceCollection();
 		services.AddSingleton<IModuleEventHandler<TestModuleEvent>>(handlerA);
@@ -61,14 +69,14 @@ public class ModuleEventConsumerTests
 
 		await consumer.HandleAsync(new TestModuleEvent("owner-1"), CancellationToken.None);
 
-		var totalCalls = handlerA.CallCount + handlerB.CallCount;
-		totalCalls.Should().Be(1, "exactly one handler runs when the inbox allows one and blocks the other");
+		(handlerA.CallCount + handlerB.CallCount).Should().Be(1);
+		inbox.Scopes.Count(scope => scope.Committed).Should().Be(1);
 	}
 
 	[Fact]
 	public async Task HandleAsync_NoRegisteredHandlers_DoesNothing()
 	{
-		var inbox = Substitute.For<IInboxStore>();
+		var inbox = new TestInboxStore();
 		var provider = new ServiceCollection().BuildServiceProvider();
 
 		var consumer = new ModuleEventConsumer<TestModuleEvent>(
@@ -78,16 +86,19 @@ public class ModuleEventConsumerTests
 
 		await consumer.HandleAsync(new TestModuleEvent("owner-1"), CancellationToken.None);
 
-		await inbox.DidNotReceive().TryMarkProcessedAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+		inbox.Scopes.Should().BeEmpty();
 	}
 
 	private sealed class RecordingHandler : IModuleEventHandler<TestModuleEvent>
 	{
 		public int CallCount { get; private set; }
 
+		public Exception? ThrowOnCall { get; init; }
+
 		public Task HandleAsync(TestModuleEvent moduleEvent, CancellationToken cancellationToken = default)
 		{
 			CallCount++;
+			if (ThrowOnCall is not null) throw ThrowOnCall;
 			return Task.CompletedTask;
 		}
 	}

--- a/tests/Yumney.Shared.Events.Tests/TestInboxStore.cs
+++ b/tests/Yumney.Shared.Events.Tests/TestInboxStore.cs
@@ -1,0 +1,73 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+/// <summary>
+/// Hand-written fake inbox so tests can drive scope outcomes
+/// (ShouldProcess true/false, optional duplicate-race detection) and assert
+/// Commit / Rollback ordering without standing up an EF Core context.
+/// </summary>
+public sealed class TestInboxStore : IInboxStore
+{
+	private readonly Queue<bool> shouldProcessQueue = new();
+	private readonly Func<Exception, bool> isDuplicate;
+
+	public TestInboxStore(IEnumerable<bool>? shouldProcessSequence = null, Func<Exception, bool>? isDuplicate = null)
+	{
+		if (shouldProcessSequence is not null)
+		{
+			foreach (var value in shouldProcessSequence)
+			{
+				shouldProcessQueue.Enqueue(value);
+			}
+		}
+
+		this.isDuplicate = isDuplicate ?? (_ => false);
+	}
+
+	public List<TestInboxScope> Scopes { get; } = [];
+
+	public Task<IInboxScope> BeginAsync(Guid messageId, string consumerName, CancellationToken cancellationToken = default)
+	{
+		var shouldProcess = shouldProcessQueue.Count > 0 ? shouldProcessQueue.Dequeue() : true;
+		var scope = new TestInboxScope(messageId, consumerName, shouldProcess, isDuplicate);
+		Scopes.Add(scope);
+		return Task.FromResult<IInboxScope>(scope);
+	}
+}
+
+public sealed class TestInboxScope(Guid messageId, string consumerName, bool shouldProcess, Func<Exception, bool> isDuplicate)
+	: IInboxScope
+{
+	public Guid MessageId { get; } = messageId;
+
+	public string ConsumerName { get; } = consumerName;
+
+	public bool ShouldProcess { get; } = shouldProcess;
+
+	public bool Committed { get; private set; }
+
+	public bool RolledBack { get; private set; }
+
+	public bool Disposed { get; private set; }
+
+	public Task CommitAsync(CancellationToken cancellationToken = default)
+	{
+		Committed = true;
+		return Task.CompletedTask;
+	}
+
+	public Task RollbackAsync(CancellationToken cancellationToken = default)
+	{
+		RolledBack = true;
+		return Task.CompletedTask;
+	}
+
+	public bool IsDuplicateInboxViolation(Exception exception) => isDuplicate(exception);
+
+	public ValueTask DisposeAsync()
+	{
+		Disposed = true;
+		return ValueTask.CompletedTask;
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces `IInboxStore.TryMarkProcessedAsync` with a scope-based contract (`BeginAsync` returns an `IInboxScope` that owns a DB transaction + Commit/Rollback)
- `EfCoreInboxStore` now stages the inbox row inside the same transaction as the handler's writes — commit persists both, rollback drops both
- Consumers detect duplicate-race (concurrent peer beat us to the row) and swallow it; any other handler exception rolls back and rethrows so Wolverine can retry against a clean inbox

## Why

Closes #571. Previously the inbox row committed *before* the handler ran. A handler failure (transient DB blip, projection conflict) left the row in place; on retry the consumer saw the row and skipped the handler, permanently losing side effects with no log signal.

This PR adopts **Option A** from the issue: inbox row + handler writes share a single transaction on the same `DbContext`. Per-module handlers in this codebase already resolve the same scoped `DbContext` as the inbox store, so the contract change is mostly mechanical.

`NoOpInboxStore` keeps pre-inbox behaviour (pass-through scope) for modules that haven't activated the EF Core store yet.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] `Yumney.Shared.Events.Tests` — 23 unit tests pass (new coverage: handler-throw rollback, duplicate-race detection, multi-handler gating)
- [ ] `Yumney.Integration.Tests/Shared/EfCoreInboxStoreTests` — rewritten for the scope API; needs CI Postgres (commit on Commit/Rollback/Dispose-without-commit/duplicate pre-check)
- [ ] Smoke test in staging: confirm a forced handler failure leaves inbox empty and retry processes the message