### PR TITLE
chore(shell): extract DashboardSuggestionsService

### DIFF
--- a/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.spec.ts
@@ -1,0 +1,88 @@
+import { DestroyRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { DashboardApiService } from '@yumney/shared/api-client';
+import { DashboardSuggestionsService } from './dashboard-suggestions.service';
+
+describe('DashboardSuggestionsService', () => {
+  function createService(api: Partial<DashboardApiService>): DashboardSuggestionsService {
+    TestBed.configureTestingModule({
+      providers: [
+        DashboardSuggestionsService,
+        { provide: DashboardApiService, useValue: api },
+        { provide: DestroyRef, useValue: { onDestroy: () => () => undefined } },
+      ],
+    });
+    return TestBed.inject(DashboardSuggestionsService);
+  }
+
+  it('populates signals and reports non-empty when suggestions arrive', () => {
+    const api = {
+      getSuggestions: vi.fn().mockReturnValue(
+        of({
+          quickActions: ['cook_now'],
+          suggestions: [
+            {
+              recipeIdentifier: 'r1',
+              title: 'A',
+              imageUrl: null,
+              prepTimeMinutes: null,
+              reason: '',
+            },
+          ],
+        }),
+      ),
+      getRecentActivity: vi.fn().mockReturnValue(of([])),
+    };
+    const service = createService(api);
+
+    let result: { initialDataIsEmpty: boolean } | null = null;
+    service.load().subscribe((value) => (result = value));
+
+    expect(result).toEqual({ initialDataIsEmpty: false });
+    expect(service.loading()).toBe(false);
+    expect(service.quickActions()).toEqual([
+      { key: 'cook_now', labelKey: 'dashboard.quickActions.cook_now' },
+    ]);
+    expect(service.suggestions()?.suggestions).toHaveLength(1);
+  });
+
+  it('reports empty when both lists are empty', () => {
+    const api = {
+      getSuggestions: vi.fn().mockReturnValue(of({ quickActions: [], suggestions: [] })),
+      getRecentActivity: vi.fn().mockReturnValue(of([])),
+    };
+    const service = createService(api);
+
+    let result: { initialDataIsEmpty: boolean } | null = null;
+    service.load().subscribe((value) => (result = value));
+
+    expect(result).toEqual({ initialDataIsEmpty: true });
+  });
+
+  it('treats suggestions error as empty and clears loading', () => {
+    const api = {
+      getSuggestions: vi.fn().mockReturnValue(throwError(() => new Error('boom'))),
+      getRecentActivity: vi.fn().mockReturnValue(of([])),
+    };
+    const service = createService(api);
+
+    let result: { initialDataIsEmpty: boolean } | null = null;
+    service.load().subscribe((value) => (result = value));
+
+    expect(result).toEqual({ initialDataIsEmpty: true });
+    expect(service.loading()).toBe(false);
+  });
+
+  it('falls back to empty list when activity request fails', () => {
+    const api = {
+      getSuggestions: vi.fn().mockReturnValue(of({ quickActions: [], suggestions: [] })),
+      getRecentActivity: vi.fn().mockReturnValue(throwError(() => new Error('boom'))),
+    };
+    const service = createService(api);
+
+    service.load().subscribe();
+
+    expect(service.recentActivity()).toEqual([]);
+  });
+});

--- a/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.ts
@@ -1,0 +1,55 @@
+import { DestroyRef, Injectable, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { catchError, map, Observable, of, tap } from 'rxjs';
+import {
+  DashboardApiService,
+  type SuggestionsResponse,
+  type UserActivityItem,
+} from '@yumney/shared/api-client';
+import type { QuickAction } from '@yumney/ui';
+
+@Injectable()
+export class DashboardSuggestionsService {
+  private api = inject(DashboardApiService);
+  private destroyRef = inject(DestroyRef);
+
+  readonly quickActions = signal<QuickAction[]>([]);
+  readonly suggestions = signal<SuggestionsResponse | null>(null);
+  readonly recentActivity = signal<UserActivityItem[]>([]);
+  readonly loading = signal(true);
+
+  load(): Observable<{ initialDataIsEmpty: boolean }> {
+    this.api
+      .getRecentActivity(5)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (activity) => this.recentActivity.set(activity),
+        error: () => this.recentActivity.set([]),
+      });
+
+    return this.api.getSuggestions().pipe(
+      tap({
+        next: (response) => {
+          this.suggestions.set(response);
+          this.quickActions.set(
+            response.quickActions.map((key) => ({
+              key,
+              labelKey: 'dashboard.quickActions.' + key,
+            })),
+          );
+          this.loading.set(false);
+        },
+      }),
+      map((response) => ({
+        initialDataIsEmpty: response.quickActions.length === 0 && response.suggestions.length === 0,
+      })),
+      catchError(() => {
+        // Keep the loading spinner from spinning forever if the API fails,
+        // and surface the same empty-state behaviour as a successful empty response.
+        this.loading.set(false);
+        return of({ initialDataIsEmpty: true });
+      }),
+      takeUntilDestroyed(this.destroyRef),
+    );
+  }
+}

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -10,13 +10,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  DashboardApiService,
-  type UserActivityItem,
-  type SuggestionsResponse,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
 import {
   createAsyncState,
   mapToSaveRecipeRequest,
@@ -27,7 +21,6 @@ import { LucideAngularModule } from 'lucide-angular';
 import {
   RecipePreviewComponent,
   QuickActionsComponent,
-  type QuickAction,
   SuggestionCardComponent,
   RecentActivityComponent,
   CameraCaptureComponent,
@@ -38,6 +31,7 @@ import {
 import { CameraService } from '@yumney/shared/models';
 import type { RecognizedIngredient } from '@yumney/shared/api-client';
 import { UrlImportComponent } from './url-import.component';
+import { DashboardSuggestionsService } from './dashboard-suggestions.service';
 
 @Component({
   selector: 'yn-dashboard',
@@ -57,16 +51,17 @@ import { UrlImportComponent } from './url-import.component';
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [DashboardSuggestionsService],
 })
 export class DashboardComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private recipeApi = inject(RecipeApiService);
-  private dashboardApi = inject(DashboardApiService);
   protected camera = inject(CameraService);
   private destroyRef = inject(DestroyRef);
   private importState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
+  private suggestionsState = inject(DashboardSuggestionsService);
 
   protected urlImport = viewChild<UrlImportComponent>(UrlImportComponent);
 
@@ -83,14 +78,16 @@ export class DashboardComponent implements OnInit {
   shareToast = signal<string | null>(null);
   recognizedIngredients = signal<RecognizedIngredient[] | null>(null);
 
-  // Smart dashboard state
-  quickActions = signal<QuickAction[]>([]);
-  suggestions = signal<SuggestionsResponse | null>(null);
-  recentActivity = signal<UserActivityItem[]>([]);
-  suggestionsLoading = signal(true);
+  // Re-exposed so the template (and existing tests) keep their flat access.
+  quickActions = this.suggestionsState.quickActions;
+  suggestions = this.suggestionsState.suggestions;
+  recentActivity = this.suggestionsState.recentActivity;
+  suggestionsLoading = this.suggestionsState.loading;
 
   ngOnInit(): void {
-    this.loadDashboardData();
+    this.suggestionsState.load().subscribe(({ initialDataIsEmpty }) => {
+      if (initialDataIsEmpty) this.importSectionExpanded.set(true);
+    });
 
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       const urlParam = params['url'] as string | undefined;
@@ -152,43 +149,6 @@ export class DashboardComponent implements OnInit {
 
   onUrlImportStarted(): void {
     this.resetImportState();
-  }
-
-  private loadDashboardData(): void {
-    this.dashboardApi
-      .getSuggestions()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (response) => {
-          this.suggestions.set(response);
-          this.quickActions.set(this.mapQuickActions(response.quickActions));
-          this.suggestionsLoading.set(false);
-
-          if (response.quickActions.length === 0 && response.suggestions.length === 0) {
-            this.importSectionExpanded.set(true);
-          }
-        },
-        error: () => {
-          // Keep the loading spinner from spinning forever if the API fails.
-          this.suggestionsLoading.set(false);
-          this.importSectionExpanded.set(true);
-        },
-      });
-
-    this.dashboardApi
-      .getRecentActivity(5)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (activity) => this.recentActivity.set(activity),
-        error: () => this.recentActivity.set([]),
-      });
-  }
-
-  private mapQuickActions(keys: string[]): QuickAction[] {
-    return keys.map((key) => ({
-      key,
-      labelKey: 'dashboard.quickActions.' + key,
-    }));
   }
 
   onImportFromPhotos(event: Event): void {


### PR DESCRIPTION
## Summary
- Move `quickActions`, `suggestions`, `recentActivity`, `suggestionsLoading` signals and their HTTP loaders into a component-scoped `DashboardSuggestionsService`
- Component re-exposes the service signals as direct references so the template (and existing specs that read `component.suggestions`) keep working
- `load()` returns an Observable carrying `{ initialDataIsEmpty }` so the dashboard owns the auto-expand side effect, the service owns the data
- Component: **303 → 263 lines** (back under the 300-line cap)
- New service: ~55 lines + 4 unit tests

## Test plan
- [x] `yarn nx build shell` ✅
- [x] `yarn nx test shell` — 227 tests pass (was 223)
- [x] Prettier clean