### PR TITLE
chore(infra): pin Ollama Aspire integration to GA (partial #463)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.2.2-preview.1.26207.2" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.2.1-beta.532" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.2.2" />


### PR DESCRIPTION
Partial fix for #463 — the achievable third of the audit's recommendation. The other two pre-release pins are upstream-blocked and documented on the issue (which I'll leave open with the rationale rather than closing it here).

## What this PR does

| Package | From | To |
|---|---|---|
| \`CommunityToolkit.Aspire.Hosting.Ollama\` | \`13.2.1-beta.532\` | \`13.1.1\` (GA) |

13.1.1 covers the \`AddOllama(...).WithDataVolume()\` surface used in \`AppHost\`. Going from a beta minor to a GA-1-minor is a deliberate downgrade; the alternative (waiting for a 13.2 GA) blocks the audit indefinitely.

## What this PR does NOT do — and why

- **\`StyleCop.Analyzers\`** stays on \`1.2.0-beta.556\`. The latest GA is \`1.1.118\` from 2018; it pre-dates target-typed \`new()\`, record-positional parameters, and other modern-C# constructs the codebase uses extensively. Strict build emits 19 false-positive errors (SA1000, SA1313, …) against 1.1.118. Wait for 1.2 GA.
- **\`Aspire.Hosting.Keycloak\` / \`Aspire.Keycloak.Authentication\`** stay on \`13.2.2-preview.1.26207.2\`. These packages **have never shipped a GA** on nuget.org — every published version since \`8.x\` has been \`-preview.*\`. Pinning to stable would mean removing the Keycloak Aspire integration entirely, which is a feature change, not a version-pin chore.

## Test plan

- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` clean
- [ ] CI green
- [ ] Smoke-test \`aspire run\` with Ollama provider (LlmProvider=Ollama) once a manual run is convenient