### PR TITLE
refactor(shared): extract StoredEventConfigurationBase

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/StoredEventConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/StoredEventConfiguration.cs
@@ -1,23 +1,5 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Configurations;
 
-#pragma warning disable SA1649
-internal sealed class StoredEventConfiguration : IEntityTypeConfiguration<StoredEvent>
-{
-	public void Configure(EntityTypeBuilder<StoredEvent> entity)
-	{
-		entity.ToTable("MealPlanEvents");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.AggregateId).IsRequired();
-		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
-		entity.Property(e => e.EventData).IsRequired();
-		entity.Property(e => e.Version).IsRequired();
-		entity.Property(e => e.OccurredAt).IsRequired();
-
-		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
-		entity.HasIndex(e => e.OccurredAt);
-	}
-}
+internal sealed class StoredEventConfiguration() : StoredEventConfigurationBase<StoredEvent>("MealPlanEvents");

--- a/src/Yumney.Shared.Persistence/EventStore/StoredEventConfigurationBase.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/StoredEventConfigurationBase.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+
+public abstract class StoredEventConfigurationBase<TStoredEvent>(string tableName) : IEntityTypeConfiguration<TStoredEvent>
+	where TStoredEvent : class, IStoredEvent
+{
+	public void Configure(EntityTypeBuilder<TStoredEvent> builder)
+	{
+		builder.ToTable(tableName);
+		builder.HasKey(stored => stored.Id);
+		builder.Property(stored => stored.AggregateId).IsRequired();
+		builder.Property(stored => stored.EventType).HasMaxLength(100).IsRequired();
+		builder.Property(stored => stored.EventData).IsRequired();
+		builder.Property(stored => stored.Version).IsRequired();
+		builder.Property(stored => stored.OccurredAt).IsRequired();
+
+		builder.HasIndex(stored => new { stored.AggregateId, stored.Version }).IsUnique();
+		builder.HasIndex(stored => stored.OccurredAt);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListStoredEventConfiguration.cs
@@ -1,23 +1,6 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
 
-#pragma warning disable SA1649
-internal sealed class ShoppingListStoredEventConfiguration : IEntityTypeConfiguration<ShoppingListStoredEvent>
-{
-	public void Configure(EntityTypeBuilder<ShoppingListStoredEvent> entity)
-	{
-		entity.ToTable("ShoppingListEvents");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.AggregateId).IsRequired();
-		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
-		entity.Property(e => e.EventData).IsRequired();
-		entity.Property(e => e.Version).IsRequired();
-		entity.Property(e => e.OccurredAt).IsRequired();
-
-		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
-		entity.HasIndex(e => e.OccurredAt);
-	}
-}
+internal sealed class ShoppingListStoredEventConfiguration() : StoredEventConfigurationBase<ShoppingListStoredEvent>("ShoppingListEvents");

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/StoredEventConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/StoredEventConfiguration.cs
@@ -1,23 +1,5 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configurations;
 
-#pragma warning disable SA1649
-internal sealed class StoredEventConfiguration : IEntityTypeConfiguration<StoredEvent>
-{
-	public void Configure(EntityTypeBuilder<StoredEvent> entity)
-	{
-		entity.ToTable("ShoppingEvents");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.AggregateId).IsRequired();
-		entity.Property(e => e.EventType).HasMaxLength(100).IsRequired();
-		entity.Property(e => e.EventData).IsRequired();
-		entity.Property(e => e.Version).IsRequired();
-		entity.Property(e => e.OccurredAt).IsRequired();
-
-		entity.HasIndex(e => new { e.AggregateId, e.Version }).IsUnique();
-		entity.HasIndex(e => e.OccurredAt);
-	}
-}
+internal sealed class StoredEventConfiguration() : StoredEventConfigurationBase<StoredEvent>("ShoppingEvents");


### PR DESCRIPTION
## Summary
- Three event-store EF configurations (`MealPlanEvents`, `ShoppingEvents`, `ShoppingListEvents`) had the same schema with only the table name differing.
- Adds `StoredEventConfigurationBase<TStoredEvent>(string tableName)` in `Yumney.Shared.Persistence.EventStore`.
- Old per-module configs collapse to a one-liner subclass.
- Net −31 lines; new event-sourced modules pick up the canonical schema for free.

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean
- [x] \`dotnet format --verify-no-changes Yumney.slnx\` — clean
- [x] All unit + architecture tests pass
- [ ] CI green
- [ ] No EF migration diff (schema unchanged)