### PR TITLE
chore(shared): replace debounced Subjects with signal+toObservable

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -9,8 +9,8 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { Subject, debounceTime } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { debounceTime, skip } from 'rxjs';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   createAsyncState,
   ERROR_MAPS,
@@ -39,7 +39,8 @@ export class ProfileSettingsComponent {
   private transloco = inject(TranslocoService);
   private loadState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
-  private autosave$ = new Subject<void>();
+  private autosaveTick = signal(0);
+  private autosave$ = toObservable(this.autosaveTick);
 
   protected profile = signal<UserProfile | null>(null);
   protected loading = this.loadState.isLoading;
@@ -100,7 +101,7 @@ export class ProfileSettingsComponent {
 
   constructor() {
     this.autosave$
-      .pipe(debounceTime(AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
+      .pipe(skip(1), debounceTime(AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.persist());
 
     effect(() => {
@@ -120,7 +121,7 @@ export class ProfileSettingsComponent {
 
   protected onChange(): void {
     this.saved.set(false);
-    this.autosave$.next();
+    this.autosaveTick.update((tick) => tick + 1);
   }
 
   protected onToggleRestriction(restriction: string): void {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -10,8 +10,8 @@ import {
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Subject, debounceTime } from 'rxjs';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { debounceTime, skip } from 'rxjs';
 import {
   ActivityApiService,
   CreateShoppingListItem,
@@ -81,7 +81,8 @@ export class RecipeDetailComponent implements OnInit {
 
   notesDraft = signal<string>('');
   notesSaved = signal(false);
-  private notesAutosave$ = new Subject<string>();
+  private notesAutosaveInput = signal('');
+  private notesAutosave$ = toObservable(this.notesAutosaveInput);
 
   scaledIngredients = computed(() => {
     const recipe = this.recipe();
@@ -116,7 +117,7 @@ export class RecipeDetailComponent implements OnInit {
 
   ngOnInit(): void {
     this.notesAutosave$
-      .pipe(debounceTime(NOTES_AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
+      .pipe(skip(1), debounceTime(NOTES_AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.persistNotes(value));
 
     const identifier = this.route.snapshot.paramMap.get('identifier');
@@ -156,7 +157,7 @@ export class RecipeDetailComponent implements OnInit {
   onNotesInput(value: string): void {
     this.notesDraft.set(value);
     this.notesSaved.set(false);
-    this.notesAutosave$.next(value);
+    this.notesAutosaveInput.set(value);
   }
 
   private persistNotes(value: string): void {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -7,8 +7,8 @@ import {
   DestroyRef,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Subject, debounceTime } from 'rxjs';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { debounceTime, skip } from 'rxjs';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
@@ -81,7 +81,8 @@ export class RecipeListComponent implements OnInit {
   private recipeApi = inject(RecipeApiService);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
-  private searchSubject = new Subject<string>();
+  private searchInput = signal('');
+  private searchInput$ = toObservable(this.searchInput);
   private loadRequestId = 0;
 
   protected assignment = inject(RecipeAssignmentService);
@@ -126,8 +127,8 @@ export class RecipeListComponent implements OnInit {
     this.multiSelect.initFromRoute();
     this.loadRecipes(false);
 
-    this.searchSubject
-      .pipe(debounceTime(UI.SEARCH_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
+    this.searchInput$
+      .pipe(skip(1), debounceTime(UI.SEARCH_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => {
         this.activeSearch.set(value.trim());
         this.resetAndReload();
@@ -137,7 +138,7 @@ export class RecipeListComponent implements OnInit {
   onSearchInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.searchQuery.set(value);
-    this.searchSubject.next(value);
+    this.searchInput.set(value);
   }
 
   onSearchClear(): void {


### PR DESCRIPTION
## Summary
- `recipe-list` search, `recipe-detail` notes autosave, `profile-settings` autosave tick all used a `Subject` only as a debounce trigger
- Replace each with a signal piped through `toObservable + skip(1) + debounceTime`. The `skip(1)` drops the synchronous initial-value emission so the side effect still only fires on user input
- profile-settings keeps a counter signal (`autosaveTick`) since the trigger is void

## Test plan
- [x] `yarn nx build recipes` / `build account` clean
- [x] `yarn nx test recipes` / `test account` pass
- [x] Prettier clean