### PR TITLE
chore(shared): extract groupByCategory util

### DIFF
--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -11,7 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem } from '../api';
-import { createAsyncState, ERROR_MAPS, ToastService } from '@yumney/shared/models';
+import { createAsyncState, ERROR_MAPS, groupByCategory, ToastService } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
 interface CategoryGroup {
@@ -44,19 +44,10 @@ export class MergedListComponent {
   private loadRequestId = 0;
 
   protected categoryGroups = computed<CategoryGroup[]>(() => {
-    const l = this.list();
-    if (!l) return [];
-
-    const grouped = new Map<string, MergedShoppingItem[]>();
-    for (const item of l.items) {
-      const existing = grouped.get(item.category) ?? [];
-      existing.push(item);
-      grouped.set(item.category, existing);
-    }
-
-    return Array.from(grouped.entries()).map(([category, items]) => ({
-      category,
-      items,
+    const list = this.list();
+    if (!list) return [];
+    return groupByCategory(list.items, (item) => item.category).map((group) => ({
+      ...group,
       isExpanded: true,
     }));
   });

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -15,9 +15,11 @@ import {
   buildBringImportUrl,
   createAsyncState,
   ERROR_MAPS,
+  groupByCategory,
   optimisticSignalUpdate,
   ROUTES,
   ToastService,
+  type CategoryGroup,
 } from '@yumney/shared/models';
 import {
   BackLinkComponent,
@@ -38,11 +40,6 @@ const CATEGORY_ORDER: readonly CategoryKey[] = [
   'household',
   'other',
 ];
-
-interface CategoryGroup {
-  category: CategoryKey;
-  items: ShoppingListItemResponse[];
-}
 
 // How long to give the OS to launch the Bring! app before assuming it isn't
 // installed and falling back to the marketing site. 1.5 s is the de-facto
@@ -81,22 +78,12 @@ export class ShoppingDetailComponent implements OnInit {
 
   totalItemCount = computed(() => this.shoppingList()?.items.length ?? 0);
 
-  groupedItems = computed<CategoryGroup[]>(() => {
+  groupedItems = computed<CategoryGroup<ShoppingListItemResponse, CategoryKey>[]>(() => {
     const list = this.shoppingList();
     if (!list) return [];
-
-    const groups = new Map<CategoryKey, ShoppingListItemResponse[]>();
-    for (const item of list.items) {
-      const key = this.normalize(item.category);
-      const bucket = groups.get(key) ?? [];
-      bucket.push(item);
-      groups.set(key, bucket);
-    }
-
-    return CATEGORY_ORDER.filter((category) => groups.has(category)).map((category) => ({
-      category,
-      items: groups.get(category) ?? [],
-    }));
+    return groupByCategory(list.items, (item) => this.normalize(item.category), {
+      order: CATEGORY_ORDER,
+    });
   });
 
   // Items still to buy — already-checked items have been added to the cart, so

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -16,6 +16,7 @@ export { createAsyncState, type AsyncState } from './lib/async-state';
 export { ensureFormValid } from './lib/form-helpers';
 export { optimisticSignalUpdate } from './lib/optimistic-update';
 export { toggleFavoriteOnItem, toggleFavoriteInList } from './lib/favorite-toggle';
+export { groupByCategory, type CategoryGroup } from './lib/group-by-category';
 export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { IS_STANDALONE } from './lib/federation-context';
 export { LanguageService } from './lib/language.service';

--- a/client/libs/shared/models/src/lib/group-by-category.spec.ts
+++ b/client/libs/shared/models/src/lib/group-by-category.spec.ts
@@ -1,0 +1,52 @@
+import { groupByCategory } from './group-by-category';
+
+interface Item {
+  name: string;
+  category: string;
+}
+
+describe('groupByCategory', () => {
+  it('groups items by their category key', () => {
+    const items: Item[] = [
+      { name: 'apple', category: 'produce' },
+      { name: 'milk', category: 'dairy' },
+      { name: 'banana', category: 'produce' },
+    ];
+
+    const groups = groupByCategory(items, (item) => item.category);
+
+    expect(groups).toEqual([
+      { category: 'produce', items: [items[0], items[2]] },
+      { category: 'dairy', items: [items[1]] },
+    ]);
+  });
+
+  it('returns groups in the supplied order, skipping empty categories', () => {
+    const items: Item[] = [
+      { name: 'milk', category: 'dairy' },
+      { name: 'apple', category: 'produce' },
+    ];
+
+    const groups = groupByCategory(items, (item) => item.category, {
+      order: ['produce', 'dairy', 'frozen'] as const,
+    });
+
+    expect(groups.map((group) => group.category)).toEqual(['produce', 'dairy']);
+  });
+
+  it('returns an empty array when there are no items', () => {
+    expect(groupByCategory([], (item: Item) => item.category)).toEqual([]);
+  });
+
+  it('preserves insertion order within a bucket', () => {
+    const items: Item[] = [
+      { name: 'a', category: 'x' },
+      { name: 'b', category: 'x' },
+      { name: 'c', category: 'x' },
+    ];
+
+    const groups = groupByCategory(items, (item) => item.category);
+
+    expect(groups[0].items.map((item) => item.name)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/client/libs/shared/models/src/lib/group-by-category.ts
+++ b/client/libs/shared/models/src/lib/group-by-category.ts
@@ -1,0 +1,34 @@
+export interface CategoryGroup<TItem, TCategory extends string = string> {
+  category: TCategory;
+  items: TItem[];
+}
+
+export interface GroupByCategoryOptions<TCategory extends string> {
+  order?: readonly TCategory[];
+}
+
+export function groupByCategory<TItem, TCategory extends string = string>(
+  items: readonly TItem[],
+  getCategory: (item: TItem) => TCategory,
+  options: GroupByCategoryOptions<TCategory> = {},
+): CategoryGroup<TItem, TCategory>[] {
+  const buckets = new Map<TCategory, TItem[]>();
+  for (const item of items) {
+    const category = getCategory(item);
+    const bucket = buckets.get(category) ?? [];
+    bucket.push(item);
+    buckets.set(category, bucket);
+  }
+
+  const { order } = options;
+  if (order) {
+    return order
+      .filter((category) => buckets.has(category))
+      .map((category) => ({ category, items: buckets.get(category) ?? [] }));
+  }
+
+  return Array.from(buckets.entries()).map(([category, bucketItems]) => ({
+    category,
+    items: bucketItems,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add `groupByCategory(items, keyOf, { order? })` in `@yumney/shared/models` with unit tests
- Switch `shopping-detail` and `merged-list` to use it; each keeps its own domain-specific decoration (`normalize`, `isExpanded`)
- ~32 lines of duplicated Map/for/filter scaffolding removed

## Test plan
- [x] New `group-by-category.spec.ts` covers unordered, ordered+skip-empty, empty, insertion order
- [x] `yarn nx test shared-models` passes
- [x] `yarn nx build shopping` passes
- [x] Prettier clean