### PR TITLE
chore(frontend): ThemeService follows OS via matchMedia in system mode (#564)

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -106,7 +106,7 @@ export class ProfileSettingsComponent {
     effect(() => {
       // Push theme + voice settings into local services so the change is
       // visible immediately, even before the server round-trip resolves.
-      this.theme.setTheme(this.themeChoice() === 'dark' ? 'dark' : 'light');
+      this.theme.setTheme(this.themeChoice());
       this.voice.setMuted(!this.voiceEnabled());
       this.voice.setLanguage(this.preferredLanguage());
       const lang = this.preferredLanguage();

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -36,7 +36,7 @@ export {
   type UnitGroupInfo,
 } from './lib/known-units';
 export { ROUTES } from './lib/route-paths';
-export { ThemeService, type Theme } from './lib/theme.service';
+export { ThemeService, type Theme, type ThemePreference } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
 export { IngredientRecognitionService } from './lib/ingredient-recognition.service';
 export { ChatStateService } from './lib/chat-state.service';

--- a/client/libs/shared/models/src/lib/theme.service.spec.ts
+++ b/client/libs/shared/models/src/lib/theme.service.spec.ts
@@ -1,53 +1,148 @@
 import { TestBed } from '@angular/core/testing';
-import { ThemeService, type Theme } from './theme.service';
+import { ThemeService } from './theme.service';
+
+interface MediaQueryStub {
+  matches: boolean;
+  listeners: Array<(event: MediaQueryListEvent) => void>;
+  addEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  removeEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  dispatch: (matches: boolean) => void;
+}
+
+function installMatchMedia(initialDark: boolean): MediaQueryStub {
+  const stub: MediaQueryStub = {
+    matches: initialDark,
+    listeners: [],
+    addEventListener: (_, listener) => stub.listeners.push(listener),
+    removeEventListener: (_, listener) => {
+      stub.listeners = stub.listeners.filter((each) => each !== listener);
+    },
+    dispatch: (matches: boolean) => {
+      stub.matches = matches;
+      const event = { matches } as MediaQueryListEvent;
+      stub.listeners.forEach((listener) => listener(event));
+    },
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      ...stub,
+      media: query,
+    })),
+  });
+
+  return stub;
+}
 
 describe('ThemeService', () => {
-  let service: ThemeService;
-
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ThemeService);
+    TestBed.resetTestingModule();
   });
 
-  it('should default to light when no preference stored and system is light', () => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-      })),
-    });
+  it('should default to system on first run when nothing is stored', () => {
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
 
-    const freshService = new ThemeService();
-    expect(freshService.theme()).toBe('light');
+    expect(service.preference()).toBe('system');
   });
 
