### PR TITLE
refactor(shared): hoist event-store publish loop into base

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/MealPlanEventStore.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/MealPlanEventStore.cs
@@ -17,10 +17,10 @@ public sealed partial class MealPlanEventStore(MealPlanDbContext context, IEvent
 	IMealPlanEventStore
 {
 #pragma warning disable SA1311
-	private static readonly IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> moduleEventWrappers =
+	private static readonly IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> moduleEventFactories =
 		ModuleEventConvention.BuildMap(typeof(MealPlanModuleEvent).Assembly, typeof(string), typeof(string));
 
-	private static readonly IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> crossModuleMappers =
+	private static readonly IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> crossModuleEventFactories =
 		CrossModuleEventConvention.BuildMap(typeof(MealPlanEventStore).Assembly);
 #pragma warning restore SA1311
 
@@ -53,33 +53,15 @@ public sealed partial class MealPlanEventStore(MealPlanDbContext context, IEvent
 			Week = aggregate.Week.Value,
 		};
 
-	protected override async Task PublishEventsAsync(WeeklyPlan aggregate, IReadOnlyList<IDomainEvent> events, CancellationToken cancellationToken)
-	{
-		var ownerId = aggregate.Owner.Value;
-		var week = aggregate.Week.Value;
+	protected override IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> ModuleEventFactories => moduleEventFactories;
 
-		LogEventsSaved(ownerId, week, events.Count, aggregate.Version);
+	protected override IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> CrossModuleEventFactories => crossModuleEventFactories;
 
-		object[] context = [ownerId, week];
+	protected override object[] BuildEventContext(WeeklyPlan aggregate) => [aggregate.Owner.Value, aggregate.Week.Value];
 
-		foreach (var @event in events)
-		{
-			if (moduleEventWrappers.TryGetValue(@event.GetType(), out var factory))
-			{
-				await EventBus.PublishAsync(factory(context, @event), cancellationToken);
-			}
-
-			if (crossModuleMappers.TryGetValue(@event.GetType(), out var crossFactory))
-			{
-				var crossEvent = crossFactory(context, @event);
-				if (crossEvent is not null)
-				{
-					await EventBus.PublishAsync(crossEvent, cancellationToken);
-				}
-			}
-		}
-	}
+	protected override void LogEventsSaved(WeeklyPlan aggregate, IReadOnlyList<IDomainEvent> events) =>
+		LogEventsSavedCore(aggregate.Owner.Value, aggregate.Week.Value, events.Count, aggregate.Version);
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "Saved {Count} events for owner {OwnerId} week {Week}, version now {Version}")]
-	private partial void LogEventsSaved(string ownerId, string week, int count, int version);
+	private partial void LogEventsSavedCore(string ownerId, string week, int count, int version);
 }

--- a/src/Yumney.Shared.Persistence/EventStore/EfCoreEventStoreBase.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EfCoreEventStoreBase.cs
@@ -71,11 +71,63 @@ public abstract class EfCoreEventStoreBase<TAggregate, TIdentifier, TMetadata, T
 
 	protected virtual string AggregateName => typeof(TAggregate).Name;
 
+#pragma warning disable SA1311
+	private static readonly IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> emptyModuleFactories =
+		new Dictionary<Type, ModuleEventConvention.ModuleEventFactory>();
+
+	private static readonly IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> emptyCrossModuleFactories =
+		new Dictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory>();
+#pragma warning restore SA1311
+
+	protected virtual IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> ModuleEventFactories =>
+		emptyModuleFactories;
+
+	protected virtual IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> CrossModuleEventFactories =>
+		emptyCrossModuleFactories;
+
 	protected abstract Guid GetAggregateId(TAggregate aggregate);
 
 	protected abstract TMetadata BuildMetadata(TAggregate aggregate);
 
