### PR TITLE
test(shared): cover ActivityApiService and AppConfigService

### DIFF
--- a/client/apps/shell/src/app/shared-auth/app-config.service.spec.ts
+++ b/client/apps/shell/src/app/shared-auth/app-config.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { AppConfigService, getAppConfigGatewayUrl } from '@yumney/shared/auth';
+
+interface AppConfig {
+  keycloakUrl: string;
+  keycloakRealm: string;
+  keycloakClientId: string;
+  gatewayUrl?: string;
+}
+
+const GLOBAL_KEY = '__yumneyAppConfig';
+type ConfigHost = { [GLOBAL_KEY]?: AppConfig };
+
+const fetchedConfig: AppConfig = {
+  keycloakUrl: 'https://kc.example.com',
+  keycloakRealm: 'yumney-prod',
+  keycloakClientId: 'yumney-web',
+  gatewayUrl: 'https://gateway.example.com/',
+};
+
+describe('AppConfigService', () => {
+  let service: AppConfigService;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    delete (globalThis as ConfigHost)[GLOBAL_KEY];
+    originalFetch = globalThis.fetch;
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppConfigService);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete (globalThis as ConfigHost)[GLOBAL_KEY];
+  });
+
+  it('returns the default config when load() has not been called', () => {
+    expect(service.get()).toEqual({
+      keycloakUrl: 'http://localhost:8080',
+      keycloakRealm: 'yumney',
+      keycloakClientId: 'yumney-web',
+    });
+  });
+
+  it('publishes the fetched config on globalThis when load succeeds', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fetchedConfig),
+    } as Response);
+
+    await service.load();
+
+    expect((globalThis as ConfigHost)[GLOBAL_KEY]).toEqual(fetchedConfig);
+    expect(service.get()).toEqual(fetchedConfig);
+  });
+
+  it('falls back to the default config when fetch returns a non-OK response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false } as Response);
+
+    await service.load();
+
+    expect(service.get().keycloakUrl).toBe('http://localhost:8080');
+  });
+
+  it('falls back to the default config when fetch throws', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('network down'));
+
+    await service.load();
+
+    expect(service.get().keycloakUrl).toBe('http://localhost:8080');
+  });
+
+  it('exposes the gateway URL with any trailing slash stripped', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fetchedConfig),
+    } as Response);
+
+    await service.load();
+
+    expect(service.gatewayUrl).toBe('https://gateway.example.com');
+    expect(getAppConfigGatewayUrl()).toBe('https://gateway.example.com');
+  });
+
+  it('returns an empty gateway URL when no config is loaded', () => {
+    expect(getAppConfigGatewayUrl()).toBe('');
+  });
+});

--- a/client/libs/shared/api-client/src/lib/activity-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ActivityApiService } from './activity-api.service';
+import { API_ENDPOINTS } from './api-endpoints';
+import type { RecipeActivityStats, UserActivityPage } from './user-activity';
+
+const mockPage: UserActivityPage = {
+  items: [
+    {
+      type: 'recipe_imported',
+      recipeIdentifier: 'recipe-abc',
+      recipeTitle: 'Pasta Carbonara',
+      occurredAt: '2026-04-15T10:00:00Z',
+    },
+  ],
+  nextCursor: 'cursor-123',
+};
+
+const mockStats: RecipeActivityStats = {
+  cookCount: 3,
+  lastCookedAt: '2026-04-14T18:30:00Z',
+  viewCount: 7,
+};
+
+describe('ActivityApiService', () => {
+  let service: ActivityApiService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(ActivityApiService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  describe('getActivity', () => {
+    it('GETs /users/me/activity without params when no options supplied', () => {
+      service.getActivity().subscribe((result) => {
+        expect(result).toEqual(mockPage);
+      });
+
+      const req = httpTesting.expectOne((r) => r.url === API_ENDPOINTS.users.activity);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toEqual([]);
+      req.flush(mockPage);
+    });
+
+    it('forwards limit, type and cursor as query params when supplied', () => {
+      service
+        .getActivity({ limit: 20, type: 'recipe_cooked', cursor: 'opaque-cursor' })
+        .subscribe((result) => {
+          expect(result).toEqual(mockPage);
+        });
+
+      const req = httpTesting.expectOne((r) => r.url === API_ENDPOINTS.users.activity);
+      expect(req.request.params.get('limit')).toBe('20');
+      expect(req.request.params.get('type')).toBe('recipe_cooked');
+      expect(req.request.params.get('cursor')).toBe('opaque-cursor');
+      req.flush(mockPage);
+    });
+
+    it('omits params that are explicitly undefined', () => {
+      service.getActivity({ limit: 5 }).subscribe();
+
+      const req = httpTesting.expectOne((r) => r.url === API_ENDPOINTS.users.activity);
+      expect(req.request.params.get('limit')).toBe('5');
+      expect(req.request.params.has('type')).toBe(false);
+      expect(req.request.params.has('cursor')).toBe(false);
+      req.flush(mockPage);
+    });
+  });
+
+  describe('getRecipeStats', () => {
+    it('GETs the recipe-scoped stats endpoint', () => {
+      service.getRecipeStats('recipe-xyz').subscribe((result) => {
+        expect(result).toEqual(mockStats);
+      });
+
+      const req = httpTesting.expectOne(API_ENDPOINTS.users.activityRecipeStats('recipe-xyz'));
+      expect(req.request.method).toBe('GET');
+      req.flush(mockStats);
+    });
+  });
+});

--- a/client/libs/shared/auth/src/index.ts
+++ b/client/libs/shared/auth/src/index.ts
@@ -4,6 +4,6 @@ export { authGuard } from './lib/auth.guard';
 export { guestGuard } from './lib/guest.guard';
 export { authInterceptor } from './lib/auth.interceptor';
 export { apiBaseInterceptor } from './lib/api-base.interceptor';
-export { AppConfigService } from './lib/app-config.service';
+export { AppConfigService, getAppConfigGatewayUrl } from './lib/app-config.service';
 export { provideAuth } from './lib/provide-auth';
 export { authStorageFactory } from './lib/auth-storage.factory';


### PR DESCRIPTION
## Summary
Backfill specs for two previously-uncovered shared services.

- **ActivityApiService** (`libs/shared/api-client/...`) — 4 tests covering `getActivity` (no params / all params / partial params) and `getRecipeStats`
- **AppConfigService** (`libs/shared/auth/...`) — 6 tests covering: default fallback, fetch-OK publishes to globalThis, fetch !ok falls back, fetch-throws falls back, trailing-slash stripping in `gatewayUrl` / `getAppConfigGatewayUrl`, empty fallback when nothing loaded
- Exposes `getAppConfigGatewayUrl` via the `@yumney/shared/auth` public barrel — it was already a documented seam for interceptors; the spec is a legitimate second consumer
- The `AppConfigService` spec lives under `apps/shell/src/app/shared-auth/` to follow the existing pattern (`shared-auth` has no test target; specs run through the shell vitest project)

`UserPreferencesService` already has a spec — dropped from the original audit list.

## Test plan
- [x] `yarn nx test shared-api-client` — 43 tests pass (was 39)
- [x] `yarn nx test shell` — 233 tests pass (was 227)
- [x] Prettier clean