### PR TITLE
refactor(shared): split publisher clients from consumer adapters

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -34,18 +34,21 @@
     <Project Path="src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj" />
     <Project Path="src/Yumney.Recipes.Extraction/Yumney.Recipes.Extraction.csproj" />
     <Project Path="src/Yumney.Recipes.Api/Yumney.Recipes.Api.csproj" />
+    <Project Path="src/Yumney.Recipes.Client/Yumney.Recipes.Client.csproj" />
   </Folder>
   <Folder Name="/src/Shopping/">
     <Project Path="src/Yumney.Shopping.Domain/Yumney.Shopping.Domain.csproj" />
     <Project Path="src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj" />
     <Project Path="src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj" />
     <Project Path="src/Yumney.Shopping.Api/Yumney.Shopping.Api.csproj" />
+    <Project Path="src/Yumney.Shopping.Client/Yumney.Shopping.Client.csproj" />
   </Folder>
   <Folder Name="/src/Users/">
     <Project Path="src/Yumney.Users.Domain/Yumney.Users.Domain.csproj" />
     <Project Path="src/Yumney.Users.Application/Yumney.Users.Application.csproj" />
     <Project Path="src/Yumney.Users.Infrastructure/Yumney.Users.Infrastructure.csproj" />
     <Project Path="src/Yumney.Users.Api/Yumney.Users.Api.csproj" />
+    <Project Path="src/Yumney.Users.Client/Yumney.Users.Client.csproj" />
   </Folder>
   <Folder Name="/tests/" />
   <Folder Name="/tests/Shared/">

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -87,7 +87,7 @@ public sealed class GenerateShoppingListCommandHandler(
 
 		if (itemsToAdd.Count > 0)
 		{
-			await shoppingListWriter.AddItemsAsync(owner, itemsToAdd, cancellationToken);
+			await shoppingListWriter.AddItemsAsync(itemsToAdd, cancellationToken);
 		}
 
 		return (staplesSkipped, itemsToAdd);

--- a/src/Yumney.MealPlan.Application/Interfaces/IShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IShoppingListWriter.cs
@@ -1,12 +1,8 @@
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
-using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 
 public interface IShoppingListWriter
 {
-	Task AddItemsAsync(
-		OwnerIdentifier owner,
-		IReadOnlyList<ShoppingItemRequest> items,
-		CancellationToken cancellationToken = default);
+	Task AddItemsAsync(IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
@@ -1,20 +1,17 @@
-using System.Net.Http.Json;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Recipes.Client;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
-public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFactory) : IRecipeIngredientLookup
+public sealed class HttpRecipeIngredientLookup(IRecipesClient recipes) : IRecipeIngredientLookup
 {
 	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
 		SlotRecipeIdentifier recipe,
 		CancellationToken cancellationToken = default)
 	{
-		var client = httpClientFactory.CreateClient("recipes-api");
-		var url = $"/api/v1/recipes/{recipe.Value}";
-		var response = await client.GetFromJsonAsync<RecipeWireResponse>(url, cancellationToken);
-
+		var response = await recipes.GetRecipeAsync(recipe.Value, cancellationToken);
 		if (response is null) return [];
 
 		return response.Ingredients
@@ -25,8 +22,4 @@ public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFact
 				response.Servings))
 			.ToList();
 	}
-
-	private sealed record RecipeWireResponse(int? Servings, IReadOnlyList<IngredientWireResponse> Ingredients);
-
-	private sealed record IngredientWireResponse(string Name, decimal? Amount, string? Unit);
 }

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
@@ -1,25 +1,43 @@
+using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
-using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
-public sealed class HttpShoppingListWriter(IHttpClientFactory httpClientFactory) : IShoppingListWriter
+#pragma warning disable SA1601
+public sealed partial class HttpShoppingListWriter(IHttpClientFactory httpClientFactory, ILogger<HttpShoppingListWriter> logger)
+	: IShoppingListWriter
 {
-	public async Task AddItemsAsync(
-		OwnerIdentifier owner,
-		IReadOnlyList<ShoppingItemRequest> items,
-		CancellationToken cancellationToken = default)
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
+#pragma warning restore SA1311
+
+	public async Task AddItemsAsync(IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default)
 	{
 		var client = httpClientFactory.CreateClient("shopping-api");
 
-		await foreach (var (itemName, quantity, unit, source) in items.ToAsyncEnumerable().WithCancellation(cancellationToken))
+		foreach (var (itemName, quantity, unit, source) in items)
 		{
-			AddItemRequest request = new(itemName, quantity, unit, source);
-			await client.PostAsJsonAsync("/api/v1/shopping-lists/items", request, cancellationToken);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var request = new AddItemRequest(itemName, quantity, unit, source);
+			var url = "/api/v1/shopping-lists/items";
+			var response = await client.PostAsJsonAsync(url, request, jsonOptions, cancellationToken);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				LogAddItemFailed(itemName, response.StatusCode);
+				response.EnsureSuccessStatusCode();
+			}
 		}
 	}
 
+	[LoggerMessage(Level = LogLevel.Error, Message = "Failed to add shopping-list item {ItemName}: HTTP {StatusCode}")]
+	private partial void LogAddItemFailed(string itemName, HttpStatusCode statusCode);
+
+#pragma warning disable SA1313, SA1402, SA1649
 	private sealed record AddItemRequest(string Name, decimal Quantity, string? Unit, string Source);
 }

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpShoppingListWriter.cs
@@ -1,43 +1,17 @@
-using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
-#pragma warning disable SA1601
-public sealed partial class HttpShoppingListWriter(IHttpClientFactory httpClientFactory, ILogger<HttpShoppingListWriter> logger)
-	: IShoppingListWriter
+public sealed class HttpShoppingListWriter(IShoppingClient shopping) : IShoppingListWriter
 {
-#pragma warning disable SA1311
-	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
-#pragma warning restore SA1311
-
 	public async Task AddItemsAsync(IReadOnlyList<ShoppingItemRequest> items, CancellationToken cancellationToken = default)
 	{
-		var client = httpClientFactory.CreateClient("shopping-api");
-
 		foreach (var (itemName, quantity, unit, source) in items)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-
-			var request = new AddItemRequest(itemName, quantity, unit, source);
-			var url = "/api/v1/shopping-lists/items";
-			var response = await client.PostAsJsonAsync(url, request, jsonOptions, cancellationToken);
-
-			if (!response.IsSuccessStatusCode)
-			{
-				LogAddItemFailed(itemName, response.StatusCode);
-				response.EnsureSuccessStatusCode();
-			}
+			await shopping.AddItemAsync(new AddShoppingItemRequest(itemName, quantity, unit, source), cancellationToken);
 		}
 	}
