### PR TITLE
feat(shared): add UnitConversion service for metric ↔ imperial (US-125 slice 1)

### DIFF
--- a/src/Yumney.Shared.Quantities/ConvertedAmount.cs
+++ b/src/Yumney.Shared.Quantities/ConvertedAmount.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Quantities;
+
+/// <summary>
+/// A conversion result — already smart-rounded for cooking. Exact source
+/// values are not preserved here because callers always want a
+/// display-ready number; the original metric/imperial value is one
+/// inverse-conversion away when needed.
+/// </summary>
+/// <param name="Amount">Numeric amount, smart-rounded for kitchen use (no <c>1.7834 oz</c>).</param>
+/// <param name="Unit">Target unit suitable for direct display, lower-cased canonical form (<c>oz</c>, <c>fl oz</c>, <c>ml</c>, …). Returned verbatim when no rule applies (count units, unknown tokens).</param>
+public sealed record ConvertedAmount(decimal Amount, string Unit);

--- a/src/Yumney.Shared.Quantities/UnitConversion.cs
+++ b/src/Yumney.Shared.Quantities/UnitConversion.cs
@@ -14,7 +14,8 @@ namespace SmartSolutionsLab.Yumney.Shared.Quantities;
 /// </summary>
 public static class UnitConversion
 {
-	private static readonly IReadOnlyDictionary<string, ConversionRule> MetricToImperialRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
+#pragma warning disable SA1311 // editorconfig requires camelCase for private fields
+	private static readonly IReadOnlyDictionary<string, ConversionRule> metricToImperialRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
 	{
 		["g"] = new("oz", 1m / 28.3495m),
 		["kg"] = new("lb", 2.20462m),
@@ -24,7 +25,7 @@ public static class UnitConversion
 		["l"] = new("cup", 1000m / 236.588m),
 	};
 
-	private static readonly IReadOnlyDictionary<string, ConversionRule> ImperialToMetricRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
+	private static readonly IReadOnlyDictionary<string, ConversionRule> imperialToMetricRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
 	{
 		["oz"] = new("g", 28.3495m),
 		["lb"] = new("g", 453.592m),
@@ -33,21 +34,26 @@ public static class UnitConversion
 		["tsp"] = new("ml", 4.92892m),
 		["tbsp"] = new("ml", 14.7868m),
 	};
+#pragma warning restore SA1311
 
 	public static ConvertedAmount ToImperial(decimal amount, string? unit) =>
-		Apply(amount, unit, MetricToImperialRules);
+		Apply(amount, unit, metricToImperialRules);
 
 	public static ConvertedAmount ToMetric(decimal amount, string? unit) =>
-		Apply(amount, unit, ImperialToMetricRules);
+		Apply(amount, unit, imperialToMetricRules);
 
 	public static ConvertedAmount ToSystem(decimal amount, string? unit, UnitSystem target) =>
 		target == UnitSystem.Imperial ? ToImperial(amount, unit) : ToMetric(amount, unit);
 
 	/// <summary>Celsius → Fahrenheit. Symmetric helper for oven-temperature conversion.</summary>
+	/// <param name="celsius">Temperature in Celsius.</param>
+	/// <returns>The same temperature in Fahrenheit, rounded to the nearest whole degree.</returns>
 	public static int CelsiusToFahrenheit(int celsius) =>
 		(int)Math.Round((celsius * 9d / 5d) + 32d);
 
 	/// <summary>Fahrenheit → Celsius.</summary>
+	/// <param name="fahrenheit">Temperature in Fahrenheit.</param>
+	/// <returns>The same temperature in Celsius, rounded to the nearest whole degree.</returns>
 	public static int FahrenheitToCelsius(int fahrenheit) =>
 		(int)Math.Round((fahrenheit - 32) * 5d / 9d);
 
@@ -56,6 +62,8 @@ public static class UnitConversion
 	/// The thresholds mirror what real cookbooks do — no <c>0.34 oz</c>,
 	/// no <c>127.4 g</c>. Exposed for spec coverage.
 	/// </summary>
+	/// <param name="value">Raw decimal amount, typically the product of a unit conversion.</param>
+	/// <returns>The cooking-friendly rounded amount.</returns>
 	public static decimal SmartRound(decimal value)
 	{
 		var absolute = Math.Abs(value);

--- a/src/Yumney.Shared.Quantities/UnitConversion.cs
+++ b/src/Yumney.Shared.Quantities/UnitConversion.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+
+namespace SmartSolutionsLab.Yumney.Shared.Quantities;
+
+/// <summary>
+/// Pure utility for converting cooking ingredient amounts between metric
+/// and imperial. Rounding is intentionally coarse — kitchens don't measure
+/// <c>1.7834 oz</c>. See <see cref="SmartRound(decimal)"/>.
+///
+/// Unknown / count units (pinch, slice, clove, "to taste", …) are returned
+/// unchanged so callers can pipe every ingredient through this service
+/// without filtering first.
+/// </summary>
+public static class UnitConversion
+{
+	private static readonly IReadOnlyDictionary<string, ConversionRule> MetricToImperialRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
+	{
+		["g"] = new("oz", 1m / 28.3495m),
+		["kg"] = new("lb", 2.20462m),
+		["ml"] = new("fl oz", 1m / 29.5735m),
+		["cl"] = new("fl oz", 10m / 29.5735m),
+		["dl"] = new("cup", 100m / 236.588m),
+		["l"] = new("cup", 1000m / 236.588m),
+	};
+
+	private static readonly IReadOnlyDictionary<string, ConversionRule> ImperialToMetricRules = new Dictionary<string, ConversionRule>(StringComparer.OrdinalIgnoreCase)
+	{
+		["oz"] = new("g", 28.3495m),
+		["lb"] = new("g", 453.592m),
+		["fl oz"] = new("ml", 29.5735m),
+		["cup"] = new("ml", 236.588m),
+		["tsp"] = new("ml", 4.92892m),
+		["tbsp"] = new("ml", 14.7868m),
+	};
+
+	public static ConvertedAmount ToImperial(decimal amount, string? unit) =>
+		Apply(amount, unit, MetricToImperialRules);
+
+	public static ConvertedAmount ToMetric(decimal amount, string? unit) =>
+		Apply(amount, unit, ImperialToMetricRules);
+
+	public static ConvertedAmount ToSystem(decimal amount, string? unit, UnitSystem target) =>
+		target == UnitSystem.Imperial ? ToImperial(amount, unit) : ToMetric(amount, unit);
+
+	/// <summary>Celsius → Fahrenheit. Symmetric helper for oven-temperature conversion.</summary>
+	public static int CelsiusToFahrenheit(int celsius) =>
+		(int)Math.Round((celsius * 9d / 5d) + 32d);
+
+	/// <summary>Fahrenheit → Celsius.</summary>
+	public static int FahrenheitToCelsius(int fahrenheit) =>
+		(int)Math.Round((fahrenheit - 32) * 5d / 9d);
+
+	/// <summary>
+	/// Coerce a converted amount to a number a cook can actually measure.
+	/// The thresholds mirror what real cookbooks do — no <c>0.34 oz</c>,
+	/// no <c>127.4 g</c>. Exposed for spec coverage.
+	/// </summary>
+	public static decimal SmartRound(decimal value)
+	{
+		var absolute = Math.Abs(value);
+		if (absolute < 1m) return RoundToStep(value, 0.25m);
+		if (absolute < 10m) return RoundToStep(value, 0.5m);
+		if (absolute < 100m) return Math.Round(value, MidpointRounding.AwayFromZero);
+		if (absolute < 1000m) return RoundToStep(value, 5m);
+		return RoundToStep(value, 10m);
+	}
+
+	private static ConvertedAmount Apply(decimal amount, string? unit, IReadOnlyDictionary<string, ConversionRule> table)
+	{
+		var normalized = (unit ?? string.Empty).Trim();
+		if (normalized.Length == 0) return new ConvertedAmount(SmartRound(amount), string.Empty);
+
+		if (!table.TryGetValue(normalized, out var rule)) return new ConvertedAmount(amount, normalized);
+
+		var converted = amount * rule.Factor;
+		return new ConvertedAmount(SmartRound(converted), rule.TargetUnit);
+	}
+
+	private static decimal RoundToStep(decimal value, decimal step) =>
+		Math.Round(value / step, MidpointRounding.AwayFromZero) * step;
+
+	private sealed record ConversionRule(string TargetUnit, decimal Factor);
+}

--- a/src/Yumney.Shared.Quantities/UnitSystem.cs
+++ b/src/Yumney.Shared.Quantities/UnitSystem.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Quantities;
+
+/// <summary>
+/// The unit system the user reads ingredients in. Stored on the user's
+/// profile (US-100); applied as the default on recipe detail (US-125).
+/// </summary>
+public enum UnitSystem
+{
+	Metric,
+	Imperial,
+}

--- a/src/Yumney.Shared.Quantities/UnitSystem.cs
+++ b/src/Yumney.Shared.Quantities/UnitSystem.cs
@@ -6,6 +6,9 @@ namespace SmartSolutionsLab.Yumney.Shared.Quantities;
 /// </summary>
 public enum UnitSystem
 {
+	/// <summary>Grams, kilograms, millilitres, litres, °C — the SI/cooking-metric stack used by the EU and most of the world.</summary>
 	Metric,
+
+	/// <summary>Ounces, pounds, fluid ounces, cups, tablespoons, °F — the US-customary stack used by most American cookbooks.</summary>
 	Imperial,
 }

--- a/tests/Yumney.Shared.Tests/Common/UnitConversionTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/UnitConversionTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class UnitConversionTests
+{
+	[Fact]
+	public void ToImperial_500g_ReturnsRoughly18oz()
+	{
+		// TC-125-01: 500g → ~17.6 oz, smart-rounded.
+		var result = UnitConversion.ToImperial(500m, "g");
+
+		result.Unit.Should().Be("oz");
+		result.Amount.Should().Be(18m);
+	}
+
+	[Fact]
+	public void ToImperial_200ml_ReturnsRoughly7FlOz()
+	{
+		// TC-125-02: 200ml → ~6.76 fl oz.
+		var result = UnitConversion.ToImperial(200m, "ml");
+
+		result.Unit.Should().Be("fl oz");
+		result.Amount.Should().BeApproximately(7m, 0.5m);
+	}
+
+	[Fact]
+	public void ToImperial_1Kilogram_ReturnsRoughly2Pounds()
+	{
+		var result = UnitConversion.ToImperial(1m, "kg");
+
+		result.Unit.Should().Be("lb");
+		result.Amount.Should().BeApproximately(2m, 0.5m);
+	}
+
+	[Fact]
+	public void ToImperial_1Litre_ReturnsRoughly4Cups()
+	{
+		var result = UnitConversion.ToImperial(1m, "l");
+
+		result.Unit.Should().Be("cup");
+		result.Amount.Should().Be(4m);
+	}
+
+	[Fact]
+	public void ToImperial_UpperCaseUnit_StillMatches()
+	{
+		var lower = UnitConversion.ToImperial(500m, "g");
+		var upper = UnitConversion.ToImperial(500m, "G");
+
+		upper.Should().Be(lower);
+	}
+
+	[Theory]
+	[InlineData("pinch")]
+	[InlineData("slice")]
+	[InlineData("clove")]
+	[InlineData("dash")]
+	public void ToImperial_NonConvertibleCountUnit_ReturnsAmountUnchanged(string unit)
+	{
+		// TC-125-05: pass-through for non-convertible count units.
+		var result = UnitConversion.ToImperial(2m, unit);
+
+		result.Should().Be(new ConvertedAmount(2m, unit));
+	}
+
+	[Fact]
+	public void ToImperial_NullOrEmptyUnit_ReturnsEmptyUnit()
+	{
+		UnitConversion.ToImperial(3m, null).Should().Be(new ConvertedAmount(3m, string.Empty));
+		UnitConversion.ToImperial(3m, string.Empty).Should().Be(new ConvertedAmount(3m, string.Empty));
+		UnitConversion.ToImperial(3m, "   ").Should().Be(new ConvertedAmount(3m, string.Empty));
+	}
+
+	[Fact]
+	public void ToMetric_1Cup_ReturnsRoughly235ml()
+	{
+		var result = UnitConversion.ToMetric(1m, "cup");
+
+		result.Unit.Should().Be("ml");
+		result.Amount.Should().Be(235m);
+	}
+
+	[Fact]
+	public void ToMetric_1Pound_ReturnsRoughly455g()
+	{
+		var result = UnitConversion.ToMetric(1m, "lb");
+
+		result.Unit.Should().Be("g");
+		result.Amount.Should().Be(455m);
+	}
+
+	[Fact]
+	public void ToMetric_1Tablespoon_Returns15ml()
+	{
+		var result = UnitConversion.ToMetric(1m, "tbsp");
+
+		result.Unit.Should().Be("ml");
+		result.Amount.Should().Be(15m);
+	}
+
+	[Theory]
+	[InlineData(UnitSystem.Imperial, "g", "oz")]
+	[InlineData(UnitSystem.Metric, "cup", "ml")]
+	public void ToSystem_RoutesToTheCorrectTable(UnitSystem target, string fromUnit, string expectedUnit)
+	{
+		var result = UnitConversion.ToSystem(100m, fromUnit, target);
+
+		result.Unit.Should().Be(expectedUnit);
+	}
+
+	[Fact]
+	public void CelsiusToFahrenheit_180C_Is356F()
+	{
+		// TC-125-03.
+		UnitConversion.CelsiusToFahrenheit(180).Should().Be(356);
+	}
+
+	[Fact]
+	public void Temperature_RoundTripsWithinOneDegree()
+	{
+		var celsius = UnitConversion.FahrenheitToCelsius(UnitConversion.CelsiusToFahrenheit(180));
+
+		celsius.Should().BeInRange(179, 181);
+	}
+
+	[Theory]
+	[InlineData(0.34, 0.25)]
+	[InlineData(0.13, 0.25)]
+	[InlineData(0.05, 0)]
+	[InlineData(1.2, 1)]
+	[InlineData(2.4, 2.5)]
+	[InlineData(7.8, 8)]
+	[InlineData(17.6, 18)]
+	[InlineData(99.5, 100)]
+	[InlineData(127.4, 125)]
+	[InlineData(503.2, 505)]
+	[InlineData(1234.7, 1230)]
+	public void SmartRound_RoundsToCookingFriendlyValues(decimal input, decimal expected)
+	{
+		UnitConversion.SmartRound(input).Should().Be(expected);
+	}
+}


### PR DESCRIPTION
First slice of US-125. **Backend-canonical** placement (per architectural choice in session): the pure conversion logic lives in \`Yumney.Shared.Quantities\` so the shopping-list merge and any future server-side ingestion normalization share one source of truth. UI integration (toggle on recipe detail, profile-default lookup, shopping-list re-merge) lands in follow-up PRs.

## API

\`\`\`csharp
UnitConversion.ToImperial(amount, unit)               // → ConvertedAmount
UnitConversion.ToMetric(amount, unit)
UnitConversion.ToSystem(amount, unit, target)         // dispatches by UnitSystem enum
UnitConversion.CelsiusToFahrenheit(int) / FahrenheitToCelsius(int)
UnitConversion.SmartRound(decimal)                    // exposed for callers
\`\`\`

\`UnitSystem\` is a 2-value enum (\`Metric\`, \`Imperial\`); \`ConvertedAmount\` is a tiny record (\`decimal Amount, string Unit\`).

## Conversion table

Cooking-relevant pairs only:

| Metric → Imperial | Imperial → Metric |
|---|---|
| \`g → oz\` | \`oz → g\` |
| \`kg → lb\` | \`lb → g\` |
| \`ml → fl oz\` | \`fl oz → ml\` |
| \`cl → fl oz\` | \`cup → ml\` |
| \`dl → cup\` | \`tsp → ml\` |
| \`l → cup\` | \`tbsp → ml\` |

## Pass-through behaviour

Unknown / count units (\`pinch\`, \`slice\`, \`clove\`, \`"to taste"\`, …) and empty / null units return unchanged so callers can pipe every ingredient row through the service without pre-filtering. Match is case-insensitive on the unit string.

## SmartRound

Cookbooks don't measure \`1.7834 oz\`. Thresholds:

- \`< 1\` → ¼-step (\`0.34\` → \`0.25\`)
- \`< 10\` → ½-step (\`2.4\` → \`2.5\`)
- \`< 100\` → integer (\`17.6\` → \`18\`)
- \`< 1000\` → 5-step (\`127.4\` → \`125\`)
- \`≥ 1000\` → 10-step (\`1234.7\` → \`1230\`)

## Test plan

- [x] \`dotnet test tests/Yumney.Shared.Tests --filter UnitConversion\` — 28/28 (covers TC-125-01/02/03/05 from US-125 by name)
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean (StyleCop happy)
- [ ] CI green

## Out of scope — follow-up PRs

1. API endpoint or query-string on recipe GET so the frontend can request a target system.
2. \`UnitToggleComponent\` in \`libs/ui\` + recipe-detail integration.
3. Profile-default application (read \`preferredUnitSystem\` from US-100 profile).
4. Shopping-list merge using \`UnitConversion\` to normalize before adding (cross-system addition).

US-125 stays open; this PR closes the foundation.