### PR TITLE
feat: recipe history activity log + cook stats (US-121)

### DIFF
--- a/client/apps/account/public/assets/i18n/account/de.json
+++ b/client/apps/account/public/assets/i18n/account/de.json
@@ -25,6 +25,7 @@
       "loadFailed": "Profil konnte nicht geladen werden."
     }
   },
+<<<<<<< HEAD
   "danger": {
     "title": "Gefahrenzone",
     "lead": "Unumkehrbare Vorgänge an deinem Konto.",
@@ -41,5 +42,21 @@
     "confirmAria": "Bestätigungswort eingeben",
     "deleting": "Wird gelöscht…",
     "retry": "Erneut versuchen"
+=======
+  "activity": {
+    "title": "Aktivität",
+    "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
+    "loading": "Aktivität wird geladen…",
+    "retry": "Erneut versuchen",
+    "filterAria": "Aktivität nach Typ filtern",
+    "filter": {
+      "all": "Alle",
+      "imported": "Importiert",
+      "viewed": "Angesehen",
+      "cooked": "Gekocht",
+      "edited": "Bearbeitet",
+      "deleted": "Gelöscht"
+    }
+>>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/account/public/assets/i18n/account/en.json
+++ b/client/apps/account/public/assets/i18n/account/en.json
@@ -25,6 +25,7 @@
       "loadFailed": "Failed to load profile."
     }
   },
+<<<<<<< HEAD
   "danger": {
     "title": "Danger Zone",
     "lead": "Irreversible operations on your account.",
@@ -41,5 +42,21 @@
     "confirmAria": "Type the confirmation token",
     "deleting": "Deleting…",
     "retry": "Try again"
+=======
+  "activity": {
+    "title": "Activity",
+    "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
+    "loading": "Loading activity…",
+    "retry": "Try again",
+    "filterAria": "Filter activity by type",
+    "filter": {
+      "all": "All",
+      "imported": "Imported",
+      "viewed": "Viewed",
+      "cooked": "Cooked",
+      "edited": "Edited",
+      "deleted": "Deleted"
+    }
+>>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -14,9 +14,16 @@ export const accountRoutes: Route[] = [
     loadComponent: () => import('./profile-settings').then((m) => m.ProfileSettingsComponent),
   },
   {
+<<<<<<< HEAD
     path: 'danger-zone',
     title: 'Danger Zone — Yumney',
     providers: [provideTranslocoScope('account')],
     loadComponent: () => import('./danger-zone').then((m) => m.DangerZoneComponent),
+=======
+    path: 'activity',
+    title: 'Activity — Yumney',
+    providers: [provideTranslocoScope('account')],
+    loadComponent: () => import('./activity').then((m) => m.ActivityComponent),
+>>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   },
 ];

--- a/client/apps/account/src/app/activity/activity.component.html
+++ b/client/apps/account/src/app/activity/activity.component.html
@@ -1,0 +1,32 @@
+<section class="activity-page" *transloco="let t">
+  <header class="activity-page__header">
+    <h1>{{ t('account.activity.title') }}</h1>
+    <p class="activity-page__lead">{{ t('account.activity.lead') }}</p>
+  </header>
+
+  <nav class="activity-page__filters" [attr.aria-label]="t('account.activity.filterAria')">
+    @for (option of filterOptions; track option.value) {
+      <button
+        type="button"
+        class="activity-page__chip"
+        [class.activity-page__chip--active]="activeFilter() === option.value"
+        [attr.aria-pressed]="activeFilter() === option.value"
+        (click)="onFilterChange(option.value)"
+      >
+        {{ t(option.labelKey) }}
+      </button>
+    }
+  </nav>
+
+  <yn-async-state
+    [loading]="loading()"
+    [error]="error()"
+    loadingKey="account.activity.loading"
+    retryKey="account.activity.retry"
+    (retry)="onRetry()"
+  />
+
+  @if (!loading() && !error()) {
+    <yn-activity-timeline [entries]="timelineEntries()" />
+  }
+</section>

--- a/client/apps/account/src/app/activity/activity.component.scss
+++ b/client/apps/account/src/app/activity/activity.component.scss
@@ -1,0 +1,48 @@
+.activity-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--yn-space-5);
+}
+
+.activity-page__header {
+  margin-bottom: var(--yn-space-5);
+
+  h1 {
+    margin: 0 0 var(--yn-space-2);
+    font-size: var(--yn-text-2xl);
+  }
+}
+
+.activity-page__lead {
+  margin: 0;
+  color: var(--yn-text-muted);
+}
+
+.activity-page__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--yn-space-2);
+  margin-bottom: var(--yn-space-5);
+}
+
+.activity-page__chip {
+  padding: var(--yn-space-2) var(--yn-space-3);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-pill);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font: inherit;
+  font-size: var(--yn-text-sm);
+  cursor: pointer;
+  transition: background var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    background: var(--yn-glass-bg-elevated);
+  }
+
+  &--active {
+    background: var(--yn-primary);
+    color: var(--yn-text-inverse, white);
+    border-color: transparent;
+  }
+}

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -1,0 +1,77 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
+import {
+  ActivityTimelineComponent,
+  AsyncStateComponent,
+  type ActivityEntry,
+} from '@yumney/ui';
+import { ActivityApiService, type ActivityTypeKey, type UserActivityItem } from '../api';
+
+const FILTER_OPTIONS: ReadonlyArray<{ value: ActivityTypeKey | 'all'; labelKey: string }> = [
+  { value: 'all', labelKey: 'account.activity.filter.all' },
+  { value: 'recipe_imported', labelKey: 'account.activity.filter.imported' },
+  { value: 'recipe_viewed', labelKey: 'account.activity.filter.viewed' },
+  { value: 'recipe_cooked', labelKey: 'account.activity.filter.cooked' },
+  { value: 'recipe_edited', labelKey: 'account.activity.filter.edited' },
+  { value: 'recipe_deleted', labelKey: 'account.activity.filter.deleted' },
+];
+
+@Component({
+  selector: 'yn-activity-page',
+  standalone: true,
+  imports: [TranslocoModule, AsyncStateComponent, ActivityTimelineComponent],
+  templateUrl: './activity.component.html',
+  styleUrl: './activity.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ActivityComponent {
+  protected readonly filterOptions = FILTER_OPTIONS;
+
+  private api = inject(ActivityApiService);
+  private destroyRef = inject(DestroyRef);
+  private state = createAsyncState(this.destroyRef);
+
+  protected loading = this.state.isLoading;
+  protected error = this.state.serverError;
+  protected entries = signal<UserActivityItem[]>([]);
+  protected activeFilter = signal<ActivityTypeKey | 'all'>('all');
+
+  protected timelineEntries = computed<ActivityEntry[]>(() =>
+    this.entries().map((entry) => ({
+      type: entry.type,
+      recipeIdentifier: entry.recipeIdentifier,
+      recipeTitle: entry.recipeTitle,
+      occurredAt: entry.occurredAt,
+    })),
+  );
+
+  constructor() {
+    this.load();
+  }
+
+  protected onFilterChange(value: ActivityTypeKey | 'all'): void {
+    if (this.activeFilter() === value) return;
+    this.activeFilter.set(value);
+    this.load();
+  }
+
+  protected onRetry(): void {
+    this.load();
+  }
+
+  private load(): void {
+    const type = this.activeFilter();
+    const options = type === 'all' ? { limit: 50 } : { limit: 50, type };
+    this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (entries) =>
+      this.entries.set(entries),
+    );
+  }
+}

--- a/client/apps/account/src/app/activity/index.ts
+++ b/client/apps/account/src/app/activity/index.ts
@@ -1,0 +1,1 @@
+export { ActivityComponent } from './activity.component';

