### PR TITLE
chore(frontend): resolve unmerged conflict markers in 12 i18n files

### DIFF
--- a/client/apps/account/public/assets/i18n/account/de.json
+++ b/client/apps/account/public/assets/i18n/account/de.json
@@ -25,7 +25,6 @@
       "loadFailed": "Profil konnte nicht geladen werden."
     }
   },
-<<<<<<< HEAD
   "danger": {
     "title": "Gefahrenzone",
     "lead": "Unumkehrbare Vorgänge an deinem Konto.",
@@ -42,7 +41,7 @@
     "confirmAria": "Bestätigungswort eingeben",
     "deleting": "Wird gelöscht…",
     "retry": "Erneut versuchen"
-=======
+  },
   "activity": {
     "title": "Aktivität",
     "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
@@ -57,6 +56,5 @@
       "edited": "Bearbeitet",
       "deleted": "Gelöscht"
     }
->>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/account/public/assets/i18n/account/en.json
+++ b/client/apps/account/public/assets/i18n/account/en.json
@@ -25,7 +25,6 @@
       "loadFailed": "Failed to load profile."
     }
   },
-<<<<<<< HEAD
   "danger": {
     "title": "Danger Zone",
     "lead": "Irreversible operations on your account.",
@@ -42,7 +41,7 @@
     "confirmAria": "Type the confirmation token",
     "deleting": "Deleting…",
     "retry": "Try again"
-=======
+  },
   "activity": {
     "title": "Activity",
     "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
@@ -57,6 +56,5 @@
       "edited": "Edited",
       "deleted": "Deleted"
     }
->>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/account/src/app/account.routes.ts
+++ b/client/apps/account/src/app/account.routes.ts
@@ -14,16 +14,15 @@ export const accountRoutes: Route[] = [
     loadComponent: () => import('./profile-settings').then((m) => m.ProfileSettingsComponent),
   },
   {
-<<<<<<< HEAD
     path: 'danger-zone',
     title: 'Danger Zone — Yumney',
     providers: [provideTranslocoScope('account')],
     loadComponent: () => import('./danger-zone').then((m) => m.DangerZoneComponent),
-=======
+  },
+  {
     path: 'activity',
     title: 'Activity — Yumney',
     providers: [provideTranslocoScope('account')],
     loadComponent: () => import('./activity').then((m) => m.ActivityComponent),
->>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   },
 ];

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -8,11 +8,7 @@ import {
 } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
-import {
-  ActivityTimelineComponent,
-  AsyncStateComponent,
-  type ActivityEntry,
-} from '@yumney/ui';
+import { ActivityTimelineComponent, AsyncStateComponent, type ActivityEntry } from '@yumney/ui';
 import { ActivityApiService, type ActivityTypeKey, type UserActivityItem } from '../api';
 
 const FILTER_OPTIONS: ReadonlyArray<{ value: ActivityTypeKey | 'all'; labelKey: string }> = [

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -18,7 +18,6 @@
       "moveDown": "Nach unten",
       "remove": "Entfernen"
     },
-<<<<<<< HEAD
     "activity": {
       "empty": "Noch keine Aktivität — leg los!",
       "deletedRecipe": "Gelöschtes Rezept",
@@ -37,11 +36,10 @@
         "days": "Vor {{value}} Tag(en)",
         "weeks": "Vor {{value}} Woche(n)"
       }
-=======
+    },
     "rating": {
       "label": "Bewertung",
       "value": "Mit {{value}} von 5 bewerten"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     }
   },
   "dashboard": {

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -18,7 +18,6 @@
       "moveDown": "Move down",
       "remove": "Remove"
     },
-<<<<<<< HEAD
     "activity": {
       "empty": "No activity yet — start cooking!",
       "deletedRecipe": "Deleted recipe",
@@ -37,11 +36,10 @@
         "days": "{{value}} d ago",
         "weeks": "{{value}} w ago"
       }
