### PR TITLE
test(recipes): add happy-path contract tests for photo endpoints (closes #533)

### DIFF
--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeFromPhotosContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeFromPhotosContractTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -12,6 +14,21 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class ImportRecipeFromPhotosContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/import-from-photos";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task ImportFromPhotos_ValidPhoto_Returns200WithExtractedRecipe()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		using var content = BuildMultipartWithPhotos(1);
+
+		var response = await client.PostAsync(Endpoint, content);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("title").GetString().Should().Be("Stub Recipe");
+	}
 
 	[Fact]
 	public async Task ImportFromPhotos_WithoutAuth_Returns401()

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/RecognizeIngredientsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/RecognizeIngredientsContractTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
@@ -12,6 +14,21 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes.Contract;
 public class RecognizeIngredientsContractTests(AspireFixture fixture)
 {
 	private const string Endpoint = "/api/v1/recipes/recognize-ingredients";
+
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	[Fact]
+	public async Task RecognizeIngredients_ValidPhoto_Returns200WithIngredientsArray()
+	{
+		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		using var content = BuildJpegMultipart();
+
+		var response = await client.PostAsync(Endpoint, content);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		body.GetProperty("ingredients").GetArrayLength().Should().BeGreaterThan(0);
+	}
 
 	[Fact]
 	public async Task RecognizeIngredients_WithoutAuth_Returns401()


### PR DESCRIPTION
Closes #533. Finishes the AC after PR #590 covered the four JSON-payload endpoints.

## Endpoints covered

| Endpoint | Stub source | Happy-path assertion |
|---|---|---|
| \`POST /api/v1/recipes/import-from-photos\` | Photos branch of \`StubRecipeExtractionService\` | \`title == "Stub Recipe"\` |
| \`POST /api/v1/recipes/recognize-ingredients\` | \`StubIngredientRecognitionService\` | \`ingredients\` array non-empty |

Both endpoints already had \`401\` and \`400\`/\`422\` tests with multipart helpers (\`BuildMultipartWithPhotos\`, \`BuildJpegMultipart\`). This PR reuses those helpers — the stubs ignore the actual image bytes (they return fixed canned responses), so a 4-byte JPEG SOI header is sufficient to satisfy the content-type guard without needing a real fixture image.

## Test plan

- [x] \`dotnet build tests/Yumney.Integration.Tests/ -p:TreatWarningsAsErrors=true\` clean
- [ ] CI Backend (Build + Test) green — the 2 new tests run inside the existing Aspire fixture and exercise the multipart code path end-to-end through the stubs

#533 closes with this — all seven AI-endpoint contract tests now have a 200/happy-path test alongside their existing negative branches.