--- a/client/apps/account/src/app/api.ts
+++ b/client/apps/account/src/app/api.ts
@@ -4,6 +4,9 @@
 // imports from the shared lib out of account/**.
 export {
   UserProfileApiService,
+  ActivityApiService,
   type UserProfile,
   type UpdateProfileRequest,
+  type UserActivityItem,
+  type ActivityTypeKey,
 } from '@yumney/shared/api-client';

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -17,6 +17,25 @@
       "moveUp": "Nach oben",
       "moveDown": "Nach unten",
       "remove": "Entfernen"
+    },
+    "activity": {
+      "empty": "Noch keine Aktivität — leg los!",
+      "deletedRecipe": "Gelöschtes Rezept",
+      "type": {
+        "recipe_imported": "Importiert",
+        "recipe_viewed": "Angesehen",
+        "recipe_cooked": "Gekocht",
+        "recipe_edited": "Bearbeitet",
+        "recipe_deleted": "Gelöscht",
+        "shopping_list_created": "Einkaufsliste erstellt"
+      },
+      "relative": {
+        "justNow": "Gerade eben",
+        "minutes": "Vor {{value}} Min.",
+        "hours": "Vor {{value}} Std.",
+        "days": "Vor {{value}} Tag(en)",
+        "weeks": "Vor {{value}} Woche(n)"
+      }
     }
   },
   "dashboard": {

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -17,6 +17,25 @@
       "moveUp": "Move up",
       "moveDown": "Move down",
       "remove": "Remove"
+    },
+    "activity": {
+      "empty": "No activity yet — start cooking!",
+      "deletedRecipe": "Deleted recipe",
+      "type": {
+        "recipe_imported": "Imported",
+        "recipe_viewed": "Viewed",
+        "recipe_cooked": "Cooked",
+        "recipe_edited": "Edited",
+        "recipe_deleted": "Deleted",
+        "shopping_list_created": "Created shopping list"
+      },
+      "relative": {
+        "justNow": "Just now",
+        "minutes": "{{value}} min ago",
+        "hours": "{{value}} h ago",
+        "days": "{{value}} d ago",
+        "weeks": "{{value}} w ago"
+      }
     }
   },
   "dashboard": {

--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -103,6 +103,13 @@
     },
     "loading": "Rezept wird geladen...",
     "notFound": "Rezept nicht gefunden.",
+    "stats": {
+      "cookCount": "{{count}}× gekocht",
+      "lastCookedToday": "Heute zuletzt gekocht",
+      "lastCookedYesterday": "Gestern zuletzt gekocht",
+      "lastCookedDays": "Vor {{value}} Tagen zuletzt gekocht",
+      "lastCookedWeeks": "Vor {{value}} Wochen zuletzt gekocht"
+    },
     "delete": {
       "confirm": "Möchtest du \"{{title}}\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
       "confirmButton": "Löschen",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -103,6 +103,13 @@
     },
     "loading": "Loading recipe...",
     "notFound": "Recipe not found.",
+    "stats": {
+      "cookCount": "Cooked {{count}} times",
+      "lastCookedToday": "Last cooked today",
+      "lastCookedYesterday": "Last cooked yesterday",
+      "lastCookedDays": "Last cooked {{value}} days ago",
+      "lastCookedWeeks": "Last cooked {{value}} weeks ago"
+    },
     "delete": {
       "confirm": "Are you sure you want to delete \"{{title}}\"? This cannot be undone.",
       "confirmButton": "Delete",

--- a/client/apps/recipes/src/app/api.ts
+++ b/client/apps/recipes/src/app/api.ts
@@ -6,6 +6,7 @@ export {
   RecipeApiService,
   MealPlanApiService,
   ShoppingApiService,
+  ActivityApiService,
   type RecipeListItem,
   type RecipeListResponse,
   type RecipeDetail,
@@ -13,4 +14,5 @@ export {
   type GetRecipesParams,
   type CreateShoppingListItem,
   type ShoppingListDetail,
+  type RecipeActivityStats,
 } from '@yumney/shared/api-client';

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -144,7 +144,19 @@ export class CookModeComponent implements OnInit, OnDestroy {
   }
 
   exit(): void {
-    const id = this.recipe()?.identifier;
+    const recipe = this.recipe();
+    const id = recipe?.identifier;
+
+    // Treat reaching the last step as "I cooked this" (US-121). Fire-and-forget
+    // — failing to log shouldn't block the navigation. The server collapses
+    // multiple opens within a window via dedup; cook tracking is intentionally
+    // not deduped because each cook is a discrete completion.
+    if (recipe && this.totalSteps() > 0 && this.currentStepIndex() >= this.totalSteps() - 1) {
+      this.recipeApi.trackCooked(recipe.identifier).subscribe({
+        error: () => undefined,
+      });
+    }
+
     if (id) {
       void this.router.navigate([ROUTES.recipes.detail(id)]);
     } else {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -108,6 +108,18 @@
       </div>
     }
 
+    @if (recipeStats(); as stats) {
+      @if (stats.cookCount > 0) {
+        <p class="cook-stats" data-testid="recipe-cook-stats">
+          {{ t('recipes.detail.stats.cookCount', { count: stats.cookCount }) }}
+          @if (lastCookedRelative(); as last) {
+            <span class="cook-stats__separator">·</span>
+            <span>{{ t(last.key, { value: last.value }) }}</span>
+          }
+        </p>
+      }
+    }
+
     <div class="actions-bar">
       <yn-favorite-button [isFavorite]="recipe.isFavorite" (toggled)="onToggleFavorite()" />
       <a class="btn-cook" [routerLink]="ROUTES.recipes.cook(recipe.identifier)">

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -345,3 +345,20 @@
     }
   }
 }
+
+.cook-stats {
+  margin: 0 0 var(--yn-space-3);
+  padding: var(--yn-space-2) var(--yn-space-3);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+  border-radius: var(--yn-radius-pill);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+}
+
+.cook-stats__separator {
+  opacity: 0.6;
+}

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -3,7 +3,13 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter, ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError, EMPTY } from 'rxjs';
 import { RecipeDetailComponent } from './recipe-detail.component';
-import { RecipeApiService, RecipeDetail, ShoppingApiService, ShoppingListDetail } from '../api';
+import {
+  ActivityApiService,
+  RecipeApiService,
+  RecipeDetail,
+  ShoppingApiService,
+  ShoppingListDetail,
+} from '../api';
 import { HttpErrorResponse } from '@angular/common/http';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 
