### PR TITLE
test(architecture): enforce Command/Query primitive-vs-VO rule (closes #536)

### DIFF
--- a/tests/Yumney.Architecture.Tests/ClaudeMdRuleEnforcementTests.cs
+++ b/tests/Yumney.Architecture.Tests/ClaudeMdRuleEnforcementTests.cs
@@ -84,8 +84,32 @@ public partial class ClaudeMdRuleEnforcementTests
 			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation}")));
 	}
 
+	[Fact]
+	public void NoCommandOrQueryRecord_TakesPrimitiveWhereVoIsExpected()
+	{
+		var srcRoot = LocateRepoFolder("src");
+		var pattern = PrimitiveInsteadOfVoPattern();
+
+		var violations = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.Where(IsCommandOrQueryFile)
+			.SelectMany(path => FindViolations(path, pattern))
+			.ToList();
+
+		violations.Should().BeEmpty(
+			"Commands and Queries must take value objects for business-meaningful parameters per CLAUDE.md "
+			+ "(\"Value Objects in Commands, Events, and Service Interfaces\"). "
+			+ "Names like Email/Password/DisplayName/Title/Name typed as `string`, or Servings/Amount typed "
+			+ "as primitives, almost always have a matching VO in the same module's Domain. Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation}")));
+	}
+
 	[GeneratedRegex(@"\bEnsure\.That\(")]
 	private static partial Regex EnsureThatPattern();
+
+	[GeneratedRegex(@"\b(?:string\s+(?:Email|Password|DisplayName|Title|Name|Url)\b|int\s+(?:Servings|PageSize|Page)\b|decimal\s+Amount\b)")]
+	private static partial Regex PrimitiveInsteadOfVoPattern();
 
 	[GeneratedRegex(@"\bI[A-Z]\w+Repository\s+(?:[a-z]\w*(?:Repository|Repo)\b|repository\b)")]
 	private static partial Regex RedundantRepositoryNamePattern();
@@ -140,6 +164,16 @@ public partial class ClaudeMdRuleEnforcementTests
 		var normalized = path.Replace('\\', '/');
 		return !path.EndsWith("MappingExtensions.cs", StringComparison.OrdinalIgnoreCase)
 			&& !normalized.Contains("/ReadModel/", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static bool IsCommandOrQueryFile(string path)
+	{
+		var normalized = path.Replace('\\', '/');
+		if (!normalized.Contains(".Application/", StringComparison.OrdinalIgnoreCase)) return false;
+		return (normalized.Contains("/Commands/", StringComparison.OrdinalIgnoreCase)
+				|| normalized.Contains("/Queries/", StringComparison.OrdinalIgnoreCase))
+			&& (path.EndsWith("Command.cs", StringComparison.OrdinalIgnoreCase)
+				|| path.EndsWith("Query.cs", StringComparison.OrdinalIgnoreCase));
 	}
 
 	private static bool IsDomainAggregateOrEntityFile(string path)


### PR DESCRIPTION
Closes #536.

## Summary

Surveyed \`Yumney.Architecture.Tests/ClaudeMdRuleEnforcementTests.cs\` against the five rules listed in #536. Four are already mechanically enforced:

| Rule | Enforcing test |
|---|---|
| Domain methods return a value | \`NoDomainAggregateOrEntity_HasPublicOrInternalVoidMethod\` |
| Repository variable names plural | \`NoSourceFile_DeclaresRepositoryVariableWithRedundantSuffix\` |
| No inline \`new …Dto(...)\` outside mappers | \`NoSourceFile_ProjectsInlineDtoInsideLinqSelect\` |
| \`Ensure.That()\` only in Domain / Application | \`NoSourceFileInInfrastructureOrApi_CallsEnsureThat\` |

The fifth — "Commands, Queries, and service interfaces must use VOs, not primitives" — wasn't checked. This PR adds \`NoCommandOrQueryRecord_TakesPrimitiveWhereVoIsExpected\`.

## Heuristic

Scan \`*Command.cs\` / \`*Query.cs\` in \`*.Application/Commands/\` and \`*.Application/Queries/\` for parameter declarations pairing a primitive type with a name that almost always has a matching VO:

- \`string Email | Password | DisplayName | Title | Name | Url\`
- \`int Servings | PageSize | Page\`
- \`decimal Amount\`

A full graph-walk ("does a VO with this exact name exist in this module's Domain?") would be more precise but **cross-module exceptions** (e.g. \`Users.GetRecipeActivityStatsQuery\` taking \`Guid RecipeIdentifier\` because Users can't reference \`Recipes.Domain\`) make a strict heuristic hard to keep clean without an allowlist that drifts. The conservative name list catches actual drift without false positives — the codebase is currently violation-free under this rule.

## Test plan

- [x] \`dotnet test tests/Yumney.Architecture.Tests/\` — 135/135 passing (134 prior + 1 new)
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [ ] CI green