### PR TITLE
fix(shared): isolate per-module RabbitMQ queues + projection wait

### DIFF
--- a/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
@@ -38,13 +38,24 @@ public static class WolverineEventBusExtensions
 		Ensure.That(connectionString!)
 			.IsNotNullOrWhiteSpace();
 
+		// Each consuming app needs its OWN queue bound to the per-event fanout
+		// exchange — otherwise Wolverine's default conventional routing names
+		// queues by event type alone, so two modules subscribing to the same
+		// event share one queue and become competing consumers (only one
+		// module's handler runs per message). Prefixing with the application
+		// name gives each module an isolated queue that receives every message.
+		var moduleQueuePrefix = builder.Environment.ApplicationName ?? "yumney-app";
+
 		builder.Host.UseWolverine(opts =>
 		{
 			opts.Discovery.DisableConventionalDiscovery();
 
 			opts.UseRabbitMq(new Uri(connectionString!))
 				.AutoProvision()
-				.UseConventionalRouting();
+				.UseConventionalRouting(routing =>
+				{
+					routing.QueueNameForListener(eventType => $"{moduleQueuePrefix}.{eventType.FullName}");
+				});
 
 			foreach (var assembly in eventHandlerAssemblies)
 			{

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -37,6 +37,18 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		var recipeId = await CreateRecipeAsync(recipesClient);
 		var listId = await CreateShoppingListAsync(shoppingClient, recipeId);
 
+		// Wait for the shopping projection to index the recipe reference before
+		// deleting. RecipeDeletedHandler queries the projection to find lists,
+		// so the projection MUST have the row indexed before the delete event
+		// arrives or the handler will return zero matches and bail out.
+		await WaitForAsync(async () =>
+		{
+			await using var ctx = await fixture.CreateShoppingReadDbContextAsync();
+			var summary = await ctx.ShoppingListSummaryReadItems
+				.SingleOrDefaultAsync(s => s.Id == listId);
+			return summary is not null && summary.RecipeIdentifier == recipeId;
+		});
+
 		var delete = await recipesClient.DeleteAsync($"/api/v1/recipes/{recipeId}");
 		delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
 


### PR DESCRIPTION
## Summary

Two related fixes for the cross-module event flow that's been failing \`RecipeDeletedPropagationTests.DeleteRecipe_WithLinkedShoppingList_NullsRecipeReference\` on every Backend CI run for over a week.

## The real bug — \`fix(shared): isolate per-module RabbitMQ queues so fanout actually fans out\`

\`Wolverine\`'s \`UseConventionalRouting()\` names queues by event type alone, with no consumer-app discriminator. When two modules subscribe to the same integration event (Users + Shopping both consume \`RecipeDeletedIntegrationEvent\`), they share one RabbitMQ queue bound to the fanout exchange. RabbitMQ delivers each message to **one** consumer, not both — silent loss of cross-module subscribers.

Symptom: \`Users.RecipeDeletedActivityHandler\` consistently won the race; \`Shopping.RecipeDeletedHandler\` never saw the message; the linked shopping list's recipe reference was never cleared.

I confirmed this from local Aspire test logs:

\`\`\`
Handling integration event RecipeDeletedIntegrationEvent with RecipeDeletedActivityHandler
\`\`\`

…with no matching log line for \`RecipeDeletedHandler\`. Both apps were declaring identical queues bound to the same fanout exchange.

Fix: prefix each listener queue name with the consuming app's name (\`builder.Environment.ApplicationName\`), so each module gets its own queue. Wolverine's \`UseConventionalRouting(routing => routing.QueueNameForListener(...))\` is the supported customization point.

## Secondary improvement — \`fix(test): wait for projection before deleting\`

\`RecipeDeletedHandler\` queries \`ShoppingListSummaryReadItem\` (a read model that's populated asynchronously) to find lists referencing the deleted recipe. The test was issuing the DELETE before the projection had indexed the just-created list's recipe reference. With the routing fix, the handler now runs reliably — but it still depends on a read-model index that races the test. The pre-delete wait closes that race deterministically.

This fix isn't strictly load-bearing once the routing is correct (the test passed in 8s without it in the second run), but eliminates flake risk on slower CI machines.

## Verified locally

- \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean (0 errors, 0 warnings)
- The previously failing test now passes in 8s (was timing out at 15s every run)
- Full integration suite: **242/242 green**

## Blast radius for the routing fix

This change affects every queue declared by \`Yumney.Shopping.Api\`, \`Yumney.Recipes.Api\`, \`Yumney.MealPlan.Api\`, \`Yumney.Users.Api\`. New queue names (with \`ApplicationName\` prefix) will be auto-provisioned on first run; the old shared queues will sit empty and can be cleaned up out-of-band. No consumer code or schema changes — only RabbitMQ infrastructure.

## Test plan

- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet test tests/Yumney.Integration.Tests/\` full pass (242/242)
- [ ] CI Backend (Build + Test) green
- [ ] CI E2E green
- [ ] Smoke-test in dev: confirm a deleted recipe nulls the linked shopping-list reference and that a recipe-cooked event still updates the user's activity log (both subscribers get the event)