-
-	[LoggerMessage(Level = LogLevel.Error, Message = "Failed to add shopping-list item {ItemName}: HTTP {StatusCode}")]
-	private partial void LogAddItemFailed(string itemName, HttpStatusCode statusCode);
-
-#pragma warning disable SA1313, SA1402, SA1649
-	private sealed record AddItemRequest(string Name, decimal Quantity, string? Unit, string Source);
 }

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -6,9 +6,8 @@ using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
 #pragma warning disable SA1601
-public sealed partial class HttpStaplesProvider(
-	IHttpClientFactory httpClientFactory,
-	ILogger<HttpStaplesProvider> logger) : IStaplesProvider
+public sealed partial class HttpStaplesProvider(IHttpClientFactory httpClientFactory, ILogger<HttpStaplesProvider> logger)
+	: IStaplesProvider
 {
 #pragma warning disable SA1311
 	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
@@ -19,7 +18,8 @@ public sealed partial class HttpStaplesProvider(
 		try
 		{
 			var client = httpClientFactory.CreateClient("users-api");
-			var staples = await client.GetFromJsonAsync<List<string>>("/api/v1/users/staples", jsonOptions, cancellationToken) ?? [];
+			var url = "/api/v1/users/staples";
+			var staples = await client.GetFromJsonAsync<List<string>>(url, jsonOptions, cancellationToken) ?? [];
 
 			return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
 		}

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -1,35 +1,13 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 
-#pragma warning disable SA1601
-public sealed partial class HttpStaplesProvider(IHttpClientFactory httpClientFactory, ILogger<HttpStaplesProvider> logger)
-	: IStaplesProvider
+public sealed class HttpStaplesProvider(IUsersClient users) : IStaplesProvider
 {
-#pragma warning disable SA1311
-	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
-#pragma warning restore SA1311
-
 	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			var client = httpClientFactory.CreateClient("users-api");
-			var url = "/api/v1/users/staples";
-			var staples = await client.GetFromJsonAsync<List<string>>(url, jsonOptions, cancellationToken) ?? [];
-
-			return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
-		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
-		{
-			LogStaplesFetchFailed(ex.Message);
-			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		}
+		var staples = await users.GetMyStaplesAsync(cancellationToken);
+		return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
 	}
-
-	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch staples from users-api ({Reason}); shopping-list generation continuing without staple filtering.")]
-	private partial void LogStaplesFetchFailed(string reason);
 }

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -6,9 +6,11 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+using SmartSolutionsLab.Yumney.Recipes.Client;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
-using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure;
 
@@ -31,9 +33,9 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipeIngredientLookup, HttpRecipeIngredientLookup>();
 		services.AddScoped<IShoppingListWriter, HttpShoppingListWriter>();
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
-		services.AddYumneyServiceClient("recipes-api");
-		services.AddYumneyServiceClient("shopping-api");
-		services.AddYumneyServiceClient("users-api");
+		services.AddRecipesClient();
+		services.AddShoppingClient();
+		services.AddUsersClient();
 		services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb");
 
 		return services;

--- a/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
+++ b/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
@@ -10,6 +10,9 @@
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.Recipes.Client\Yumney.Recipes.Client.csproj" />
+    <ProjectReference Include="..\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
+    <ProjectReference Include="..\Yumney.Users.Client\Yumney.Users.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Recipes.Client/IRecipesClient.cs
+++ b/src/Yumney.Recipes.Client/IRecipesClient.cs
@@ -1,0 +1,10 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Client;
+
+public interface IRecipesClient
+{
+	Task<RecipeResponse?> GetRecipeAsync(Guid recipeId, CancellationToken cancellationToken = default);
+}
+
+public sealed record RecipeResponse(int? Servings, IReadOnlyList<RecipeIngredientPayload> Ingredients);
+
+public sealed record RecipeIngredientPayload(string Name, decimal? Amount, string? Unit);

--- a/src/Yumney.Recipes.Client/RecipesClient.cs
+++ b/src/Yumney.Recipes.Client/RecipesClient.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Client;
+
+internal sealed class RecipesClient(IModuleHttpClientFactory factory) : IRecipesClient
+{
+	private readonly IModuleHttpClient http = factory.For("recipes-api");
+
+	public Task<RecipeResponse?> GetRecipeAsync(Guid recipeId, CancellationToken cancellationToken = default) =>
+		http.FindAsync<RecipeResponse>(
+			$"/api/v1/recipes/{recipeId}",
+			"GetRecipe",
+			cancellationToken);
+}

--- a/src/Yumney.Recipes.Client/RecipesClientServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Client/RecipesClientServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Client;
+
+public static class RecipesClientServiceCollectionExtensions
+{
+	public static IServiceCollection AddRecipesClient(this IServiceCollection services)
+	{
+		services.AddYumneyServiceClient("recipes-api");
+		services.AddSingleton<IRecipesClient, RecipesClient>();
+		return services;
+	}
+}

--- a/src/Yumney.Recipes.Client/Yumney.Recipes.Client.csproj
+++ b/src/Yumney.Recipes.Client/Yumney.Recipes.Client.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpDietaryProfileProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpDietaryProfileProvider.cs
@@ -1,55 +1,17 @@
-using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
 
-#pragma warning disable SA1601
-public sealed partial class HttpDietaryProfileProvider(
-	IHttpClientFactory httpClientFactory,
-	ILogger<HttpDietaryProfileProvider> logger) : IDietaryProfileProvider
+public sealed class HttpDietaryProfileProvider(IUsersClient users) : IDietaryProfileProvider
 {
-#pragma warning disable SA1311
-	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
-#pragma warning restore SA1311
-
 	public async Task<DietaryProfileSnapshot> GetAsync(CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			var client = httpClientFactory.CreateClient("users-api");
-			var response = await client.GetAsync("/api/v1/users/me/profile", cancellationToken);
+		var profile = await users.GetMyProfileAsync(cancellationToken);
+		var dietary = profile?.DietaryProfile;
+		if (dietary is null) return DietaryProfileSnapshot.Empty;
 
-			if (response.StatusCode == HttpStatusCode.NotFound) return DietaryProfileSnapshot.Empty;
-			if (!response.IsSuccessStatusCode)
-			{
-				LogProfileFetchFailed($"HTTP {(int)response.StatusCode}");
-				return DietaryProfileSnapshot.Empty;
-			}
-
-			var dto = await response.Content.ReadFromJsonAsync<UserProfileResponse>(jsonOptions, cancellationToken);
-			var dietary = dto?.DietaryProfile;
-			if (dietary is null) return DietaryProfileSnapshot.Empty;
-
-			return new DietaryProfileSnapshot(
-				dietary.DietaryType,
-				dietary.Restrictions ?? []);
-		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
-		{
-			LogProfileFetchFailed(ex.Message);
-			return DietaryProfileSnapshot.Empty;
-		}
+		return new DietaryProfileSnapshot(dietary.DietaryType, dietary.Restrictions ?? []);
 	}
-
-	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch dietary profile from users-api ({Reason}); recipe-suggestion handler continuing without dietary preferences.")]
-	private partial void LogProfileFetchFailed(string reason);
-
-#pragma warning disable SA1313, SA1402, SA1649
-	private sealed record UserProfileResponse(DietaryProfilePayload? DietaryProfile);
-
-	private sealed record DietaryProfilePayload(string? DietaryType, IReadOnlyList<string>? Restrictions);
 }

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
@@ -1,49 +1,23 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Client;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
 
-#pragma warning disable SA1601
-public sealed partial class HttpIngredientBalanceProvider(
-	IHttpClientFactory httpClientFactory,
-	ILogger<HttpIngredientBalanceProvider> logger) : IIngredientBalanceProvider
+public sealed class HttpIngredientBalanceProvider(IShoppingClient shopping) : IIngredientBalanceProvider
 {
-#pragma warning disable SA1311
-	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
-	{
-		Converters = { new JsonStringEnumConverter() },
-	};
-#pragma warning restore SA1311
-
 	public async Task<IReadOnlyDictionary<string, Freshness>> GetAvailableIngredientsAsync(CancellationToken cancellationToken = default)
 	{
 		var result = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
 
-		BalanceDto? dto;
-		try
-		{
-			var client = httpClientFactory.CreateClient("shopping-api");
-			dto = await client.GetFromJsonAsync<BalanceDto>("/api/v1/shopping-lists/balance", jsonOptions, cancellationToken);
-		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
-		{
-			LogBalanceFetchFailed(ex.Message);
-			return result;
-		}
+		var balance = await shopping.GetBalanceAsync(cancellationToken);
+		if (balance?.Items is null) return result;
 
-		if (dto?.Items is null) return result;
-
-		foreach (var item in dto.Items)
+		foreach (var item in balance.Items)
 		{
 			var name = item.ItemName.Trim();
 			if (name.Length == 0) continue;
 
-			// Items with the same name but different units share a freshness slot;
-			// the most urgent wins so the matcher is not misled by a fresher duplicate.
 			if (!result.TryGetValue(name, out var existing) || item.Freshness.Urgency() > existing.Urgency())
 			{
 				result[name] = item.Freshness;
@@ -52,12 +26,4 @@ public sealed partial class HttpIngredientBalanceProvider(
 
 		return result;
 	}
-
-	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch ingredient balance from shopping-api ({Reason}); cookable-recipes matcher continuing with empty balance.")]
-	private partial void LogBalanceFetchFailed(string reason);
-
-#pragma warning disable SA1313, SA1402, SA1649
-	private sealed record BalanceDto(IReadOnlyList<BalanceItemDto> Items);
-
-	private sealed record BalanceItemDto(string ItemName, Freshness Freshness);
 }

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -7,7 +7,8 @@ using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
-using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure;
 
@@ -29,8 +30,8 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
-		services.AddYumneyServiceClient("shopping-api");
-		services.AddYumneyServiceClient("users-api");
+		services.AddShoppingClient();
+		services.AddUsersClient();
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
 		return services;

--- a/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
+++ b/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
+    <ProjectReference Include="..\Yumney.Users.Client\Yumney.Users.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Shared.Web/AssemblyInfo.cs
+++ b/src/Yumney.Shared.Web/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Yumney.Shared.Tests")]

--- a/src/Yumney.Shared.Web/IModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClient.cs
@@ -1,0 +1,27 @@
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+public interface IModuleHttpClient
+{
+	Task<TResult> GetOrDefaultAsync<TResult>(
+		string url,
+		TResult fallback,
+		string operation,
+		CancellationToken cancellationToken = default);
+
+	Task<TResult?> FindAsync<TResult>(
+		string url,
+		string operation,
+		CancellationToken cancellationToken = default)
+		where TResult : class;
+
+	Task PostAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default);
+}
+
+public interface IModuleHttpClientFactory
+{
+	IModuleHttpClient For(string upstreamName);
+}

--- a/src/Yumney.Shared.Web/ModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/ModuleHttpClient.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+#pragma warning disable SA1601
+internal sealed partial class ModuleHttpClient(
+	HttpClient httpClient,
+	string upstreamName,
+	ILogger<ModuleHttpClient> logger) : IModuleHttpClient
+{
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		Converters = { new JsonStringEnumConverter() },
+	};
+#pragma warning restore SA1311
+
+	public async Task<TResult> GetOrDefaultAsync<TResult>(
+		string url,
+		TResult fallback,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			var result = await httpClient.GetFromJsonAsync<TResult>(url, jsonOptions, cancellationToken);
+			return result ?? fallback;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogGetFailed(operation, upstreamName, ex.Message);
+			return fallback;
+		}
+	}
+
+	public async Task<TResult?> FindAsync<TResult>(
+		string url,
+		string operation,
+		CancellationToken cancellationToken = default)
+		where TResult : class
+	{
+		try
+		{
+			using var response = await httpClient.GetAsync(url, cancellationToken);
+			if (response.StatusCode == HttpStatusCode.NotFound) return null;
+			response.EnsureSuccessStatusCode();
+			return await response.Content.ReadFromJsonAsync<TResult>(jsonOptions, cancellationToken);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogFindFailed(operation, upstreamName, ex.Message);
+			return null;
+		}
+	}
+
+	public async Task PostAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await httpClient.PostAsJsonAsync(url, body, jsonOptions, cancellationToken);
+			response.EnsureSuccessStatusCode();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogPostFailed(operation, upstreamName, ex.Message);
+			throw;
+		}
+	}
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "{Operation} GET against {Upstream} failed ({Reason}); returning fallback.")]
+	private partial void LogGetFailed(string operation, string upstream, string reason);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "{Operation} GET against {Upstream} failed ({Reason}); returning null.")]
+	private partial void LogFindFailed(string operation, string upstream, string reason);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} POST to {Upstream} failed ({Reason}).")]
+	private partial void LogPostFailed(string operation, string upstream, string reason);
+}

