### PR TITLE
feat(ui): add ButtonComponent and MessageBannerComponent

### DIFF
--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
@@ -4,7 +4,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (recipe(); as r) {

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -26,6 +26,7 @@ import { LucideAngularModule } from 'lucide-angular';
 import {
   CookingTimerComponent,
   LoadingSpinnerComponent,
+  MessageBannerComponent,
   StepDisplayComponent,
   VoiceIndicatorComponent,
 } from '@yumney/ui';
@@ -41,6 +42,7 @@ const SWIPE_THRESHOLD = 50;
     CookingTimerComponent,
     VoiceIndicatorComponent,
     LoadingSpinnerComponent,
+    MessageBannerComponent,
   ],
   templateUrl: './cook-mode.component.html',
   styleUrl: './cook-mode.component.scss',

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
@@ -48,28 +48,26 @@
     </section>
 
     <div class="dialog-actions">
-      <button
-        type="button"
-        class="btn-secondary"
+      <yn-button
+        variant="secondary"
+        testId="create-shopping-list-cancel"
         [disabled]="isCreating()"
         (click)="onCancel()"
-        data-testid="create-shopping-list-cancel"
       >
         {{ t('recipes.detail.createShoppingList.cancel') }}
-      </button>
-      <button
-        type="button"
-        class="btn-primary"
+      </yn-button>
+      <yn-button
+        variant="primary"
+        testId="create-shopping-list-confirm"
         [disabled]="isCreating()"
         (click)="onConfirm()"
-        data-testid="create-shopping-list-confirm"
       >
         {{
           isCreating()
             ? t('recipes.detail.createShoppingList.creating')
             : t('recipes.detail.createShoppingList.confirm')
         }}
-      </button>
+      </yn-button>
     </div>
   </div>
 </div>

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
@@ -8,10 +8,11 @@ import {
 } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import type { ScalableIngredient } from '@yumney/shared/models';
