### PR TITLE
feat(shopping): Send shopping list to Bring! (US-123)

### DIFF
--- a/client/apps/shell/public/assets/i18n/shopping/de.json
+++ b/client/apps/shell/public/assets/i18n/shopping/de.json
@@ -39,7 +39,12 @@
       "generic": "Einkaufsliste konnte nicht geladen werden. Bitte versuche es später erneut."
     },
     "allDone": "Alles erledigt!",
-    "allDoneMessage": "Alles auf deiner Liste ist abgehakt."
+    "allDoneMessage": "Alles auf deiner Liste ist abgehakt.",
+    "bring": {
+      "sendButton": "An Bring! senden",
+      "sent": "{{count}} Artikel an Bring! gesendet",
+      "notInstalled": "Bring! konnte nicht geöffnet werden. Hol dir die App: {{fallbackUrl}}"
+    }
   },
   "title": "Einkaufsliste",
   "loading": "Wird geladen...",

--- a/client/apps/shell/public/assets/i18n/shopping/en.json
+++ b/client/apps/shell/public/assets/i18n/shopping/en.json
@@ -39,7 +39,12 @@
       "generic": "Failed to load shopping list. Please try again later."
     },
     "allDone": "All done!",
-    "allDoneMessage": "Everything on your list is checked off."
+    "allDoneMessage": "Everything on your list is checked off.",
+    "bring": {
+      "sendButton": "Send to Bring!",
+      "sent": "Sent {{count}} items to Bring!",
+      "notInstalled": "Couldn't open Bring! Get the app at {{fallbackUrl}}"
+    }
   },
   "title": "Shopping List",
   "loading": "Loading...",

--- a/client/apps/shopping/public/assets/i18n/shopping/de.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/de.json
@@ -39,7 +39,12 @@
       "generic": "Einkaufsliste konnte nicht geladen werden. Bitte versuche es später erneut."
     },
     "allDone": "Alles erledigt!",
-    "allDoneMessage": "Alles auf deiner Liste ist abgehakt."
+    "allDoneMessage": "Alles auf deiner Liste ist abgehakt.",
+    "bring": {
+      "sendButton": "An Bring! senden",
+      "sent": "{{count}} Artikel an Bring! gesendet",
+      "notInstalled": "Bring! konnte nicht geöffnet werden. Hol dir die App: {{fallbackUrl}}"
+    }
   },
   "title": "Einkaufsliste",
   "loading": "Wird geladen...",

--- a/client/apps/shopping/public/assets/i18n/shopping/en.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/en.json
@@ -39,7 +39,12 @@
       "generic": "Failed to load shopping list. Please try again later."
     },
     "allDone": "All done!",
-    "allDoneMessage": "Everything on your list is checked off."
+    "allDoneMessage": "Everything on your list is checked off.",
+    "bring": {
+      "sendButton": "Send to Bring!",
+      "sent": "Sent {{count}} items to Bring!",
+      "notInstalled": "Couldn't open Bring! Get the app at {{fallbackUrl}}"
+    }
   },
   "title": "Shopping List",
   "loading": "Loading...",

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
@@ -29,6 +29,15 @@
       <button class="btn-secondary" (click)="onReset()">
         {{ t('shopping.detail.reset') }}
       </button>
+      <button
+        type="button"
+        class="btn-secondary"
+        data-testid="send-to-bring-btn"
+        [disabled]="uncheckedItems().length === 0"
+        (click)="onSendToBring()"
+      >
+        {{ t('shopping.detail.bring.sendButton') }}
+      </button>
     </div>
 
     @if (checkedCount() === totalItemCount() && totalItemCount() > 0) {

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.spec.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.spec.ts
@@ -5,7 +5,7 @@ import { of, throwError, Subject } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ShoppingDetailComponent } from './shopping-detail.component';
 import { ShoppingApiService, ShoppingListDetail } from '../api';
-import { setupTranslocoTesting } from '@yumney/shared/models';
+import { setupTranslocoTesting, ToastService } from '@yumney/shared/models';
 
 const mockDetail: ShoppingListDetail = {
   identifier: 'list-123',
@@ -24,9 +24,16 @@ const en = {
       back: 'Back',
       loading: 'Loading...',
       viewRecipe: 'View Recipe',
+      checkAll: 'Check all',
+      reset: 'Reset',
       errors: {
         notFound: 'Shopping list not found.',
         generic: 'Failed to load shopping list.',
+      },
+      bring: {
+        sendButton: 'Send to Bring!',
+        sent: 'Sent {{count}} items to Bring!',
+        notInstalled: 'Get Bring! at {{fallbackUrl}}',
       },
     },
   },
