### PR TITLE
refactor(shared): extract ReadModelUpsertExtensions

### DIFF
--- a/src/Yumney.Shared.Persistence/ReadModelUpsertExtensions.cs
+++ b/src/Yumney.Shared.Persistence/ReadModelUpsertExtensions.cs
@@ -1,0 +1,40 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace SmartSolutionsLab.Yumney.Shared.Persistence;
+
+public static class ReadModelUpsertExtensions
+{
+	public static async Task UpsertAsync<TEntity>(
+		this DbContext context,
+		Expression<Func<TEntity, bool>> predicate,
+		Func<TEntity> create,
+		Action<TEntity> mutate,
+		CancellationToken cancellationToken = default)
+		where TEntity : class
+	{
+		var row = await context.Set<TEntity>().FirstOrDefaultAsync(predicate, cancellationToken);
+		if (row is null)
+		{
+			row = create();
+			context.Set<TEntity>().Add(row);
+		}
+
+		mutate(row);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+
+	public static async Task UpdateAsync<TEntity>(
+		this DbContext context,
+		Expression<Func<TEntity, bool>> predicate,
+		Action<TEntity> mutate,
+		CancellationToken cancellationToken = default)
+		where TEntity : class
+	{
+		var row = await context.Set<TEntity>().FirstOrDefaultAsync(predicate, cancellationToken);
+		if (row is null) return;
+
+		mutate(row);
+		await context.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceProjectionHandler.cs
@@ -1,5 +1,5 @@
-using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
@@ -86,28 +86,26 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 			cancellationToken);
 	}
 
-	/// <inheritdoc />
-	public async Task HandleAsync(ShoppingItemMarkedAsFrozenModuleEvent @event, CancellationToken cancellationToken = default)
+	public Task HandleAsync(ShoppingItemMarkedAsFrozenModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		// Pure update: don't create a row if the item isn't on the ledger —
 		// freezing a non-existent item is a no-op rather than a phantom entry.
 		var inner = @event.Inner;
 		var nameKey = inner.ItemName.Value.ToLowerInvariant();
 		var unit = inner.Unit?.Value;
-		var row = await context.Set<IngredientBalanceReadItem>()
-			.FirstOrDefaultAsync(
-				r => r.OwnerId == @event.OwnerId && r.NameKey == nameKey && r.Unit == unit,
-				cancellationToken);
-		if (row is null) return;
-
 		var now = timeProvider.GetUtcNow().UtcDateTime;
-		row.Category = IngredientCategory.Frozen.Value;
-		row.LastBoughtAt = now;
-		row.LastUpdated = now;
-		await context.SaveChangesAsync(cancellationToken);
+		return context.UpdateAsync<IngredientBalanceReadItem>(
+			row => row.OwnerId == @event.OwnerId && row.NameKey == nameKey && row.Unit == unit,
+			row =>
+			{
+				row.Category = IngredientCategory.Frozen.Value;
+				row.LastBoughtAt = now;
+				row.LastUpdated = now;
+			},
+			cancellationToken);
 	}
 
-	private async Task UpsertAsync(
+	private Task UpsertAsync(
 		string ownerId,
 		string itemName,
 		string? unit,
@@ -115,30 +113,22 @@ public sealed class IngredientBalanceProjectionHandler(ShoppingDbContext context
 		CancellationToken cancellationToken)
 	{
 		var nameKey = itemName.ToLowerInvariant();
-		var row = await context.Set<IngredientBalanceReadItem>()
-			.FirstOrDefaultAsync(
-				r => r.OwnerId == ownerId
-					&& r.NameKey == nameKey
-					&& r.Unit == unit,
-				cancellationToken);
-
-		if (row is null)
-		{
-			var category = IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other;
-			row = new IngredientBalanceReadItem
+		return context.UpsertAsync<IngredientBalanceReadItem>(
+			row => row.OwnerId == ownerId && row.NameKey == nameKey && row.Unit == unit,
+			() => new IngredientBalanceReadItem
 			{
 				Id = Guid.CreateVersion7(),
 				OwnerId = ownerId,
 				ItemName = itemName,
 				NameKey = nameKey,
 				Unit = unit,
-				Category = category.Value,
-			};
-			context.Set<IngredientBalanceReadItem>().Add(row);
-		}
-
-		mutate(row);
-		row.LastUpdated = timeProvider.GetUtcNow().UtcDateTime;
-		await context.SaveChangesAsync(cancellationToken);
+				Category = (IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other).Value,
+			},
+			row =>
+			{
+				mutate(row);
+				row.LastUpdated = timeProvider.GetUtcNow().UtcDateTime;
+			},
+			cancellationToken);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 
@@ -22,125 +23,109 @@ public sealed class ShoppingLedgerProjectionHandler(ShoppingDbContext context)
 	  IModuleEventHandler<ShoppingItemRemovedModuleEvent>,
 	  IModuleEventHandler<ShoppingItemQuantityAdjustedModuleEvent>
 {
-	/// <inheritdoc />
 	public Task HandleAsync(ShoppingItemAddedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-
-		Action<ShoppingLedgerReadItem> mutate = readItem =>
-		{
-			readItem.TotalQuantity += inner.Quantity.Amount;
-			AppendSource(readItem, inner.Quantity.Amount, inner.Source);
-		};
-
-		return UpsertAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, mutate, cancellationToken);
+		return UpsertItemAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			readItem =>
+			{
+				readItem.TotalQuantity += inner.Quantity.Amount;
+				AppendSource(readItem, inner.Quantity.Amount, inner.Source);
+			},
+			cancellationToken);
 	}
 
-	/// <inheritdoc />
 	public Task HandleAsync(ShoppingItemBoughtModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-
-		Action<ShoppingLedgerReadItem> mutate = readItem =>
-		{
-			readItem.IsBought = true;
-			readItem.BoughtAt = DateTime.UtcNow;
-		};
-
-		return UpdateAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, mutate, cancellationToken);
+		return UpdateItemAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			readItem =>
+			{
+				readItem.IsBought = true;
+				readItem.BoughtAt = DateTime.UtcNow;
+			},
+			cancellationToken);
 	}
 