-	protected abstract Task PublishEventsAsync(TAggregate aggregate, IReadOnlyList<IDomainEvent> events, CancellationToken cancellationToken);
+	protected virtual object[] BuildEventContext(TAggregate aggregate) => [];
+
+	protected virtual IModuleEvent? MapModuleEvent(TAggregate aggregate, IDomainEvent domainEvent) => null;
+
+	protected virtual void LogEventsSaved(TAggregate aggregate, IReadOnlyList<IDomainEvent> events)
+	{
+	}
+
+	protected virtual async Task PublishEventsAsync(TAggregate aggregate, IReadOnlyList<IDomainEvent> events, CancellationToken cancellationToken)
+	{
+		LogEventsSaved(aggregate, events);
+
+		var context = BuildEventContext(aggregate);
+		var moduleFactories = ModuleEventFactories;
+		var crossFactories = CrossModuleEventFactories;
+
+		foreach (var domainEvent in events)
+		{
+			var moduleEvent = MapModuleEvent(aggregate, domainEvent);
+			if (moduleEvent is null && moduleFactories.TryGetValue(domainEvent.GetType(), out var moduleFactory))
+			{
+				moduleEvent = moduleFactory(context, domainEvent);
+			}
+
+			if (moduleEvent is not null)
+			{
+				await EventBus.PublishAsync(moduleEvent, cancellationToken);
+			}
+
+			if (crossFactories.TryGetValue(domainEvent.GetType(), out var crossFactory))
+			{
+				var crossEvent = crossFactory(context, domainEvent);
+				if (crossEvent is not null)
+				{
+					await EventBus.PublishAsync(crossEvent, cancellationToken);
+				}
+			}
+		}
+	}
 
 	protected async Task<IReadOnlyList<IDomainEvent>> LoadEventsAsync(Guid aggregateId, CancellationToken cancellationToken)
 	{

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingEventStore.cs
@@ -18,7 +18,7 @@ public sealed partial class ShoppingEventStore(ShoppingDbContext context, IEvent
 	IShoppingEventStore
 {
 #pragma warning disable SA1311
-	private static readonly IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> moduleEventWrappers =
+	private static readonly IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> moduleEventFactories =
 		ModuleEventConvention.BuildMap(typeof(ShoppingEventStore).Assembly, typeof(string));
 #pragma warning restore SA1311
 
@@ -48,21 +48,13 @@ public sealed partial class ShoppingEventStore(ShoppingDbContext context, IEvent
 			OwnerId = aggregate.OwnerId,
 		};
 
-	protected override async Task PublishEventsAsync(ShoppingLedger aggregate, IReadOnlyList<IDomainEvent> events, CancellationToken cancellationToken)
-	{
-		LogEventsSaved(aggregate.OwnerId, events.Count, aggregate.Version);
+	protected override IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> ModuleEventFactories => moduleEventFactories;
 
-		object[] context = [aggregate.OwnerId.Value];
+	protected override object[] BuildEventContext(ShoppingLedger aggregate) => [aggregate.OwnerId.Value];
 
-		foreach (var @event in events)
-		{
-			if (moduleEventWrappers.TryGetValue(@event.GetType(), out var factory))
-			{
-				await EventBus.PublishAsync(factory(context, @event), cancellationToken);
-			}
-		}
-	}
+	protected override void LogEventsSaved(ShoppingLedger aggregate, IReadOnlyList<IDomainEvent> events) =>
+		LogEventsSavedCore(aggregate.OwnerId, events.Count, aggregate.Version);
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "Saved {Count} events for owner {OwnerId}, version now {Version}")]
-	private partial void LogEventsSaved(string ownerId, int count, int version);
+	private partial void LogEventsSavedCore(string ownerId, int count, int version);
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListEventStore.cs
@@ -17,7 +17,7 @@ public sealed partial class ShoppingListEventStore(ShoppingDbContext context, IE
 	IShoppingListEventStore
 {
 #pragma warning disable SA1311
-	private static readonly IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> crossModuleMappers =
+	private static readonly IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> crossModuleEventFactories =
 		CrossModuleEventConvention.BuildMap(typeof(ShoppingListEventStore).Assembly);
 #pragma warning restore SA1311
 
@@ -50,37 +50,16 @@ public sealed partial class ShoppingListEventStore(ShoppingDbContext context, IE
 			OwnerId = aggregate.Owner.Value,
 		};
 
-	protected override async Task PublishEventsAsync(
-		ShoppingList aggregate,
-		IReadOnlyList<IDomainEvent> events,
-		CancellationToken cancellationToken)
-	{
-		var ownerId = aggregate.Owner.Value;
-		var aggregateId = aggregate.Identifier.Value;
+	protected override IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> CrossModuleEventFactories => crossModuleEventFactories;
 
-		LogEventsSaved(aggregateId, events.Count, aggregate.Version);
+	protected override object[] BuildEventContext(ShoppingList aggregate) => [aggregate.Owner.Value, aggregate.Identifier.Value];
 
-		object[] context = [ownerId, aggregateId];
+	protected override IModuleEvent? MapModuleEvent(ShoppingList aggregate, IDomainEvent domainEvent) =>
+		ShoppingListModuleEventMapper.Map(aggregate.Owner.Value, aggregate.Identifier.Value, domainEvent);
 
-		foreach (var domainEvent in events)
-		{
-			var moduleEvent = ShoppingListModuleEventMapper.Map(ownerId, aggregateId, domainEvent);
-			if (moduleEvent is not null)
-			{
-				await EventBus.PublishAsync(moduleEvent, cancellationToken);
-			}
-
-			if (crossModuleMappers.TryGetValue(domainEvent.GetType(), out var factory))
-			{
-				var crossModuleEvent = factory(context, domainEvent);
-				if (crossModuleEvent is not null)
-				{
-					await EventBus.PublishAsync(crossModuleEvent, cancellationToken);
-				}
-			}
-		}
-	}
+	protected override void LogEventsSaved(ShoppingList aggregate, IReadOnlyList<IDomainEvent> events) =>
+		LogEventsSavedCore(aggregate.Identifier.Value, events.Count, aggregate.Version);
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "Saved {Count} ShoppingList events for aggregate {AggregateId}, version now {Version}")]
-	private partial void LogEventsSaved(Guid aggregateId, int count, int version);
+	private partial void LogEventsSavedCore(Guid aggregateId, int count, int version);
 }


### PR DESCRIPTION
## Summary
The three event-sourced stores (\`MealPlanEventStore\`, \`ShoppingEventStore\`, \`ShoppingListEventStore\`) each had near-identical \`PublishEventsAsync\` loops that:

1. logged a per-aggregate-flavor info line
2. built a context \`object[]\` for the convention factories
3. iterated events, resolving a module-event factory + cross-module factory and publishing each result

\`EfCoreEventStoreBase\` now owns that loop. Subclasses expose only the differences:
- \`BuildEventContext(aggregate)\`
- \`ModuleEventFactories\` / \`CrossModuleEventFactories\` (defaults to empty)
- \`MapModuleEvent(aggregate, event)\` (override when convention isn't usable, e.g. \`ShoppingListModuleEventMapper\`)
- \`LogEventsSaved(aggregate, events)\` — wraps the subclass's \`[LoggerMessage]\` source-gen log

Net +5 lines, but the duplicated loop, null-coalescing, and ordering invariants now live in one place.

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean
- [x] \`dotnet format --verify-no-changes Yumney.slnx\` — clean
- [x] All unit + architecture tests pass
- [ ] CI green
- [ ] Cross-module integration tests pass (these are the real coverage for the publish path)