-=======
+    },
     "rating": {
       "label": "Rating",
       "value": "Rate {{value}} of 5"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     }
   },
   "dashboard": {

--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -106,14 +106,13 @@
     },
     "loading": "Rezept wird geladen...",
     "notFound": "Rezept nicht gefunden.",
-<<<<<<< HEAD
     "stats": {
       "cookCount": "{{count}}× gekocht",
       "lastCookedToday": "Heute zuletzt gekocht",
       "lastCookedYesterday": "Gestern zuletzt gekocht",
       "lastCookedDays": "Vor {{value}} Tagen zuletzt gekocht",
       "lastCookedWeeks": "Vor {{value}} Wochen zuletzt gekocht"
-=======
+    },
     "rating": {
       "label": "Deine Bewertung"
     },
@@ -121,7 +120,6 @@
       "label": "Kochnotizen",
       "placeholder": "Wie ist es geworden? Anpassungen für nächstes Mal?",
       "saved": "Gespeichert"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     },
     "delete": {
       "confirm": "Möchtest du \"{{title}}\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -106,14 +106,13 @@
     },
     "loading": "Loading recipe...",
     "notFound": "Recipe not found.",
-<<<<<<< HEAD
     "stats": {
       "cookCount": "Cooked {{count}} times",
       "lastCookedToday": "Last cooked today",
       "lastCookedYesterday": "Last cooked yesterday",
       "lastCookedDays": "Last cooked {{value}} days ago",
       "lastCookedWeeks": "Last cooked {{value}} weeks ago"
-=======
+    },
     "rating": {
       "label": "Your rating"
     },
@@ -121,7 +120,6 @@
       "label": "Cooking notes",
       "placeholder": "How did it turn out? Any tweaks for next time?",
       "saved": "Saved"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     },
     "delete": {
       "confirm": "Are you sure you want to delete \"{{title}}\"? This cannot be undone.",

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -108,7 +108,6 @@
       </div>
     }
 
-<<<<<<< HEAD
     @if (recipeStats(); as stats) {
       @if (stats.cookCount > 0) {
         <p class="cook-stats" data-testid="recipe-cook-stats">
@@ -120,7 +119,7 @@
         </p>
       }
     }
-=======
+
     <section class="rating-section" data-testid="recipe-rating">
       <span class="rating-section__label">{{ t('recipes.detail.rating.label') }}</span>
       <yn-star-rating [rating]="recipe.rating" (ratingChange)="onRatingChange($event)" />
@@ -145,7 +144,6 @@
         (ngModelChange)="onNotesInput($event)"
       ></textarea>
     </section>
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
 
     <div class="actions-bar">
       <yn-favorite-button [isFavorite]="recipe.isFavorite" (toggled)="onToggleFavorite()" />

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -346,7 +346,6 @@
   }
 }
 
-<<<<<<< HEAD
 .cook-stats {
   margin: 0 0 var(--yn-space-3);
   padding: var(--yn-space-2) var(--yn-space-3);
@@ -362,7 +361,8 @@
 
 .cook-stats__separator {
   opacity: 0.6;
-=======
+}
+
 .rating-section {
   display: flex;
   align-items: center;
@@ -417,5 +417,4 @@
 .notes-section__saved {
   font-size: var(--yn-text-sm);
   color: var(--yn-success);
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
 }

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -10,7 +10,8 @@ import {
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-<<<<<<< HEAD
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subject, debounceTime } from 'rxjs';
 import {
   ActivityApiService,
   CreateShoppingListItem,
@@ -19,11 +20,6 @@ import {
   RecipeDetail,
   ShoppingApiService,
 } from '../api';
-=======
-import { Subject, debounceTime } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CreateShoppingListItem, RecipeApiService, RecipeDetail, ShoppingApiService } from '../api';
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
 import {
   createAsyncState,
   scaleIngredients,

--- a/client/apps/shell/public/assets/i18n/account/de.json
+++ b/client/apps/shell/public/assets/i18n/account/de.json
@@ -25,7 +25,6 @@
       "loadFailed": "Profil konnte nicht geladen werden."
     }
   },
-<<<<<<< HEAD
   "danger": {
     "title": "Gefahrenzone",
     "lead": "Unumkehrbare Vorgänge an deinem Konto.",
@@ -42,7 +41,7 @@
     "confirmAria": "Bestätigungswort eingeben",
     "deleting": "Wird gelöscht…",
     "retry": "Erneut versuchen"
-=======
+  },
   "activity": {
     "title": "Aktivität",
     "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
@@ -57,6 +56,5 @@
       "edited": "Bearbeitet",
       "deleted": "Gelöscht"
     }
->>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/shell/public/assets/i18n/account/en.json
+++ b/client/apps/shell/public/assets/i18n/account/en.json
@@ -25,7 +25,6 @@
       "loadFailed": "Failed to load profile."
     }
   },
