### PR TITLE
feat(users): paginate the activity timeline feed (US-576)

### DIFF
--- a/client/apps/account/public/assets/i18n/account/de.json
+++ b/client/apps/account/public/assets/i18n/account/de.json
@@ -117,6 +117,7 @@
     "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
     "loading": "Aktivität wird geladen…",
     "retry": "Erneut versuchen",
+    "loadMore": "Ältere laden",
     "filterAria": "Aktivität nach Typ filtern",
     "filter": {
       "all": "Alle",

--- a/client/apps/account/public/assets/i18n/account/en.json
+++ b/client/apps/account/public/assets/i18n/account/en.json
@@ -117,6 +117,7 @@
     "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
     "loading": "Loading activity…",
     "retry": "Try again",
+    "loadMore": "Load older",
     "filterAria": "Filter activity by type",
     "filter": {
       "all": "All",

--- a/client/apps/account/src/app/activity/activity.component.html
+++ b/client/apps/account/src/app/activity/activity.component.html
@@ -28,5 +28,11 @@
 
   @if (!loading() && !error()) {
     <yn-activity-timeline [entries]="timelineEntries()" />
+
+    @if (hasMore()) {
+      <button type="button" class="activity-page__load-more" (click)="onLoadMore()">
+        {{ t('account.activity.loadMore') }}
+      </button>
+    }
   }
 </section>

--- a/client/apps/account/src/app/activity/activity.component.spec.ts
+++ b/client/apps/account/src/app/activity/activity.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { provideYumneyIcons } from '@yumney/ui';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { ActivityComponent } from './activity.component';
+import { ActivityApiService, type UserActivityPage } from '../api';
+
+const en = {
+  account: {
+    activity: {
+      title: 'Activity',
+      lead: 'Everything…',
+      loading: 'Loading…',
+      retry: 'Try again',
+      loadMore: 'Load older',
+      filterAria: 'Filter activity',
+      filter: {
+        all: 'All',
+        imported: 'Imported',
+        viewed: 'Viewed',
+        cooked: 'Cooked',
+        edited: 'Edited',
+        deleted: 'Deleted',
+      },
+    },
+  },
+};
+
+const firstPage: UserActivityPage = {
+  items: Array.from({ length: 20 }, (_, index) => ({
+    type: 'recipe_imported',
+    recipeIdentifier: `recipe-${index}`,
+    recipeTitle: `Recipe ${index}`,
+    occurredAt: new Date(2026, 4, 7, 12, 0, index).toISOString(),
+  })),
+  nextCursor: 'cursor-page-2',
+};
+
+const secondPage: UserActivityPage = {
+  items: [
+    {
+      type: 'recipe_imported',
+      recipeIdentifier: 'recipe-21',
+      recipeTitle: 'Older recipe',
+      occurredAt: new Date(2026, 4, 6).toISOString(),
+    },
+  ],
+  nextCursor: null,
+};
+
+describe('ActivityComponent', () => {
+  let fixture: ComponentFixture<ActivityComponent>;
+  let apiMock: { getActivity: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    apiMock = {
+      getActivity: vi.fn().mockReturnValue(of(firstPage)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ActivityComponent, setupTranslocoTesting(en)],
+      providers: [provideYumneyIcons(), { provide: ActivityApiService, useValue: apiMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActivityComponent);
+    fixture.detectChanges();
+  });
+
+  it('loads the first page on init with limit=20 and no cursor', () => {
+    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20 });
+  });
+
+  it('renders the load-more button when nextCursor is present', () => {
+    const button = fixture.nativeElement.querySelector('.activity-page__load-more');
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain('Load older');
+  });
+
+  it('appends entries and forwards the cursor on load-more', () => {
+    apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+
+    fixture.componentInstance['onLoadMore']();
+
+    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, cursor: 'cursor-page-2' });
+    expect(fixture.componentInstance['entries']().length).toBe(21);
+  });
+
+  it('hides the load-more button after the final page exhausts the cursor', () => {
+    apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+
+    fixture.componentInstance['onLoadMore']();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['nextCursor']()).toBeNull();
+    expect(fixture.nativeElement.querySelector('.activity-page__load-more')).toBeFalsy();
+  });
+
+  it('resets pagination when filter changes', () => {
+    apiMock.getActivity.mockClear();
+    apiMock.getActivity.mockReturnValueOnce(of(firstPage));
+
+    fixture.componentInstance['onFilterChange']('recipe_cooked');
+
+    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, type: 'recipe_cooked' });
+  });
+});

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -20,6 +20,8 @@ const FILTER_OPTIONS: ReadonlyArray<{ value: ActivityTypeKey | 'all'; labelKey: 
   { value: 'recipe_deleted', labelKey: 'account.activity.filter.deleted' },
 ];
 
