### PR TITLE
chore(recipes): extract RecipeNotesAutosaveService

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -10,8 +10,6 @@ import {
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { debounceTime, skip } from 'rxjs';
 import {
   ActivityApiService,
   CreateShoppingListItem,
@@ -20,6 +18,7 @@ import {
   RecipeDetail,
   ShoppingApiService,
 } from '../api';
+import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
 import {
   createAsyncState,
   scaleIngredients,
@@ -37,8 +36,6 @@ import {
 } from '@yumney/ui';
 import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog/create-shopping-list-dialog.component';
 
-const NOTES_AUTOSAVE_DEBOUNCE_MS = 400;
-
 @Component({
   selector: 'yn-recipe-detail',
   imports: [
@@ -55,6 +52,7 @@ const NOTES_AUTOSAVE_DEBOUNCE_MS = 400;
   templateUrl: './recipe-detail.component.html',
   styleUrl: './recipe-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [RecipeNotesAutosaveService],
 })
 export class RecipeDetailComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
@@ -68,6 +66,7 @@ export class RecipeDetailComponent implements OnInit {
   private loadState = createAsyncState(this.destroyRef);
   private deleteState = createAsyncState(this.destroyRef);
   private createShoppingListState = createAsyncState(this.destroyRef);
+  private notesAutosave = inject(RecipeNotesAutosaveService);
 
   recipe = signal<RecipeDetail | null>(null);
   recipeStats = signal<RecipeActivityStats | null>(null);
@@ -79,10 +78,8 @@ export class RecipeDetailComponent implements OnInit {
   showDeleteConfirm = signal(false);
   showCreateShoppingListConfirm = signal(false);
 
-  notesDraft = signal<string>('');
-  notesSaved = signal(false);
-  private notesAutosaveInput = signal('');
-  private notesAutosave$ = toObservable(this.notesAutosaveInput);
+  notesDraft = this.notesAutosave.draft;
+  notesSaved = this.notesAutosave.saved;
 
   scaledIngredients = computed(() => {
     const recipe = this.recipe();
@@ -116,10 +113,6 @@ export class RecipeDetailComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    this.notesAutosave$
-      .pipe(skip(1), debounceTime(NOTES_AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
-      .subscribe((value) => this.persistNotes(value));
-
     const identifier = this.route.snapshot.paramMap.get('identifier');
     if (!identifier) {
       this.serverError.set('recipes.detail.notFound');
@@ -138,7 +131,7 @@ export class RecipeDetailComponent implements OnInit {
       (recipe) => {
         this.recipe.set(recipe);
         this.desiredServings.set(recipe.servings);
-        this.notesDraft.set(recipe.notes ?? '');
+        this.notesAutosave.attach(this.recipe);
       },
       (error) => this.serverError.set(error),
     );
@@ -155,25 +148,7 @@ export class RecipeDetailComponent implements OnInit {
   }
 
   onNotesInput(value: string): void {
-    this.notesDraft.set(value);
-    this.notesSaved.set(false);
-    this.notesAutosaveInput.set(value);
-  }
-
-  private persistNotes(value: string): void {
-    const recipe = this.recipe();
-    if (!recipe) return;
-    const trimmed = value.trim();
-    const payload = trimmed.length === 0 ? null : trimmed;
-    if (payload === (recipe.notes ?? null)) return;
-
-    this.recipeApi.updateRecipeNotes(recipe.identifier, payload).subscribe({
-      next: () => {
-        this.recipe.set({ ...recipe, notes: payload });
-        this.notesSaved.set(true);
-        setTimeout(() => this.notesSaved.set(false), 2000);
-      },
-    });
+    this.notesAutosave.update(value);
   }
 
   totalTime = computed(() => {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.spec.ts
@@ -1,0 +1,68 @@
+import { DestroyRef, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { RecipeApiService, RecipeDetail } from '../api';
+import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
+
+function buildRecipe(overrides: Partial<RecipeDetail> = {}): RecipeDetail {
+  return {
+    identifier: 'r1',
+    title: 'Test',
+    description: null,
+    ingredients: [],
+    steps: [],
+    servings: 4,
+    prepTimeMinutes: null,
+    cookTimeMinutes: null,
+    difficulty: null,
+    imageUrl: null,
+    rating: null,
+    isFavorite: false,
+    notes: null,
+    sourceUrl: null,
+    tags: [],
+    ...overrides,
+  } as RecipeDetail;
+}
+
+describe('RecipeNotesAutosaveService', () => {
+  function createService(api: Partial<RecipeApiService>): RecipeNotesAutosaveService {
+    TestBed.configureTestingModule({
+      providers: [
+        RecipeNotesAutosaveService,
+        { provide: RecipeApiService, useValue: api },
+        { provide: DestroyRef, useValue: { onDestroy: () => () => undefined } },
+      ],
+    });
+    return TestBed.inject(RecipeNotesAutosaveService);
+  }
+
+  it('seeds the draft from the attached recipe notes', () => {
+    const service = createService({ updateRecipeNotes: vi.fn() });
+    const recipeRef = signal<RecipeDetail | null>(buildRecipe({ notes: 'existing' }));
+
+    service.attach(recipeRef);
+
+    expect(service.draft()).toBe('existing');
+  });
+
+  it('treats absent notes as an empty draft', () => {
+    const service = createService({ updateRecipeNotes: vi.fn() });
+    const recipeRef = signal<RecipeDetail | null>(buildRecipe({ notes: null }));
+
+    service.attach(recipeRef);
+
+    expect(service.draft()).toBe('');
+  });
+
+  it('update() sets the draft and clears saved', () => {
+    const service = createService({ updateRecipeNotes: vi.fn() });
+    const recipeRef = signal<RecipeDetail | null>(buildRecipe({ notes: 'old' }));
+    service.attach(recipeRef);
+    service.saved.set(true);
+
+    service.update('typed');
+
+    expect(service.draft()).toBe('typed');
+    expect(service.saved()).toBe(false);
+  });
+});

--- a/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
@@ -1,0 +1,53 @@
+import { DestroyRef, Injectable, WritableSignal, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { debounceTime, skip } from 'rxjs';
+import { RecipeApiService, RecipeDetail } from '../api';
+
+const NOTES_AUTOSAVE_DEBOUNCE_MS = 400;
+const SAVED_INDICATOR_MS = 2000;
+
+@Injectable()
+export class RecipeNotesAutosaveService {
+  private api = inject(RecipeApiService);
+  private destroyRef = inject(DestroyRef);
+
+  readonly draft = signal('');
+  readonly saved = signal(false);
+  private input = signal('');
+  private recipeRef: WritableSignal<RecipeDetail | null> | null = null;
+
+  constructor() {
+    toObservable(this.input)
+      .pipe(skip(1), debounceTime(NOTES_AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => this.persist(value));
+  }
+
+  attach(recipeRef: WritableSignal<RecipeDetail | null>): void {
+    this.recipeRef = recipeRef;
+    this.draft.set(recipeRef()?.notes ?? '');
+  }
+
+  update(value: string): void {
+    this.draft.set(value);
+    this.saved.set(false);
+    this.input.set(value);
+  }
+
+  private persist(value: string): void {
+    const recipeRef = this.recipeRef;
+    if (!recipeRef) return;
+    const recipe = recipeRef();
+    if (!recipe) return;
+    const trimmed = value.trim();
+    const payload = trimmed.length === 0 ? null : trimmed;
+    if (payload === (recipe.notes ?? null)) return;
+
+    this.api.updateRecipeNotes(recipe.identifier, payload).subscribe({
+      next: () => {
+        recipeRef.set({ ...recipe, notes: payload });
+        this.saved.set(true);
+        setTimeout(() => this.saved.set(false), SAVED_INDICATOR_MS);
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Move notes-autosave (debounced input -> persist -> saved indicator) into a component-scoped `RecipeNotesAutosaveService`
- Drops the `Subject`/`toObservable`/`debounceTime`/`skip` plumbing out of the component, including `takeUntilDestroyed` (no longer needed there)
- Component re-exposes `notesDraft` / `notesSaved` as direct service-signal references, so the template is unchanged
- Component: **291 → 267 lines**

## Trade-off acknowledged
The original audit also called for a `RecipeScalingService` extraction. Skipped — it would wrap two computeds and three trivial increment/decrement methods, no real win and the file is already comfortably under the 300-line cap.

## Test plan
- [x] `yarn nx build recipes` ✅
- [x] `yarn nx test recipes` — 184 tests pass
- [x] Prettier clean

## Follow-up
The service's debounced persist path is currently exercised only through the wider component flow. Direct unit testing requires flushing the `toObservable` effect bridge under `fakeAsync`, which doesn't fire reliably outside a fixture in this test setup. Worth revisiting once we have a generic helper for that — not in scope for this PR.