### PR TITLE
test(integration): bump Eventually default timeout to 15s

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -15,7 +15,13 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 /// </summary>
 public static class Eventually
 {
-	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+	// 15s is a deliberate trade between fast feedback and tolerance for
+	// suite-wide load. Wolverine handlers race the polling assert; with the
+	// full integration suite running, RabbitMQ + projection workers can stack
+	// up enough that a single check-off event needs more than 5s to surface
+	// in the read model. 15s leaves headroom without making a real failure
+	// (a handler bug that never converges) feel sluggish.
+	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
 	private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
 
 	public static async Task AssertAsync(


### PR DESCRIPTION
## Problem
\`Shopping.ShoppingListCreateFlowTests.CreateAndCheckOff_PersistsCheckedState\` passes in isolation and as part of its own class, but flakes under the full integration suite — the check-off projection can't catch up in 5s when RabbitMQ + Wolverine workers are dealing with traffic from earlier test classes.

## Fix
Bump the default \`Eventually.AssertAsync\` timeout from 5s to 15s. Comment in the file explains the trade-off.

15s leaves headroom for suite-wide load while still failing fast on a real never-converges bug. Tests with bespoke timeouts that pass an explicit \`timeout:\` argument are unaffected.

## Test plan
- [x] \`dotnet test tests/Yumney.Integration.Tests\` — **242/242 passing** (was 241/242 with the 5s default).