### PR TITLE
chore(api): drop unused usings and reformat fluent chains

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -60,7 +60,8 @@ else
 
 if (!options.DatabaseOnly)
 {
-	var migrationRunner = builder.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
+	var migrationRunner = builder
+		.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
 		.WithReference(recipesDb)
 		.WithReference(shoppingDb)
 		.WithReference(usersDb)
@@ -74,13 +75,17 @@ if (!options.DatabaseOnly)
 	// task. Each sits idle until the dev clicks Start in the dashboard.
 	if (isRunMode)
 	{
-		DashboardResetEntries.AddShoppingAndMealPlanResetEntries(
-			builder, recipesDb, shoppingDb, usersDb, mealplanDb);
+		DashboardResetEntries.AddShoppingAndMealPlanResetEntries(builder, recipesDb, shoppingDb, usersDb, mealplanDb);
 	}
 
 	// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)
-	var redis = builder.AddRedis("redis", password: redisPassword).WithImageTag("alpine");
-	var messaging = builder.AddRabbitMQ("messaging", password: messagingPassword).WithImageTag("4-management-alpine").WithManagementPlugin();
+	var redis = builder
+		.AddRedis("redis", password: redisPassword)
+		.WithImageTag("alpine");
+	var messaging = builder
+		.AddRabbitMQ("messaging", password: messagingPassword)
+		.WithImageTag("4-management-alpine")
+		.WithManagementPlugin();
 	var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword);
 
 	if (isRunMode && !options.E2ETests)
@@ -94,7 +99,8 @@ if (!options.DatabaseOnly)
 
 	if (isRunMode && !options.E2ETests)
 	{
-		builder.AddContainer("mailpit", "axllent/mailpit", "v1.22")
+		builder
+			.AddContainer("mailpit", "axllent/mailpit", "v1.22")
 			.WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
 			.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
 			.WithLifetime(ContainerLifetime.Persistent);

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -6,7 +6,6 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using Requests = SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -28,8 +27,8 @@ public static class MealPlanEndpoints
 			CancellationToken cancellationToken)
 		{
 			var week = WeekIdentifier.From(year, weekNumber);
-			var result = await handler.HandleAsync(new GetWeeklyPlanQuery(week), cancellationToken);
 
+			var result = await handler.HandleAsync(new GetWeeklyPlanQuery(week), cancellationToken);
 			return result.ToOk();
 		}
 

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -10,9 +10,7 @@ using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
-using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using Requests = SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -2,13 +2,11 @@ using FluentValidation;
 using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
-using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
-using Requests = SmartSolutionsLab.Yumney.Recipes.Api.Requests;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 


### PR DESCRIPTION
## Summary

Cosmetic cleanup, no functional changes.

- **Recipes/MealPlan endpoint files** — remove dead `using Requests = …` aliases and unreferenced namespace imports left over from earlier refactors (kernel split, Outcomes rename).
- **AppHost** — split fluent chains for `AddRedis` / `AddRabbitMQ` / `AddContainer` across lines so each method call sits on its own line.

## Test plan

- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean (0 errors, 0 warnings)
- [ ] CI green