+import { ButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-create-shopping-list-dialog',
-  imports: [TranslocoModule],
+  imports: [TranslocoModule, ButtonComponent],
   templateUrl: './create-shopping-list-dialog.component.html',
   styleUrl: './create-shopping-list-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -6,7 +6,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (recipe(); as recipe) {
@@ -150,28 +150,27 @@
       <a class="btn-cook" [routerLink]="ROUTES.recipes.cook(recipe.identifier)">
         {{ t('recipes.detail.actions.startCooking') }}
       </a>
-      <a class="btn-primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
+      <yn-button variant="primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
-      </a>
-      <button
-        class="btn-danger"
-        data-testid="recipe-delete-btn"
+      </yn-button>
+      <yn-button
+        variant="danger"
+        testId="recipe-delete-btn"
         [disabled]="isDeleting()"
         (click)="onDelete()"
       >
         {{
           isDeleting() ? t('recipes.detail.delete.deleting') : t('recipes.detail.actions.delete')
         }}
-      </button>
-      <button
-        type="button"
-        class="btn-secondary"
-        data-testid="recipe-create-shopping-list-btn"
+      </yn-button>
+      <yn-button
+        variant="secondary"
+        testId="recipe-create-shopping-list-btn"
         [disabled]="isCreatingShoppingList()"
         (click)="onCreateShoppingList()"
       >
         {{ t('recipes.detail.actions.shoppingList') }}
-      </button>
+      </yn-button>
     </div>
 
     <section class="ingredients-section">
@@ -215,18 +214,17 @@
       <a class="btn-cook" [routerLink]="ROUTES.recipes.cook(recipe.identifier)">
         {{ t('recipes.detail.actions.startCooking') }}
       </a>
-      <a class="btn-primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
+      <yn-button variant="primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
-      </a>
-      <button
-        type="button"
-        class="btn-secondary"
-        data-testid="recipe-create-shopping-list-btn"
+      </yn-button>
+      <yn-button
+        variant="secondary"
+        testId="recipe-create-shopping-list-btn"
         [disabled]="isCreatingShoppingList()"
         (click)="onCreateShoppingList()"
       >
         {{ t('recipes.detail.actions.shoppingList') }}
-      </button>
+      </yn-button>
     </div>
 
     @if (showDeleteConfirm()) {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -29,9 +29,11 @@ import {
 } from '@yumney/shared/models';
 import {
   BackLinkComponent,
+  ButtonComponent,
   ConfirmDialogComponent,
   FavoriteButtonComponent,
   LoadingSpinnerComponent,
+  MessageBannerComponent,
   StarRatingComponent,
 } from '@yumney/ui';
 import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog/create-shopping-list-dialog.component';
@@ -42,10 +44,12 @@ import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog
     FormsModule,
     TranslocoModule,
     RouterLink,
+    ButtonComponent,
     ConfirmDialogComponent,
     CreateShoppingListDialogComponent,
     BackLinkComponent,
     LoadingSpinnerComponent,
+    MessageBannerComponent,
     FavoriteButtonComponent,
     StarRatingComponent,
   ],

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.html
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.html
@@ -6,7 +6,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (recipeData(); as recipe) {

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -21,6 +21,7 @@ import {
   BackLinkComponent,
   ConfirmDialogComponent,
   LoadingSpinnerComponent,
+  MessageBannerComponent,
   RecipePreviewComponent,
 } from '@yumney/ui';
 
@@ -31,6 +32,7 @@ import {
     BackLinkComponent,
     ConfirmDialogComponent,
     LoadingSpinnerComponent,
+    MessageBannerComponent,
     RecipePreviewComponent,
   ],
   templateUrl: './recipe-edit.component.html',

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
@@ -20,11 +20,7 @@
         <yn-loading-spinner label="recipes.list.multiSelect.preview.loading" />
       </div>
     } @else {
-      <section
-        class="dialog-recipes"
-        aria-labelledby="multi-preview-recipes-heading"
-        data-testid="multi-recipe-preview-recipes"
-      >
+      <section class="dialog-recipes" aria-labelledby="multi-preview-recipes-heading" data-testid="multi-recipe-preview-recipes">
         <h3 id="multi-preview-recipes-heading" class="section-heading">
           {{ t('recipes.list.multiSelect.preview.recipesHeading') }}
         </h3>
@@ -33,11 +29,7 @@
             <li class="recipe-row">
               <span class="recipe-row-title">{{ recipe.title }}</span>
               <div class="servings-control">
-                <button
-                  type="button"
-                  class="servings-button"
-                  data-testid="multi-recipe-decrease-servings"
-                  [disabled]="recipe.desiredServings <= 1"
+                <button type="button" class="servings-button" data-testid="multi-recipe-decrease-servings" [disabled]="recipe.desiredServings <= 1"
                   [attr.aria-label]="
                     t('recipes.list.multiSelect.preview.decreaseAriaLabel', {
                       title: recipe.title,
@@ -73,11 +65,7 @@
         </ul>
       </section>
 
-      <section
-        class="dialog-merged"
-        aria-labelledby="multi-preview-merged-heading"
-        data-testid="multi-recipe-preview-merged"
-      >
+      <section class="dialog-merged" aria-labelledby="multi-preview-merged-heading" data-testid="multi-recipe-preview-merged">
         <h3 id="multi-preview-merged-heading" class="section-heading">
           {{
             t('recipes.list.multiSelect.preview.mergedHeading', {
@@ -105,22 +93,10 @@
     }
 
     <div class="dialog-actions">
-      <button
-        type="button"
-        class="btn-secondary"
-        [disabled]="isCreating()"
-        (click)="onCancel()"
-        data-testid="multi-recipe-preview-cancel"
-      >
+      <button type="button" class="btn-secondary" [disabled]="isCreating()" (click)="onCancel()" data-testid="multi-recipe-preview-cancel">
         {{ t('recipes.list.multiSelect.preview.cancel') }}
       </button>
-      <button
-        type="button"
-        class="btn-primary"
-        [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0"
-        (click)="onConfirm()"
-        data-testid="multi-recipe-preview-confirm"
-      >
+      <button type="button" class="btn-primary" [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0" (click)="onConfirm()" data-testid="multi-recipe-preview-confirm">
         {{
           isCreating()
             ? t('recipes.list.multiSelect.preview.creating')

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
@@ -93,16 +93,16 @@
     }
 
     <div class="dialog-actions">
-      <button type="button" class="btn-secondary" [disabled]="isCreating()" (click)="onCancel()" data-testid="multi-recipe-preview-cancel">
+      <yn-button variant="secondary" testId="multi-recipe-preview-cancel" [disabled]="isCreating()" (click)="onCancel()">
         {{ t('recipes.list.multiSelect.preview.cancel') }}
-      </button>
-      <button type="button" class="btn-primary" [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0" (click)="onConfirm()" data-testid="multi-recipe-preview-confirm">
+      </yn-button>
+      <yn-button variant="primary" testId="multi-recipe-preview-confirm" [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0" (click)="onConfirm()">
         {{
           isCreating()
             ? t('recipes.list.multiSelect.preview.creating')
             : t('recipes.list.multiSelect.preview.confirm')
         }}
-      </button>
+      </yn-button>
     </div>
   </div>
 </div>

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
@@ -1,18 +1,6 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  HostListener,
-  computed,
-  input,
-  output,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, HostListener, computed, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  mergeRecipeIngredients,
-  type MergedIngredient,
-  type RecipeForMerge,
-  type ScalableIngredient,
-} from '@yumney/shared/models';
+import { mergeRecipeIngredients, type MergedIngredient, type RecipeForMerge, type ScalableIngredient } from '@yumney/shared/models';
 import { LoadingSpinnerComponent } from '@yumney/ui';
 
 export interface MultiRecipeSelection {

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, HostListener, computed, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { mergeRecipeIngredients, type MergedIngredient, type RecipeForMerge, type ScalableIngredient } from '@yumney/shared/models';
-import { LoadingSpinnerComponent } from '@yumney/ui';
+import { ButtonComponent, LoadingSpinnerComponent } from '@yumney/ui';
 
 export interface MultiRecipeSelection {
   identifier: string;
@@ -13,7 +13,7 @@ export interface MultiRecipeSelection {
 
 @Component({
   selector: 'yn-multi-recipe-preview-dialog',
-  imports: [TranslocoModule, LoadingSpinnerComponent],
+  imports: [TranslocoModule, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './multi-recipe-preview-dialog.component.html',
   styleUrl: './multi-recipe-preview-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -82,7 +82,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (!isLoading() && recipes().length === 0 && !serverError()) {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -24,6 +24,7 @@ import {
   EMPTY_FILTER,
   FilterPanelComponent,
   InfiniteScrollDirective,
+  MessageBannerComponent,
   type RecipeFilterValue,
   StaggerNewItemsDirective,
 } from '@yumney/ui';
@@ -47,6 +48,7 @@ interface SortOption extends SortMenuOption {
     InfiniteScrollDirective,
     StaggerNewItemsDirective,
     FilterPanelComponent,
+    MessageBannerComponent,
     RecipeCardComponent,
     SortMenuComponent,
     MultiRecipePreviewDialogComponent,

--- a/client/apps/shell/src/app/app.ts
+++ b/client/apps/shell/src/app/app.ts
@@ -1,25 +1,13 @@
 import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { RouterModule } from '@angular/router';
-import {
-  ChatPanelComponent,
-  CommandFabComponent,
-  HeaderComponent,
-  ToastHostComponent,
-} from '@yumney/ui';
+import { ChatPanelComponent, CommandFabComponent, HeaderComponent, ToastHostComponent } from '@yumney/ui';
 import { ChatStateService } from '@yumney/shared/models';
 import { OfflineIndicatorComponent } from './layout/offline-indicator';
 import { filter } from 'rxjs';
 
 @Component({
-  imports: [
-    RouterModule,
-    HeaderComponent,
-    ChatPanelComponent,
-    CommandFabComponent,
-    OfflineIndicatorComponent,
-    ToastHostComponent,
-  ],
+  imports: [RouterModule, HeaderComponent, ChatPanelComponent, CommandFabComponent, OfflineIndicatorComponent, ToastHostComponent],
   selector: 'yn-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',
@@ -32,8 +20,6 @@ export class App implements OnInit {
   ngOnInit(): void {
     if (!this.swUpdate.isEnabled) return;
 
-    this.swUpdate.versionUpdates
-      .pipe(filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
-      .subscribe(() => document.location.reload());
+    this.swUpdate.versionUpdates.pipe(filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY')).subscribe(() => document.location.reload());
   }
 }

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -8,9 +8,7 @@
         <h2>{{ t('auth.register.success.title') }}</h2>
         <p>{{ t('auth.register.success.message') }}</p>
         <p class="resend-link">
-          <a [routerLink]="ROUTES.auth.resendVerification">{{
-            t('auth.register.success.resendLink')
-          }}</a>
+          <a [routerLink]="ROUTES.auth.resendVerification">{{ t('auth.register.success.resendLink') }}</a>
         </p>
       </div>
     } @else {
@@ -29,13 +27,7 @@
             maxlength: 'auth.register.errors.emailMaxLength',
           }"
         >
-          <input
-            id="email"
-            type="email"
-            formControlName="email"
-            autocomplete="email"
-            [placeholder]="t('auth.register.emailPlaceholder')"
-          />
+          <input id="email" type="email" formControlName="email" autocomplete="email" [placeholder]="t('auth.register.emailPlaceholder')"/>
         </yn-form-field>
 
         <yn-form-field
@@ -47,13 +39,7 @@
             maxlength: 'auth.register.errors.displayNameMaxLength',
           }"
         >
-          <input
-            id="displayName"
-            type="text"
-            formControlName="displayName"
-            autocomplete="name"
-            [placeholder]="t('auth.register.displayNamePlaceholder')"
-          />
+          <input id="displayName" type="text" formControlName="displayName" autocomplete="name" [placeholder]="t('auth.register.displayNamePlaceholder')"/>
         </yn-form-field>
 
         <yn-form-field
@@ -66,12 +52,7 @@
             pattern: 'auth.register.errors.passwordPattern',
           }"
         >
-          <input
-            id="password"
-            type="password"
-            formControlName="password"
-            autocomplete="new-password"
-          />
+          <input id="password" type="password" formControlName="password" autocomplete="new-password"/>
         </yn-form-field>
 
         <yn-form-field
@@ -82,19 +63,10 @@
           [group]="form"
           [groupErrors]="{ passwordsMismatch: 'auth.register.errors.passwordsMismatch' }"
         >
-          <input
-            id="confirmPassword"
-            type="password"
-            formControlName="confirmPassword"
-            autocomplete="new-password"
-          />
+          <input id="confirmPassword" type="password" formControlName="confirmPassword" autocomplete="new-password"/>
         </yn-form-field>
 
-        <yn-submit-button
-          [loading]="isLoading()"
-          label="auth.register.submit"
-          loadingLabel="auth.register.submitting"
-        />
+        <yn-submit-button [loading]="isLoading()" label="auth.register.submit" loadingLabel="auth.register.submitting"/>
       </form>
     }
   </div>

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -14,7 +14,7 @@
     } @else {
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
         @if (serverError(); as error) {
-          <div class="error-banner" role="alert">{{ t(error) }}</div>
+          <yn-message-banner tone="error" [message]="error"/>
         }
 
         <yn-form-field

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -11,11 +11,11 @@ import {
   ERROR_MAPS,
   ROUTES,
 } from '@yumney/shared/models';
-import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
+import { FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-register',
-  imports: [ReactiveFormsModule, TranslocoModule, RouterLink, FormFieldComponent, SubmitButtonComponent],
+  imports: [ReactiveFormsModule, TranslocoModule, RouterLink, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -15,13 +15,7 @@ import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-register',
-  imports: [
-    ReactiveFormsModule,
-    TranslocoModule,
-    RouterLink,
-    FormFieldComponent,
-    SubmitButtonComponent,
-  ],
+  imports: [ReactiveFormsModule, TranslocoModule, RouterLink, FormFieldComponent, SubmitButtonComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
@@ -11,7 +11,7 @@
     } @else {
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
         @if (serverError(); as error) {
-          <div class="error-banner" role="alert">{{ t(error) }}</div>
+          <yn-message-banner tone="error" [message]="error"/>
         }
 
         <yn-form-field

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
@@ -24,20 +24,10 @@
             maxlength: 'auth.resendVerification.errors.emailMaxLength',
           }"
         >
-          <input
-            id="email"
-            type="email"
-            formControlName="email"
-            autocomplete="email"
-            [placeholder]="t('auth.resendVerification.emailPlaceholder')"
-          />
+          <input id="email" type="email"formControlName="email" autocomplete="email" [placeholder]="t('auth.resendVerification.emailPlaceholder')"/>
         </yn-form-field>
 
-        <yn-submit-button
-          [loading]="isLoading()"
-          label="auth.resendVerification.submit"
-          loadingLabel="auth.resendVerification.submitting"
-        />
+        <yn-submit-button [loading]="isLoading()" label="auth.resendVerification.submit" loadingLabel="auth.resendVerification.submitting"/>
       </form>
     }
 

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
@@ -10,7 +10,7 @@ import {
   ERROR_MAPS,
   ROUTES,
 } from '@yumney/shared/models';
-import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
+import { FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-resend-verification',
@@ -19,6 +19,7 @@ import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
     TranslocoModule,
     RouterLink,
     FormFieldComponent,
+    MessageBannerComponent,
     SubmitButtonComponent,
   ],
   templateUrl: './resend-verification.component.html',

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -25,80 +25,38 @@
       <h2>{{ t('dashboard.suggestions.title') }}</h2>
       <div class="suggestions-scroll">
         @for (s of suggestions()!.suggestions; track s.recipeIdentifier) {
-          <yn-suggestion-card
-            [identifier]="s.recipeIdentifier"
-            [title]="s.title"
-            [imageUrl]="s.imageUrl"
-            [prepTimeMinutes]="s.prepTimeMinutes"
-            [reason]="s.reason"
-          />
+          <yn-suggestion-card [identifier]="s.recipeIdentifier" [title]="s.title" [imageUrl]="s.imageUrl" [prepTimeMinutes]="s.prepTimeMinutes" [reason]="s.reason"/>
         }
       </div>
     </section>
   }
 
-  <section
-    class="import-section"
-    data-testid="import-section"
-    [class.expanded]="importSectionExpanded()"
-  >
-    <button
-      class="import-toggle"
-      data-testid="import-toggle"
-      [attr.data-expanded]="importSectionExpanded()"
-      (click)="toggleImportSection()"
-    >
+  <section class="import-section" data-testid="import-section" [class.expanded]="importSectionExpanded()">
+    <button class="import-toggle" data-testid="import-toggle" [attr.data-expanded]="importSectionExpanded()" (click)="toggleImportSection()">
       <h2>{{ t('dashboard.import.sectionTitle') }}</h2>
-      <span class="toggle-chevron" [class.open]="importSectionExpanded()"
-        ><lucide-icon name="chevron-down" [size]="18"
-      /></span>
+      <span class="toggle-chevron" [class.open]="importSectionExpanded()">
+        <lucide-icon name="chevron-down" [size]="18"/>
+      </span>
     </button>
 
     @if (importSectionExpanded()) {
       <div class="import-content">
-        <yn-url-import
-          [isSaving]="isSaving()"
-          (importStarted)="onUrlImportStarted()"
-          (extracted)="onUrlExtracted($event)"
-          (failed)="onUrlImportFailed($event)"
-        />
+        <yn-url-import [isSaving]="isSaving()" (importStarted)="onUrlImportStarted()" (extracted)="onUrlExtracted($event)" (failed)="onUrlImportFailed($event)"/>
 
         <section class="photo-import">
           <h3>{{ t('dashboard.photoImport.title') }}</h3>
           <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
           <div class="photo-import-actions">
             @if (camera.cameraSupported()) {
-              <button
-                type="button"
-                class="btn-dashed"
-                [disabled]="isLoading() || isSaving()"
-                (click)="onOpenCamera()"
-              >
+              <button type="button"class="btn-dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
                 {{ t('dashboard.photoImport.scanRecipe') }}
               </button>
-              <button
-                type="button"
-                class="btn-dashed"
-                [disabled]="isLoading() || isSaving()"
-                (click)="onOpenScanner()"
-              >
+              <button type="button" class="btn-dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
                 {{ t('dashboard.photoImport.scanIngredients') }}
               </button>
             }
-            <label
-              class="btn-dashed"
-              data-testid="photo-upload-btn"
-              [class.disabled]="isLoading() || isSaving()"
-            >
-              <input
-                type="file"
-                data-testid="photo-upload-input"
-                accept="image/jpeg,image/png,image/webp"
-                multiple
-                [disabled]="isLoading() || isSaving()"
-                (change)="onImportFromPhotos($event)"
-                hidden
-              />
+            <label class="btn-dashed" data-testid="photo-upload-btn" [class.disabled]="isLoading() || isSaving()">
+              <input type="file" data-testid="photo-upload-input" accept="image/jpeg,image/png,image/webp" multiple [disabled]="isLoading() || isSaving()" (change)="onImportFromPhotos($event)" hidden/>
               @if (isLoading()) {
                 <span class="btn-spinner"></span>
                 <span>{{ t('dashboard.photoImport.extracting') }}</span>
@@ -113,13 +71,7 @@
         <section class="manual-create">
           <h3>{{ t('dashboard.create.title') }}</h3>
           <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
-          <button
-            type="button"
-            class="btn-dashed create-btn"
-            data-testid="create-recipe-btn"
-            [disabled]="isLoading() || isSaving() || extractedRecipe()"
-            (click)="onCreateManually()"
-          >
+          <button type="button" class="btn-dashed create-btn" data-testid="create-recipe-btn" [disabled]="isLoading() || isSaving() || extractedRecipe()" (click)="onCreateManually()">
             {{ t('dashboard.create.submit') }}
           </button>
         </section>
@@ -132,51 +84,32 @@
       <div class="success-banner" data-testid="success-banner">
         {{ t('dashboard.save.success', { title: saveSuccess() }) }}
       </div>
-      <button
-        class="btn-ghost import-another"
-        (click)="onDiscardRecipe(); importSectionExpanded.set(true)"
-      >
+      <button class="btn-ghost import-another" (click)="onDiscardRecipe(); importSectionExpanded.set(true)">
         {{ t('dashboard.save.importAnother') }}
       </button>
     </div>
   }
   @if (extractedRecipe()) {
-    <yn-recipe-preview
-      [recipe]="extractedRecipe()!"
-      [isSaving]="isSaving()"
-      [previewTitle]="isManualEntry() ? t('dashboard.create.previewTitle') : undefined"
-      (save)="onSaveRecipe($event)"
-      (discard)="onDiscardRecipe()"
-    />
+    <yn-recipe-preview [recipe]="extractedRecipe()!" [isSaving]="isSaving()" [previewTitle]="isManualEntry() ? t('dashboard.create.previewTitle') : undefined" (save)="onSaveRecipe($event)" (discard)="onDiscardRecipe()"/>
   }
 
   @if (recentActivity().length > 0) {
-    <yn-recent-activity [activities]="recentActivity()" />
+    <yn-recent-activity [activities]="recentActivity()"/>
   }
 
   @if (cameraActive()) {
     @defer {
-      <yn-camera-capture
-        (capturedReady)="onCameraCaptured($event)"
-        (cancelled)="onCameraCancelled()"
-        (fallbackRequested)="onCameraFallback()"
-      />
+      <yn-camera-capture (capturedReady)="onCameraCaptured($event)" (cancelled)="onCameraCancelled()" (fallbackRequested)="onCameraFallback()"/>
     }
   }
 
   @if (scannerActive()) {
     @defer {
-      <yn-ingredient-scanner
-        (ingredientsConfirmed)="onIngredientsConfirmed($event)"
-        (cancelled)="onScannerCancelled()"
-      />
+      <yn-ingredient-scanner (ingredientsConfirmed)="onIngredientsConfirmed($event)" (cancelled)="onScannerCancelled()"/>
     }
   }
 
   @if (recognizedIngredients(); as ingredients) {
-    <yn-ingredients-toast
-      [ingredients]="ingredients"
-      (dismissed)="dismissRecognizedIngredients()"
-    />
+    <yn-ingredients-toast [ingredients]="ingredients" (dismissed)="dismissRecognizedIngredients()"/>
   }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -7,7 +7,7 @@
   <p>{{ t('dashboard.welcome') }}</p>
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (quickActions().length > 0) {
@@ -48,12 +48,12 @@
           <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
           <div class="photo-import-actions">
             @if (camera.cameraSupported()) {
-              <button type="button"class="btn-dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
                 {{ t('dashboard.photoImport.scanRecipe') }}
-              </button>
-              <button type="button" class="btn-dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
+              </yn-button>
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
                 {{ t('dashboard.photoImport.scanIngredients') }}
-              </button>
+              </yn-button>
             }
             <label class="btn-dashed" data-testid="photo-upload-btn" [class.disabled]="isLoading() || isSaving()">
               <input type="file" data-testid="photo-upload-input" accept="image/jpeg,image/png,image/webp" multiple [disabled]="isLoading() || isSaving()" (change)="onImportFromPhotos($event)" hidden/>
@@ -71,22 +71,20 @@
         <section class="manual-create">
           <h3>{{ t('dashboard.create.title') }}</h3>
           <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
-          <button type="button" class="btn-dashed create-btn" data-testid="create-recipe-btn" [disabled]="isLoading() || isSaving() || extractedRecipe()" (click)="onCreateManually()">
+          <yn-button variant="dashed" extraClass="create-btn" testId="create-recipe-btn" [disabled]="isLoading() || isSaving() || !!extractedRecipe()" (click)="onCreateManually()">
             {{ t('dashboard.create.submit') }}
-          </button>
+          </yn-button>
         </section>
       </div>
     }
   </section>
 
-  @if (saveSuccess()) {
-    <div class="save-success" role="status" aria-live="polite">
-      <div class="success-banner" data-testid="success-banner">
-        {{ t('dashboard.save.success', { title: saveSuccess() }) }}
-      </div>
-      <button class="btn-ghost import-another" (click)="onDiscardRecipe(); importSectionExpanded.set(true)">
+  @if (saveSuccess(); as savedTitle) {
+    <div class="save-success">
+      <yn-message-banner tone="success" message="dashboard.save.success" [params]="{ title: savedTitle }" testId="success-banner"/>
+      <yn-button variant="ghost" extraClass="import-another" (click)="onDiscardRecipe(); importSectionExpanded.set(true)">
         {{ t('dashboard.save.importAnother') }}
-      </button>
+      </yn-button>
     </div>
   }
   @if (extractedRecipe()) {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -5,12 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
 import { setupTranslocoTesting } from '@yumney/shared/models';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  SavedRecipeResponse,
-  DashboardApiService,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse, SavedRecipeResponse, DashboardApiService} from '@yumney/shared/api-client';
 
 const mockRecipe: ImportRecipeResponse = {
   title: 'Pasta Carbonara',

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -19,14 +19,16 @@ import {
 } from '@yumney/shared/models';
 import { LucideAngularModule } from 'lucide-angular';
 import {
-  RecipePreviewComponent,
-  QuickActionsComponent,
-  SuggestionCardComponent,
-  RecentActivityComponent,
+  ButtonComponent,
   CameraCaptureComponent,
   IngredientScannerComponent,
-  ShareToastComponent,
   IngredientsToastComponent,
+  MessageBannerComponent,
+  QuickActionsComponent,
+  RecentActivityComponent,
+  RecipePreviewComponent,
+  ShareToastComponent,
+  SuggestionCardComponent,
 } from '@yumney/ui';
 import { CameraService } from '@yumney/shared/models';
 import type { RecognizedIngredient } from '@yumney/shared/api-client';
@@ -39,6 +41,8 @@ import { DashboardSuggestionsService } from './dashboard-suggestions.service';
     TranslocoModule,
     LucideAngularModule,
     UrlImportComponent,
+    ButtonComponent,
+    MessageBannerComponent,
     RecipePreviewComponent,
     QuickActionsComponent,
     SuggestionCardComponent,

--- a/client/apps/shell/src/app/dashboard/url-import.component.html
+++ b/client/apps/shell/src/app/dashboard/url-import.component.html
@@ -13,22 +13,10 @@
           invalidUrl: 'dashboard.import.errors.urlInvalid',
         }"
       >
-        <input
-          id="url"
-          type="url"
-          formControlName="url"
-          [placeholder]="t('dashboard.import.placeholder')"
-          [attr.aria-label]="t('dashboard.import.urlLabel')"
-        />
+        <input id="url" type="url" formControlName="url" [placeholder]="t('dashboard.import.placeholder')" [attr.aria-label]="t('dashboard.import.urlLabel')"/>
       </yn-form-field>
 
-      <yn-submit-button
-        [loading]="isLoading()"
-        [disabled]="isSaving()"
-        label="dashboard.import.submit"
-        loadingLabel="dashboard.import.submitting"
-        [showSpinner]="true"
-      />
+      <yn-submit-button [loading]="isLoading()" [disabled]="isSaving()" label="dashboard.import.submit" loadingLabel="dashboard.import.submitting" [showSpinner]="true"/>
     </div>
   </form>
 

--- a/client/apps/shell/src/app/dashboard/url-import.component.ts
+++ b/client/apps/shell/src/app/dashboard/url-import.component.ts
@@ -1,20 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  signal,
-  inject,
-  DestroyRef,
-  output,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef, output, input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  ImportStreamEvent,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse, ImportStreamEvent } from '@yumney/shared/api-client';
 import { urlValidator, VALIDATION, ensureFormValid } from '@yumney/shared/models';
 import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
 

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -1,31 +1,15 @@
 <div class="meal-planner" *transloco="let t">
   <div class="planner-header">
-    <button
-      class="nav-btn"
-      data-testid="meal-planner-nav-prev"
-      (click)="onPreviousWeek()"
-      [attr.aria-label]="t('mealPlanner.previousWeek')"
-    >
+    <button class="nav-btn" data-testid="meal-planner-nav-prev" (click)="onPreviousWeek()" [attr.aria-label]="t('mealPlanner.previousWeek')">
       <lucide-icon name="chevron-left" [size]="20" />
     </button>
     <h1>{{ weekLabel() }}</h1>
-    <button
-      class="nav-btn"
-      data-testid="meal-planner-nav-next"
-      (click)="onNextWeek()"
-      [attr.aria-label]="t('mealPlanner.nextWeek')"
-    >
+    <button class="nav-btn" data-testid="meal-planner-nav-next" (click)="onNextWeek()" [attr.aria-label]="t('mealPlanner.nextWeek')">
       <lucide-icon name="chevron-right" [size]="20" />
     </button>
   </div>
 
-  <yn-async-state
-    [loading]="loading()"
-    [error]="error()"
-    loadingKey="mealPlanner.loading"
-    retryKey="mealPlanner.retry"
-    (retry)="onRetry()"
-  />
+  <yn-async-state [loading]="loading()" [error]="error()" loadingKey="mealPlanner.loading" retryKey="mealPlanner.retry" (retry)="onRetry()"/>
 
   @if (hasRecipeSlots()) {
     <div class="planner-actions">
@@ -48,11 +32,7 @@
 
   <div class="week-grid">
     @for (entry of dinnerSlots(); track entry.day) {
-      <div
-        class="day-card"
-        [class.today]="isToday(entry.day)"
-        [class.has-meal]="entry.slot && !entry.slot.isEmpty"
-      >
+      <div class="day-card" [class.today]="isToday(entry.day)" [class.has-meal]="entry.slot && !entry.slot.isEmpty">
         <div class="day-header">{{ entry.day }}</div>
 
         @if (entry.slot && !entry.slot.isEmpty) {
@@ -78,11 +58,7 @@
               </div>
             }
 
-            <button
-              class="clear-btn"
-              (click)="onClearSlot(entry.day)"
-              [attr.aria-label]="t('mealPlanner.clearSlot')"
-            >
+            <button class="clear-btn" (click)="onClearSlot(entry.day)" [attr.aria-label]="t('mealPlanner.clearSlot')">
               <lucide-icon name="x" [size]="14" />
             </button>
           </div>

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -1,22 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  DestroyRef,
-  ElementRef,
-  HostListener,
-  inject,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, ElementRef, HostListener, inject, signal, computed } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  MealPlanApiService,
-  type WeeklyPlan,
-  type MealSlot,
-  type GenerateShoppingListResult,
-} from '@yumney/shared/api-client';
+import { MealPlanApiService, type WeeklyPlan, type MealSlot, type GenerateShoppingListResult } from '@yumney/shared/api-client';
 import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
@@ -48,18 +34,11 @@ export class MealPlannerComponent {
   protected weekNumber = signal(this.getCurrentWeek());
   protected plan = signal<WeeklyPlan | null>(null);
   protected loading = this.loadState.isLoading;
-  protected error = computed(
-    () =>
-      this.loadState.serverError() ??
-      this.generateState.serverError() ??
-      this.clearSlotState.serverError(),
-  );
+  protected error = computed(() => this.loadState.serverError() ?? this.generateState.serverError() ?? this.clearSlotState.serverError());
   protected generatingList = this.generateState.isLoading;
   protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
-  protected weekLabel = computed(
-    () => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`,
-  );
+  protected weekLabel = computed(() => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`);
 
   protected days = DAY_NAMES;
 

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.html
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.html
@@ -6,7 +6,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (recipe(); as recipe) {

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -12,11 +12,11 @@ import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '../api';
 import { ShoppingApiService, CreateShoppingListItem } from '../api';
 import { createAsyncState, ERROR_MAPS, ROUTES, VALIDATION } from '@yumney/shared/models';
-import { BackLinkComponent, LoadingSpinnerComponent } from '@yumney/ui';
+import { BackLinkComponent, LoadingSpinnerComponent, MessageBannerComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-shopping-create',
-  imports: [TranslocoModule, BackLinkComponent, LoadingSpinnerComponent],
+  imports: [TranslocoModule, BackLinkComponent, LoadingSpinnerComponent, MessageBannerComponent],
   templateUrl: './shopping-create.component.html',
   styleUrl: './shopping-create.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
@@ -6,7 +6,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (shoppingList(); as list) {
@@ -23,21 +23,20 @@
     </div>
 
     <div class="actions">
-      <button class="btn-secondary" (click)="onCheckAll()">
+      <yn-button variant="secondary" (click)="onCheckAll()">
         {{ t('shopping.detail.checkAll') }}
-      </button>
-      <button class="btn-secondary" (click)="onReset()">
+      </yn-button>
+      <yn-button variant="secondary" (click)="onReset()">
         {{ t('shopping.detail.reset') }}
-      </button>
-      <button
-        type="button"
-        class="btn-secondary"
-        data-testid="send-to-bring-btn"
+      </yn-button>
+      <yn-button
+        variant="secondary"
+        testId="send-to-bring-btn"
         [disabled]="uncheckedItems().length === 0"
         (click)="onSendToBring()"
       >
         {{ t('shopping.detail.bring.sendButton') }}
-      </button>
+      </yn-button>
     </div>
 
     @if (checkedCount() === totalItemCount() && totalItemCount() > 0) {

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -23,9 +23,11 @@ import {
 } from '@yumney/shared/models';
 import {
   BackLinkComponent,
+  ButtonComponent,
   CategorySectionComponent,
   CategoryKey,
   LoadingSpinnerComponent,
+  MessageBannerComponent,
 } from '@yumney/ui';
 
 const CATEGORY_ORDER: readonly CategoryKey[] = [
@@ -53,7 +55,9 @@ const BRING_LAUNCH_PROBE_MS = 1500;
     TranslocoModule,
     RouterLink,
     BackLinkComponent,
+    ButtonComponent,
     LoadingSpinnerComponent,
+    MessageBannerComponent,
     CategorySectionComponent,
   ],
   templateUrl: './shopping-detail.component.html',

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
@@ -6,7 +6,7 @@
   }
 
   @if (serverError(); as error) {
-    <div class="error-banner" role="alert">{{ t(error) }}</div>
+    <yn-message-banner tone="error" [message]="error"/>
   }
 
   @if (!isLoading() && !serverError()) {

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
@@ -11,11 +11,11 @@ import { DatePipe } from '@angular/common';
 import { TranslocoModule } from '@jsverse/transloco';
 import { ShoppingApiService, ShoppingListSummary } from '../api';
 import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
-import { LoadingSpinnerComponent } from '@yumney/ui';
+import { LoadingSpinnerComponent, MessageBannerComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-shopping-list',
-  imports: [TranslocoModule, RouterLink, DatePipe, LoadingSpinnerComponent],
+  imports: [TranslocoModule, RouterLink, DatePipe, LoadingSpinnerComponent, MessageBannerComponent],
   templateUrl: './shopping-list.component.html',
   styleUrl: './shopping-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -1,5 +1,14 @@
 export { BackLinkComponent } from './lib/back-link/back-link.component';
+export {
+  ButtonComponent,
+  type ButtonVariant,
+  type ButtonType,
+} from './lib/button/button.component';
 export { FormFieldComponent } from './lib/form-field/form-field.component';
+export {
+  MessageBannerComponent,
+  type MessageBannerTone,
+} from './lib/message-banner/message-banner.component';
 export { SubmitButtonComponent } from './lib/submit-button/submit-button.component';
 export { RecipePreviewComponent } from './lib/recipe-preview/recipe-preview.component';
 export { EditableListItemComponent } from './lib/editable-list-item/editable-list-item.component';

--- a/client/libs/ui/src/lib/button/button.component.html
+++ b/client/libs/ui/src/lib/button/button.component.html
@@ -1,0 +1,26 @@
+<ng-template #content><ng-content /></ng-template>
+
+@if (routerLink(); as link) {
+  <a
+    [routerLink]="link"
+    [class]="className()"
+    [attr.aria-label]="ariaLabel() ?? null"
+    [attr.aria-disabled]="disabled() || loading() ? 'true' : null"
+    [attr.data-testid]="testId() ?? null"
+  >
+    <ng-container [ngTemplateOutlet]="content" />
+  </a>
+} @else {
+  <button
+    [type]="type()"
+    [disabled]="disabled() || loading()"
+    [class]="className()"
+    [attr.aria-label]="ariaLabel() ?? null"
+    [attr.data-testid]="testId() ?? null"
+  >
+    @if (loading() && showSpinner()) {
+      <span class="btn-spinner"></span>
+    }
+    <ng-container [ngTemplateOutlet]="content" />
+  </button>
+}

--- a/client/libs/ui/src/lib/button/button.component.scss
+++ b/client/libs/ui/src/lib/button/button.component.scss
@@ -1,0 +1,5 @@
+@use 'buttons';
+
+yn-button {
+  display: inline-flex;
+}

--- a/client/libs/ui/src/lib/button/button.component.spec.ts
+++ b/client/libs/ui/src/lib/button/button.component.spec.ts
@@ -1,0 +1,201 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ButtonComponent, type ButtonVariant } from './button.component';
+
+@Component({
+  imports: [ButtonComponent],
+  template: `<yn-button
+    [variant]="variant"
+    [disabled]="disabled"
+    [loading]="loading"
+    [showSpinner]="showSpinner"
+    [type]="type"
+    [routerLink]="routerLink"
+    [ariaLabel]="ariaLabel"
+    [testId]="testId"
+    [extraClass]="extraClass"
+  >
+    <span>Click me</span>
+  </yn-button>`,
+})
+class HostComponent {
+  variant: ButtonVariant = 'primary';
+  disabled = false;
+  loading = false;
+  showSpinner = false;
+  type: 'button' | 'submit' | 'reset' = 'button';
+  routerLink: string | undefined = undefined;
+  ariaLabel: string | undefined = undefined;
+  testId: string | undefined = undefined;
+  extraClass = '';
+}
+
+describe('ButtonComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  // ── Variant rendering ──────────────────────────────────────────────────────
+
+  it('should apply the btn-primary class for the primary variant', () => {
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('btn-primary')).toBe(true);
+  });
+
+  it('should apply the btn-secondary class for the secondary variant', () => {
+    fixture.componentInstance.variant = 'secondary';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('btn-secondary')).toBe(true);
+  });
+
+  it('should apply the btn-danger class for the danger variant', () => {
+    fixture.componentInstance.variant = 'danger';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('btn-danger')).toBe(true);
+  });
+
+  // ── Button vs link rendering ───────────────────────────────────────────────
+
+  it('should render a button element by default', () => {
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(button).toBeTruthy();
+    expect(anchor).toBeFalsy();
+  });
+
+  it('should render an anchor element when routerLink is provided', () => {
+    fixture.componentInstance.routerLink = '/recipes';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(button).toBeFalsy();
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toContain('/recipes');
+  });
+
+  // ── Disabled / loading state ───────────────────────────────────────────────
+
+  it('should disable the button when disabled is true', () => {
+    fixture.componentInstance.disabled = true;
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should disable the button when loading is true', () => {
+    fixture.componentInstance.loading = true;
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should mark anchor with aria-disabled when disabled and using routerLink', () => {
+    fixture.componentInstance.routerLink = '/recipes';
+    fixture.componentInstance.disabled = true;
+
+    fixture.detectChanges();
+
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  // ── Spinner ────────────────────────────────────────────────────────────────
+
+  it('should render a spinner when loading and showSpinner are both true', () => {
+    fixture.componentInstance.loading = true;
+    fixture.componentInstance.showSpinner = true;
+
+    fixture.detectChanges();
+
+    const spinner = fixture.nativeElement.querySelector('.btn-spinner');
+    expect(spinner).toBeTruthy();
+  });
+
+  it('should not render a spinner when loading but showSpinner is false', () => {
+    fixture.componentInstance.loading = true;
+
+    fixture.detectChanges();
+
+    const spinner = fixture.nativeElement.querySelector('.btn-spinner');
+    expect(spinner).toBeFalsy();
+  });
+
+  // ── Type / extraClass / aria / testId ──────────────────────────────────────
+
+  it('should default the button type to "button"', () => {
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('type')).toBe('button');
+  });
+
+  it('should respect a submit type input', () => {
+    fixture.componentInstance.type = 'submit';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('type')).toBe('submit');
+  });
+
+  it('should append extra classes alongside the variant class', () => {
+    fixture.componentInstance.extraClass = 'import-another';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('btn-primary')).toBe(true);
+    expect(button.classList.contains('import-another')).toBe(true);
+  });
+
+  it('should mirror the testId input as data-testid on the rendered element', () => {
+    fixture.componentInstance.testId = 'save-button';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('data-testid')).toBe('save-button');
+  });
+
+  it('should mirror the ariaLabel input as aria-label on the rendered element', () => {
+    fixture.componentInstance.ariaLabel = 'Save the recipe';
+
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-label')).toBe('Save the recipe');
+  });
+
+  // ── Content projection ─────────────────────────────────────────────────────
+
+  it('should project content into the rendered element', () => {
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.textContent).toContain('Click me');
+  });
+});

--- a/client/libs/ui/src/lib/button/button.component.ts
+++ b/client/libs/ui/src/lib/button/button.component.ts
@@ -1,0 +1,39 @@
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'ghost'
+  | 'danger'
+  | 'danger-filled'
+  | 'dashed'
+  | 'link';
+
+export type ButtonType = 'button' | 'submit' | 'reset';
+
+@Component({
+  selector: 'yn-button',
+  imports: [NgTemplateOutlet, RouterLink],
+  templateUrl: './button.component.html',
+  styleUrl: './button.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ButtonComponent {
+  variant = input<ButtonVariant>('primary');
+  type = input<ButtonType>('button');
+  disabled = input(false);
+  loading = input(false);
+  showSpinner = input(false);
+  routerLink = input<string | unknown[] | null | undefined>(undefined);
+  ariaLabel = input<string | undefined>(undefined);
+  testId = input<string | undefined>(undefined);
+  extraClass = input<string>('');
+
+  protected readonly className = computed(() => {
+    const extra = this.extraClass();
+    return extra ? `btn-${this.variant()} ${extra}` : `btn-${this.variant()}`;
+  });
+}

--- a/client/libs/ui/src/lib/button/button.stories.ts
+++ b/client/libs/ui/src/lib/button/button.stories.ts
@@ -1,0 +1,60 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+import { ButtonComponent } from './button.component';
+
+const meta: Meta<ButtonComponent> = {
+  title: 'Components/Button',
+  component: ButtonComponent,
+  decorators: [moduleMetadata({ providers: [provideRouter([])] })],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost', 'danger', 'danger-filled', 'dashed', 'link'],
+    },
+    type: { control: 'select', options: ['button', 'submit', 'reset'] },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    showSpinner: { control: 'boolean' },
+    routerLink: { control: 'text' },
+    ariaLabel: { control: 'text' },
+    testId: { control: 'text' },
+    extraClass: { control: 'text' },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<yn-button
+      [variant]="variant"
+      [type]="type"
+      [disabled]="disabled"
+      [loading]="loading"
+      [showSpinner]="showSpinner"
+      [routerLink]="routerLink"
+      [ariaLabel]="ariaLabel"
+      [testId]="testId"
+      [extraClass]="extraClass"
+    >Click me</yn-button>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<ButtonComponent>;
+
+export const Primary: Story = { args: { variant: 'primary' } };
+export const Secondary: Story = { args: { variant: 'secondary' } };
+export const Ghost: Story = { args: { variant: 'ghost' } };
+export const Danger: Story = { args: { variant: 'danger' } };
+export const DangerFilled: Story = { args: { variant: 'danger-filled' } };
+export const Dashed: Story = { args: { variant: 'dashed' } };
+export const Link: Story = { args: { variant: 'link' } };
+
+export const Loading: Story = {
+  args: { variant: 'primary', loading: true, showSpinner: true },
+};
+
+export const Disabled: Story = {
+  args: { variant: 'primary', disabled: true },
+};
+
+export const RouterLinkAnchor: Story = {
+  args: { variant: 'primary', routerLink: '/recipes' },
+};

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.html
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.html
@@ -1,0 +1,8 @@
+<div
+  [class]="bannerClass()"
+  [attr.role]="role()"
+  [attr.aria-live]="ariaLive()"
+  [attr.data-testid]="testId() ?? null"
+>
+  {{ message() | transloco: params() }}
+</div>

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.scss
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.scss
@@ -1,0 +1,5 @@
+@use 'banners';
+
+yn-message-banner {
+  display: block;
+}

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.spec.ts
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { MessageBannerComponent } from './message-banner.component';
+
+const en = {
+  errors: {
+    saveFailed: 'Failed to save the recipe',
+    invalidUrl: 'The URL "{{ url }}" is not valid',
+  },
+  success: {
+    saved: 'Saved {{ title }}',
+  },
+};
+
+describe('MessageBannerComponent', () => {
+  let fixture: ComponentFixture<MessageBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessageBannerComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MessageBannerComponent);
+  });
+
+  // ── Tone-based classes ─────────────────────────────────────────────────────
+
+  it('should render the error-banner class for the error tone', () => {
+    fixture.componentRef.setInput('tone', 'error');
+    fixture.componentRef.setInput('message', 'errors.saveFailed');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.classList.contains('error-banner')).toBe(true);
+  });
+
+  it('should render the success-banner class for the success tone', () => {
+    fixture.componentRef.setInput('tone', 'success');
+    fixture.componentRef.setInput('message', 'success.saved');
+    fixture.componentRef.setInput('params', { title: 'Pasta' });
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.classList.contains('success-banner')).toBe(true);
+  });
+
+  // ── ARIA wiring ────────────────────────────────────────────────────────────
+
+  it('should set role="alert" for the error tone', () => {
+    fixture.componentRef.setInput('tone', 'error');
+    fixture.componentRef.setInput('message', 'errors.saveFailed');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.getAttribute('role')).toBe('alert');
+    expect(banner.getAttribute('aria-live')).toBeNull();
+  });
+
+  it('should set role="status" with aria-live="polite" for the success tone', () => {
+    fixture.componentRef.setInput('tone', 'success');
+    fixture.componentRef.setInput('message', 'success.saved');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.getAttribute('role')).toBe('status');
+    expect(banner.getAttribute('aria-live')).toBe('polite');
+  });
+
+  // ── Translation rendering ──────────────────────────────────────────────────
+
+  it('should translate the message key', () => {
+    fixture.componentRef.setInput('tone', 'error');
+    fixture.componentRef.setInput('message', 'errors.saveFailed');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.textContent.trim()).toBe('Failed to save the recipe');
+  });
+
+  it('should interpolate params when provided', () => {
+    fixture.componentRef.setInput('tone', 'success');
+    fixture.componentRef.setInput('message', 'success.saved');
+    fixture.componentRef.setInput('params', { title: 'Pasta' });
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.textContent.trim()).toBe('Saved Pasta');
+  });
+
+  // ── Test id passthrough ────────────────────────────────────────────────────
+
+  it('should set data-testid when testId input is provided', () => {
+    fixture.componentRef.setInput('tone', 'success');
+    fixture.componentRef.setInput('message', 'success.saved');
+    fixture.componentRef.setInput('params', { title: 'Pasta' });
+    fixture.componentRef.setInput('testId', 'success-banner');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.getAttribute('data-testid')).toBe('success-banner');
+  });
+
+  it('should omit data-testid when testId input is not provided', () => {
+    fixture.componentRef.setInput('tone', 'error');
+    fixture.componentRef.setInput('message', 'errors.saveFailed');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector('div');
+    expect(banner.getAttribute('data-testid')).toBeNull();
+  });
+});

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.ts
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.ts
@@ -1,0 +1,23 @@
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+
+export type MessageBannerTone = 'error' | 'success';
+
+@Component({
+  selector: 'yn-message-banner',
+  imports: [TranslocoPipe],
+  templateUrl: './message-banner.component.html',
+  styleUrl: './message-banner.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MessageBannerComponent {
+  tone = input.required<MessageBannerTone>();
+  message = input.required<string>();
+  params = input<Record<string, unknown> | undefined>(undefined);
+  testId = input<string | undefined>(undefined);
+
+  protected readonly bannerClass = computed(() => `${this.tone()}-banner`);
+  protected readonly role = computed(() => (this.tone() === 'error' ? 'alert' : 'status'));
+  protected readonly ariaLive = computed(() => (this.tone() === 'error' ? null : 'polite'));
+}

--- a/client/libs/ui/src/lib/message-banner/message-banner.stories.ts
+++ b/client/libs/ui/src/lib/message-banner/message-banner.stories.ts
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { MessageBannerComponent } from './message-banner.component';
+
+const meta: Meta<MessageBannerComponent> = {
+  title: 'Components/Message Banner',
+  component: MessageBannerComponent,
+  argTypes: {
+    tone: { control: 'select', options: ['error', 'success'] },
+    message: { control: 'text' },
+    testId: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<MessageBannerComponent>;
+
+export const Error: Story = {
+  args: {
+    tone: 'error',
+    message: 'errors.saveFailed',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    tone: 'success',
+    message: 'success.saved',
+  },
+};


### PR DESCRIPTION
## Summary
- New `yn-button` in `libs/ui` with `variant` input (primary, secondary, ghost, danger, danger-filled, dashed, link) — renders `<button>` or `<a routerLink>` via inputs, content projection, optional loading spinner, `testId` and `extraClass` passthrough.
- New `yn-message-banner` in `libs/ui` with `tone` (error/success), transloco message + params, ARIA wiring (`role="alert"` for error, `role="status" aria-live="polite"` for success).
- Both components reuse the existing global `_buttons.scss` / `_banners.scss` partials — no style duplication.
- Migrated 22 hand-rolled `btn-*` instances and 12 `error-banner` / `success-banner` divs across shell, recipes, shopping (10 templates).

Out of scope (left as-is, noted for future work):
- `btn-cook` / `btn-back` — one-off local variants in recipe-detail / recipe-list.
- `<label class="btn-dashed">` in dashboard — file picker trigger, not a button element.
- The first commit on this branch (`style(frontend)`) collapses pre-existing multi-line attributes/imports that were already modified in the working tree; included so the PR's tree starts from a clean state.

## Test plan
- [x] `yarn nx run-many --target=lint --projects=ui,shell,recipes,shopping,account` — passes (only pre-existing warnings).
- [x] `yarn nx run-many --target=test --projects=ui,shell,recipes,shopping,account` — 100% green (incl. 16 new ButtonComponent specs and 8 new MessageBannerComponent specs).
- [x] `yarn build:all` — succeeds (two pre-existing SCSS budget warnings on recipe-detail.scss / chat-panel.scss, both untouched here).
- [ ] Manual smoke: load shell, recipes, shopping in browser; click through buttons and trigger error banners.