-  it('should apply theme to document on initialize', () => {
+  it('should restore an explicit light preference from localStorage', () => {
+    localStorage.setItem('yn-theme', 'light');
+    installMatchMedia(true); // OS dark, but explicit choice wins
+    const service = TestBed.inject(ThemeService);
+
+    expect(service.preference()).toBe('light');
+    expect(service.theme()).toBe('light');
+  });
+
+  it('should restore an explicit dark preference from localStorage', () => {
+    localStorage.setItem('yn-theme', 'dark');
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+
+    expect(service.preference()).toBe('dark');
+    expect(service.theme()).toBe('dark');
+  });
+
+  it('should resolve system preference to dark when OS is dark', () => {
+    localStorage.setItem('yn-theme', 'system');
+    installMatchMedia(true);
+    const service = TestBed.inject(ThemeService);
+
+    expect(service.preference()).toBe('system');
+    expect(service.theme()).toBe('dark');
+  });
+
+  it('should resolve system preference to light when OS is light', () => {
+    localStorage.setItem('yn-theme', 'system');
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+
+    expect(service.preference()).toBe('system');
+    expect(service.theme()).toBe('light');
+  });
+
+  it('should follow OS toggles mid-session when in system mode', () => {
+    localStorage.setItem('yn-theme', 'system');
+    const media = installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
     service.initialize();
-    expect(document.documentElement.getAttribute('data-theme')).toBe(service.theme());
-  });
 
-  it('should toggle between light and dark', () => {
-    service.setTheme('light');
-    service.toggle();
+    expect(service.theme()).toBe('light');
+
+    media.dispatch(true);
     expect(service.theme()).toBe('dark');
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
 
-    service.toggle();
+    media.dispatch(false);
     expect(service.theme()).toBe('light');
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('should persist theme to localStorage', () => {
-    service.setTheme('dark');
-    expect(localStorage.getItem('yn-theme')).toBe('dark');
+  it('should ignore OS toggles when an explicit preference is set', () => {
+    localStorage.setItem('yn-theme', 'light');
+    const media = installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+    service.initialize();
+
+    media.dispatch(true);
+
+    expect(service.theme()).toBe('light');
   });
 
-  it('should restore theme from localStorage', () => {
+  it('should apply the resolved theme to the document on initialize', () => {
     localStorage.setItem('yn-theme', 'dark');
-    const freshService = new ThemeService();
-    expect(freshService.theme()).toBe('dark');
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+    service.initialize();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('should toggle between light and dark', () => {
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+
+    service.setTheme('light');
+    service.toggle();
+    expect(service.theme()).toBe('dark');
+    expect(service.preference()).toBe('dark');
+
+    service.toggle();
+    expect(service.theme()).toBe('light');
+    expect(service.preference()).toBe('light');
+  });
+
+  it('should persist the chosen preference to localStorage', () => {
+    installMatchMedia(false);
+    const service = TestBed.inject(ThemeService);
+
+    service.setTheme('system');
+
+    expect(localStorage.getItem('yn-theme')).toBe('system');
   });
 });

--- a/client/libs/shared/models/src/lib/theme.service.ts
+++ b/client/libs/shared/models/src/lib/theme.service.ts
@@ -1,43 +1,91 @@
 import { Injectable, signal } from '@angular/core';
 
+/**
+ * The user's stored preference. `'system'` defers to the OS via
+ * `prefers-color-scheme` and re-applies if the OS toggles mid-session.
+ */
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+/**
+ * The resolved applied theme — what the document actually wears. Always
+ * concrete; never `'system'`.
+ */
 export type Theme = 'light' | 'dark';
 
 const THEME_KEY = 'yn-theme';
 const THEME_ATTRIBUTE = 'data-theme';
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
 
 @Injectable({ providedIn: 'root' })
 export class ThemeService {
-  readonly theme = signal<Theme>(this.resolveInitialTheme());
+  /** Stored preference (what the user picked, including `'system'`). */
+  readonly preference = signal<ThemePreference>(this.resolveInitialPreference());
+
+  /** Applied theme on the document. Driven by preference + OS state. */
+  readonly theme = signal<Theme>(this.resolveAppliedTheme(this.preference()));
+
+  private mediaQuery: MediaQueryList | null = null;
+  private mediaListenerAttached = false;
 
   initialize(): void {
     this.applyTheme(this.theme());
+    this.attachSystemListener();
   }
 
+  /**
+   * Toggle between explicit light and dark. Leaves `'system'` mode if
+   * the user was on it — flips to whichever is currently *not* applied.
+   */
   toggle(): void {
-    const next: Theme = this.theme() === 'light' ? 'dark' : 'light';
+    const next: ThemePreference = this.theme() === 'light' ? 'dark' : 'light';
     this.setTheme(next);
   }
 
-  setTheme(theme: Theme): void {
-    this.theme.set(theme);
-    this.applyTheme(theme);
-    localStorage.setItem(THEME_KEY, theme);
+  setTheme(preference: ThemePreference): void {
+    this.preference.set(preference);
+    const applied = this.resolveAppliedTheme(preference);
+    this.theme.set(applied);
+    this.applyTheme(applied);
+    localStorage.setItem(THEME_KEY, preference);
   }
 
-  private resolveInitialTheme(): Theme {
+  private resolveInitialPreference(): ThemePreference {
     const stored = localStorage.getItem(THEME_KEY);
-    if (stored === 'light' || stored === 'dark') {
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
       return stored;
     }
-    return this.detectSystemPreference();
+    // First-time users get OS-following behaviour by default.
+    return 'system';
   }
 
-  private detectSystemPreference(): Theme {
+  private resolveAppliedTheme(preference: ThemePreference): Theme {
+    if (preference === 'light' || preference === 'dark') return preference;
+    return this.detectSystemTheme();
+  }
+
+  private detectSystemTheme(): Theme {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
       return 'light';
     }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    return window.matchMedia(SYSTEM_DARK_QUERY).matches ? 'dark' : 'light';
   }
+
+  private attachSystemListener(): void {
+    if (this.mediaListenerAttached) return;
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    this.mediaQuery = window.matchMedia(SYSTEM_DARK_QUERY);
+    this.mediaQuery.addEventListener('change', this.onSystemThemeChange);
+    this.mediaListenerAttached = true;
+  }
+
+  private readonly onSystemThemeChange = (): void => {
+    // Only react when the user has delegated to the OS — explicit choices win.
+    if (this.preference() !== 'system') return;
+    const applied = this.detectSystemTheme();
+    this.theme.set(applied);
+    this.applyTheme(applied);
+  };
 
   private applyTheme(theme: Theme): void {
     document.documentElement.setAttribute(THEME_ATTRIBUTE, theme);


### PR DESCRIPTION
Closes #564.

## Summary

US-100 introduced \`Theme\` with three values — \`light\`, \`dark\`, \`system\` — and persisted them. The frontend \`ThemeService\` modelled only \`'light' | 'dark'\`, so profile-settings coerced \`'system' → 'light'\` in the auto-save effect. That worked but discarded user intent.

## Changes

**\`ThemeService\`** now separates stored preference from resolved applied theme:

| Signal | Type | Meaning |
|---|---|---|
| \`preference\` | \`'light' \| 'dark' \| 'system'\` | What the user picked. Persisted to \`localStorage\`. |
| \`theme\` | \`'light' \| 'dark'\` | What the document actually wears. Always concrete. |

When \`preference === 'system'\`, \`theme\` follows \`window.matchMedia('(prefers-color-scheme: dark)')\` and re-applies on that media query's \`change\` events. Explicit preferences ignore OS toggles.

First-time users default to \`'system'\` (was: detect-once-and-freeze). Existing \`'light'\` / \`'dark'\` values in \`localStorage\` stay valid.

**\`profile-settings\`** drops \`themeChoice() === 'dark' ? 'dark' : 'light'\` and passes the choice through verbatim.

## Acceptance criteria

- [x] \`ThemeService\` accepts \`'light' | 'dark' | 'system'\` as the stored preference
- [x] When the preference is \`system\`, the resolved/applied theme follows \`matchMedia\` and re-applies on \`change\` events (not just on init)
- [x] \`profile-settings\` no longer coerces \`system\` → \`light\`
- [x] Existing \`localStorage\` migration path preserved; first-time users default to \`'system'\`
- [x] Spec covers: explicit light → light, explicit dark → dark, system + OS dark → dark, system + OS light → light, system + OS toggles mid-session → applied theme follows

## Test plan

- [x] \`yarn nx test shared-models\` — 171 passed (incl. 10 ThemeService tests covering all contracted cases)
- [x] \`yarn nx run-many --target=lint --all\` — clean
- [x] \`yarn prettier --check\` — clean
- [ ] Smoke-test in dev: pick each option in profile settings, verify the document attribute updates immediately and persists across reloads
- [ ] Smoke-test: with \`'system'\` selected, toggle OS dark mode and confirm the page follows