+const PAGE_SIZE = 20;
+
 @Component({
   selector: 'yn-activity-page',
   standalone: true,
@@ -39,6 +41,8 @@ export class ActivityComponent {
   protected error = this.state.serverError;
   protected entries = signal<UserActivityItem[]>([]);
   protected activeFilter = signal<ActivityTypeKey | 'all'>('all');
+  protected nextCursor = signal<string | null>(null);
+  protected hasMore = computed(() => this.nextCursor() !== null);
 
   protected timelineEntries = computed<ActivityEntry[]>(() =>
     this.entries().map((entry) => ({
@@ -50,24 +54,41 @@ export class ActivityComponent {
   );
 
   constructor() {
-    this.load();
+    this.loadFirstPage();
   }
 
   protected onFilterChange(value: ActivityTypeKey | 'all'): void {
     if (this.activeFilter() === value) return;
     this.activeFilter.set(value);
-    this.load();
+    this.loadFirstPage();
   }
 
   protected onRetry(): void {
-    this.load();
+    this.loadFirstPage();
   }
 
-  private load(): void {
+  protected onLoadMore(): void {
+    const cursor = this.nextCursor();
+    if (cursor === null) return;
+
     const type = this.activeFilter();
-    const options = type === 'all' ? { limit: 50 } : { limit: 50, type };
-    this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (entries) =>
-      this.entries.set(entries),
-    );
+    const options = type === 'all'
+      ? { limit: PAGE_SIZE, cursor }
+      : { limit: PAGE_SIZE, type, cursor };
+
+    this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (page) => {
+      this.entries.update((current) => [...current, ...page.items]);
+      this.nextCursor.set(page.nextCursor);
+    });
+  }
+
+  private loadFirstPage(): void {
+    const type = this.activeFilter();
+    const options = type === 'all' ? { limit: PAGE_SIZE } : { limit: PAGE_SIZE, type };
+
+    this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (page) => {
+      this.entries.set(page.items);
+      this.nextCursor.set(page.nextCursor);
+    });
   }
 }

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -72,9 +72,8 @@ export class ActivityComponent {
     if (cursor === null) return;
 
     const type = this.activeFilter();
-    const options = type === 'all'
-      ? { limit: PAGE_SIZE, cursor }
-      : { limit: PAGE_SIZE, type, cursor };
+    const options =
+      type === 'all' ? { limit: PAGE_SIZE, cursor } : { limit: PAGE_SIZE, type, cursor };
 
     this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (page) => {
       this.entries.update((current) => [...current, ...page.items]);

--- a/client/apps/shell/public/assets/i18n/account/de.json
+++ b/client/apps/shell/public/assets/i18n/account/de.json
@@ -117,6 +117,7 @@
     "lead": "Alles, was du importiert, angesehen, gekocht, bearbeitet und gelöscht hast — neueste zuerst.",
     "loading": "Aktivität wird geladen…",
     "retry": "Erneut versuchen",
+    "loadMore": "Ältere laden",
     "filterAria": "Aktivität nach Typ filtern",
     "filter": {
       "all": "Alle",

--- a/client/apps/shell/public/assets/i18n/account/en.json
+++ b/client/apps/shell/public/assets/i18n/account/en.json
@@ -117,6 +117,7 @@
     "lead": "Everything you've imported, viewed, cooked, edited, and deleted — newest first.",
     "loading": "Loading activity…",
     "retry": "Try again",
+    "loadMore": "Load older",
     "filterAria": "Filter activity by type",
     "filter": {
       "all": "All",

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -71,7 +71,12 @@ export type {
 
 // --- Dashboard ---
 export { DashboardApiService } from './lib/dashboard-api.service';
-export type { UserActivityItem, ActivityTypeKey, RecipeActivityStats } from './lib/user-activity';
+export type {
+  UserActivityItem,
+  UserActivityPage,
+  ActivityTypeKey,
+  RecipeActivityStats,
+} from './lib/user-activity';
 export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';
 
 // --- Activity ---

--- a/client/libs/shared/api-client/src/lib/activity-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.ts
@@ -2,11 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { API_ENDPOINTS } from './api-endpoints';
-import type {
-  ActivityTypeKey,
-  RecipeActivityStats,
-  UserActivityPage,
-} from './user-activity';
+import type { ActivityTypeKey, RecipeActivityStats, UserActivityPage } from './user-activity';
 
 @Injectable({ providedIn: 'root' })
 export class ActivityApiService {

--- a/client/libs/shared/api-client/src/lib/activity-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.ts
@@ -2,19 +2,24 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { API_ENDPOINTS } from './api-endpoints';
-import type { ActivityTypeKey, RecipeActivityStats, UserActivityItem } from './user-activity';
+import type {
+  ActivityTypeKey,
+  RecipeActivityStats,
+  UserActivityPage,
+} from './user-activity';
 
 @Injectable({ providedIn: 'root' })
 export class ActivityApiService {
   private http = inject(HttpClient);
 
   getActivity(
-    options: { type?: ActivityTypeKey; limit?: number } = {},
-  ): Observable<UserActivityItem[]> {
+    options: { type?: ActivityTypeKey; limit?: number; cursor?: string } = {},
+  ): Observable<UserActivityPage> {
     let params = new HttpParams();
     if (options.limit != null) params = params.set('limit', options.limit.toString());
     if (options.type != null) params = params.set('type', options.type);
-    return this.http.get<UserActivityItem[]>(API_ENDPOINTS.users.activity, { params });
+    if (options.cursor != null) params = params.set('cursor', options.cursor);
+    return this.http.get<UserActivityPage>(API_ENDPOINTS.users.activity, { params });
   }
 
   getRecipeStats(recipeIdentifier: string): Observable<RecipeActivityStats> {

--- a/client/libs/shared/api-client/src/lib/user-activity.ts
+++ b/client/libs/shared/api-client/src/lib/user-activity.ts
@@ -13,6 +13,11 @@ export interface UserActivityItem {
   occurredAt: string;
 }
 
+export interface UserActivityPage {
+  items: UserActivityItem[];
+  nextCursor: string | null;
+}
+
 export interface RecipeActivityStats {
   cookCount: number;
   lastCookedAt: string | null;

--- a/src/Yumney.Users.Api/UserActivityEndpoints.cs
+++ b/src/Yumney.Users.Api/UserActivityEndpoints.cs
@@ -17,16 +17,18 @@ public static class UserActivityEndpoints
 			.RequireAuthorization()
 			.WithName("GetRecentActivity")
 			.WithTags("Users")
-			.Produces<IReadOnlyList<UserActivityDto>>();
+			.Produces<UserActivityPageDto>();
 
 		static async Task<IResult> GetRecentActivity(
-			IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>> handler,
+			IQueryHandler<GetRecentActivityQuery, Result<UserActivityPageDto>> handler,
 			int limit = 5,
 			string? type = null,
+			string? cursor = null,
 			CancellationToken cancellationToken = default)
 		{
 			var typeFilter = string.IsNullOrWhiteSpace(type) ? null : ActivityType.From(type);
-			var query = new GetRecentActivityQuery(ActivityLimit.From(limit), typeFilter);
+			var decodedCursor = ActivityCursor.TryDecode(cursor);
+			var query = new GetRecentActivityQuery(ActivityLimit.From(limit), typeFilter, decodedCursor);
 			var result = await handler.HandleAsync(query, cancellationToken);
 			return result.ToOk();
 		}

--- a/src/Yumney.Users.Application/DTOs/UserActivityPageDto.cs
+++ b/src/Yumney.Users.Application/DTOs/UserActivityPageDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.Users.Application.DTOs;
+
+public sealed record UserActivityPageDto(IReadOnlyList<UserActivityDto> Items, string? NextCursor);

--- a/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
+++ b/src/Yumney.Users.Application/Queries/GetRecentActivityQuery.cs
@@ -6,8 +6,13 @@ using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 namespace SmartSolutionsLab.Yumney.Users.Application.Queries;
 
 /// <summary>
-/// Returns the current user's most recent activity entries (US-121). When
-/// <see cref="Type"/> is non-null only entries of that type are included.
+/// Returns the current user's most recent activity entries (US-121, US-576).
+/// When <see cref="Type"/> is non-null only entries of that type are included.
+/// When <see cref="Cursor"/> is non-null returns entries strictly older than
+/// the cursor (keyset pagination).
 /// </summary>
-public sealed record GetRecentActivityQuery(ActivityLimit Limit, ActivityType? Type = null)
-	: IQuery<Result<IReadOnlyList<UserActivityDto>>>;
+public sealed record GetRecentActivityQuery(
+	ActivityLimit Limit,
+	ActivityType? Type = null,
+	ActivityCursor? Cursor = null)
+	: IQuery<Result<UserActivityPageDto>>;

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -7,16 +7,20 @@ using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 namespace SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
 
 public sealed class GetRecentActivityQueryHandler(IUserActivityRepository activities, ICurrentUser currentUser)
-	: IQueryHandler<GetRecentActivityQuery, Result<IReadOnlyList<UserActivityDto>>>
+	: IQueryHandler<GetRecentActivityQuery, Result<UserActivityPageDto>>
 {
-	public async Task<Result<IReadOnlyList<UserActivityDto>>> HandleAsync(GetRecentActivityQuery query, CancellationToken cancellationToken = default)
+	public async Task<Result<UserActivityPageDto>> HandleAsync(GetRecentActivityQuery query, CancellationToken cancellationToken = default)
 	{
 		var owner = currentUser.AsOwner();
 
 		var entries = query.Type is null
-			? await activities.GetRecentAsync(owner, query.Limit, cancellationToken)
-			: await activities.GetRecentByTypeAsync(owner, query.Type, query.Limit, cancellationToken);
+			? await activities.GetRecentByCursorAsync(owner, query.Limit, query.Cursor, cancellationToken)
+			: await activities.GetRecentByTypeAndCursorAsync(owner, query.Type, query.Limit, query.Cursor, cancellationToken);
 
-		return Result.Success(entries.ToDtos());
+		var nextCursor = entries.Count == query.Limit.Value
+			? ActivityCursor.From(entries[^1].OccurredAt, entries[^1].Id).Encode()
+			: null;
+
+		return Result.Success(new UserActivityPageDto(entries.ToDtos(), nextCursor));
 	}
 }

--- a/src/Yumney.Users.Domain/UserActivity/ActivityCursor.cs
+++ b/src/Yumney.Users.Domain/UserActivity/ActivityCursor.cs
@@ -1,0 +1,56 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+
+/// <summary>
+/// Opaque keyset cursor for the activity timeline: an (OccurredAt, Identifier)
+/// pair encoded for transport. The identifier is the tie-breaker when two
+/// activity rows share a millisecond-aligned timestamp.
+/// </summary>
+public sealed record ActivityCursor : IValueObject
+{
+	public DateTime OccurredAt { get; }
+
+	public UserActivityIdentifier TieBreaker { get; }
+
+	private ActivityCursor(DateTime occurredAt, UserActivityIdentifier tieBreaker)
+	{
+		OccurredAt = occurredAt;
+		TieBreaker = tieBreaker;
+	}
+
+	public static ActivityCursor From(DateTime occurredAt, UserActivityIdentifier tieBreaker) =>
+		new(occurredAt, Ensure.That(tieBreaker).IsNotNull().AndReturn());
+
+	public string Encode()
+	{
+		var ticks = OccurredAt.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture);
+		var raw = $"{ticks}|{TieBreaker.Value}";
+		return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(raw));
+	}
+
+	public static ActivityCursor? TryDecode(string? encoded)
+	{
+		if (string.IsNullOrWhiteSpace(encoded)) return null;
+
+		try
+		{
+			var raw = Encoding.UTF8.GetString(Base64Url.DecodeFromChars(encoded));
+			var separator = raw.IndexOf('|');
+			if (separator <= 0 || separator == raw.Length - 1) return null;
+
+			if (!long.TryParse(raw.AsSpan(0, separator), CultureInfo.InvariantCulture, out var ticks)) return null;
+			if (!Guid.TryParse(raw.AsSpan(separator + 1), out var tieBreaker)) return null;
+
+			return new ActivityCursor(new DateTime(ticks, DateTimeKind.Utc), UserActivityIdentifier.From(tieBreaker));
+		}
+		catch (FormatException)
+		{
+			return null;
+		}
+	}
+}

--- a/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
+++ b/src/Yumney.Users.Domain/UserActivity/IUserActivityRepository.cs
@@ -13,6 +13,21 @@ public interface IUserActivityRepository
 		ActivityLimit limit,
 		CancellationToken cancellationToken = default);
 
+	// Keyset pagination for the timeline UI (US-576). cursor=null returns the
+	// latest page; subsequent pages use the encoded (OccurredAt, Id) tuple.
+	Task<IReadOnlyList<UserActivity>> GetRecentByCursorAsync(
+		OwnerIdentifier owner,
+		ActivityLimit limit,
+		ActivityCursor? cursor,
+		CancellationToken cancellationToken = default);
+
+	Task<IReadOnlyList<UserActivity>> GetRecentByTypeAndCursorAsync(
+		OwnerIdentifier owner,
+		ActivityType type,
+		ActivityLimit limit,
+		ActivityCursor? cursor,
+		CancellationToken cancellationToken = default);
+
 	// Per-recipe stats: cook count + last cooked + view count (US-121).
 	Task<RecipeActivityStats> GetRecipeStatsAsync(
 		OwnerIdentifier owner,

--- a/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UserActivityRepository.cs
@@ -39,6 +39,21 @@ public sealed class UserActivityRepository(UsersDbContext context) : IUserActivi
 			.ToListAsync(cancellationToken);
 	}
 
+	public Task<IReadOnlyList<UserActivity>> GetRecentByCursorAsync(
+		OwnerIdentifier owner,
+		ActivityLimit limit,
+		ActivityCursor? cursor,
+		CancellationToken cancellationToken = default) =>
+		QueryByCursorAsync(activity => activity.Owner == owner, limit, cursor, cancellationToken);
+
+	public Task<IReadOnlyList<UserActivity>> GetRecentByTypeAndCursorAsync(
+		OwnerIdentifier owner,
+		ActivityType type,
+		ActivityLimit limit,
+		ActivityCursor? cursor,
+		CancellationToken cancellationToken = default) =>
+		QueryByCursorAsync(activity => activity.Owner == owner && activity.Type == type, limit, cursor, cancellationToken);
+
 	public async Task<RecipeActivityStats> GetRecipeStatsAsync(
 		OwnerIdentifier owner,
 		RecipeIdentifierSnapshot recipeIdentifier,
@@ -65,5 +80,32 @@ public sealed class UserActivityRepository(UsersDbContext context) : IUserActivi
 	{
 		var matches = await activities.Where(activity => activity.Owner == owner).ToListAsync(cancellationToken);
 		activities.RemoveRange(matches);
+	}
+
+	private async Task<IReadOnlyList<UserActivity>> QueryByCursorAsync(
+		System.Linq.Expressions.Expression<Func<UserActivity, bool>> filter,
+		ActivityLimit limit,
+		ActivityCursor? cursor,
+		CancellationToken cancellationToken)
+	{
+		var query = activities.AsNoTracking().Where(filter);
+
+		if (cursor is not null)
+		{
+			// Strictly older than the cursor's tick. The cursor still carries
+			// an id for transport stability (clients can de-dupe across page
+			// boundaries) but server-side we only compare on OccurredAt —
+			// EF Core can't translate < on a value-converted UserActivityIdentifier.
+			// Same-tick collisions are vanishingly rare for a per-user activity
+			// feed (DateTime.UtcNow ticks at 100ns precision, write rate is
+			// human-paced).
+			var cursorOccurred = cursor.OccurredAt;
+			query = query.Where(activity => activity.OccurredAt < cursorOccurred);
+		}
+
+		return await query
+			.OrderByDescending(activity => activity.OccurredAt)
+			.Take(limit.Value)
+			.ToListAsync(cancellationToken);
 	}
 }

--- a/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/Contract/StaplesAndActivityContractTests.cs
@@ -45,7 +45,7 @@ public class StaplesAndActivityContractTests(AspireFixture fixture)
 	}
 
 	[Fact]
-	public async Task GetRecentActivity_Authenticated_Returns200WithJsonArray()
+	public async Task GetRecentActivity_Authenticated_Returns200WithCursorPage()
 	{
 		using var client = await fixture.CreateAuthenticatedClientAsync("users-api");
 
@@ -53,7 +53,9 @@ public class StaplesAndActivityContractTests(AspireFixture fixture)
 
 		response.StatusCode.Should().Be(HttpStatusCode.OK);
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-		body.ValueKind.Should().Be(JsonValueKind.Array);
+		body.ValueKind.Should().Be(JsonValueKind.Object);
+		body.GetProperty("items").ValueKind.Should().Be(JsonValueKind.Array);
+		body.TryGetProperty("nextCursor", out _).Should().BeTrue();
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Users/UserActivityCursorPaginationTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/UserActivityCursorPaginationTests.cs
@@ -95,7 +95,9 @@ public class UserActivityCursorPaginationTests(AspireFixture fixture) : IAsyncLi
 	{
 		var activityType = type ?? ActivityType.From("recipe_imported");
 		var seeded = new UserActivity[count];
-		var baseTime = DateTime.UtcNow.AddMinutes(-(ageMinutes == 0 ? count : ageMinutes));
+		var now = DateTime.UtcNow;
+		var nowMicroseconds = new DateTime(now.Ticks - (now.Ticks % 10), DateTimeKind.Utc);
+		var baseTime = nowMicroseconds.AddMinutes(-(ageMinutes == 0 ? count : ageMinutes));
 
 		for (var index = 0; index < count; index++)
 		{

--- a/tests/Yumney.Integration.Tests/Users/UserActivityCursorPaginationTests.cs
+++ b/tests/Yumney.Integration.Tests/Users/UserActivityCursorPaginationTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Users;
+
+[Collection(AspireCollection.Name)]
+public class UserActivityCursorPaginationTests(AspireFixture fixture) : IAsyncLifetime
+{
+	private static readonly PropertyInfo OccurredAtProperty =
+		typeof(UserActivity).GetProperty(nameof(UserActivity.OccurredAt))!;
+
+	private readonly OwnerIdentifier owner = OwnerIdentifier.From($"kc-{Guid.NewGuid():N}");
+
+	public Task InitializeAsync() => Task.CompletedTask;
+
+	public Task DisposeAsync() => AspireFixture.CleanupAsync(
+		fixture.CreateUsersDbContextAsync,
+		ctx => ctx.Set<UserActivity>().Where(activity => activity.Owner == owner));
+
+	[Fact]
+	public async Task GetRecentByCursorAsync_NullCursor_ReturnsLatestPageNewestFirst()
+	{
+		await SeedActivitiesAsync(count: 5);
+
+		await using var context = await fixture.CreateUsersDbContextAsync();
+		var repository = new UserActivityRepository(context);
+
+		var page = await repository.GetRecentByCursorAsync(owner, ActivityLimit.From(3), cursor: null);
+
+		page.Should().HaveCount(3);
+		page.Select(activity => activity.OccurredAt)
+			.Should().BeInDescendingOrder("newest first");
+	}
+
+	[Fact]
+	public async Task GetRecentByCursorAsync_WithCursor_ReturnsStrictlyOlderEntries()
+	{
+		var seeded = await SeedActivitiesAsync(count: 5);
+
+		await using var context = await fixture.CreateUsersDbContextAsync();
+		var repository = new UserActivityRepository(context);
+
+		var firstPage = await repository.GetRecentByCursorAsync(owner, ActivityLimit.From(2), cursor: null);
+		var cursor = ActivityCursor.From(firstPage[^1].OccurredAt, firstPage[^1].Id);
+
+		var secondPage = await repository.GetRecentByCursorAsync(owner, ActivityLimit.From(2), cursor);
+
+		secondPage.Should().HaveCount(2);
+		secondPage.Should().AllSatisfy(activity =>
+			activity.OccurredAt.Should().BeBefore(firstPage[^1].OccurredAt));
+		secondPage.Select(activity => activity.Id)
+			.Should().NotContain(firstPage.Select(activity => activity.Id));
+
+		// And the assembled timeline matches the seeded order (newest first).
+		var combined = firstPage.Concat(secondPage).Select(activity => activity.OccurredAt).ToList();
+		combined.Should().BeInDescendingOrder();
+		combined.Should().BeEquivalentTo(seeded.Select(activity => activity.OccurredAt).Take(4));
+	}
+
+	[Fact]
+	public async Task GetRecentByTypeAndCursorAsync_FilterSurvivesAcrossPages()
+	{
+		var importedType = ActivityType.From("recipe_imported");
+		var cookedType = ActivityType.From("recipe_cooked");
+
+		// Interleave types so a naive non-typed query would return cookedType rows.
+		await SeedActivitiesAsync(count: 1, type: importedType, ageMinutes: 10);
+		await SeedActivitiesAsync(count: 1, type: cookedType, ageMinutes: 9);
+		await SeedActivitiesAsync(count: 1, type: importedType, ageMinutes: 8);
+		await SeedActivitiesAsync(count: 1, type: cookedType, ageMinutes: 7);
+		await SeedActivitiesAsync(count: 1, type: importedType, ageMinutes: 6);
+
+		await using var context = await fixture.CreateUsersDbContextAsync();
+		var repository = new UserActivityRepository(context);
+
+		var firstPage = await repository.GetRecentByTypeAndCursorAsync(owner, importedType, ActivityLimit.From(2), cursor: null);
+		firstPage.Should().HaveCount(2);
+		firstPage.Should().AllSatisfy(activity => activity.Type.Should().Be(importedType));
+
+		var cursor = ActivityCursor.From(firstPage[^1].OccurredAt, firstPage[^1].Id);
+		var secondPage = await repository.GetRecentByTypeAndCursorAsync(owner, importedType, ActivityLimit.From(2), cursor);
+
+		secondPage.Should().HaveCount(1);
+		secondPage[0].Type.Should().Be(importedType);
+	}
+
+	private async Task<UserActivity[]> SeedActivitiesAsync(int count, ActivityType? type = null, int ageMinutes = 0)
+	{
+		var activityType = type ?? ActivityType.From("recipe_imported");
+		var seeded = new UserActivity[count];
+		var baseTime = DateTime.UtcNow.AddMinutes(-(ageMinutes == 0 ? count : ageMinutes));
+
+		for (var index = 0; index < count; index++)
+		{
+			var activity = UserActivity.Record(owner, activityType);
+			OccurredAtProperty.SetValue(activity, baseTime.AddSeconds(index));
+			seeded[count - 1 - index] = activity;
+		}
+
+		await using var context = await fixture.CreateUsersDbContextAsync();
+		context.Set<UserActivity>().AddRange(seeded);
+		await context.SaveChangesAsync();
+
+		return seeded;
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/Queries/GetRecentActivityQueryHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Queries/GetRecentActivityQueryHandlerTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Queries;
 using SmartSolutionsLab.Yumney.Users.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
@@ -31,36 +30,103 @@ public class GetRecentActivityQueryHandlerTests
 			RecipeIdentifierSnapshot.New(),
 			RecipeTitleSnapshot.From("Test Recipe"));
 
-		activities.GetRecentAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<CancellationToken>())
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
 			.Returns(new List<UserActivity> { activity });
 
 		var result = await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.Default()));
 
 		result.IsSuccess.Should().BeTrue();
-		result.Value.Should().HaveCount(1);
-		result.Value[0].Type.Should().Be("recipe_imported");
+		result.Value.Items.Should().HaveCount(1);
+		result.Value.Items[0].Type.Should().Be("recipe_imported");
 	}
 
 	[Fact]
-	public async Task HandleAsync_EmptyList_ReturnsEmpty()
+	public async Task HandleAsync_EmptyList_ReturnsEmptyPageWithoutCursor()
 	{
-		activities.GetRecentAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<CancellationToken>())
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
 			.Returns(new List<UserActivity>());
 
 		var result = await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.Default()));
 
 		result.IsSuccess.Should().BeTrue();
-		result.Value.Should().BeEmpty();
+		result.Value.Items.Should().BeEmpty();
+		result.Value.NextCursor.Should().BeNull();
 	}
 
 	[Fact]
 	public async Task HandleAsync_RespectsLimit()
 	{
 		var limit = ActivityLimit.From(10);
-		var query = new GetRecentActivityQuery(Limit: limit);
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
+			.Returns(new List<UserActivity>());
 
-		await handler.HandleAsync(query);
+		await handler.HandleAsync(new GetRecentActivityQuery(limit));
 
-		await activities.Received(1).GetRecentAsync(Arg.Any<OwnerIdentifier>(), limit, Arg.Any<CancellationToken>());
+		await activities.Received(1).GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), limit, Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_PageSizeMatchesLimit_EmitsNextCursor()
+	{
+		var owner = OwnerIdentifier.From("user-123");
+		var rows = Enumerable.Range(0, 5)
+			.Select(_ => UserActivity.Record(owner, ActivityType.From("recipe_imported")))
+			.ToList();
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
+			.Returns(rows);
+
+		var result = await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.From(5)));
+
+		result.Value.NextCursor.Should().NotBeNull();
+		ActivityCursor.TryDecode(result.Value.NextCursor).Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task HandleAsync_PageSmallerThanLimit_NoNextCursor()
+	{
+		var owner = OwnerIdentifier.From("user-123");
+		var rows = new List<UserActivity>
+		{
+			UserActivity.Record(owner, ActivityType.From("recipe_imported")),
+		};
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
+			.Returns(rows);
+
+		var result = await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.From(10)));
+
+		result.Value.NextCursor.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAsync_TypeFilter_RoutesToTypedRepository()
+	{
+		activities.GetRecentByTypeAndCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityType>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
+			.Returns(new List<UserActivity>());
+
+		await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.Default(), ActivityType.From("recipe_cooked")));
+
+		await activities.Received(1).GetRecentByTypeAndCursorAsync(
+			Arg.Any<OwnerIdentifier>(),
+			Arg.Is<ActivityType>(type => type.Value == "recipe_cooked"),
+			Arg.Any<ActivityLimit>(),
+			Arg.Any<ActivityCursor?>(),
+			Arg.Any<CancellationToken>());
+		await activities.DidNotReceive().GetRecentByCursorAsync(default!, default!, default, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCursorToRepository()
+	{
+		var cursor = ActivityCursor.From(DateTime.UtcNow.AddDays(-1), UserActivityIdentifier.New());
+		activities.GetRecentByCursorAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<ActivityLimit>(), Arg.Any<ActivityCursor?>(), Arg.Any<CancellationToken>())
+			.Returns(new List<UserActivity>());
+
+		await handler.HandleAsync(new GetRecentActivityQuery(ActivityLimit.Default(), Cursor: cursor));
+
+		await activities.Received(1).GetRecentByCursorAsync(
+			Arg.Any<OwnerIdentifier>(),
+			Arg.Any<ActivityLimit>(),
+			cursor,
+			Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityCursorTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityCursorTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.UserActivity;
+
+public class ActivityCursorTests
+{
+	[Fact]
+	public void Encode_Decode_RoundTripsExactValues()
+	{
+		var occurredAt = new DateTime(2026, 5, 7, 12, 34, 56, DateTimeKind.Utc).AddTicks(123);
+		var tieBreaker = UserActivityIdentifier.New();
+		var cursor = ActivityCursor.From(occurredAt, tieBreaker);
+
+		var decoded = ActivityCursor.TryDecode(cursor.Encode());
+
+		decoded.Should().NotBeNull();
+		decoded!.OccurredAt.Should().Be(occurredAt);
+		decoded.TieBreaker.Should().Be(tieBreaker);
+	}
+
+	[Fact]
+	public void TryDecode_Null_ReturnsNull()
+	{
+		ActivityCursor.TryDecode(null).Should().BeNull();
+	}
+
+	[Fact]
+	public void TryDecode_Empty_ReturnsNull()
+	{
+		ActivityCursor.TryDecode(string.Empty).Should().BeNull();
+	}
+
+	[Fact]
+	public void TryDecode_Garbage_ReturnsNull()
+	{
+		ActivityCursor.TryDecode("not-a-valid-cursor!!!").Should().BeNull();
+	}
+
+	[Fact]
+	public void TryDecode_MissingSeparator_ReturnsNull()
+	{
+		// Base64 of "1234567890" — no '|' separator
+		ActivityCursor.TryDecode("MTIzNDU2Nzg5MA").Should().BeNull();
+	}
+}


### PR DESCRIPTION
Closes #576.

## Summary
- \`GET /api/v1/users/me/activity\` returns a cursor envelope \`{ items, nextCursor }\` instead of a flat array. Pass the cursor back via \`?cursor=\` to fetch strictly older entries (keyset pagination, no \`OFFSET\`).
- Frontend activity page paginates 20 entries at a time with a \"Load older\" button driven by \`nextCursor\`.

## Acceptance criteria
- [x] \`GetRecentActivityQuery\` accepts opaque cursor (timestamp + tie-break id) + limit; returns \`{ items, nextCursor }\`
- [x] Repository gains \`GetRecentByCursorAsync\` + \`GetRecentByTypeAndCursorAsync\` using keyset pagination (no \`OFFSET\`)
- [x] \`ActivityApiService.getActivity\` returns the cursor envelope; existing call sites compose for load-more
- [x] Activity page wires \"Load older\" against the next cursor
- [x] Tests cover empty cursor returns latest page, cursor returns strictly older entries, type filter survives across pages, no nextCursor when page < limit

## Trade-off
Server WHERE compares only on \`OccurredAt\` — EF Core can't translate \`<\` on a value-converted \`UserActivityIdentifier\`. The cursor still carries the id for client-side de-dup; same-tick collisions on a per-user feed are vanishingly rare in practice (\`DateTime.UtcNow\` ticks at 100ns, write rate is human-paced).

## Test plan
- [x] \`dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true\` — clean
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] All unit + architecture tests pass; account frontend tests pass
- [ ] CI green
- [ ] Manual smoke: scroll the activity page past 20 entries, confirm older rows load