### PR TITLE
test(recipes): add happy-path contract tests for AI endpoints (partial #533)

### DIFF
--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ChatContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ChatContractTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -13,6 +14,20 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class ChatContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/chat";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task Chat_ValidMessage_Returns200WithReply()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { message = "What can I cook?", history = Array.Empty<object>() });
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("reply").GetString().Should().NotBeNullOrEmpty();
+	}
 
 	[Fact]
 	public async Task Chat_WithoutAuth_Returns401()

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipeSuggestionsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/GetRecipeSuggestionsContractTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -11,6 +13,21 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class GetRecipeSuggestionsContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/suggestions";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task GetSuggestions_AuthenticatedRequest_Returns200WithSuggestionsArray()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.GetAsync($"{Endpoint}?count=2");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.ValueKind.Should().Be(JsonValueKind.Array);
+		body.GetArrayLength().Should().BeGreaterThan(0);
+	}
 
 	[Fact]
 	public async Task GetSuggestions_WithoutAuth_Returns401()

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeContractTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -12,6 +13,22 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class ImportRecipeContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/import";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task Import_ValidUrl_Returns200WithExtractedRecipe()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { url = "https://example.com/recipe" });
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("title").GetString().Should().Be("Stub Recipe");
+		body.GetProperty("ingredients").GetArrayLength().Should().BeGreaterThan(0);
+		body.GetProperty("steps").GetArrayLength().Should().BeGreaterThan(0);
+	}
 
 	[Fact]
 	public async Task Import_WithoutAuth_Returns401()

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeFromTextContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeFromTextContractTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -12,6 +13,20 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class ImportRecipeFromTextContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/import-from-text";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task ImportFromText_ValidText_Returns200WithExtractedRecipe()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { text = "Mix flour with water. Bake for 20 minutes." });
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("title").GetString().Should().Be("Stub Recipe");
+	}
 
 	[Fact]
 	public async Task ImportFromText_WithoutAuth_Returns401()

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ParseIntentContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ParseIntentContractTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -12,6 +13,20 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class ParseIntentContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/parse-intent";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task ParseIntent_ValidMessage_Returns200WithIntent()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+
+		var response = await client.PostAsJsonAsync(Endpoint, new { message = "find me a pasta recipe", context = (string?)null });
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("intent").GetString().Should().NotBeNullOrEmpty();
+	}
 
 	[Fact]
 	public async Task ParseIntent_WithoutAuth_Returns401()


### PR DESCRIPTION
Partial fix for #533. Adds the missing **200-OK happy path** for the four JSON-payload Recipes AI endpoints. The contract test files already existed but only covered negative branches (\`401\` unauthenticated, \`422\` validation), leaving the headline "200 with the right response shape" claim untested.

## What's covered

| Endpoint | Stub source | Happy-path assertion |
|---|---|---|
| \`POST /api/v1/recipes/import\` | \`StubRecipeExtractionService\` (via \`StubWebScraper\` + extractor) | \`title == "Stub Recipe"\`, ingredients/steps non-empty |
| \`POST /api/v1/recipes/import-from-text\` | \`StubRecipeExtractionService\` | \`title == "Stub Recipe"\` |
| \`POST /api/v1/recipes/chat\` | \`StubChatService\` | \`reply\` is non-empty |
| \`POST /api/v1/recipes/parse-intent\` | \`StubIntentParserService\` | \`intent\` is non-empty |
| \`GET /api/v1/recipes/suggestions\` | \`StubRecipeSuggestionService\` | response is a non-empty array |

The stubs were already wired in \`AddRecipeExtraction\` when \`E2ETests=true\` (see #541). This PR is just the test coverage that was missing on top of that scaffolding.

## Deferred — separate PR

- \`POST /api/v1/recipes/import-from-photos\`
- \`POST /api/v1/recipes/recognize-ingredients\`

Both take \`multipart/form-data\` with image bytes; happy-path coverage needs an image-bytes fixture and correct boundary handling, which is enough scope to justify its own focused PR. \`StubIngredientRecognitionService\` and the photo branch of \`StubRecipeExtractionService\` are already in place — just the test plumbing is missing.

## Test plan

- [x] \`dotnet build tests/Yumney.Integration.Tests/ -p:TreatWarningsAsErrors=true\` — clean
- [ ] CI Backend (Build + Test) green — the 5 new tests run inside the existing Aspire fixture and exercise the stubs end-to-end

## Issue status

#533 stays open (2 of 7 endpoints' happy paths still missing) and the photo-multipart follow-up will close it.