-	/// <inheritdoc />
 	public Task HandleAsync(ShoppingItemConsumedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		return UpdateAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, _ => { }, cancellationToken);
+		return UpdateItemAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, _ => { }, cancellationToken);
 	}
 
-	/// <inheritdoc />
 	public Task HandleAsync(ShoppingItemRemovedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-
-		Action<ShoppingLedgerReadItem> mutate = readItem =>
-		{
-			readItem.TotalQuantity = Math.Max(0, readItem.TotalQuantity - inner.Quantity.Amount);
-			if (readItem.TotalQuantity <= 0)
+		return UpdateItemAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			readItem =>
 			{
-				context.Set<ShoppingLedgerReadItem>().Remove(readItem);
-			}
-		};
-
-		return UpdateAsync(@event.OwnerId, inner.ItemName, inner.Quantity.Unit?.Value, mutate, cancellationToken);
+				readItem.TotalQuantity = Math.Max(0, readItem.TotalQuantity - inner.Quantity.Amount);
+				if (readItem.TotalQuantity <= 0)
+				{
+					context.Set<ShoppingLedgerReadItem>().Remove(readItem);
+				}
+			},
+			cancellationToken);
 	}
 
-	/// <inheritdoc />
 	public Task HandleAsync(ShoppingItemQuantityAdjustedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-
-		Action<ShoppingLedgerReadItem> mutate = readItem =>
-		{
-			readItem.TotalQuantity = inner.NewQuantity.Amount;
-		};
-
-		return UpdateAsync(@event.OwnerId, inner.ItemName, inner.NewQuantity.Unit?.Value, mutate, cancellationToken);
+		return UpdateItemAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.NewQuantity.Unit?.Value,
+			readItem => readItem.TotalQuantity = inner.NewQuantity.Amount,
+			cancellationToken);
 	}
 
