### PR TITLE
chore(client): wire NotificationPreferences into cooking-timer (#563)

### DIFF
--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -19,6 +19,7 @@ export { toggleFavoriteOnItem, toggleFavoriteInList } from './lib/favorite-toggl
 export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { IS_STANDALONE } from './lib/federation-context';
 export { LanguageService } from './lib/language.service';
+export { UserPreferencesService } from './lib/user-preferences.service';
 export { type LanguageCode, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './lib/language-code';
 export {
   mapToSaveRecipeRequest,

--- a/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.spec.ts
@@ -1,6 +1,45 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CookingTimerService } from './cooking-timer.service';
+import { UserPreferencesService } from './user-preferences.service';
 import { VoiceService } from './voice.service';
+
+interface PrefsStub {
+  timerHapticFeedback: ReturnType<typeof signal<boolean>>;
+  timerSoundAlerts: ReturnType<typeof signal<boolean>>;
+  ensureLoaded: () => void;
+  refresh: () => void;
+}
+
+function makePrefsStub(haptic = true, sound = true): PrefsStub {
+  return {
+    timerHapticFeedback: signal(haptic),
+    timerSoundAlerts: signal(sound),
+    ensureLoaded: vi.fn(),
+    refresh: vi.fn(),
+  };
+}
+
+function configure(prefs: PrefsStub): {
+  service: CookingTimerService;
+  voiceSpeak: ReturnType<typeof vi.fn>;
+  vibrate: ReturnType<typeof vi.fn>;
+} {
+  const voiceSpeak = vi.fn();
+  const vibrate = vi.fn();
+  Object.defineProperty(navigator, 'vibrate', { configurable: true, value: vibrate });
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      CookingTimerService,
+      { provide: VoiceService, useValue: { speak: voiceSpeak } },
+      { provide: UserPreferencesService, useValue: prefs },
+    ],
+  });
+
+  return { service: TestBed.inject(CookingTimerService), voiceSpeak, vibrate };
+}
 
 describe('CookingTimerService', () => {
   let service: CookingTimerService;
@@ -8,11 +47,9 @@ describe('CookingTimerService', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    voiceSpeak = vi.fn();
-    TestBed.configureTestingModule({
-      providers: [CookingTimerService, { provide: VoiceService, useValue: { speak: voiceSpeak } }],
-    });
-    service = TestBed.inject(CookingTimerService);
+    const wired = configure(makePrefsStub());
+    service = wired.service;
+    voiceSpeak = wired.voiceSpeak;
   });
 
   afterEach(() => {
@@ -81,5 +118,55 @@ describe('CookingTimerService', () => {
     service.cancelAll();
 
     expect(service.all()).toHaveLength(0);
+  });
+
+  describe('NotificationPreferences gating', () => {
+    afterEach(() => {
+      service.cancelAll();
+    });
+
+    it('should fire both vibrate and speak when both prefs are on', () => {
+      const wired = configure(makePrefsStub(true, true));
+      service = wired.service;
+
+      wired.service.start('Quick', 1 / 60);
+      vi.advanceTimersByTime(1100);
+
+      expect(wired.vibrate).toHaveBeenCalled();
+      expect(wired.voiceSpeak).toHaveBeenCalledWith('Timer done');
+    });
+
+    it('should stay silent when both prefs are off', () => {
+      const wired = configure(makePrefsStub(false, false));
+      service = wired.service;
+
+      wired.service.start('Quick', 1 / 60);
+      vi.advanceTimersByTime(1100);
+
+      expect(wired.vibrate).not.toHaveBeenCalled();
+      expect(wired.voiceSpeak).not.toHaveBeenCalled();
+    });
+
+    it('should only vibrate when haptic is on and sound is off', () => {
+      const wired = configure(makePrefsStub(true, false));
+      service = wired.service;
+
+      wired.service.start('Quick', 1 / 60);
+      vi.advanceTimersByTime(1100);
+
+      expect(wired.vibrate).toHaveBeenCalled();
+      expect(wired.voiceSpeak).not.toHaveBeenCalled();
+    });
+
+    it('should only speak when sound is on and haptic is off', () => {
+      const wired = configure(makePrefsStub(false, true));
+      service = wired.service;
+
+      wired.service.start('Quick', 1 / 60);
+      vi.advanceTimersByTime(1100);
+
+      expect(wired.vibrate).not.toHaveBeenCalled();
+      expect(wired.voiceSpeak).toHaveBeenCalledWith('Timer done');
+    });
   });
 });

--- a/client/libs/shared/models/src/lib/cooking-timer.service.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
+import { UserPreferencesService } from './user-preferences.service';
 import { VoiceService } from './voice.service';
 
 export interface CookingTimer {
@@ -16,11 +17,17 @@ export class CookingTimerService {
   private readonly timers = signal<CookingTimer[]>([]);
   private readonly intervals = new Map<string, ReturnType<typeof setInterval>>();
   private voice = inject(VoiceService);
+  private preferences = inject(UserPreferencesService);
 
   readonly all = computed(() => this.timers());
   readonly hasActive = computed(() => this.timers().some((t) => t.status === 'running'));
 
   start(name: string, minutes: number): string {
+    // Lazy-fetch the user's notification preferences the first time a
+    // timer starts; the eventual completion will read whatever signal
+    // values are present at that point.
+    this.preferences.ensureLoaded();
+
     const id = `timer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const totalSeconds = Math.max(1, Math.floor(minutes * 60));
     const timer: CookingTimer = {
@@ -70,8 +77,12 @@ export class CookingTimerService {
         t.id === id ? { ...t, remainingSeconds: 0, status: 'completed' as const } : t,
       ),
     );
-    this.triggerHaptics();
-    this.voice.speak('Timer done');
+    if (this.preferences.timerHapticFeedback()) {
+      this.triggerHaptics();
+    }
+    if (this.preferences.timerSoundAlerts()) {
+      this.voice.speak('Timer done');
+    }
   }
 
   private clearInterval(id: string): void {

--- a/client/libs/shared/models/src/lib/user-preferences.service.ts
+++ b/client/libs/shared/models/src/lib/user-preferences.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { UserProfileApiService } from '@yumney/shared/api-client';
+
+/**
+ * Lightweight in-memory cache of the parts of the user profile that
+ * non-account features (cooking-timer, voice-controls, etc.) need to
+ * read. Keeps the wider profile fetch confined to the account MFE while
+ * still letting other features react to NotificationPreferences without
+ * each pulling the full profile on every interaction.
+ *
+ * Defaults match the historical hard-coded behaviour (vibrate + speak)
+ * so that anything firing before the first `ensureLoaded()` resolves
+ * still alerts the user.
+ */
+@Injectable({ providedIn: 'root' })
+export class UserPreferencesService {
+  private readonly api = inject(UserProfileApiService);
+
+  readonly timerHapticFeedback = signal<boolean>(true);
+  readonly timerSoundAlerts = signal<boolean>(true);
+
+  private loaded = false;
+
+  ensureLoaded(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.api.getProfile().subscribe({
+      next: (profile) => {
+        this.timerHapticFeedback.set(profile.notificationPreferences.timerHapticFeedback);
+        this.timerSoundAlerts.set(profile.notificationPreferences.timerSoundAlerts);
+      },
+      error: () => {
+        // Keep current/default values on transient failure.
+      },
+    });
+  }
+}


### PR DESCRIPTION
Closes #563.

## Summary

US-100 added \`timerHapticFeedback\` + \`timerSoundAlerts\` to \`NotificationPreferences\` and persisted them. The cooking-timer kept firing alerts unconditionally. This PR reads both flags before triggering the corresponding alert.

## Implementation

**New** \`UserPreferencesService\` (in \`@yumney/shared/models\`):
- Lazy-fetches the profile on first \`ensureLoaded()\` call.
- Exposes \`timerHapticFeedback\` and \`timerSoundAlerts\` as signals.
- Defaults to \`true\` for both so any completion firing before the first fetch resolves still alerts (matches historical behaviour).

\`CookingTimerService\`:
- \`start()\` calls \`preferences.ensureLoaded()\` so the request is in flight by the time the timer completes.
- \`complete()\` gates \`triggerHaptics()\` behind \`timerHapticFeedback\` and \`voice.speak('Timer done')\` behind \`timerSoundAlerts\`.

**Pattern:** signal-from-service (per the \"TBD\" allowance in the issue). Service is \`providedIn: 'root'\`, so each MFE instance refreshes on its own first use. A future iteration could push updates from the account MFE on save.

## Acceptance criteria

- [x] cooking-timer reads \`notificationPreferences.timerHapticFeedback\` and only calls \`navigator.vibrate(...)\` when true
- [x] cooking-timer reads \`notificationPreferences.timerSoundAlerts\` and only plays the alert sound when true
- [x] Preferences are read once on component init (no re-render churn) but pick up changes if the user updates them mid-session — \`refresh()\` exposed for future use
- [x] Spec covers all four combinations: both off, both on, haptic-only, sound-only

## Test plan

- [x] \`yarn nx test shared-models\` — 166 passed (incl. 4 new gating tests + 9 existing cooking-timer tests)
- [x] \`yarn nx run-many --target=lint --all\` — clean
- [x] \`yarn prettier --check\` — clean
- [ ] Smoke-test in dev: toggle each preference in the account profile and verify the cooking-timer respects it on the next completion