--- a/src/Yumney.Shared.Web/ModuleHttpClientFactory.cs
+++ b/src/Yumney.Shared.Web/ModuleHttpClientFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+internal sealed class ModuleHttpClientFactory(IServiceProvider serviceProvider) : IModuleHttpClientFactory
+{
+	public IModuleHttpClient For(string upstreamName)
+	{
+		var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+		var logger = serviceProvider.GetRequiredService<ILogger<ModuleHttpClient>>();
+		var client = httpClientFactory.CreateClient(upstreamName);
+		return new ModuleHttpClient(client, upstreamName, logger);
+	}
+}

--- a/src/Yumney.Shared.Web/YumneyServiceClientRegistration.cs
+++ b/src/Yumney.Shared.Web/YumneyServiceClientRegistration.cs
@@ -13,6 +13,8 @@ public static class YumneyServiceClientRegistration
 		services.AddHttpClient(serviceName, client => client.BaseAddress = new Uri($"http://{serviceName}"))
 			.AddHttpMessageHandler(sp => sp.GetRequiredService<AuthTokenDelegatingHandler>());
 
+		services.TryAddSingleton<IModuleHttpClientFactory, ModuleHttpClientFactory>();
+
 		return services;
 	}
 }

--- a/src/Yumney.Shopping.Application/Interfaces/IStaplesProvider.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IStaplesProvider.cs
@@ -1,8 +1,6 @@
-using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
-
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 public interface IStaplesProvider
 {
-	Task<IReadOnlySet<string>> GetStapleNamesAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
+	Task<IReadOnlySet<string>> GetStapleNamesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -17,7 +17,7 @@ public sealed class GetIngredientBalanceQueryHandler(
 		var owner = currentUser.AsOwner();
 
 		var atHomeTask = readModel.GetAtHomeItemsAsync(owner.Value, cancellationToken);
-		var staplesTask = staplesProvider.GetStapleNamesAsync(owner, cancellationToken);
+		var staplesTask = staplesProvider.GetStapleNamesAsync(cancellationToken);
 		await Task.WhenAll(atHomeTask, staplesTask);
 
 		var atHomeItems = atHomeTask.Result;

--- a/src/Yumney.Shopping.Client/IShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/IShoppingClient.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Client;
+
+public interface IShoppingClient
+{
+	Task<ShoppingBalanceResponse?> GetBalanceAsync(CancellationToken cancellationToken = default);
+
+	Task AddItemAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> Items);
+
+public sealed record ShoppingBalanceItem(string ItemName, Freshness Freshness);
+
+public sealed record AddShoppingItemRequest(string Name, decimal Quantity, string? Unit, string Source);

--- a/src/Yumney.Shopping.Client/ShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClient.cs
@@ -1,0 +1,21 @@
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Client;
+
+internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppingClient
+{
+	private readonly IModuleHttpClient http = factory.For("shopping-api");
+
+	public Task<ShoppingBalanceResponse?> GetBalanceAsync(CancellationToken cancellationToken = default) =>
+		http.FindAsync<ShoppingBalanceResponse>(
+			"/api/v1/shopping-lists/balance",
+			"GetShoppingBalance",
+			cancellationToken);
+
+	public Task AddItemAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default) =>
+		http.PostAsync(
+			"/api/v1/shopping-lists/items",
+			request,
+			"AddShoppingItem",
+			cancellationToken);
+}

--- a/src/Yumney.Shopping.Client/ShoppingClientServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClientServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Client;
+
+public static class ShoppingClientServiceCollectionExtensions
+{
+	public static IServiceCollection AddShoppingClient(this IServiceCollection services)
+	{
+		services.AddYumneyServiceClient("shopping-api");
+		services.AddSingleton<IShoppingClient, ShoppingClient>();
+		return services;
+	}
+}

--- a/src/Yumney.Shopping.Client/Yumney.Shopping.Client.csproj
+++ b/src/Yumney.Shopping.Client/Yumney.Shopping.Client.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Quantities\Yumney.Shared.Quantities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
@@ -1,20 +1,17 @@
-using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Recipes.Client;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 
-public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFactory) : IRecipeIngredientLookup
+public sealed class HttpRecipeIngredientLookup(IRecipesClient recipes) : IRecipeIngredientLookup
 {
 	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
 		RecipeReference recipe,
 		CancellationToken cancellationToken = default)
 	{
-		var client = httpClientFactory.CreateClient("recipes-api");
-		var url = $"/api/v1/recipes/{recipe.Value}";
-		var response = await client.GetFromJsonAsync<RecipeWireResponse>(url, cancellationToken);
-
+		var response = await recipes.GetRecipeAsync(recipe.Value, cancellationToken);
 		if (response is null) return [];
 
 		return response.Ingredients
@@ -25,8 +22,4 @@ public sealed class HttpRecipeIngredientLookup(IHttpClientFactory httpClientFact
 				response.Servings))
 			.ToList();
 	}