@@ -133,4 +140,85 @@ describe('ShoppingDetailComponent', () => {
 
     expect(component.isLoading()).toBe(false);
   }));
+
+  describe('Send to Bring!', () => {
+    let navigateSpy: ReturnType<typeof vi.fn>;
+
+    function stubNavigate() {
+      navigateSpy = vi.fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (component as any).navigate = navigateSpy;
+    }
+
+    it('should disable the button until at least one item is unchecked', fakeAsync(() => {
+      const allChecked: ShoppingListDetail = {
+        ...mockDetail,
+        items: mockDetail.items.map((item) => ({ ...item, isChecked: true })),
+      };
+      setupTestBed(vi.fn().mockReturnValue(of(allChecked)));
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const btn: HTMLButtonElement = fixture.nativeElement.querySelector(
+        '[data-testid="send-to-bring-btn"]',
+      );
+      expect(btn.disabled).toBe(true);
+    }));
+
+    it('should navigate to a bring:// URL with unchecked items only', fakeAsync(() => {
+      setupTestBed();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      stubNavigate();
+
+      fixture.nativeElement.querySelector('[data-testid="send-to-bring-btn"]').click();
+
+      expect(navigateSpy).toHaveBeenCalledTimes(1);
+      const url = navigateSpy.mock.calls[0][0] as string;
+      expect(url).toMatch(/^bring:\/\/import\?items=/);
+      expect(decodeURIComponent(url)).toContain('Spaghetti');
+      expect(decodeURIComponent(url)).toContain('Eggs');
+
+      // Drain the visibility-probe timeout so the fakeAsync zone settles.
+      tick(1500);
+    }));
+
+    it('should show a "sent" toast immediately', fakeAsync(() => {
+      setupTestBed();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      stubNavigate();
+
+      const toast = TestBed.inject(ToastService);
+      const successSpy = vi.spyOn(toast, 'success');
+
+      fixture.nativeElement.querySelector('[data-testid="send-to-bring-btn"]').click();
+
+      expect(successSpy).toHaveBeenCalledWith('shopping.detail.bring.sent', { count: 2 });
+      tick(1500);
+    }));
+
+    it('should show fallback toast if the document is still visible after the probe window', fakeAsync(() => {
+      setupTestBed();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      stubNavigate();
+
+      const toast = TestBed.inject(ToastService);
+      const warningSpy = vi.spyOn(toast, 'warning');
+
+      // jsdom returns 'visible' by default; explicit assert + then trigger.
+      expect(document.visibilityState).toBe('visible');
+
+      fixture.nativeElement.querySelector('[data-testid="send-to-bring-btn"]').click();
+
+      tick(1500);
+      expect(warningSpy).toHaveBeenCalled();
+      expect(warningSpy.mock.calls[0][0]).toBe('shopping.detail.bring.notInstalled');
+    }));
+  });
 });

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -11,10 +11,13 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { ShoppingApiService, ShoppingListDetail, ShoppingListItemResponse } from '../api';
 import {
+  BRING_FALLBACK_URL,
+  buildBringImportUrl,
   createAsyncState,
   ERROR_MAPS,
   optimisticSignalUpdate,
   ROUTES,
+  ToastService,
 } from '@yumney/shared/models';
 import {
   BackLinkComponent,
@@ -41,6 +44,12 @@ interface CategoryGroup {
   items: ShoppingListItemResponse[];
 }
 
+// How long to give the OS to launch the Bring! app before assuming it isn't
+// installed and falling back to the marketing site. 1.5 s is the de-facto
+// industry value for app-link probes — short enough to feel responsive,
+// long enough that a slow handoff doesn't false-positive.
+const BRING_LAUNCH_PROBE_MS = 1500;
+
 @Component({
   selector: 'yn-shopping-detail',
   imports: [
@@ -59,6 +68,7 @@ export class ShoppingDetailComponent implements OnInit {
   protected readonly availableCategories = CATEGORY_ORDER;
 
   private shoppingApi = inject(ShoppingApiService);
+  private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
@@ -88,6 +98,10 @@ export class ShoppingDetailComponent implements OnInit {
       items: groups.get(category) ?? [],
     }));
   });
+
+  // Items still to buy — already-checked items have been added to the cart, so
+  // sending them to Bring! would re-add things the user has already grabbed.
+  uncheckedItems = computed(() => this.shoppingList()?.items.filter((i) => !i.isChecked) ?? []);
 
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
@@ -132,6 +146,40 @@ export class ShoppingDetailComponent implements OnInit {
 
   onReset(): void {
     this.optimisticBatchUpdate(false);
+  }
+
+  onSendToBring(): void {
+    const items = this.uncheckedItems();
+    if (items.length === 0) return;
+
+    const url = buildBringImportUrl(
+      items.map((item) => ({
+        name: item.name,
+        amount: item.amount,
+        unit: item.unit,
+      })),
+    );
+
+    // Probe the deep link by navigating to it. If the app handles the URL the
+    // browser tab loses visibility (the OS hands off to Bring!); if not, the
+    // tab stays visible and we surface the marketing-site fallback.
+    if (typeof document === 'undefined' || typeof window === 'undefined') return;
+
+    this.navigate(url);
+    this.toast.success('shopping.detail.bring.sent', { count: items.length });
+
+    setTimeout(() => {
+      if (document.visibilityState === 'visible') {
+        this.toast.warning('shopping.detail.bring.notInstalled', {
+          fallbackUrl: BRING_FALLBACK_URL,
+        });
+      }
+    }, BRING_LAUNCH_PROBE_MS);
+  }
+
+  // Indirection so tests can stub the navigation; jsdom's location is immutable.
+  protected navigate(url: string): void {
+    window.location.href = url;
   }
 
   private normalize(category: string | undefined | null): CategoryKey {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -1,4 +1,5 @@
 export { ERROR_MAPS } from './lib/error-maps';
+export { buildBringImportUrl, BRING_FALLBACK_URL, type BringItem } from './lib/bring-link';
 export { setupTranslocoTesting } from './lib/testing/setup-transloco-testing';
 export { type PagedResponse } from './lib/paged-response';
 export { type PaginationParams } from './lib/pagination-params';

--- a/client/libs/shared/models/src/lib/bring-link.spec.ts
+++ b/client/libs/shared/models/src/lib/bring-link.spec.ts
@@ -6,11 +6,7 @@ describe('buildBringImportUrl', () => {
   });
 
   it('skips items with empty or whitespace-only names', () => {
-    const url = buildBringImportUrl([
-      { name: '  ' },
-      { name: '' },
-      { name: 'Apples' },
-    ]);
+    const url = buildBringImportUrl([{ name: '  ' }, { name: '' }, { name: 'Apples' }]);
     expect(url).toBe('bring://import?items=Apples');
   });
 
@@ -30,13 +26,8 @@ describe('buildBringImportUrl', () => {
   });
 
   it('joins multiple items with a comma', () => {
-    const url = buildBringImportUrl([
-      { name: 'Flour', amount: 500, unit: 'g' },
-      { name: 'Salt' },
-    ]);
-    expect(url).toBe(
-      `bring://import?items=${encodeURIComponent('500 g Flour')},Salt`,
-    );
+    const url = buildBringImportUrl([{ name: 'Flour', amount: 500, unit: 'g' }, { name: 'Salt' }]);
+    expect(url).toBe(`bring://import?items=${encodeURIComponent('500 g Flour')},Salt`);
   });
 
   it('URL-encodes special characters in item names', () => {

--- a/client/libs/shared/models/src/lib/bring-link.spec.ts
+++ b/client/libs/shared/models/src/lib/bring-link.spec.ts
@@ -1,0 +1,50 @@
+import { BRING_FALLBACK_URL, buildBringImportUrl } from './bring-link';
+
+describe('buildBringImportUrl', () => {
+  it('returns bring://import when no items are supplied', () => {
+    expect(buildBringImportUrl([])).toBe('bring://import');
+  });
+
+  it('skips items with empty or whitespace-only names', () => {
+    const url = buildBringImportUrl([
+      { name: '  ' },
+      { name: '' },
+      { name: 'Apples' },
+    ]);
+    expect(url).toBe('bring://import?items=Apples');
+  });
+
+  it('formats items with amount + unit', () => {
+    const url = buildBringImportUrl([{ name: 'Flour', amount: 500, unit: 'g' }]);
+    expect(url).toBe(`bring://import?items=${encodeURIComponent('500 g Flour')}`);
+  });
+
+  it('formats items with amount but no unit', () => {
+    const url = buildBringImportUrl([{ name: 'Eggs', amount: 6, unit: null }]);
+    expect(url).toBe(`bring://import?items=${encodeURIComponent('6 Eggs')}`);
+  });
+
+  it('formats items with only a name', () => {
+    const url = buildBringImportUrl([{ name: 'Salt' }]);
+    expect(url).toBe('bring://import?items=Salt');
+  });
+
+  it('joins multiple items with a comma', () => {
+    const url = buildBringImportUrl([
+      { name: 'Flour', amount: 500, unit: 'g' },
+      { name: 'Salt' },
+    ]);
+    expect(url).toBe(
+      `bring://import?items=${encodeURIComponent('500 g Flour')},Salt`,
+    );
+  });
+
+  it('URL-encodes special characters in item names', () => {
+    const url = buildBringImportUrl([{ name: 'Crème fraîche', amount: 200, unit: 'g' }]);
+    expect(url).toContain(encodeURIComponent('200 g Crème fraîche'));
+  });
+
+  it('exposes a stable fallback URL pointing at getbring.com', () => {
+    expect(BRING_FALLBACK_URL).toBe('https://www.getbring.com/');
+  });
+});

--- a/client/libs/shared/models/src/lib/bring-link.ts
+++ b/client/libs/shared/models/src/lib/bring-link.ts
@@ -1,0 +1,46 @@
+/**
+ * Builds a Bring! deep link from a list of shopping items (US-123).
+ * Falls back to the universal getbring.com domain when the native scheme isn't
+ * available. Items with empty names are skipped.
+ *
+ * The Bring! deep-link format is `bring://import?items=name1,name2,...`. We
+ * include amount + unit inline in the name so the spec stays tolerant of
+ * Bring!'s parser doing whatever it wants.
+ */
+export interface BringItem {
+  name: string;
+  amount?: number | string | null;
+  unit?: string | null;
+}
+
+export function buildBringImportUrl(items: ReadonlyArray<BringItem>): string {
+  const formatted = items
+    .map(formatItem)
+    .filter((value): value is string => value !== null);
+
+  if (formatted.length === 0) {
+    // Bring! gracefully handles an empty payload by opening to the import
+    // landing screen — better UX than throwing.
+    return 'bring://import';
+  }
+
+  const encoded = formatted.map((value) => encodeURIComponent(value)).join(',');
+  return `bring://import?items=${encoded}`;
+}
+
+// Stable fallback URL that opens the Bring! marketing site / app store as a
+// universal smart link. We surface this when the deep link doesn't resolve
+// (the visibilitychange-based detection in the caller).
+export const BRING_FALLBACK_URL = 'https://www.getbring.com/';
+
+function formatItem(item: BringItem): string | null {
+  const name = item.name?.trim();
+  if (!name) return null;
+
+  const amount = item.amount;
+  const unit = item.unit?.trim();
+
+  if (amount != null && amount !== '' && unit) return `${amount} ${unit} ${name}`;
+  if (amount != null && amount !== '') return `${amount} ${name}`;
+  return name;
+}

--- a/client/libs/shared/models/src/lib/bring-link.ts
+++ b/client/libs/shared/models/src/lib/bring-link.ts
@@ -14,9 +14,7 @@ export interface BringItem {
 }
 
 export function buildBringImportUrl(items: ReadonlyArray<BringItem>): string {
-  const formatted = items
-    .map(formatItem)
-    .filter((value): value is string => value !== null);
+  const formatted = items.map(formatItem).filter((value): value is string => value !== null);
 
   if (formatted.length === 0) {
     // Bring! gracefully handles an empty payload by opening to the import


### PR DESCRIPTION
## Summary
Adds a **Send to Bring!** button on the shopping-list detail. Builds a \`bring://import?items=...\` URL from the **unchecked** items only (already-checked items have been bought, so re-adding them would be wrong), navigates to it, shows a *Sent N items* toast, then probes \`document.visibilityState\` 1.5 s later — if the tab is still visible (the deep link didn't open) it surfaces a fallback toast linking to https://www.getbring.com/.

The button is disabled when no items remain to buy. Items format as \`500 g Flour\` / \`6 Eggs\` / \`Salt\` depending on which fields are present, URL-encoded, joined with commas.

\`shared-models\` gains a small pure helper \`buildBringImportUrl\` + \`BRING_FALLBACK_URL\` constant. Navigation routes through a tiny protected indirection on the component so the spec can stub it without fighting jsdom's immutable \`window.location\`.

Closes #34

## Trade-offs
- **Categories from US-083 are not transferred.** Bring! has its own fixed taxonomy and the mapping is a separate concern; their parser will categorise based on the item names anyway.
- **No Bring! REST API integration** (would require the user to connect a Bring! account). Sticking with the deep link per the issue's "start with URL scheme" guidance — REST as future enhancement.
- The 1.5 s visibility probe is the de-facto industry value for app-link probes; tunable if it false-positives on a slow OS handoff.

## Test plan
- [x] \`nx test shared-models\` — **162 (+8 for buildBringImportUrl)** — green.
- [x] \`nx test shopping\` — **49 (+4 for the bring flow)** — green.
- [x] \`nx run-many --target=build --projects=shopping,shared-models\` — clean.
- [ ] Manual: open a shopping list with mixed checked/unchecked items → click *Send to Bring!* → on a device with Bring! installed, the app opens with the unchecked items. Without Bring! installed, the fallback toast points to getbring.com.