-<<<<<<< HEAD
   "danger": {
     "title": "Danger Zone",
     "lead": "Irreversible operations on your account.",
@@ -42,7 +41,7 @@
     "confirmAria": "Type the confirmation token",
     "deleting": "Deleting…",
     "retry": "Try again"
-=======
+  },
   "activity": {
     "title": "Activity",
     "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
@@ -57,6 +56,5 @@
       "edited": "Edited",
       "deleted": "Deleted"
     }
->>>>>>> 9ff921ba (feat(ui): activity timeline + recipe cook stats badge (US-121))
   }
 }

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -68,7 +68,6 @@
       "moveDown": "Nach unten",
       "remove": "Entfernen"
     },
-<<<<<<< HEAD
     "activity": {
       "empty": "Noch keine Aktivität — leg los!",
       "deletedRecipe": "Gelöschtes Rezept",
@@ -87,11 +86,10 @@
         "days": "Vor {{value}} Tag(en)",
         "weeks": "Vor {{value}} Woche(n)"
       }
-=======
+    },
     "rating": {
       "label": "Bewertung",
       "value": "Mit {{value}} von 5 bewerten"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     }
   },
   "layout": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -68,7 +68,6 @@
       "moveDown": "Move down",
       "remove": "Remove"
     },
-<<<<<<< HEAD
     "activity": {
       "empty": "No activity yet — start cooking!",
       "deletedRecipe": "Deleted recipe",
@@ -87,11 +86,10 @@
         "days": "{{value}} d ago",
         "weeks": "{{value}} w ago"
       }
-=======
+    },
     "rating": {
       "label": "Rating",
       "value": "Rate {{value}} of 5"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     }
   },
   "layout": {

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -106,14 +106,13 @@
     },
     "loading": "Rezept wird geladen...",
     "notFound": "Rezept nicht gefunden.",
-<<<<<<< HEAD
     "stats": {
       "cookCount": "{{count}}× gekocht",
       "lastCookedToday": "Heute zuletzt gekocht",
       "lastCookedYesterday": "Gestern zuletzt gekocht",
       "lastCookedDays": "Vor {{value}} Tagen zuletzt gekocht",
       "lastCookedWeeks": "Vor {{value}} Wochen zuletzt gekocht"
-=======
+    },
     "rating": {
       "label": "Deine Bewertung"
     },
@@ -121,7 +120,6 @@
       "label": "Kochnotizen",
       "placeholder": "Wie ist es geworden? Anpassungen für nächstes Mal?",
       "saved": "Gespeichert"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     },
     "delete": {
       "confirm": "Möchtest du \"{{title}}\" wirklich löschen? Dies kann nicht rückgängig gemacht werden.",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -106,14 +106,13 @@
     },
     "loading": "Loading recipe...",
     "notFound": "Recipe not found.",
-<<<<<<< HEAD
     "stats": {
       "cookCount": "Cooked {{count}} times",
       "lastCookedToday": "Last cooked today",
       "lastCookedYesterday": "Last cooked yesterday",
       "lastCookedDays": "Last cooked {{value}} days ago",
       "lastCookedWeeks": "Last cooked {{value}} weeks ago"
-=======
+    },
     "rating": {
       "label": "Your rating"
     },