-
-	private sealed record RecipeWireResponse(int? Servings, IReadOnlyList<IngredientWireResponse> Ingredients);
-
-	private sealed record IngredientWireResponse(string Name, decimal? Amount, string? Unit);
 }

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -1,35 +1,13 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 
-#pragma warning disable SA1601
-public sealed partial class HttpStaplesProvider(IHttpClientFactory httpClientFactory, ILogger<HttpStaplesProvider> logger)
-	: IStaplesProvider
+public sealed class HttpStaplesProvider(IUsersClient users) : IStaplesProvider
 {
-#pragma warning disable SA1311
-	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
-#pragma warning restore SA1311
-
 	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(CancellationToken cancellationToken = default)
 	{
-		try
-		{
-			var client = httpClientFactory.CreateClient("users-api");
-			var url = "/api/v1/users/staples";
-			var staples = await client.GetFromJsonAsync<List<string>>(url, jsonOptions, cancellationToken) ?? [];
-
-			return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
-		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
-		{
-			LogStaplesFetchFailed(ex.Message);
-			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		}
+		var staples = await users.GetMyStaplesAsync(cancellationToken);
+		return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
 	}
-
-	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch staples from users-api ({Reason}); ingredient-balance continuing without staple augmentation.")]
-	private partial void LogStaplesFetchFailed(string reason);
 }

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -1,17 +1,35 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
-using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 
-public sealed class HttpStaplesProvider(IHttpClientFactory httpClientFactory) : IStaplesProvider
+#pragma warning disable SA1601
+public sealed partial class HttpStaplesProvider(
+	IHttpClientFactory httpClientFactory,
+	ILogger<HttpStaplesProvider> logger) : IStaplesProvider
 {
-	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
-	{
-		var client = httpClientFactory.CreateClient("users-api");
-		var url = "/api/v1/users/staples";
-		List<string> staples = await client.GetFromJsonAsync<List<string>>(url, cancellationToken) ?? [];
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
+#pragma warning restore SA1311
 
-		return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	public async Task<IReadOnlySet<string>> GetStapleNamesAsync(CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			var client = httpClientFactory.CreateClient("users-api");
+			var staples = await client.GetFromJsonAsync<List<string>>("/api/v1/users/staples", jsonOptions, cancellationToken) ?? [];
+
+			return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogStaplesFetchFailed(ex.Message);
+			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		}
 	}
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch staples from users-api ({Reason}); ingredient-balance continuing without staple augmentation.")]
+	private partial void LogStaplesFetchFailed(string reason);
 }

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpStaplesProvider.cs
@@ -6,9 +6,8 @@ using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 
 #pragma warning disable SA1601
-public sealed partial class HttpStaplesProvider(
-	IHttpClientFactory httpClientFactory,
-	ILogger<HttpStaplesProvider> logger) : IStaplesProvider
+public sealed partial class HttpStaplesProvider(IHttpClientFactory httpClientFactory, ILogger<HttpStaplesProvider> logger)
+	: IStaplesProvider
 {
 #pragma warning disable SA1311
 	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web);
@@ -19,7 +18,8 @@ public sealed partial class HttpStaplesProvider(
 		try
 		{
 			var client = httpClientFactory.CreateClient("users-api");
-			var staples = await client.GetFromJsonAsync<List<string>>("/api/v1/users/staples", jsonOptions, cancellationToken) ?? [];
+			var url = "/api/v1/users/staples";
+			var staples = await client.GetFromJsonAsync<List<string>>(url, jsonOptions, cancellationToken) ?? [];
 
 			return staples.ToHashSet(StringComparer.OrdinalIgnoreCase);
 		}

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Client;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
-using SmartSolutionsLab.Yumney.Shared.Web;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
@@ -13,6 +13,7 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure;
 
@@ -35,10 +36,10 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIngredientBalanceReadModelRepository, IngredientBalanceReadModelRepository>();
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
 		services.AddScoped<IRecipeIngredientLookup, HttpRecipeIngredientLookup>();
-		services.AddYumneyServiceClient("recipes-api");
+		services.AddRecipesClient();
 		services.AddScoped<IInboxStore, EfCoreInboxStore<ShoppingDbContext>>();
 		services.AddBusEventHandlersFromAssemblyContaining<ShoppingListProjection>();
-		services.AddYumneyServiceClient("users-api");
+		services.AddUsersClient();
 		services.AddScoped<IShoppingUserDataPurger, EfCoreShoppingUserDataPurger>();
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 

--- a/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
+++ b/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.Recipes.Client\Yumney.Recipes.Client.csproj" />
+    <ProjectReference Include="..\Yumney.Users.Client\Yumney.Users.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Yumney.Users.Client/IUsersClient.cs
+++ b/src/Yumney.Users.Client/IUsersClient.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Users.Client;
+
+public interface IUsersClient
+{
+	Task<IReadOnlyList<string>> GetMyStaplesAsync(CancellationToken cancellationToken = default);
+
+	Task<UsersProfileResponse?> GetMyProfileAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record UsersProfileResponse(DietaryProfilePayload? DietaryProfile);
+
+public sealed record DietaryProfilePayload(string? DietaryType, IReadOnlyList<string>? Restrictions);

--- a/src/Yumney.Users.Client/UsersClient.cs
+++ b/src/Yumney.Users.Client/UsersClient.cs
@@ -1,0 +1,21 @@
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Users.Client;
+
+internal sealed class UsersClient(IModuleHttpClientFactory factory) : IUsersClient
+{
+	private readonly IModuleHttpClient http = factory.For("users-api");
+
+	public Task<IReadOnlyList<string>> GetMyStaplesAsync(CancellationToken cancellationToken = default) =>
+		http.GetOrDefaultAsync<IReadOnlyList<string>>(
+			"/api/v1/users/staples",
+			[],
+			"GetStaples",
+			cancellationToken);
+
+	public Task<UsersProfileResponse?> GetMyProfileAsync(CancellationToken cancellationToken = default) =>
+		http.FindAsync<UsersProfileResponse>(
+			"/api/v1/users/me/profile",
+			"GetUserProfile",
+			cancellationToken);
+}

--- a/src/Yumney.Users.Client/UsersClientServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Client/UsersClientServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.Users.Client;
+
+public static class UsersClientServiceCollectionExtensions
+{
+	public static IServiceCollection AddUsersClient(this IServiceCollection services)
+	{
+		services.AddYumneyServiceClient("users-api");
+		services.AddSingleton<IUsersClient, UsersClient>();
+		return services;
+	}
+}

--- a/src/Yumney.Users.Client/Yumney.Users.Client.csproj
+++ b/src/Yumney.Users.Client/Yumney.Users.Client.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Yumney.MealPlan.Application.Tests/Commands/GenerateShoppingListCommandHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Commands/GenerateShoppingListCommandHandlerTests.cs
@@ -63,7 +63,6 @@ public class GenerateShoppingListCommandHandlerTests
 		result.IsSuccess.Should().BeTrue();
 		result.Value.ItemsAdded.Should().Be(2);
 		await shoppingListWriter.Received(1).AddItemsAsync(
-			Arg.Is<OwnerIdentifier>(owner => owner.Value == "user-123"),
 			Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items => items.Count == 2),
 			Arg.Any<CancellationToken>());
 	}
@@ -83,7 +82,6 @@ public class GenerateShoppingListCommandHandlerTests
 
 		result.IsSuccess.Should().BeTrue();
 		await shoppingListWriter.Received(1).AddItemsAsync(
-			Arg.Is<OwnerIdentifier>(owner => owner.Value == "user-123"),
 			Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items =>
 				items.Count == 1 && items[0].Quantity == 1000m),
 			Arg.Any<CancellationToken>());