-	private async Task UpdateAsync(
+	private Task UpsertItemAsync(
 		string ownerId,
 		string itemName,
 		string? unit,
 		Action<ShoppingLedgerReadItem> mutate,
-		CancellationToken cancellationToken)
-	{
-		var readItem = await FindAsync(ownerId, itemName, unit, cancellationToken);
-		if (readItem is null) return;
+		CancellationToken cancellationToken) =>
+		context.UpsertAsync<ShoppingLedgerReadItem>(
+			row => row.OwnerId == ownerId && EF.Functions.ILike(row.ItemName, itemName) && row.Unit == unit,
+			() => new ShoppingLedgerReadItem
+			{
+				Id = Guid.CreateVersion7(),
+				OwnerId = ownerId,
+				ItemName = itemName,
+				Unit = unit,
+				Category = (IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other).Value,
+				LastUpdated = DateTime.UtcNow,
+			},
+			row =>
+			{
+				mutate(row);
+				row.LastUpdated = DateTime.UtcNow;
+			},
+			cancellationToken);
 
-		mutate(readItem);
-		readItem.LastUpdated = DateTime.UtcNow;
-		await context.SaveChangesAsync(cancellationToken);
-	}
-
-	private async Task UpsertAsync(
+	private Task UpdateItemAsync(
 		string ownerId,
 		string itemName,
 		string? unit,
 		Action<ShoppingLedgerReadItem> mutate,
-		CancellationToken cancellationToken)
-	{
-		var readItem = await FindAsync(ownerId, itemName, unit, cancellationToken)
-			?? Create(ownerId, itemName, unit);
-		mutate(readItem);
-		readItem.LastUpdated = DateTime.UtcNow;
-		await context.SaveChangesAsync(cancellationToken);
-	}
-
-	private ShoppingLedgerReadItem Create(string ownerId, string itemName, string? unit)
-	{
-		var category = IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other;
-		var readItem = new ShoppingLedgerReadItem
-		{
-			Id = Guid.CreateVersion7(),
-			OwnerId = ownerId,
-			ItemName = itemName,
-			Unit = unit,
-			Category = category.Value,
-			LastUpdated = DateTime.UtcNow,
-		};
-		context.Set<ShoppingLedgerReadItem>().Add(readItem);
-		return readItem;
-	}
-
-	private async Task<ShoppingLedgerReadItem?> FindAsync(string ownerId, string itemName, string? unit, CancellationToken cancellationToken)
-	{
-		return await context.Set<ShoppingLedgerReadItem>()
-			.FirstOrDefaultAsync(
-				r => r.OwnerId == ownerId
-					&& EF.Functions.ILike(r.ItemName, itemName)
-					&& r.Unit == unit,
-				cancellationToken);
-	}
+		CancellationToken cancellationToken) =>
+		context.UpdateAsync<ShoppingLedgerReadItem>(
+			row => row.OwnerId == ownerId && EF.Functions.ILike(row.ItemName, itemName) && row.Unit == unit,
+			row =>
+			{
+				mutate(row);
+				row.LastUpdated = DateTime.UtcNow;
+			},
+			cancellationToken);
 
 #pragma warning disable SA1204
 	private static void AppendSource(ShoppingLedgerReadItem readItem, decimal quantity, string source)
@@ -149,6 +134,7 @@ public sealed class ShoppingLedgerProjectionHandler(ShoppingDbContext context)
 		sources.Add(new SourceEntry(quantity, source, DateTime.UtcNow));
 		readItem.SourcesJson = JsonSerializer.Serialize(sources);
 	}
+#pragma warning restore SA1204
 
 	private sealed record SourceEntry(decimal Quantity, string Source, DateTime OccurredAt);
 }


### PR DESCRIPTION
## Summary
- Extracts \`DbContext.UpsertAsync<T>\` and \`DbContext.UpdateAsync<T>\` into \`Yumney.Shared.Persistence\` — the find-or-create-mutate-save plumbing the two Shopping ledger projection handlers were re-implementing.
- Refactors \`IngredientBalanceProjectionHandler\` and \`ShoppingLedgerProjectionHandler\` onto the shared helpers. Per-handler \`UpsertAsync\` / \`UpdateAsync\` private wrappers stay (they encode the lookup predicate + create-row factory for that aggregate's read row), but they now delegate plumbing to the shared extension.
- Net −24 lines.

## Why MealPlan is left alone
\`MealPlanProjectionHandler\` deliberately uses raw \`INSERT … ON CONFLICT DO NOTHING\` SQL because its events race on the in-process Wolverine bus — slot mutations can land before \`WeeklyPlanCreated\` seeds the row. That's a different concurrency model from the Shopping handlers and folding it into a generic helper would be the wrong abstraction.

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean
- [x] \`dotnet format --verify-no-changes Yumney.slnx\` — clean
- [x] All unit + architecture tests pass
- [ ] CI green
- [ ] Cross-module integration tests (the real coverage for projection behaviour) pass