### PR TITLE
test(shared): bump Eventually default timeout from 15s to 30s

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -15,13 +15,16 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 /// </summary>
 public static class Eventually
 {
-	// 15s is a deliberate trade between fast feedback and tolerance for
+	// 30s is a deliberate trade between fast feedback and tolerance for
 	// suite-wide load. Wolverine handlers race the polling assert; with the
-	// full integration suite running, RabbitMQ + projection workers can stack
-	// up enough that a single check-off event needs more than 5s to surface
-	// in the read model. 15s leaves headroom without making a real failure
-	// (a handler bug that never converges) feel sluggish.
-	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
+	// full integration suite running on a cold GitHub Actions runner,
+	// RabbitMQ + projection workers can stack up enough that a single
+	// check-off event needs >15s to surface in the read model — see
+	// issue #606 for the recurrence trail. 30s leaves headroom without
+	// making a real failure (a handler bug that never converges) feel
+	// sluggish; a converging handler typically wins on the first or second
+	// poll, so the timeout is only paid on genuine breakage.
+	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 	private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
 
 	public static async Task AssertAsync(


### PR DESCRIPTION
## Summary
- Mitigation for issue #606 — shopping integration tests have flaked on three consecutive PRs (#604, #605, #607) on the same projection-convergence assertion
- Bumps the `Eventually.AssertAsync` default timeout from 15s to 30s
- Updated the comment to reference #606 and acknowledge this is a band-aid; the root-cause work (synchronous projection-wait hook) remains in #606

## Why now
PR #607 hit the same flake on the initial run AND the rerun, blocking otherwise-green frontend work.

## Risk
Minimal — a converging handler still wins on the first or second poll (interval 100ms), so the longer timeout is only paid on genuine breakage. The downside is a single failing handler bug now fails 15s slower, which we can live with.

## Test plan
- [x] No code changes outside the timeout constant + comment
- [ ] CI confirms the flake stops recurring (this PR is the validation)