@@ -110,7 +108,6 @@ public class GenerateShoppingListCommandHandlerTests
 		result.IsSuccess.Should().BeTrue();
 		result.Value.ItemsAdded.Should().Be(1);
 		await shoppingListWriter.Received(1).AddItemsAsync(
-			Arg.Is<OwnerIdentifier>(owner => owner.Value == "user-123"),
 			Arg.Is<IReadOnlyList<ShoppingItemRequest>>(items =>
 				items.Count == 1 && items[0].Quantity == 5m),
 			Arg.Any<CancellationToken>());
@@ -153,7 +150,6 @@ public class GenerateShoppingListCommandHandlerTests
 		result.IsSuccess.Should().BeTrue();
 		result.Value.ItemsAdded.Should().Be(0);
 		await shoppingListWriter.DidNotReceive().AddItemsAsync(
-			Arg.Any<OwnerIdentifier>(),
 			Arg.Any<IReadOnlyList<ShoppingItemRequest>>(),
 			Arg.Any<CancellationToken>());
 	}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeIngredientLookupTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeIngredientLookupTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Recipes.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpRecipeIngredientLookupTests
+{
+	private static readonly SlotRecipeIdentifier TestRecipe = SlotRecipeIdentifier.New();
+
+	[Fact]
+	public async Task LookupAsync_NullResponse_ReturnsEmpty()
+	{
+		var lookup = CreateLookup(response: null);
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task LookupAsync_EmptyIngredients_ReturnsEmpty()
+	{
+		var lookup = CreateLookup(new RecipeResponse(4, []));
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task LookupAsync_ProjectsServingsOntoEveryIngredient()
+	{
+		var lookup = CreateLookup(new RecipeResponse(
+			Servings: 4,
+			Ingredients:
+			[
+				new RecipeIngredientPayload("Tomato", 200m, "g"),
+				new RecipeIngredientPayload("Olive Oil", 30m, "ml"),
+			]));
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result.Should().HaveCount(2);
+		result.Should().AllSatisfy(ingredient => ingredient.RecipeServings.Should().Be(4));
+		result[0].Name.Should().Be("Tomato");
+		result[0].Amount.Should().Be(200m);
+		result[0].Unit.Should().Be("g");
+	}
+
+	[Fact]
+	public async Task LookupAsync_NullServings_PropagatesNull()
+	{
+		var lookup = CreateLookup(new RecipeResponse(
+			Servings: null,
+			Ingredients: [new RecipeIngredientPayload("Salt", 1m, "tsp")]));
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result[0].RecipeServings.Should().BeNull();
+	}
+
+	private static HttpRecipeIngredientLookup CreateLookup(RecipeResponse? response)
+	{
+		var recipes = Substitute.For<IRecipesClient>();
+		recipes.GetRecipeAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(response);
+		return new HttpRecipeIngredientLookup(recipes);
+	}
+}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpShoppingListWriterTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpShoppingListWriterTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpShoppingListWriterTests
+{
+	[Fact]
+	public async Task AddItemsAsync_NoItems_DoesNotCallClient()
+	{
+		var shopping = Substitute.For<IShoppingClient>();
+		var writer = new HttpShoppingListWriter(shopping);
+
+		await writer.AddItemsAsync([]);
+
+		await shopping.DidNotReceiveWithAnyArgs().AddItemAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_PostsOneRequestPerItem()
+	{
+		var shopping = Substitute.For<IShoppingClient>();
+		var writer = new HttpShoppingListWriter(shopping);
+
+		await writer.AddItemsAsync(
+		[
+			new ShoppingItemRequest("Tomato", 200m, "g", "meal-plan"),
+			new ShoppingItemRequest("Cheese", 100m, "g", "meal-plan"),
+		]);
+
+		await shopping.Received(2).AddItemAsync(Arg.Any<AddShoppingItemRequest>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_MapsFieldsToWireRequest()
+	{
+		var shopping = Substitute.For<IShoppingClient>();
+		var writer = new HttpShoppingListWriter(shopping);
+
+		await writer.AddItemsAsync([new ShoppingItemRequest("Pasta", 500m, "g", "meal-plan")]);
+
+		await shopping.Received(1).AddItemAsync(
+			Arg.Is<AddShoppingItemRequest>(request =>
+				request.Name == "Pasta" &&
+				request.Quantity == 500m &&
+				request.Unit == "g" &&
+				request.Source == "meal-plan"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task AddItemsAsync_CancelledBeforeStart_ThrowsAndNoItemsPosted()
+	{
+		var shopping = Substitute.For<IShoppingClient>();
+		var writer = new HttpShoppingListWriter(shopping);
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		var act = async () => await writer.AddItemsAsync(
+			[new ShoppingItemRequest("Pasta", 500m, "g", "meal-plan")],
+			cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+		await shopping.DidNotReceiveWithAnyArgs().AddItemAsync(default!, default);
+	}
+}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpStaplesProviderTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpStaplesProviderTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Users.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpStaplesProviderTests
+{
+	[Fact]
+	public async Task GetStapleNamesAsync_EmptyList_ReturnsEmptySet()
+	{
+		var provider = CreateProvider([]);
+
+		var result = await provider.GetStapleNamesAsync();
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetStapleNamesAsync_PopulatedList_ReturnsCaseInsensitiveSet()
+	{
+		var provider = CreateProvider(["Flour", "Sugar"]);
+
+		var result = await provider.GetStapleNamesAsync();
+
+		result.Contains("flour").Should().BeTrue();
+		result.Contains("SUGAR").Should().BeTrue();
+	}
+
+	private static HttpStaplesProvider CreateProvider(IReadOnlyList<string> staples)
+	{
+		var users = Substitute.For<IUsersClient>();
+		users.GetMyStaplesAsync(Arg.Any<CancellationToken>()).Returns(staples);
+		return new HttpStaplesProvider(users);
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpDietaryProfileProviderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpDietaryProfileProviderTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Users.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services;
+
+public class HttpDietaryProfileProviderTests
+{
+	[Fact]
+	public async Task GetAsync_NullProfileResponse_ReturnsEmpty()
+	{
+		var provider = CreateProvider(profile: null);
+
+		var result = await provider.GetAsync();
+
+		result.Should().Be(DietaryProfileSnapshot.Empty);
+	}
+
+	[Fact]
+	public async Task GetAsync_NullDietaryProfile_ReturnsEmpty()
+	{
+		var provider = CreateProvider(new UsersProfileResponse(null));
+
+		var result = await provider.GetAsync();
+
+		result.Should().Be(DietaryProfileSnapshot.Empty);
+	}
+
+	[Fact]
+	public async Task GetAsync_PopulatedProfile_MapsFields()
+	{
+		var provider = CreateProvider(new UsersProfileResponse(
+			new DietaryProfilePayload("vegan", ["nuts", "soy"])));
+
+		var result = await provider.GetAsync();
+
+		result.DietaryType.Should().Be("vegan");
+		result.Restrictions.Should().BeEquivalentTo("nuts", "soy");
+	}
+
+	[Fact]
+	public async Task GetAsync_NullRestrictions_ProjectsToEmptyList()
+	{
+		var provider = CreateProvider(new UsersProfileResponse(
+			new DietaryProfilePayload("vegetarian", null)));
+
+		var result = await provider.GetAsync();
+
+		result.Restrictions.Should().BeEmpty();
+	}
+
+	private static HttpDietaryProfileProvider CreateProvider(UsersProfileResponse? profile)
+	{
+		var users = Substitute.For<IUsersClient>();
+		users.GetMyProfileAsync(Arg.Any<CancellationToken>()).Returns(profile);
+		return new HttpDietaryProfileProvider(users);
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpIngredientBalanceProviderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/HttpIngredientBalanceProviderTests.cs
@@ -1,12 +1,8 @@
-using System.Net;
-using System.Net.Http;
-using System.Text;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
-using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Client;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services;
@@ -14,9 +10,9 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services;
 public class HttpIngredientBalanceProviderTests
 {
 	[Fact]
-	public async Task GetAvailableIngredientsAsync_EmptyResponse_ReturnsEmptyDictionary()
+	public async Task GetAvailableIngredientsAsync_NullResponse_ReturnsEmptyDictionary()
 	{
-		var provider = CreateProvider("""{ "items": [] }""");
+		var provider = CreateProvider(balance: null);
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
@@ -24,37 +20,21 @@ public class HttpIngredientBalanceProviderTests
 	}
 
 	[Fact]
-	public async Task GetAvailableIngredientsAsync_NullItems_ReturnsEmptyDictionary()
+	public async Task GetAvailableIngredientsAsync_EmptyItems_ReturnsEmptyDictionary()
 	{
-		var provider = CreateProvider("""{ "items": null }""");
+		var provider = CreateProvider(new ShoppingBalanceResponse([]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
 		result.Should().BeEmpty();
-	}
-
-	[Fact]
-	public async Task GetAvailableIngredientsAsync_DeserializesEnumAsString()
-	{
-		var provider = CreateProvider("""
-            {
-              "items": [
-                { "itemName": "Milk", "freshness": "UseSoon" },
-                { "itemName": "Salt", "freshness": "NotTracked" }
-              ]
-            }
-            """);
-
-		var result = await provider.GetAvailableIngredientsAsync();
-
-		result["Milk"].Should().Be(Freshness.UseSoon);
-		result["Salt"].Should().Be(Freshness.NotTracked);
 	}
 
 	[Fact]
 	public async Task GetAvailableIngredientsAsync_LookupIsCaseInsensitive()
 	{
-		var provider = CreateProvider("""{ "items": [ { "itemName": "Milk", "freshness": "Fresh" } ] }""");
+		var provider = CreateProvider(new ShoppingBalanceResponse([
+			new ShoppingBalanceItem("Milk", Freshness.Fresh),
+		]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
@@ -65,7 +45,9 @@ public class HttpIngredientBalanceProviderTests
 	[Fact]
 	public async Task GetAvailableIngredientsAsync_TrimsWhitespaceFromNames()
 	{
-		var provider = CreateProvider("""{ "items": [ { "itemName": "  Milk  ", "freshness": "Fresh" } ] }""");
+		var provider = CreateProvider(new ShoppingBalanceResponse([
+			new ShoppingBalanceItem("  Milk  ", Freshness.Fresh),
+		]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
@@ -75,14 +57,10 @@ public class HttpIngredientBalanceProviderTests
 	[Fact]
 	public async Task GetAvailableIngredientsAsync_BlankName_Skipped()
 	{
-		var provider = CreateProvider("""
-            {
-              "items": [
-                { "itemName": "   ", "freshness": "Fresh" },
-                { "itemName": "Eggs", "freshness": "Fresh" }
-              ]
-            }
-            """);
+		var provider = CreateProvider(new ShoppingBalanceResponse([
+			new ShoppingBalanceItem("   ", Freshness.Fresh),
+			new ShoppingBalanceItem("Eggs", Freshness.Fresh),
+		]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
@@ -92,17 +70,11 @@ public class HttpIngredientBalanceProviderTests
 	[Fact]
 	public async Task GetAvailableIngredientsAsync_DuplicateNameMostUrgentWins()
 	{
-		// Same name with different freshness (e.g. "milk in liters" UseSoon and
-		// "milk in ml" Fresh). The matcher needs the urgent one to surface.
-		var provider = CreateProvider("""
-            {
-              "items": [
-                { "itemName": "Milk", "freshness": "Fresh" },
-                { "itemName": "milk", "freshness": "UseSoon" },
-                { "itemName": "MILK", "freshness": "NotTracked" }
-              ]
-            }
-            """);
+		var provider = CreateProvider(new ShoppingBalanceResponse([
+			new ShoppingBalanceItem("Milk", Freshness.Fresh),
+			new ShoppingBalanceItem("milk", Freshness.UseSoon),
+			new ShoppingBalanceItem("MILK", Freshness.NotTracked),
+		]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
@@ -112,51 +84,20 @@ public class HttpIngredientBalanceProviderTests
 	[Fact]
 	public async Task GetAvailableIngredientsAsync_DuplicateNameOrderIndependent()
 	{
-		// Same scenario but reversed order — most-urgent first, then less urgent.
-		var provider = CreateProvider("""
-            {
-              "items": [
-                { "itemName": "Chicken", "freshness": "CheckIt" },
-                { "itemName": "Chicken", "freshness": "Fresh" }
-              ]
-            }
-            """);
+		var provider = CreateProvider(new ShoppingBalanceResponse([
+			new ShoppingBalanceItem("Chicken", Freshness.CheckIt),
+			new ShoppingBalanceItem("Chicken", Freshness.Fresh),
+		]));
 
 		var result = await provider.GetAvailableIngredientsAsync();
 
 		result["Chicken"].Should().Be(Freshness.CheckIt);
 	}
 
-	[Fact]
-	public async Task GetAvailableIngredientsAsync_HttpError_ReturnsEmptyForDegradedMode()
+	private static HttpIngredientBalanceProvider CreateProvider(ShoppingBalanceResponse? balance)
 	{
-		var provider = CreateProvider(string.Empty, HttpStatusCode.InternalServerError);
-
-		var result = await provider.GetAvailableIngredientsAsync();
-
-		result.Should().BeEmpty();
-	}
-
-	private static HttpIngredientBalanceProvider CreateProvider(string responseBody, HttpStatusCode status = HttpStatusCode.OK)
-	{
-		var handler = new StubHttpMessageHandler(responseBody, status);
-		var client = new HttpClient(handler) { BaseAddress = new Uri("http://shopping-api") };
-
-		var factory = Substitute.For<IHttpClientFactory>();
-		factory.CreateClient("shopping-api").Returns(client);
-
-		return new HttpIngredientBalanceProvider(factory, Substitute.For<ILogger<HttpIngredientBalanceProvider>>());
-	}
-
-	private sealed class StubHttpMessageHandler(string body, HttpStatusCode status) : HttpMessageHandler
-	{
-		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-		{
-			var response = new HttpResponseMessage(status)
-			{
-				Content = new StringContent(body, Encoding.UTF8, "application/json"),
-			};
-			return Task.FromResult(response);
-		}
+		var shopping = Substitute.For<IShoppingClient>();
+		shopping.GetBalanceAsync(Arg.Any<CancellationToken>()).Returns(balance);
+		return new HttpIngredientBalanceProvider(shopping);
 	}
 }

--- a/tests/Yumney.Shared.Tests/Web/ModuleHttpClientTests.cs
+++ b/tests/Yumney.Shared.Tests/Web/ModuleHttpClientTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Web;
+
+public class ModuleHttpClientTests
+{
+	[Fact]
+	public async Task GetOrDefaultAsync_Success_ReturnsBody()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.OK, """{ "name": "ok" }"""));
+
+		var result = await http.GetOrDefaultAsync("/anything", new Payload("fallback"), "Op");
+
+		result.Name.Should().Be("ok");
+	}
+
+	[Fact]
+	public async Task GetOrDefaultAsync_NonSuccess_ReturnsFallback()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.InternalServerError));
+
+		var result = await http.GetOrDefaultAsync("/anything", new Payload("fallback"), "Op");
+
+		result.Name.Should().Be("fallback");
+	}
+
+	[Fact]
+	public async Task GetOrDefaultAsync_NetworkException_ReturnsFallback()
+	{
+		var http = CreateClient(new ThrowingHandler(new HttpRequestException("boom")));
+
+		var result = await http.GetOrDefaultAsync("/anything", new Payload("fallback"), "Op");
+
+		result.Name.Should().Be("fallback");
+	}
+
+	[Fact]
+	public async Task GetOrDefaultAsync_Cancelled_Rethrows()
+	{
+		var http = CreateClient(new ThrowingHandler(new OperationCanceledException()));
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		var act = async () => await http.GetOrDefaultAsync("/anything", new Payload("fallback"), "Op", cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
+	public async Task FindAsync_Success_ReturnsBody()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.OK, """{ "name": "found" }"""));
+
+		var result = await http.FindAsync<Payload>("/anything", "Op");
+
+		result!.Name.Should().Be("found");
+	}
+
+	[Fact]
+	public async Task FindAsync_NotFound_ReturnsNull()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.NotFound));
+
+		var result = await http.FindAsync<Payload>("/anything", "Op");
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task FindAsync_NonSuccess_ReturnsNull()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.InternalServerError));
+
+		var result = await http.FindAsync<Payload>("/anything", "Op");
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task FindAsync_Cancelled_Rethrows()
+	{
+		var http = CreateClient(new ThrowingHandler(new OperationCanceledException()));
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		var act = async () => await http.FindAsync<Payload>("/anything", "Op", cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
+	public async Task PostAsync_Success_DoesNotThrow()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.NoContent));
+
+		var act = async () => await http.PostAsync("/anything", new Payload("body"), "Op");
+
+		await act.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task PostAsync_NonSuccess_Throws()
+	{
+		var http = CreateClient(new StubHandler(HttpStatusCode.InternalServerError));
+
+		var act = async () => await http.PostAsync("/anything", new Payload("body"), "Op");
+
+		await act.Should().ThrowAsync<HttpRequestException>();
+	}
+
+	[Fact]
+	public async Task PostAsync_Cancelled_Rethrows()
+	{
+		var http = CreateClient(new ThrowingHandler(new OperationCanceledException()));
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		var act = async () => await http.PostAsync("/anything", new Payload("body"), "Op", cts.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	private static ModuleHttpClient CreateClient(HttpMessageHandler handler) =>
+		new(
+			new HttpClient(handler) { BaseAddress = new Uri("http://test") },
+			"test-upstream",
+			NullLogger<ModuleHttpClient>.Instance);
+
+	private sealed record Payload(string Name);
+
+	private sealed class StubHandler(HttpStatusCode status, string? body = null) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var response = new HttpResponseMessage(status);
+			if (body is not null)
+			{
+				response.Content = new StringContent(body, Encoding.UTF8, "application/json");
+			}
+
+			return Task.FromResult(response);
+		}
+	}
+
+	private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			throw exception;
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
@@ -87,7 +87,7 @@ public class GetIngredientBalanceQueryHandlerTests
 		await handler.HandleAsync(new GetIngredientBalanceQuery());
 
 		await readModel.Received(1).GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>());
-		await staplesProvider.Received(1).GetStapleNamesAsync(Arg.Is<OwnerIdentifier>(owner => owner.Value == "user-123"), Arg.Any<CancellationToken>());
+		await staplesProvider.Received(1).GetStapleNamesAsync(Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
@@ -110,7 +110,7 @@ public class GetIngredientBalanceQueryHandlerTests
 	private void ConfigureRepositories(IReadOnlyList<IngredientBalanceItemDto> atHome, IReadOnlyCollection<string> staples)
 	{
 		readModel.GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>()).Returns(atHome);
-		staplesProvider.GetStapleNamesAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<CancellationToken>())
+		staplesProvider.GetStapleNamesAsync(Arg.Any<CancellationToken>())
 			.Returns(staples.ToHashSet(StringComparer.OrdinalIgnoreCase));
 	}
 }

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/HttpRecipeIngredientLookupTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/HttpRecipeIngredientLookupTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Client;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Services;
+
+public class HttpRecipeIngredientLookupTests
+{
+	private static readonly RecipeReference TestRecipe = RecipeReference.New();
+
+	[Fact]
+	public async Task LookupAsync_NullResponse_ReturnsEmpty()
+	{
+		var lookup = CreateLookup(response: null);
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task LookupAsync_ProjectsServingsOntoEveryIngredient()
+	{
+		var lookup = CreateLookup(new RecipeResponse(
+			Servings: 2,
+			Ingredients:
+			[
+				new RecipeIngredientPayload("Pasta", 250m, "g"),
+				new RecipeIngredientPayload("Cheese", 100m, "g"),
+			]));
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result.Should().HaveCount(2);
+		result.Should().AllSatisfy(ingredient => ingredient.RecipeServings.Should().Be(2));
+	}
+
+	[Fact]
+	public async Task LookupAsync_NullServings_PropagatesNull()
+	{
+		var lookup = CreateLookup(new RecipeResponse(
+			Servings: null,
+			Ingredients: [new RecipeIngredientPayload("Pepper", 1m, "tsp")]));
+
+		var result = await lookup.LookupAsync(TestRecipe);
+
+		result[0].RecipeServings.Should().BeNull();
+	}
+
+	private static HttpRecipeIngredientLookup CreateLookup(RecipeResponse? response)
+	{
+		var recipes = Substitute.For<IRecipesClient>();
+		recipes.GetRecipeAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(response);
+		return new HttpRecipeIngredientLookup(recipes);
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Services/HttpStaplesProviderTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Services/HttpStaplesProviderTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Users.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Services;
+
+public class HttpStaplesProviderTests
+{
+	[Fact]
+	public async Task GetStapleNamesAsync_EmptyList_ReturnsEmptySet()
+	{
+		var provider = CreateProvider([]);
+
+		var result = await provider.GetStapleNamesAsync();
+
+		result.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetStapleNamesAsync_PopulatedList_ReturnsCaseInsensitiveSet()
+	{
+		var provider = CreateProvider(["Salt", "Pepper"]);
+
+		var result = await provider.GetStapleNamesAsync();
+
+		result.Contains("salt").Should().BeTrue();
+		result.Contains("PEPPER").Should().BeTrue();
+	}
+
+	private static HttpStaplesProvider CreateProvider(IReadOnlyList<string> staples)
+	{
+		var users = Substitute.For<IUsersClient>();
+		users.GetMyStaplesAsync(Arg.Any<CancellationToken>()).Returns(staples);
+		return new HttpStaplesProvider(users);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds three publisher-owned client packages (`Yumney.Users.Client`, `Yumney.Recipes.Client`, `Yumney.Shopping.Client`) so each module ships its wire DTOs once instead of every consumer redefining them.
- Adds `IModuleHttpClient` in `Yumney.Shared.Web` with fail-soft `GetOrDefaultAsync`, 404→null `FindAsync`, and fail-loud `PostAsync` — try/catch + `LoggerMessage` source-gen + shared `JsonSerializerOptions(Web)` with `JsonStringEnumConverter`.
- Rewrites the 7 consumer adapters (`HttpDietaryProfileProvider`, `HttpIngredientBalanceProvider`, both `HttpStaplesProvider`, both `HttpRecipeIngredientLookup`, `HttpShoppingListWriter`) to depend on the typed publisher client and only map publisher DTO → consumer's domain projection.

Wire-level concerns (named `HttpClient`, JSON options, status-code branching, structured logging) now live in one place. Each consumer adapter is ~10 lines.

## Test plan
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes Yumney.slnx` — clean
- [x] All unit + architecture tests pass (~2400 tests)
- [ ] CI green
- [ ] Smoke-test cross-module HTTP calls in dev (suggestions, balance, shopping-list generation)