@@ -94,6 +100,9 @@ describe('RecipeDetailComponent', () => {
   let shoppingApiMock: {
     createShoppingList: ReturnType<typeof vi.fn>;
   };
+  let activityApiMock: {
+    getRecipeStats: ReturnType<typeof vi.fn>;
+  };
 
   function setupTestBed(
     getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
@@ -106,6 +115,9 @@ describe('RecipeDetailComponent', () => {
     shoppingApiMock = {
       createShoppingList: vi.fn().mockReturnValue(EMPTY),
     };
+    activityApiMock = {
+      getRecipeStats: vi.fn().mockReturnValue(EMPTY),
+    };
 
     TestBed.configureTestingModule({
       imports: [RecipeDetailComponent, setupTranslocoTesting(en)],
@@ -114,6 +126,7 @@ describe('RecipeDetailComponent', () => {
         provideRouter([]),
         { provide: RecipeApiService, useValue: recipeApiMock },
         { provide: ShoppingApiService, useValue: shoppingApiMock },
+        { provide: ActivityApiService, useValue: activityApiMock },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -9,7 +9,14 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { CreateShoppingListItem, RecipeApiService, RecipeDetail, ShoppingApiService } from '../api';
+import {
+  ActivityApiService,
+  CreateShoppingListItem,
+  RecipeApiService,
+  RecipeActivityStats,
+  RecipeDetail,
+  ShoppingApiService,
+} from '../api';
 import {
   createAsyncState,
   scaleIngredients,
@@ -46,6 +53,7 @@ export class RecipeDetailComponent implements OnInit {
 
   private recipeApi = inject(RecipeApiService);
   private shoppingApi = inject(ShoppingApiService);
+  private activityApi = inject(ActivityApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
@@ -54,6 +62,7 @@ export class RecipeDetailComponent implements OnInit {
   private createShoppingListState = createAsyncState(this.destroyRef);
 
   recipe = signal<RecipeDetail | null>(null);
+  recipeStats = signal<RecipeActivityStats | null>(null);
   isLoading = this.loadState.isLoading;
   isDeleting = this.deleteState.isLoading;
   isCreatingShoppingList = this.createShoppingListState.isLoading;
@@ -81,12 +90,30 @@ export class RecipeDetailComponent implements OnInit {
     return recipe?.servings != null && desired != null && desired !== recipe.servings;
   });
 
+  lastCookedRelative = computed(() => {
+    const stats = this.recipeStats();
+    if (!stats?.lastCookedAt) return null;
+    const diffMs = Date.now() - new Date(stats.lastCookedAt).getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays < 1) return { key: 'recipes.detail.stats.lastCookedToday', value: 0 };
+    if (diffDays === 1) return { key: 'recipes.detail.stats.lastCookedYesterday', value: 1 };
+    if (diffDays < 7) return { key: 'recipes.detail.stats.lastCookedDays', value: diffDays };
+    const weeks = Math.floor(diffDays / 7);
+    return { key: 'recipes.detail.stats.lastCookedWeeks', value: weeks };
+  });
+
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
     if (!identifier) {
       this.serverError.set('recipes.detail.notFound');
       return;
     }
+
+    // Stats can fail silently — the page is still useful without the badge.
+    this.activityApi.getRecipeStats(identifier).subscribe({
+      next: (stats) => this.recipeStats.set(stats),
+      error: () => this.recipeStats.set(null),
+    });
 
     this.loadState.execute(
       this.recipeApi.getRecipeById(identifier),

--- a/client/apps/shell/public/assets/i18n/account/de.json
+++ b/client/apps/shell/public/assets/i18n/account/de.json
@@ -25,6 +25,7 @@
       "loadFailed": "Profil konnte nicht geladen werden."
     }
   },
+<<<<<<< HEAD
   "danger": {
     "title": "Gefahrenzone",
     "lead": "Unumkehrbare Vorgänge an deinem Konto.",
@@ -41,5 +42,21 @@
     "confirmAria": "Bestätigungswort eingeben",
     "deleting": "Wird gelöscht…",
     "retry": "Erneut versuchen"
+=======
+  "activity": {
+    "title": "Aktivität",
+    "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
+    "loading": "Aktivität wird geladen…",
+    "retry": "Erneut versuchen",
+    "filterAria": "Aktivität nach Typ filtern",
+    "filter": {
+      "all": "Alle",
+      "imported": "Importiert",
+      "viewed": "Angesehen",
+      "cooked": "Gekocht",
+      "edited": "Bearbeitet",
+      "deleted": "Gelöscht"
+    }
+>>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/shell/public/assets/i18n/account/en.json
+++ b/client/apps/shell/public/assets/i18n/account/en.json
@@ -25,6 +25,7 @@
       "loadFailed": "Failed to load profile."
     }
   },
+<<<<<<< HEAD
   "danger": {
     "title": "Danger Zone",
     "lead": "Irreversible operations on your account.",
@@ -41,5 +42,21 @@
     "confirmAria": "Type the confirmation token",
     "deleting": "Deleting…",
     "retry": "Try again"
+=======
+  "activity": {
+    "title": "Activity",
+    "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
+    "loading": "Loading activity…",
+    "retry": "Try again",
+    "filterAria": "Filter activity by type",
+    "filter": {
+      "all": "All",
+      "imported": "Imported",
+      "viewed": "Viewed",
+      "cooked": "Cooked",
+      "edited": "Edited",
+      "deleted": "Deleted"
+    }
+>>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -67,6 +67,25 @@
       "moveUp": "Nach oben",
       "moveDown": "Nach unten",
       "remove": "Entfernen"
+    },
+    "activity": {
+      "empty": "Noch keine Aktivität — leg los!",
+      "deletedRecipe": "Gelöschtes Rezept",
+      "type": {
+        "recipe_imported": "Importiert",
+        "recipe_viewed": "Angesehen",
+        "recipe_cooked": "Gekocht",
+        "recipe_edited": "Bearbeitet",
+        "recipe_deleted": "Gelöscht",
+        "shopping_list_created": "Einkaufsliste erstellt"
+      },
+      "relative": {
+        "justNow": "Gerade eben",
+        "minutes": "Vor {{value}} Min.",
+        "hours": "Vor {{value}} Std.",
+        "days": "Vor {{value}} Tag(en)",
+        "weeks": "Vor {{value}} Woche(n)"
+      }
     }
   },
   "layout": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -67,6 +67,25 @@
       "moveUp": "Move up",
       "moveDown": "Move down",
       "remove": "Remove"
+    },
+    "activity": {
+      "empty": "No activity yet — start cooking!",
+      "deletedRecipe": "Deleted recipe",
+      "type": {
+        "recipe_imported": "Imported",
+        "recipe_viewed": "Viewed",
+        "recipe_cooked": "Cooked",
+        "recipe_edited": "Edited",
+        "recipe_deleted": "Deleted",
+        "shopping_list_created": "Created shopping list"
+      },
+      "relative": {
+        "justNow": "Just now",
+        "minutes": "{{value}} min ago",
+        "hours": "{{value}} h ago",
+        "days": "{{value}} d ago",
+        "weeks": "{{value}} w ago"
+      }
     }
   },
   "layout": {

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -103,6 +103,13 @@
     },
     "loading": "Rezept wird geladen...",
     "notFound": "Rezept nicht gefunden.",
+    "stats": {
+      "cookCount": "{{count}}× gekocht",
+      "lastCookedToday": "Heute zuletzt gekocht",
+      "lastCookedYesterday": "Gestern zuletzt gekocht",
+      "lastCookedDays": "Vor {{value}} Tagen zuletzt gekocht",
+      "lastCookedWeeks": "Vor {{value}} Wochen zuletzt gekocht"
+    },
     "delete": {
       "confirm": "Möchtest du \"{{title}}\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.",
       "confirmButton": "Löschen",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -103,6 +103,13 @@
     },
     "loading": "Loading recipe...",
     "notFound": "Recipe not found.",
+    "stats": {
+      "cookCount": "Cooked {{count}} times",
+      "lastCookedToday": "Last cooked today",
+      "lastCookedYesterday": "Last cooked yesterday",
+      "lastCookedDays": "Last cooked {{value}} days ago",
+      "lastCookedWeeks": "Last cooked {{value}} weeks ago"
+    },
     "delete": {
       "confirm": "Are you sure you want to delete \"{{title}}\"? This cannot be undone.",
       "confirmButton": "Delete",

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -71,8 +71,15 @@ export type {
 
 // --- Dashboard ---
 export { DashboardApiService } from './lib/dashboard-api.service';
-export type { UserActivityItem } from './lib/user-activity';
+export type {
+  UserActivityItem,
+  ActivityTypeKey,
+  RecipeActivityStats,
+} from './lib/user-activity';
 export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';
+
+// --- Activity ---
+export { ActivityApiService } from './lib/activity-api.service';
 
 // --- User Profile ---
 export { UserProfileApiService } from './lib/user-profile-api.service';

--- a/client/libs/shared/api-client/src/lib/activity-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_ENDPOINTS } from './api-endpoints';
+import type { ActivityTypeKey, RecipeActivityStats, UserActivityItem } from './user-activity';
+
+@Injectable({ providedIn: 'root' })
+export class ActivityApiService {
+  private http = inject(HttpClient);
+
+  getActivity(options: { type?: ActivityTypeKey; limit?: number } = {}): Observable<UserActivityItem[]> {
+    let params = new HttpParams();
+    if (options.limit != null) params = params.set('limit', options.limit.toString());
+    if (options.type != null) params = params.set('type', options.type);
+    return this.http.get<UserActivityItem[]>(API_ENDPOINTS.users.activity, { params });
+  }
+
+  getRecipeStats(recipeIdentifier: string): Observable<RecipeActivityStats> {
+    return this.http.get<RecipeActivityStats>(
+      API_ENDPOINTS.users.activityRecipeStats(recipeIdentifier),
+    );
+  }
+}

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -13,6 +13,7 @@ export const API_ENDPOINTS = {
     importFromText: `${API_BASE}/recipes/import-from-text`,
     byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
     favorite: (identifier: string) => `${API_BASE}/recipes/${identifier}/favorite`,
+    cooked: (identifier: string) => `${API_BASE}/recipes/${identifier}/cooked`,
   },
   shoppingLists: {
     base: `${API_BASE}/shopping-lists`,
@@ -53,6 +54,8 @@ export const API_ENDPOINTS = {
   },
   users: {
     activity: `${API_BASE}/users/me/activity`,
+    activityRecipeStats: (identifier: string) =>
+      `${API_BASE}/users/me/activity/recipes/${identifier}/stats`,
     suggestions: `${API_BASE}/users/me/suggestions`,
     profile: `${API_BASE}/users/me/profile`,
     me: `${API_BASE}/users/me`,

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -211,6 +211,12 @@ export class RecipeApiService {
     });
   }
 
+  // Records a cook-mode completion (US-121). The server publishes a
+  // RecipeCookedIntegrationEvent which the Users module persists as activity.
+  trackCooked(identifier: string): Observable<void> {
+    return this.http.post<void>(API_ENDPOINTS.recipes.cooked(identifier), {});
+  }
+
   toggleFavorite(identifier: string): Observable<FavoriteState> {
     // Invalidate the in-memory shareReplay cache so a subsequent
     // getRecipeById refetches with the new isFavorite — without this the

--- a/client/libs/shared/api-client/src/lib/user-activity.ts
+++ b/client/libs/shared/api-client/src/lib/user-activity.ts
@@ -1,6 +1,20 @@
+export type ActivityTypeKey =
+  | 'recipe_imported'
+  | 'recipe_viewed'
+  | 'recipe_cooked'
+  | 'recipe_edited'
+  | 'recipe_deleted'
+  | 'shopping_list_created';
+
 export interface UserActivityItem {
-  type: string;
+  type: ActivityTypeKey;
   recipeIdentifier: string | null;
   recipeTitle: string | null;
   occurredAt: string;
+}
+
+export interface RecipeActivityStats {
+  cookCount: number;
+  lastCookedAt: string | null;
+  viewCount: number;
 }

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -42,6 +42,12 @@ export { StepDisplayComponent } from './lib/step-display/step-display.component'
 export { CookingTimerComponent } from './lib/cooking-timer/cooking-timer.component';
 export { VoiceIndicatorComponent } from './lib/voice-indicator/voice-indicator.component';
 export { FavoriteButtonComponent } from './lib/favorite-button/favorite-button.component';
+export {
+  ActivityTimelineComponent,
+  type ActivityEntry,
+  type ActivityTypeKey,
+  relativeTimeFromNow,
+} from './lib/activity-timeline/activity-timeline.component';
 
 // Icons
 export { provideYumneyIcons } from './lib/icons/provide-icons';

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.html
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.html
@@ -1,0 +1,24 @@
+<ol class="activity-timeline" *transloco="let t">
+  @for (entry of view(); track entry.occurredAt + entry.type) {
+    <li class="activity-timeline__item">
+      <span class="activity-timeline__icon" aria-hidden="true">
+        <lucide-icon [name]="entry.icon" [size]="18" />
+      </span>
+      <div class="activity-timeline__body">
+        <span class="activity-timeline__type">{{ t('shared.activity.type.' + entry.type) }}</span>
+        @if (entry.recipeTitle) {
+          <span class="activity-timeline__title">{{ entry.recipeTitle }}</span>
+        } @else if (entry.type === 'recipe_deleted') {
+          <span class="activity-timeline__title activity-timeline__title--muted">
+            {{ t('shared.activity.deletedRecipe') }}
+          </span>
+        }
+      </div>
+      <time class="activity-timeline__time" [attr.datetime]="entry.occurredAt">
+        {{ t(entry.relative.key, { value: entry.relative.value }) }}
+      </time>
+    </li>
+  } @empty {
+    <li class="activity-timeline__empty">{{ t('shared.activity.empty') }}</li>
+  }
+</ol>

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.scss
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.scss
@@ -1,0 +1,70 @@
+.activity-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.activity-timeline__item {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border-subtle);
+}
+
+.activity-timeline__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--yn-radius-pill);
+  background: var(--yn-glass-bg-elevated);
+  color: var(--yn-text-muted);
+  flex-shrink: 0;
+}
+
+.activity-timeline__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.activity-timeline__type {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+}
+
+.activity-timeline__title {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &--muted {
+    font-style: italic;
+    color: var(--yn-text-muted);
+    font-weight: 400;
+  }
+}
+
+.activity-timeline__time {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.activity-timeline__empty {
+  padding: var(--yn-space-5);
+  text-align: center;
+  color: var(--yn-text-muted);
+  font-style: italic;
+}

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
@@ -1,0 +1,114 @@
+import { provideYumneyIcons } from '../icons/provide-icons';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import {
+  ActivityTimelineComponent,
+  type ActivityEntry,
+  relativeTimeFromNow,
+} from './activity-timeline.component';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+
+const en = {
+  shared: {
+    activity: {
+      empty: 'No activity yet',
+      deletedRecipe: 'Deleted recipe',
+      type: {
+        recipe_imported: 'Imported',
+        recipe_viewed: 'Viewed',
+        recipe_cooked: 'Cooked',
+        recipe_edited: 'Edited',
+        recipe_deleted: 'Deleted',
+        shopping_list_created: 'Created list',
+      },
+      relative: {
+        justNow: 'Just now',
+        minutes: '{{value}} min ago',
+        hours: '{{value}} h ago',
+        days: '{{value}} d ago',
+        weeks: '{{value}} w ago',
+      },
+    },
+  },
+};
+
+@Component({
+  template: `<yn-activity-timeline [entries]="entries()" />`,
+  imports: [ActivityTimelineComponent],
+})
+class TestHostComponent {
+  entries = signal<ActivityEntry[]>([]);
+}
+
+describe('ActivityTimelineComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideYumneyIcons()],
+      imports: [TestHostComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render the empty state when no entries are provided', () => {
+    const empty = fixture.nativeElement.querySelector('.activity-timeline__empty');
+    expect(empty.textContent.trim()).toBe('No activity yet');
+  });
+
+  it('should render one item per entry with the recipe title', () => {
+    host.entries.set([
+      { type: 'recipe_cooked', recipeIdentifier: 'r1', recipeTitle: 'Pasta', occurredAt: new Date().toISOString() },
+      { type: 'recipe_imported', recipeIdentifier: 'r2', recipeTitle: 'Pizza', occurredAt: new Date().toISOString() },
+    ]);
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.activity-timeline__item');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain('Pasta');
+    expect(items[1].textContent).toContain('Pizza');
+  });
+
+  it('should fall back to "Deleted recipe" label when title is null and type is recipe_deleted', () => {
+    host.entries.set([
+      { type: 'recipe_deleted', recipeIdentifier: 'r1', recipeTitle: null, occurredAt: new Date().toISOString() },
+    ]);
+    fixture.detectChanges();
+
+    const item = fixture.nativeElement.querySelector('.activity-timeline__item');
+    expect(item.textContent).toContain('Deleted recipe');
+  });
+});
+
+describe('relativeTimeFromNow', () => {
+  const now = new Date('2026-05-05T12:00:00Z');
+
+  it('returns justNow for under a minute', () => {
+    const when = new Date('2026-05-05T11:59:30Z');
+    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.justNow', value: 0 });
+  });
+
+  it('returns minutes for under an hour', () => {
+    const when = new Date('2026-05-05T11:45:00Z');
+    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.minutes', value: 15 });
+  });
+
+  it('returns hours for under a day', () => {
+    const when = new Date('2026-05-05T08:00:00Z');
+    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.hours', value: 4 });
+  });
+
+  it('returns days for under a week', () => {
+    const when = new Date('2026-05-02T12:00:00Z');
+    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.days', value: 3 });
+  });
+
+  it('returns weeks beyond a week', () => {
+    const when = new Date('2026-04-15T12:00:00Z');
+    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.weeks', value: 2 });
+  });
+});

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+
+export type ActivityTypeKey =
+  | 'recipe_imported'
+  | 'recipe_viewed'
+  | 'recipe_cooked'
+  | 'recipe_edited'
+  | 'recipe_deleted'
+  | 'shopping_list_created';
+
+export interface ActivityEntry {
+  type: ActivityTypeKey;
+  recipeIdentifier: string | null;
+  recipeTitle: string | null;
+  occurredAt: string;
+}
+
+const ACTIVITY_ICONS: Record<ActivityTypeKey, string> = {
+  recipe_imported: 'book-open',
+  recipe_viewed: 'eye',
+  recipe_cooked: 'flame',
+  recipe_edited: 'pencil',
+  recipe_deleted: 'trash-2',
+  shopping_list_created: 'shopping-cart',
+};
+
+@Component({
+  selector: 'yn-activity-timeline',
+  imports: [TranslocoModule, LucideAngularModule],
+  templateUrl: './activity-timeline.component.html',
+  styleUrl: './activity-timeline.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ActivityTimelineComponent {
+  entries = input.required<ActivityEntry[]>();
+
+  protected readonly view = computed(() =>
+    this.entries().map((entry) => ({
+      ...entry,
+      icon: ACTIVITY_ICONS[entry.type] ?? 'circle',
+      relative: relativeTimeFromNow(new Date(entry.occurredAt)),
+    })),
+  );
+}
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+// Locale-agnostic relative-time formatter — returns the raw key + count so the
+// caller's i18n layer can pluralize. Keeps the component free of date-fns.
+export function relativeTimeFromNow(when: Date, now: Date = new Date()): {
+  key: string;
+  value: number;
+} {
+  const diff = now.getTime() - when.getTime();
+  if (diff < MINUTE) return { key: 'shared.activity.relative.justNow', value: 0 };
+  if (diff < HOUR) return { key: 'shared.activity.relative.minutes', value: Math.floor(diff / MINUTE) };
+  if (diff < DAY) return { key: 'shared.activity.relative.hours', value: Math.floor(diff / HOUR) };
+  if (diff < WEEK) return { key: 'shared.activity.relative.days', value: Math.floor(diff / DAY) };
+  return { key: 'shared.activity.relative.weeks', value: Math.floor(diff / WEEK) };
+}

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
@@ -1,0 +1,32 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Api;
+
+#pragma warning disable SA1601
+public static partial class RecipesEndpoints
+#pragma warning restore SA1601
+{
+	private static void MapHistoryEndpoints(RouteGroupBuilder group)
+	{
+		group.MapPost("/{identifier:guid}/cooked", TrackCooked)
+			.WithName("TrackRecipeCooked")
+			.WithTags("Recipes")
+			.Produces(StatusCodes.Status204NoContent)
+			.ProducesProblem(StatusCodes.Status404NotFound);
+	}
+
+	private static async Task<IResult> TrackCooked(
+		Guid identifier,
+		ICommandHandler<TrackRecipeCookedCommand, Result> handler,
+		CancellationToken cancellationToken)
+	{
+		var command = new TrackRecipeCookedCommand(RecipeIdentifier.From(identifier));
+		var result = await handler.HandleAsync(command, cancellationToken);
+		return result.ToNoContent();
+	}
+}

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
@@ -13,14 +13,14 @@ public static partial class RecipesEndpoints
 {
 	private static void MapHistoryEndpoints(RouteGroupBuilder group)
 	{
-		group.MapPost("/{identifier:guid}/cooked", TrackCooked)
+		group.MapPost("/{identifier:guid}/cooked", TrackCookedAsync)
 			.WithName("TrackRecipeCooked")
 			.WithTags("Recipes")
 			.Produces(StatusCodes.Status204NoContent)
 			.ProducesProblem(StatusCodes.Status404NotFound);
 	}
 
-	private static async Task<IResult> TrackCooked(
+	private static async Task<IResult> TrackCookedAsync(
 		Guid identifier,
 		ICommandHandler<TrackRecipeCookedCommand, Result> handler,
 		CancellationToken cancellationToken)

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -23,6 +23,7 @@ public static partial class RecipesEndpoints
 		MapCrudEndpoints(group);
 		MapImportEndpoints(group);
 		MapChatEndpoints(group);
+		MapHistoryEndpoints(group);
 
 		return app;
 	}

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -2,13 +2,16 @@ using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 
 public sealed class SaveRecipeCommandHandler(
 	IRecipesUnitOfWork unitOfWork,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IEventBus eventBus)
 	: ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>>
 {
 	public async Task<Result<SavedRecipeDto>> HandleAsync(SaveRecipeCommand command, CancellationToken cancellationToken = default)
@@ -42,6 +45,10 @@ public sealed class SaveRecipeCommandHandler(
 
 		await unitOfWork.Recipes.AddAsync(recipe, cancellationToken);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
+
+		await eventBus.PublishAsync(
+			new RecipeImportedIntegrationEvent(owner.Value, recipe.Id.Value, recipe.Title.Value),
+			cancellationToken);
 
 		return recipe.ToSavedDto();
 	}

--- a/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
@@ -1,0 +1,31 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+
+public sealed class TrackRecipeCookedCommandHandler(
+	IRecipesUnitOfWork unitOfWork,
+	ICurrentUser currentUser,
+	IEventBus eventBus)
+	: ICommandHandler<TrackRecipeCookedCommand, Result>
+{
+	public async Task<Result> HandleAsync(TrackRecipeCookedCommand command, CancellationToken cancellationToken = default)
+	{
+		var recipe = await unitOfWork.Recipes.GetByIdAsync(command.Identifier, cancellationToken);
+
+		if (recipe.Owner != currentUser.AsOwner())
+		{
+			return Result.Failure(DeleteRecipeErrors.AccessDenied);
+		}
+
+		await eventBus.PublishAsync(
+			new RecipeCookedIntegrationEvent(recipe.Owner.Value, recipe.Id.Value, recipe.Title.Value),
+			cancellationToken);
+
+		return Result.Success();
+	}
+}

--- a/src/Yumney.Recipes.Application/Commands/TrackRecipeCookedCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/TrackRecipeCookedCommand.cs
@@ -1,0 +1,11 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+
+/// <summary>
+/// Records that the user finished cooking the recipe (US-121). Publishes a
+/// <c>RecipeCookedIntegrationEvent</c> for the Users module to log.
+/// </summary>
+public sealed record TrackRecipeCookedCommand(RecipeIdentifier Identifier) : ICommand<Result>;

--- a/src/Yumney.Recipes.Application/Interfaces/IRecipeViewTracker.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IRecipeViewTracker.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Records that the current user opened a recipe (US-121). Implementations
+/// must apply a per-(user, recipe) dedup window so a refresh storm doesn't
+/// flood the activity log; only the first view inside the window publishes
+/// <c>RecipeViewedIntegrationEvent</c>.
+/// </summary>
+public interface IRecipeViewTracker
+{
+	Task TrackAsync(OwnerIdentifier owner, Recipe recipe, CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeByIdQueryHandler.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
 using SmartSolutionsLab.Yumney.Shared.Common;
@@ -10,6 +11,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.Queries.Handlers;
 public sealed class GetRecipeByIdQueryHandler(
 	IRecipeRepository recipes,
 	IRecipeFavoriteRepository favorites,
+	IRecipeViewTracker viewTracker,
 	ICurrentUser currentUser)
 	: IQueryHandler<GetRecipeByIdQuery, Result<RecipeDetailDto>>
 {
@@ -24,6 +26,8 @@ public sealed class GetRecipeByIdQueryHandler(
 		{
 			return GetRecipeByIdErrors.AccessDenied;
 		}
+
+		await viewTracker.TrackAsync(owner, recipe, cancellationToken);
 
 		var isFavorite = await favorites.IsFavoritedAsync(owner, identifier, cancellationToken);
 		return recipe.ToDetailDto(isFavorite);

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web;
 
@@ -27,6 +28,7 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipesUserDataPurger, EfCoreRecipesUserDataPurger>();
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
+		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddYumneyServiceClient("shopping-api");
 		services.AddYumneyServiceClient("users-api");
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");

--- a/src/Yumney.Recipes.Infrastructure/Services/CachedRecipeViewTracker.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/CachedRecipeViewTracker.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Caching.Distributed;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+
+/// <summary>
+/// IDistributedCache-backed view tracker (US-121). Uses a 5-minute per-(user,
+/// recipe) lockout so a refresh storm doesn't flood the activity log with
+/// duplicate views. The cache key carries the owner so two users opening the
+/// same recipe each get tracked.
+/// </summary>
+#pragma warning disable SA1311
+public sealed class CachedRecipeViewTracker(IDistributedCache cache, IEventBus eventBus) : IRecipeViewTracker
+{
+	private static readonly DistributedCacheEntryOptions windowOptions = new()
+	{
+		AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+	};
+#pragma warning restore SA1311
+
+	public async Task TrackAsync(OwnerIdentifier owner, Recipe recipe, CancellationToken cancellationToken = default)
+	{
+		var key = $"recipe-view:{owner.Value}:{recipe.Id.Value}";
+		var existing = await cache.GetStringAsync(key, cancellationToken);
+		if (existing is not null) return;
+
+		await cache.SetStringAsync(key, "1", windowOptions, cancellationToken);
+		await eventBus.PublishAsync(
+			new RecipeViewedIntegrationEvent(owner.Value, recipe.Id.Value, recipe.Title.Value),
+			cancellationToken);
+	}
+}

--- a/src/Yumney.Shared.Events/CrossModule/RecipeCookedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/RecipeCookedIntegrationEvent.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Recipes module when the user finishes cook mode for a
+/// recipe (US-121). Each completion is a discrete event so subscribers can
+/// count cooks; no dedup is applied here.
+/// </summary>
+public sealed record RecipeCookedIntegrationEvent(
+	string OwnerId,
+	Guid RecipeIdentifier,
+	string RecipeTitle) : IntegrationEvent;

--- a/src/Yumney.Shared.Events/CrossModule/RecipeImportedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/RecipeImportedIntegrationEvent.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Recipes module after a recipe is saved (manually or via
+/// import). Subscribers (e.g. Users) record activity for the smart dashboard
+/// and recipe history (US-121).
+/// </summary>
+public sealed record RecipeImportedIntegrationEvent(
+	string OwnerId,
+	Guid RecipeIdentifier,
+	string RecipeTitle) : IntegrationEvent;

--- a/src/Yumney.Shared.Events/CrossModule/RecipeViewedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/CrossModule/RecipeViewedIntegrationEvent.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+
+/// <summary>
+/// Published by the Recipes module when a user opens a recipe's detail view
+/// (US-121). The publisher applies a per-(user, recipe) dedup window so
+/// subscribers don't need to. Carries no aggregate state — it's a pure
+/// notification used by the activity log.
+/// </summary>
+public sealed record RecipeViewedIntegrationEvent(
+	string OwnerId,
+	Guid RecipeIdentifier,
+	string RecipeTitle) : IntegrationEvent;

--- a/src/Yumney.Users.Api/Program.cs
+++ b/src/Yumney.Users.Api/Program.cs
@@ -2,11 +2,12 @@ using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Web;
 using SmartSolutionsLab.Yumney.Users.Api;
 using SmartSolutionsLab.Yumney.Users.Application;
+using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Users.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddYumneyDefaults();
+builder.AddYumneyDefaults(typeof(RecipeImportedActivityHandler).Assembly);
 
 builder.Services.AddUsersApi();
 builder.Services.AddUsersApplication();

--- a/src/Yumney.Users.Api/UserActivityEndpoints.cs
+++ b/src/Yumney.Users.Api/UserActivityEndpoints.cs
@@ -22,10 +22,27 @@ public static class UserActivityEndpoints
 		static async Task<IResult> GetRecentActivity(
 			IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>> handler,
 			int limit = 5,
+			string? type = null,
 			CancellationToken cancellationToken = default)
 		{
-			var query = new GetRecentActivityQuery(ActivityLimit.From(limit));
+			var typeFilter = string.IsNullOrWhiteSpace(type) ? null : ActivityType.From(type);
+			var query = new GetRecentActivityQuery(ActivityLimit.From(limit), typeFilter);
 			var result = await handler.HandleAsync(query, cancellationToken);
+			return result.ToOk();
+		}
+
+		group.MapGet("/activity/recipes/{identifier:guid}/stats", GetRecipeStats)
+			.RequireAuthorization()
+			.WithName("GetRecipeActivityStats")
+			.WithTags("Users")
+			.Produces<RecipeActivityStatsDto>();
+
+		static async Task<IResult> GetRecipeStats(
+			Guid identifier,
+			IQueryHandler<GetRecipeActivityStatsQuery, Result<RecipeActivityStatsDto>> handler,
+			CancellationToken cancellationToken)
+		{
+			var result = await handler.HandleAsync(new GetRecipeActivityStatsQuery(identifier), cancellationToken);
 			return result.ToOk();
 		}
 

--- a/src/Yumney.Users.Application/DTOs/RecipeActivityStatsDto.cs
+++ b/src/Yumney.Users.Application/DTOs/RecipeActivityStatsDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record RecipeActivityStatsDto(int CookCount, DateTime? LastCookedAt, int ViewCount);

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeCookedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeCookedActivityHandler.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Records a "recipe cooked" entry. Each completion is a discrete event so
+/// the cook count derives directly from the count of these activity rows.
+/// </summary>
+public sealed class RecipeCookedActivityHandler(IUserActivityRepository activities)
+	: IIntegrationEventHandler<RecipeCookedIntegrationEvent>
+{
+	public async Task HandleAsync(RecipeCookedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var entry = UserActivity.Record(
+			OwnerIdentifier.From(@event.OwnerId),
+			ActivityType.RecipeCooked,
+			RecipeIdentifierSnapshot.From(@event.RecipeIdentifier),
+			RecipeTitleSnapshot.From(@event.RecipeTitle));
+		await activities.AddAsync(entry, cancellationToken);
+	}
+}

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeDeletedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeDeletedActivityHandler.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Records a "recipe deleted" entry. The recipe title is no longer available
+/// here (the published event carries only the identifier), so the activity
+/// row stores the identifier with a null title — UI shows "Deleted recipe".
+/// </summary>
+public sealed class RecipeDeletedActivityHandler(IUserActivityRepository activities)
+	: IIntegrationEventHandler<RecipeDeletedIntegrationEvent>
+{
+	public async Task HandleAsync(RecipeDeletedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var entry = UserActivity.Record(
+			OwnerIdentifier.From(@event.OwnerId),
+			ActivityType.RecipeDeleted,
+			RecipeIdentifierSnapshot.From(@event.RecipeIdentifier));
+		await activities.AddAsync(entry, cancellationToken);
+	}
+}

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeImportedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeImportedActivityHandler.cs
@@ -1,0 +1,22 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Records a "recipe imported" entry in the user's activity log (US-121).
+/// </summary>
+public sealed class RecipeImportedActivityHandler(IUserActivityRepository activities)
+	: IIntegrationEventHandler<RecipeImportedIntegrationEvent>
+{
+	public async Task HandleAsync(RecipeImportedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var entry = UserActivity.Record(
+			OwnerIdentifier.From(@event.OwnerId),
+			ActivityType.RecipeImported,
+			RecipeIdentifierSnapshot.From(@event.RecipeIdentifier),
+			RecipeTitleSnapshot.From(@event.RecipeTitle));
+		await activities.AddAsync(entry, cancellationToken);
+	}
+}

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeViewedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeViewedActivityHandler.cs
@@ -1,0 +1,24 @@
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+
+/// <summary>
+/// Records a "recipe viewed" entry. The Recipes module already debounces
+/// view events with a 5-minute window per (user, recipe), so this handler
+/// stays naive and just persists what arrives.
+/// </summary>
+public sealed class RecipeViewedActivityHandler(IUserActivityRepository activities)
+	: IIntegrationEventHandler<RecipeViewedIntegrationEvent>
+{
+	public async Task HandleAsync(RecipeViewedIntegrationEvent @event, CancellationToken cancellationToken = default)
+	{
+		var entry = UserActivity.Record(
+			OwnerIdentifier.From(@event.OwnerId),
+			ActivityType.RecipeViewed,
+			RecipeIdentifierSnapshot.From(@event.RecipeIdentifier),
+			RecipeTitleSnapshot.From(@event.RecipeTitle));
+		await activities.AddAsync(entry, cancellationToken);
+	}
+}

--- a/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
@@ -5,5 +5,9 @@ using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
 
-public sealed record GetRecentActivityQuery(ActivityLimit Limit)
+/// <summary>
+/// Returns the current user's most recent activity entries (US-121). When
+/// <see cref="Type"/> is non-null only entries of that type are included.
+/// </summary>
+public sealed record GetRecentActivityQuery(ActivityLimit Limit, ActivityType? Type = null)
 	: IQuery<Result<IReadOnlyList<UserActivityDto>>>;

--- a/src/Yumney.Users.Application/Queries/GetRecipeActivityStatsQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetRecipeActivityStatsQuery.cs
@@ -1,0 +1,8 @@
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
+
+public sealed record GetRecipeActivityStatsQuery(Guid RecipeIdentifier)
+	: IQuery<Result<RecipeActivityStatsDto>>;

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -13,8 +13,10 @@ public sealed class GetRecentActivityQueryHandler(IUserActivityRepository activi
 	{
 		var owner = currentUser.AsOwner();
 
-		var recentActivities = await activities.GetRecentAsync(owner, query.Limit, cancellationToken);
+		var entries = query.Type is null
+			? await activities.GetRecentAsync(owner, query.Limit, cancellationToken)
+			: await activities.GetRecentByTypeAsync(owner, query.Type, query.Limit, cancellationToken);
 
-		return Result.Success(recentActivities.ToDtos());
+		return Result.Success(entries.ToDtos());
 	}
 }

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
+
+public sealed class GetRecipeActivityStatsQueryHandler(
+	IUserActivityRepository activities,
+	ICurrentUser currentUser)
+	: IQueryHandler<GetRecipeActivityStatsQuery, Result<RecipeActivityStatsDto>>
+{
+	public async Task<Result<RecipeActivityStatsDto>> HandleAsync(GetRecipeActivityStatsQuery query, CancellationToken cancellationToken = default)
+	{
+		var owner = currentUser.AsOwner();
+		var stats = await activities.GetRecipeStatsAsync(
+			owner,
+			RecipeIdentifierSnapshot.From(query.RecipeIdentifier),
+			cancellationToken);
+		return Result.Success(new RecipeActivityStatsDto(stats.CookCount, stats.LastCookedAt, stats.ViewCount));
+	}
+}

--- a/src/Yumney.Users.Application/UsersApplicationServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Application/UsersApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;
 
 namespace SmartSolutionsLab.Yumney.Users.Application;
@@ -9,6 +10,7 @@ public static class UsersApplicationServiceCollectionExtensions
 	public static IServiceCollection AddUsersApplication(this IServiceCollection services)
 	{
 		services.AddHandlersFromAssemblyContaining<RegisterUserCommandHandler>();
+		services.AddBusEventHandlersFromAssemblyContaining<RegisterUserCommandHandler>();
 
 		return services;
 	}

--- a/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityType.cs
@@ -7,6 +7,7 @@ public sealed record ActivityType : IValueObject<string>
 {
 	public static readonly ActivityType RecipeImported = new("recipe_imported");
 	public static readonly ActivityType RecipeViewed = new("recipe_viewed");
+	public static readonly ActivityType RecipeCooked = new("recipe_cooked");
 	public static readonly ActivityType RecipeEdited = new("recipe_edited");
 	public static readonly ActivityType RecipeDeleted = new("recipe_deleted");
 	public static readonly ActivityType ShoppingListCreated = new("shopping_list_created");
@@ -17,6 +18,7 @@ public sealed record ActivityType : IValueObject<string>
 	[
 		RecipeImported.Value,
 		RecipeViewed.Value,
+		RecipeCooked.Value,
 		RecipeEdited.Value,
 		RecipeDeleted.Value,
 		ShoppingListCreated.Value

--- a/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
+++ b/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
@@ -6,6 +6,21 @@ public interface IUserActivityRepository
 
 	Task<IReadOnlyList<UserActivity>> GetRecentAsync(OwnerIdentifier owner, ActivityLimit limit, CancellationToken cancellationToken = default);
 
+	// Filter-by-type variant for the activity timeline UI (US-121).
+	Task<IReadOnlyList<UserActivity>> GetRecentByTypeAsync(
+		OwnerIdentifier owner,
+		ActivityType type,
+		ActivityLimit limit,
+		CancellationToken cancellationToken = default);
+
+	// Per-recipe stats: cook count + last cooked + view count (US-121).
+	Task<RecipeActivityStats> GetRecipeStatsAsync(
+		OwnerIdentifier owner,
+		RecipeIdentifierSnapshot recipeIdentifier,
+		CancellationToken cancellationToken = default);
+
 	// Idempotent. Returns the number of rows removed.
 	Task<int> DeleteAllByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }
+
+public sealed record RecipeActivityStats(int CookCount, DateTime? LastCookedAt, int ViewCount);

--- a/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
@@ -25,6 +25,42 @@ public sealed class UserActivityRepository(UsersDbContext context) : IUserActivi
 			.ToListAsync(cancellationToken);
 	}
 
+	public async Task<IReadOnlyList<UserActivity>> GetRecentByTypeAsync(
+		OwnerIdentifier owner,
+		ActivityType type,
+		ActivityLimit limit,
+		CancellationToken cancellationToken = default)
+	{
+		return await activities
+			.AsNoTracking()
+			.Where(activity => activity.Owner == owner && activity.Type == type)
+			.OrderByDescending(activity => activity.OccurredAt)
+			.Take(limit.Value)
+			.ToListAsync(cancellationToken);
+	}
+
+	public async Task<RecipeActivityStats> GetRecipeStatsAsync(
+		OwnerIdentifier owner,
+		RecipeIdentifierSnapshot recipeIdentifier,
+		CancellationToken cancellationToken = default)
+	{
+		var recipeRows = activities
+			.AsNoTracking()
+			.Where(activity => activity.Owner == owner && activity.RecipeIdentifier == recipeIdentifier);
+
+		var cooked = recipeRows.Where(activity => activity.Type == ActivityType.RecipeCooked);
+
+		var cookCount = await cooked.CountAsync(cancellationToken);
+		var lastCookedAt = await cooked
+			.OrderByDescending(activity => activity.OccurredAt)
+			.Select(activity => (DateTime?)activity.OccurredAt)
+			.FirstOrDefaultAsync(cancellationToken);
+		var viewCount = await recipeRows
+			.CountAsync(activity => activity.Type == ActivityType.RecipeViewed, cancellationToken);
+
+		return new RecipeActivityStats(cookCount, lastCookedAt, viewCount);
+	}
+
 	public async Task<int> DeleteAllByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
 		return await activities.Where(activity => activity.Owner == owner).ExecuteDeleteAsync(cancellationToken);

--- a/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/SaveRecipeCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using Xunit;
 
@@ -14,13 +15,14 @@ public class SaveRecipeCommandHandlerTests
 	private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
 	private readonly IRecipesUnitOfWork unitOfWork = Substitute.For<IRecipesUnitOfWork>();
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
 	private readonly SaveRecipeCommandHandler handler;
 
 	public SaveRecipeCommandHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
 		unitOfWork.Recipes.Returns(recipes);
-		handler = new SaveRecipeCommandHandler(unitOfWork, currentUser);
+		handler = new SaveRecipeCommandHandler(unitOfWork, currentUser, eventBus);
 	}
 
 	[Fact]

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetRecipeByIdQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
@@ -15,13 +16,14 @@ public class GetRecipeByIdQueryHandlerTests
 {
 	private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
 	private readonly IRecipeFavoriteRepository favorites = Substitute.For<IRecipeFavoriteRepository>();
+	private readonly IRecipeViewTracker viewTracker = Substitute.For<IRecipeViewTracker>();
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
 	private readonly GetRecipeByIdQueryHandler handler;
 
 	public GetRecipeByIdQueryHandlerTests()
 	{
 		currentUser.UserId.Returns("user-123");
-		handler = new GetRecipeByIdQueryHandler(recipes, favorites, currentUser);
+		handler = new GetRecipeByIdQueryHandler(recipes, favorites, viewTracker, currentUser);
 	}
 
 	[Fact]

--- a/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeCookedActivityHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeCookedActivityHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.IntegrationEventHandlers;
+
+public class RecipeCookedActivityHandlerTests
+{
+	private readonly IUserActivityRepository activities = Substitute.For<IUserActivityRepository>();
+	private readonly RecipeCookedActivityHandler handler;
+
+	public RecipeCookedActivityHandlerTests()
+	{
+		handler = new RecipeCookedActivityHandler(activities);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PersistsRecipeCookedActivity()
+	{
+		var recipeId = Guid.NewGuid();
+		var @event = new RecipeCookedIntegrationEvent("user-123", recipeId, "Pasta");
+
+		UserActivity? captured = null;
+		await activities.AddAsync(
+			Arg.Do<UserActivity>(activity => captured = activity),
+			Arg.Any<CancellationToken>());
+
+		await handler.HandleAsync(@event);
+
+		captured.Should().NotBeNull();
+		captured!.Type.Should().Be(ActivityType.RecipeCooked);
+		captured.Owner.Value.Should().Be("user-123");
+		captured.RecipeIdentifier!.Value.Should().Be(recipeId);
+		captured.RecipeTitle!.Value.Should().Be("Pasta");
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCancellationToken()
+	{
+		var cts = new CancellationTokenSource();
+		var @event = new RecipeCookedIntegrationEvent("user-123", Guid.NewGuid(), "Pasta");
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await activities.Received(1).AddAsync(Arg.Any<UserActivity>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityTypeTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityTypeTests.cs
@@ -10,6 +10,7 @@ public class ActivityTypeTests
 	[Theory]
 	[InlineData("recipe_imported")]
 	[InlineData("recipe_viewed")]
+	[InlineData("recipe_cooked")]
 	[InlineData("recipe_edited")]
 	[InlineData("recipe_deleted")]
 	[InlineData("shopping_list_created")]
@@ -44,6 +45,7 @@ public class ActivityTypeTests
 	{
 		ActivityType.RecipeImported.Value.Should().Be("recipe_imported");
 		ActivityType.RecipeViewed.Value.Should().Be("recipe_viewed");
+		ActivityType.RecipeCooked.Value.Should().Be("recipe_cooked");
 		ActivityType.RecipeEdited.Value.Should().Be("recipe_edited");
 		ActivityType.RecipeDeleted.Value.Should().Be("recipe_deleted");
 		ActivityType.ShoppingListCreated.Value.Should().Be("shopping_list_created");


### PR DESCRIPTION
## Summary
**Cross-module events** — three new events in \`Yumney.Shared.Events.CrossModule\`: \`RecipeImportedIntegrationEvent\` (fired by \`SaveRecipeCommandHandler\`), \`RecipeViewedIntegrationEvent\` (fired by a new \`IRecipeViewTracker\` from \`GetRecipeByIdQueryHandler\` with a 5-minute IDistributedCache dedup window per (user, recipe)), and \`RecipeCookedIntegrationEvent\` (published by a new \`TrackRecipeCookedCommand\` exposed at \`POST /api/v1/recipes/{id}/cooked\`).

**Users module** — adds \`RecipeCooked\` to \`ActivityType\`. Four new \`IIntegrationEventHandler\` subscribers in \`Yumney.Users.Application.IntegrationEventHandlers\` map each event onto \`UserActivity.Record(...)\`. \`Yumney.Users.Api.Program.cs\` now passes the Application assembly to \`AddYumneyDefaults\` so the bus scanner picks them up.

**New queries** — \`GetRecentActivityQuery\` gains an optional \`ActivityType\` filter for the timeline UI's chip filters. New \`GetRecipeActivityStatsQuery\` returns \`{ cookCount, lastCookedAt, viewCount }\` for the current user × recipe pair, exposed at \`GET /api/v1/users/me/activity/recipes/{id}/stats\`.

**Frontend** — new \`yn-activity-timeline\` UI component (glass cards, lucide icon per type, locale-agnostic relative timestamps via a small \`relativeTimeFromNow\` helper, empty state). New \`/account/activity\` route uses it with chip filters. Recipe-detail loads stats and renders a \"Cooked N times · last cooked X\" pill. Cook-mode's \`exit()\` fires \`trackCooked()\` once the user reaches the final step. Full DE+EN i18n.

Closes #32

## Trade-offs
- **View tracking** runs server-side from \`GetRecipeByIdQueryHandler\` so we don't trust the client to be honest about whether they actually opened the recipe. The 5-minute lockout is per-(user, recipe) and stored in \`IDistributedCache\` — survives a single instance restart only if Redis is wired; otherwise the in-memory implementation drops the keys.
- **Cook tracking** is explicitly a discrete client-fired POST when the user reaches the last step and exits cook-mode. No dedup — each cook is a real cook.
- **Per-recipe stats** queried directly from \`UserActivity\` rows (cross-module via the existing API gateway instead of a denormalized cache on Recipe). Single source of truth, simpler invalidation, fine until the activity log gets very large.
- **US-220 dashboard suggestion algorithm** is deliberately out of scope for this PR — the data is now flowing into \`UserActivity\` ready for the suggestion handler to consume in its own story.
- The activity log has no pagination yet — page returns \`limit=50\` ceiling. Filing a follow-up if the timeline ever needs cursoring.

## Test plan
- [x] \`dotnet test\` — Users.Domain **220 (+1)**, Users.Application **37 (+2)**, Users.Infrastructure 19, Users.Api 24, Recipes.Application 165 (existing tests updated for the new \`IRecipeViewTracker\` ctor + \`IEventBus\` ctor), Architecture 134 — all green.
- [x] \`nx test ui\` — **211 (+8 for yn-activity-timeline + relativeTimeFromNow)** — green.
- [x] \`nx test recipes\` — **181** (recipe-detail spec gains an ActivityApi mock) — green.
- [x] \`nx test account\` — 14 — green.
- [x] \`nx test shared-api-client\` — 36 — green.
- [x] \`dotnet build Yumney.slnx\` — 0 warnings, 0 errors.
- [ ] Manual: import a recipe → /account/activity shows it. Open the recipe detail twice within 5 min → only one \"Viewed\" entry. Cook → reach last step → exit → \"Cooked\" entry appears + \"Cooked 1 times · today\" pill on the detail page.

## Follow-ups
- Pagination/cursoring on the activity feed (defer until UI hits the 50-row ceiling in real usage).
- Persistent dedup store: Redis-backed IDistributedCache for the view tracker's window so the 5-minute window holds across instance restarts.