@@ -121,7 +120,6 @@
       "label": "Cooking notes",
       "placeholder": "How did it turn out? Any tweaks for next time?",
       "saved": "Saved"
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
     },
     "delete": {
       "confirm": "Are you sure you want to delete \"{{title}}\"? This cannot be undone.",

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -71,11 +71,7 @@ export type {
 
 // --- Dashboard ---
 export { DashboardApiService } from './lib/dashboard-api.service';
-export type {
-  UserActivityItem,
-  ActivityTypeKey,
-  RecipeActivityStats,
-} from './lib/user-activity';
+export type { UserActivityItem, ActivityTypeKey, RecipeActivityStats } from './lib/user-activity';
 export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';
 
 // --- Activity ---

--- a/client/libs/shared/api-client/src/lib/activity-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.ts
@@ -8,7 +8,9 @@ import type { ActivityTypeKey, RecipeActivityStats, UserActivityItem } from './u
 export class ActivityApiService {
   private http = inject(HttpClient);
 
-  getActivity(options: { type?: ActivityTypeKey; limit?: number } = {}): Observable<UserActivityItem[]> {
+  getActivity(
+    options: { type?: ActivityTypeKey; limit?: number } = {},
+  ): Observable<UserActivityItem[]> {
     let params = new HttpParams();
     if (options.limit != null) params = params.set('limit', options.limit.toString());
     if (options.type != null) params = params.set('type', options.type);

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -13,12 +13,9 @@ export const API_ENDPOINTS = {
     importFromText: `${API_BASE}/recipes/import-from-text`,
     byIdentifier: (identifier: string) => `${API_BASE}/recipes/${identifier}`,
     favorite: (identifier: string) => `${API_BASE}/recipes/${identifier}/favorite`,
-<<<<<<< HEAD
     cooked: (identifier: string) => `${API_BASE}/recipes/${identifier}/cooked`,
-=======
     rating: (identifier: string) => `${API_BASE}/recipes/${identifier}/rating`,
     notes: (identifier: string) => `${API_BASE}/recipes/${identifier}/notes`,
->>>>>>> a50fba7d (feat(recipes): star rating + cooking notes on recipe detail (US-120))
   },
   shoppingLists: {
     base: `${API_BASE}/shopping-lists`,

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
@@ -62,8 +62,18 @@ describe('ActivityTimelineComponent', () => {
 
   it('should render one item per entry with the recipe title', () => {
     host.entries.set([
-      { type: 'recipe_cooked', recipeIdentifier: 'r1', recipeTitle: 'Pasta', occurredAt: new Date().toISOString() },
-      { type: 'recipe_imported', recipeIdentifier: 'r2', recipeTitle: 'Pizza', occurredAt: new Date().toISOString() },
+      {
+        type: 'recipe_cooked',
+        recipeIdentifier: 'r1',
+        recipeTitle: 'Pasta',
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        type: 'recipe_imported',
+        recipeIdentifier: 'r2',
+        recipeTitle: 'Pizza',
+        occurredAt: new Date().toISOString(),
+      },
     ]);
     fixture.detectChanges();
 
@@ -75,7 +85,12 @@ describe('ActivityTimelineComponent', () => {
 
   it('should fall back to "Deleted recipe" label when title is null and type is recipe_deleted', () => {
     host.entries.set([
-      { type: 'recipe_deleted', recipeIdentifier: 'r1', recipeTitle: null, occurredAt: new Date().toISOString() },
+      {
+        type: 'recipe_deleted',
+        recipeIdentifier: 'r1',
+        recipeTitle: null,
+        occurredAt: new Date().toISOString(),
+      },
     ]);
     fixture.detectChanges();
 
@@ -89,26 +104,41 @@ describe('relativeTimeFromNow', () => {
 
   it('returns justNow for under a minute', () => {
     const when = new Date('2026-05-05T11:59:30Z');
-    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.justNow', value: 0 });
+    expect(relativeTimeFromNow(when, now)).toEqual({
+      key: 'shared.activity.relative.justNow',
+      value: 0,
+    });
   });
 
   it('returns minutes for under an hour', () => {
     const when = new Date('2026-05-05T11:45:00Z');
-    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.minutes', value: 15 });
+    expect(relativeTimeFromNow(when, now)).toEqual({
+      key: 'shared.activity.relative.minutes',
+      value: 15,
+    });
   });
 
   it('returns hours for under a day', () => {
     const when = new Date('2026-05-05T08:00:00Z');
-    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.hours', value: 4 });
+    expect(relativeTimeFromNow(when, now)).toEqual({
+      key: 'shared.activity.relative.hours',
+      value: 4,
+    });
   });
 
   it('returns days for under a week', () => {
     const when = new Date('2026-05-02T12:00:00Z');
-    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.days', value: 3 });
+    expect(relativeTimeFromNow(when, now)).toEqual({
+      key: 'shared.activity.relative.days',
+      value: 3,
+    });
   });
 
   it('returns weeks beyond a week', () => {
     const when = new Date('2026-04-15T12:00:00Z');
-    expect(relativeTimeFromNow(when, now)).toEqual({ key: 'shared.activity.relative.weeks', value: 2 });
+    expect(relativeTimeFromNow(when, now)).toEqual({
+      key: 'shared.activity.relative.weeks',
+      value: 2,
+    });
   });
 });

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
@@ -53,13 +53,17 @@ const WEEK = 7 * DAY;
 
 // Locale-agnostic relative-time formatter — returns the raw key + count so the
 // caller's i18n layer can pluralize. Keeps the component free of date-fns.
-export function relativeTimeFromNow(when: Date, now: Date = new Date()): {
+export function relativeTimeFromNow(
+  when: Date,
+  now: Date = new Date(),
+): {
   key: string;
   value: number;
 } {
   const diff = now.getTime() - when.getTime();
   if (diff < MINUTE) return { key: 'shared.activity.relative.justNow', value: 0 };
-  if (diff < HOUR) return { key: 'shared.activity.relative.minutes', value: Math.floor(diff / MINUTE) };
+  if (diff < HOUR)
+    return { key: 'shared.activity.relative.minutes', value: Math.floor(diff / MINUTE) };
   if (diff < DAY) return { key: 'shared.activity.relative.hours', value: Math.floor(diff / HOUR) };
   if (diff < WEEK) return { key: 'shared.activity.relative.days', value: Math.floor(diff / DAY) };
   return { key: 'shared.activity.relative.weeks', value: Math.floor(diff / WEEK) };


### PR DESCRIPTION
## Summary

Two recent merges (US-120 star rating + cooking notes, US-121 activity timeline) committed unresolved \`<<<<<<< HEAD\` / \`=======\` / \`>>>>>>> commit\` markers into 12 translation files. \`yarn sync:i18n:check\` fails to \`JSON.parse\` them, breaking the Frontend job — and the E2E job that depends on the frontend bundle — on **every** PR opened against develop.

The conflicting sections were always independent additive blocks (activity vs. rating, danger vs. activity, stats vs. rating/notes). Resolution keeps both sides in each file.

### Files fixed
- \`apps/account/public/assets/i18n/account/{de,en}.json\` (danger ↔ activity)
- \`apps/recipes/public/assets/i18n/{de,en}.json\` (activity ↔ rating)
- \`apps/recipes/public/assets/i18n/recipes/{de,en}.json\` (stats ↔ rating/notes)
- \`apps/shell/public/assets/i18n/{de,en}.json\` (activity ↔ rating)
- \`apps/shell/public/assets/i18n/account/{de,en}.json\` (danger ↔ activity)
- \`apps/shell/public/assets/i18n/recipes/{de,en}.json\` (stats ↔ rating)

## Test plan

- [x] \`yarn sync:i18n:check\` — \`✔ All 6 scoped i18n file(s) in sync; no top-level drift.\`
- [x] \`yarn prettier --check apps/*/public/assets/i18n/**/*.json\` — all files conform
- [x] All 12 files re-validate as JSON
- [ ] CI Frontend + E2E green again

Without this, every open and future PR will fail Frontend + E2E for the same reason.