### PR TITLE
feat(ui): add DialogShellComponent and CardComponent

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
@@ -1,73 +1,73 @@
-<div class="create-shopping-list-overlay" (click)="onOverlayClick($event)" *transloco="let t">
-  <div
-    class="create-shopping-list-dialog"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="create-shopping-list-title"
-    data-testid="create-shopping-list-dialog"
-  >
-    <header class="dialog-header">
-      <h2 id="create-shopping-list-title" class="dialog-title">
-        {{ t('recipes.detail.createShoppingList.title') }}
-      </h2>
-      <p class="dialog-subtitle" data-testid="create-shopping-list-suggested-title">
-        {{ suggestedTitle() }}
-      </p>
-    </header>
+<yn-dialog-shell
+  *transloco="let t"
+  size="md"
+  labelledBy="create-shopping-list-title"
+  testId="create-shopping-list-dialog"
+  [cancelOnBackdrop]="!isCreating()"
+  [cancelOnEscape]="!isCreating()"
+  (cancelled)="onCancel()"
+>
+  <header class="dialog-header">
+    <h2 id="create-shopping-list-title" class="dialog-title">
+      {{ t('recipes.detail.createShoppingList.title') }}
+    </h2>
+    <p class="dialog-subtitle" data-testid="create-shopping-list-suggested-title">
+      {{ suggestedTitle() }}
+    </p>
+  </header>
 
-    <section class="dialog-preview" aria-labelledby="create-shopping-list-preview-heading">
-      <h3 id="create-shopping-list-preview-heading" class="preview-heading">
-        @if (desiredServings() !== null) {
-          {{
-            t('recipes.detail.createShoppingList.preview', {
-              count: ingredients().length,
-              servings: desiredServings(),
-            })
-          }}
-        } @else {
-          {{
-            t('recipes.detail.createShoppingList.previewNoServings', {
-              count: ingredients().length,
-            })
-          }}
-        }
-      </h3>
-      <ul class="preview-list">
-        @for (ingredient of ingredients(); track ingredient.name) {
-          <li>
-            @if (ingredient.amount !== null) {
-              <span class="preview-amount">{{ ingredient.amount }}</span>
-            }
-            @if (ingredient.unit) {
-              <span class="preview-unit">{{ ingredient.unit }}</span>
-            }
-            <span class="preview-name">{{ ingredient.name }}</span>
-          </li>
-        }
-      </ul>
-    </section>
-
-    <div class="dialog-actions">
-      <yn-button
-        variant="secondary"
-        testId="create-shopping-list-cancel"
-        [disabled]="isCreating()"
-        (click)="onCancel()"
-      >
-        {{ t('recipes.detail.createShoppingList.cancel') }}
-      </yn-button>
-      <yn-button
-        variant="primary"
-        testId="create-shopping-list-confirm"
-        [disabled]="isCreating()"
-        (click)="onConfirm()"
-      >
+  <section class="dialog-preview" aria-labelledby="create-shopping-list-preview-heading">
+    <h3 id="create-shopping-list-preview-heading" class="preview-heading">
+      @if (desiredServings() !== null) {
         {{
-          isCreating()
-            ? t('recipes.detail.createShoppingList.creating')
-            : t('recipes.detail.createShoppingList.confirm')
+          t('recipes.detail.createShoppingList.preview', {
+            count: ingredients().length,
+            servings: desiredServings(),
+          })
         }}
-      </yn-button>
-    </div>
+      } @else {
+        {{
+          t('recipes.detail.createShoppingList.previewNoServings', {
+            count: ingredients().length,
+          })
+        }}
+      }
+    </h3>
+    <ul class="preview-list">
+      @for (ingredient of ingredients(); track ingredient.name) {
+        <li>
+          @if (ingredient.amount !== null) {
+            <span class="preview-amount">{{ ingredient.amount }}</span>
+          }
+          @if (ingredient.unit) {
+            <span class="preview-unit">{{ ingredient.unit }}</span>
+          }
+          <span class="preview-name">{{ ingredient.name }}</span>
+        </li>
+      }
+    </ul>
+  </section>
+
+  <div class="dialog-actions">
+    <yn-button
+      variant="secondary"
+      testId="create-shopping-list-cancel"
+      [disabled]="isCreating()"
+      (click)="onCancel()"
+    >
+      {{ t('recipes.detail.createShoppingList.cancel') }}
+    </yn-button>
+    <yn-button
+      variant="primary"
+      testId="create-shopping-list-confirm"
+      [disabled]="isCreating()"
+      (click)="onConfirm()"
+    >
+      {{
+        isCreating()
+          ? t('recipes.detail.createShoppingList.creating')
+          : t('recipes.detail.createShoppingList.confirm')
+      }}
+    </yn-button>
   </div>
-</div>
+</yn-dialog-shell>

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.scss
@@ -1,36 +1,3 @@
-@use 'buttons';
-@use 'glass';
-
-.create-shopping-list-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--yn-z-modal);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--yn-space-5);
-  background: var(--yn-overlay);
-  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
-}
-
-.create-shopping-list-dialog {
-  @include glass.glass-dialog;
-  width: min(560px, 100%);
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  gap: var(--yn-space-6);
-  padding: var(--yn-space-7);
-  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .create-shopping-list-overlay,
-  .create-shopping-list-dialog {
-    animation: none;
-  }
-}
-
 .dialog-header {
   display: flex;
   flex-direction: column;

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
@@ -94,7 +94,7 @@ describe('CreateShoppingListDialogComponent', () => {
     let emitted = 0;
     component.cancelled.subscribe(() => emitted++);
 
-    component.onEscapeKey();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(emitted).toBe(0);
   });
@@ -104,7 +104,7 @@ describe('CreateShoppingListDialogComponent', () => {
     let emitted = 0;
     component.cancelled.subscribe(() => emitted++);
 
-    component.onEscapeKey();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(emitted).toBe(1);
   });
@@ -114,7 +114,7 @@ describe('CreateShoppingListDialogComponent', () => {
     let emitted = 0;
     component.cancelled.subscribe(() => emitted++);
 
-    const overlay = fixture.nativeElement.querySelector('.create-shopping-list-overlay');
+    const overlay = fixture.nativeElement.querySelector('.yn-dialog-overlay');
     overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(emitted).toBe(1);
@@ -125,7 +125,7 @@ describe('CreateShoppingListDialogComponent', () => {
     let emitted = 0;
     component.cancelled.subscribe(() => emitted++);
 
-    const overlay = fixture.nativeElement.querySelector('.create-shopping-list-overlay');
+    const overlay = fixture.nativeElement.querySelector('.yn-dialog-overlay');
     overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(emitted).toBe(0);

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.ts
@@ -1,18 +1,11 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  HostListener,
-  computed,
-  input,
-  output,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import type { ScalableIngredient } from '@yumney/shared/models';
-import { ButtonComponent } from '@yumney/ui';
+import { ButtonComponent, DialogShellComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-create-shopping-list-dialog',
-  imports: [TranslocoModule, ButtonComponent],
+  imports: [TranslocoModule, ButtonComponent, DialogShellComponent],
   templateUrl: './create-shopping-list-dialog.component.html',
   styleUrl: './create-shopping-list-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,24 +24,11 @@ export class CreateShoppingListDialogComponent {
     return servings === null ? this.recipeTitle() : `${this.recipeTitle()} (x${servings})`;
   });
 
-  @HostListener('document:keydown.escape')
-  onEscapeKey(): void {
-    if (!this.isCreating()) {
-      this.cancelled.emit();
-    }
-  }
-
   onConfirm(): void {
     this.confirmed.emit();
   }
 
   onCancel(): void {
     this.cancelled.emit();
-  }
-
-  onOverlayClick(event: MouseEvent): void {
-    if (event.target === event.currentTarget && !this.isCreating()) {
-      this.cancelled.emit();
-    }
   }
 }

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
@@ -1,108 +1,108 @@
-<div class="multi-preview-overlay" (click)="onOverlayClick($event)" *transloco="let t">
-  <div
-    class="multi-preview-dialog"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="multi-preview-title"
-    data-testid="multi-recipe-preview-dialog"
-  >
-    <header class="dialog-header">
-      <h2 id="multi-preview-title" class="dialog-title">
-        {{ t('recipes.list.multiSelect.preview.title') }}
-      </h2>
-      <p class="dialog-subtitle">
-        {{ t('recipes.list.multiSelect.preview.subtitle', { count: recipes().length }) }}
-      </p>
-    </header>
+<yn-dialog-shell
+  *transloco="let t"
+  size="lg"
+  labelledBy="multi-preview-title"
+  testId="multi-recipe-preview-dialog"
+  [cancelOnBackdrop]="!isCreating()"
+  [cancelOnEscape]="!isCreating()"
+  (cancelled)="onCancel()"
+>
+  <header class="dialog-header">
+    <h2 id="multi-preview-title" class="dialog-title">
+      {{ t('recipes.list.multiSelect.preview.title') }}
+    </h2>
+    <p class="dialog-subtitle">
+      {{ t('recipes.list.multiSelect.preview.subtitle', { count: recipes().length }) }}
+    </p>
+  </header>
 
-    @if (isLoading()) {
-      <div class="dialog-loading">
-        <yn-loading-spinner label="recipes.list.multiSelect.preview.loading" />
-      </div>
-    } @else {
-      <section class="dialog-recipes" aria-labelledby="multi-preview-recipes-heading" data-testid="multi-recipe-preview-recipes">
-        <h3 id="multi-preview-recipes-heading" class="section-heading">
-          {{ t('recipes.list.multiSelect.preview.recipesHeading') }}
-        </h3>
-        <ul class="recipe-list">
-          @for (recipe of recipes(); track recipe.identifier) {
-            <li class="recipe-row">
-              <span class="recipe-row-title">{{ recipe.title }}</span>
-              <div class="servings-control">
-                <button type="button" class="servings-button" data-testid="multi-recipe-decrease-servings" [disabled]="recipe.desiredServings <= 1"
-                  [attr.aria-label]="
-                    t('recipes.list.multiSelect.preview.decreaseAriaLabel', {
-                      title: recipe.title,
-                    })
-                  "
-                  (click)="onDecrease(recipe.identifier)"
-                >
-                  &minus;
-                </button>
-                <span class="servings-value" aria-live="polite">
-                  {{
-                    t('recipes.list.multiSelect.preview.servings', {
-                      count: recipe.desiredServings,
-                    })
-                  }}
-                </span>
-                <button
-                  type="button"
-                  class="servings-button"
-                  data-testid="multi-recipe-increase-servings"
-                  [attr.aria-label]="
-                    t('recipes.list.multiSelect.preview.increaseAriaLabel', {
-                      title: recipe.title,
-                    })
-                  "
-                  (click)="onIncrease(recipe.identifier)"
-                >
-                  +
-                </button>
-              </div>
-            </li>
-          }
-        </ul>
-      </section>
-
-      <section class="dialog-merged" aria-labelledby="multi-preview-merged-heading" data-testid="multi-recipe-preview-merged">
-        <h3 id="multi-preview-merged-heading" class="section-heading">
-          {{
-            t('recipes.list.multiSelect.preview.mergedHeading', {
-              count: mergedIngredients().length,
-            })
-          }}
-        </h3>
-        <ul class="merged-list">
-          @for (
-            ingredient of mergedIngredients();
-            track ingredient.name + (ingredient.unit ?? '')
-          ) {
-            <li>
-              @if (ingredient.amount !== null) {
-                <span class="merged-amount">{{ ingredient.amount }}</span>
-              }
-              @if (ingredient.unit) {
-                <span class="merged-unit">{{ ingredient.unit }}</span>
-              }
-              <span class="merged-name">{{ ingredient.name }}</span>
-            </li>
-          }
-        </ul>
-      </section>
-    }
-
-    <div class="dialog-actions">
-      <yn-button variant="secondary" testId="multi-recipe-preview-cancel" [disabled]="isCreating()" (click)="onCancel()">
-        {{ t('recipes.list.multiSelect.preview.cancel') }}
-      </yn-button>
-      <yn-button variant="primary" testId="multi-recipe-preview-confirm" [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0" (click)="onConfirm()">
-        {{
-          isCreating()
-            ? t('recipes.list.multiSelect.preview.creating')
-            : t('recipes.list.multiSelect.preview.confirm')
-        }}
-      </yn-button>
+  @if (isLoading()) {
+    <div class="dialog-loading">
+      <yn-loading-spinner label="recipes.list.multiSelect.preview.loading" />
     </div>
+  } @else {
+    <section class="dialog-recipes" aria-labelledby="multi-preview-recipes-heading" data-testid="multi-recipe-preview-recipes">
+      <h3 id="multi-preview-recipes-heading" class="section-heading">
+        {{ t('recipes.list.multiSelect.preview.recipesHeading') }}
+      </h3>
+      <ul class="recipe-list">
+        @for (recipe of recipes(); track recipe.identifier) {
+          <li class="recipe-row">
+            <span class="recipe-row-title">{{ recipe.title }}</span>
+            <div class="servings-control">
+              <button type="button" class="servings-button" data-testid="multi-recipe-decrease-servings" [disabled]="recipe.desiredServings <= 1"
+                [attr.aria-label]="
+                  t('recipes.list.multiSelect.preview.decreaseAriaLabel', {
+                    title: recipe.title,
+                  })
+                "
+                (click)="onDecrease(recipe.identifier)"
+              >
+                &minus;
+              </button>
+              <span class="servings-value" aria-live="polite">
+                {{
+                  t('recipes.list.multiSelect.preview.servings', {
+                    count: recipe.desiredServings,
+                  })
+                }}
+              </span>
+              <button
+                type="button"
+                class="servings-button"
+                data-testid="multi-recipe-increase-servings"
+                [attr.aria-label]="
+                  t('recipes.list.multiSelect.preview.increaseAriaLabel', {
+                    title: recipe.title,
+                  })
+                "
+                (click)="onIncrease(recipe.identifier)"
+              >
+                +
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    </section>
+
+    <section class="dialog-merged" aria-labelledby="multi-preview-merged-heading" data-testid="multi-recipe-preview-merged">
+      <h3 id="multi-preview-merged-heading" class="section-heading">
+        {{
+          t('recipes.list.multiSelect.preview.mergedHeading', {
+            count: mergedIngredients().length,
+          })
+        }}
+      </h3>
+      <ul class="merged-list">
+        @for (
+          ingredient of mergedIngredients();
+          track ingredient.name + (ingredient.unit ?? '')
+        ) {
+          <li>
+            @if (ingredient.amount !== null) {
+              <span class="merged-amount">{{ ingredient.amount }}</span>
+            }
+            @if (ingredient.unit) {
+              <span class="merged-unit">{{ ingredient.unit }}</span>
+            }
+            <span class="merged-name">{{ ingredient.name }}</span>
+          </li>
+        }
+      </ul>
+    </section>
+  }
+
+  <div class="dialog-actions">
+    <yn-button variant="secondary" testId="multi-recipe-preview-cancel" [disabled]="isCreating()" (click)="onCancel()">
+      {{ t('recipes.list.multiSelect.preview.cancel') }}
+    </yn-button>
+    <yn-button variant="primary" testId="multi-recipe-preview-confirm" [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0" (click)="onConfirm()">
+      {{
+        isCreating()
+          ? t('recipes.list.multiSelect.preview.creating')
+          : t('recipes.list.multiSelect.preview.confirm')
+      }}
+    </yn-button>
   </div>
-</div>
+</yn-dialog-shell>

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.scss
@@ -1,37 +1,3 @@
-@use 'buttons';
-@use 'glass';
-
-.multi-preview-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--yn-z-modal);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--yn-space-5);
-  background: var(--yn-overlay);
-  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
-}
-
-.multi-preview-dialog {
-  @include glass.glass-dialog;
-  width: min(640px, 100%);
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  gap: var(--yn-space-6);
-  padding: var(--yn-space-7);
-  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
-  overflow: hidden;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .multi-preview-overlay,
-  .multi-preview-dialog {
-    animation: none;
-  }
-}
-
 .dialog-header {
   display: flex;
   flex-direction: column;

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
@@ -172,7 +172,7 @@ describe('MultiRecipePreviewDialogComponent', () => {
     let count = 0;
     component.cancelled.subscribe(() => count++);
 
-    component.onEscapeKey();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(count).toBe(0);
   });
@@ -182,7 +182,7 @@ describe('MultiRecipePreviewDialogComponent', () => {
     let count = 0;
     component.cancelled.subscribe(() => count++);
 
-    component.onEscapeKey();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(count).toBe(1);
   });
@@ -193,7 +193,7 @@ describe('MultiRecipePreviewDialogComponent', () => {
     component.cancelled.subscribe(() => count++);
 
     fixture.nativeElement
-      .querySelector('.multi-preview-overlay')
+      .querySelector('.yn-dialog-overlay')
       .dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(count).toBe(1);

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
@@ -1,7 +1,7 @@
-import { Component, ChangeDetectionStrategy, HostListener, computed, input, output } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { mergeRecipeIngredients, type MergedIngredient, type RecipeForMerge, type ScalableIngredient } from '@yumney/shared/models';
-import { ButtonComponent, LoadingSpinnerComponent } from '@yumney/ui';
+import { ButtonComponent, DialogShellComponent, LoadingSpinnerComponent } from '@yumney/ui';
 
 export interface MultiRecipeSelection {
   identifier: string;
@@ -13,7 +13,7 @@ export interface MultiRecipeSelection {
 
 @Component({
   selector: 'yn-multi-recipe-preview-dialog',
-  imports: [TranslocoModule, ButtonComponent, LoadingSpinnerComponent],
+  imports: [TranslocoModule, ButtonComponent, DialogShellComponent, LoadingSpinnerComponent],
   templateUrl: './multi-recipe-preview-dialog.component.html',
   styleUrl: './multi-recipe-preview-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -38,25 +38,12 @@ export class MultiRecipePreviewDialogComponent {
     return mergeRecipeIngredients(recipes);
   });
 
-  @HostListener('document:keydown.escape')
-  onEscapeKey(): void {
-    if (!this.isCreating()) {
-      this.cancelled.emit();
-    }
-  }
-
   onConfirm(): void {
     this.confirmed.emit();
   }
 
   onCancel(): void {
     this.cancelled.emit();
-  }
-
-  onOverlayClick(event: MouseEvent): void {
-    if (event.target === event.currentTarget && !this.isCreating()) {
-      this.cancelled.emit();
-    }
   }
 
   onIncrease(identifier: string): void {

--- a/client/apps/shell/src/app/auth/login/login.component.html
+++ b/client/apps/shell/src/app/auth/login/login.component.html
@@ -1,8 +1,5 @@
 <div class="login-container" *transloco="let t">
-  <div class="login-card">
-    <h1>{{ t('auth.login.title') }}</h1>
-    <p class="subtitle">{{ t('auth.login.subtitle') }}</p>
-
+  <yn-card title="auth.login.title" subtitle="auth.login.subtitle">
     <div class="login-form">
       <label class="remember-me">
         <input type="checkbox" [checked]="rememberMe()" (change)="onRememberMeChange($event)" />
@@ -29,5 +26,5 @@
         <a [routerLink]="ROUTES.auth.register">{{ t('auth.login.registerLink') }}</a>
       </p>
     </div>
-  </div>
+  </yn-card>
 </div>

--- a/client/apps/shell/src/app/auth/login/login.component.scss
+++ b/client/apps/shell/src/app/auth/login/login.component.scss
@@ -5,10 +5,6 @@
   @extend .auth-container;
 }
 
-.login-card {
-  @extend .auth-card;
-}
-
 .remember-me {
   display: flex;
   align-items: center;

--- a/client/apps/shell/src/app/auth/login/login.component.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.ts
@@ -3,10 +3,11 @@ import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthService } from '@yumney/shared/auth';
 import { ROUTES } from '@yumney/shared/models';
+import { CardComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-login',
-  imports: [TranslocoModule, RouterLink],
+  imports: [TranslocoModule, RouterLink, CardComponent],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -1,8 +1,5 @@
 <div class="register-container" *transloco="let t">
-  <div class="register-card">
-    <h1>{{ t('auth.register.title') }}</h1>
-    <p class="subtitle">{{ t('auth.register.subtitle') }}</p>
-
+  <yn-card title="auth.register.title" subtitle="auth.register.subtitle">
     @if (isSuccess()) {
       <div class="success-message" role="status" aria-live="polite">
         <h2>{{ t('auth.register.success.title') }}</h2>
@@ -69,5 +66,5 @@
         <yn-submit-button [loading]="isLoading()" label="auth.register.submit" loadingLabel="auth.register.submitting"/>
       </form>
     }
-  </div>
+  </yn-card>
 </div>

--- a/client/apps/shell/src/app/auth/register/register.component.scss
+++ b/client/apps/shell/src/app/auth/register/register.component.scss
@@ -8,10 +8,6 @@
   @extend .auth-container;
 }
 
-.register-card {
-  @extend .auth-card;
-}
-
 .success-message {
   @include glass.glass-surface(1);
   text-align: center;

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -11,11 +11,11 @@ import {
   ERROR_MAPS,
   ROUTES,
 } from '@yumney/shared/models';
-import { FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
+import { CardComponent, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-register',
-  imports: [ReactiveFormsModule, TranslocoModule, RouterLink, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent],
+  imports: [ReactiveFormsModule, TranslocoModule, RouterLink, CardComponent, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.html
@@ -1,8 +1,5 @@
 <div class="resend-container" *transloco="let t">
-  <div class="resend-card">
-    <h1>{{ t('auth.resendVerification.title') }}</h1>
-    <p class="subtitle">{{ t('auth.resendVerification.subtitle') }}</p>
-
+  <yn-card title="auth.resendVerification.title" subtitle="auth.resendVerification.subtitle">
     @if (isSuccess()) {
       <div class="success-message" role="status" aria-live="polite">
         <h2>{{ t('auth.resendVerification.success.title') }}</h2>
@@ -34,5 +31,5 @@
     <p class="back-link">
       <a [routerLink]="ROUTES.auth.register">{{ t('auth.resendVerification.backToRegister') }}</a>
     </p>
-  </div>
+  </yn-card>
 </div>

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.scss
@@ -8,10 +8,6 @@
   @extend .auth-container;
 }
 
-.resend-card {
-  @extend .auth-card;
-}
-
 .success-message {
   @include glass.glass-surface(1);
   text-align: center;

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
@@ -10,7 +10,7 @@ import {
   ERROR_MAPS,
   ROUTES,
 } from '@yumney/shared/models';
-import { FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
+import { CardComponent, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-resend-verification',
@@ -18,6 +18,7 @@ import { FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } fro
     ReactiveFormsModule,
     TranslocoModule,
     RouterLink,
+    CardComponent,
     FormFieldComponent,
     MessageBannerComponent,
     SubmitButtonComponent,

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -4,6 +4,12 @@ export {
   type ButtonVariant,
   type ButtonType,
 } from './lib/button/button.component';
+export { CardComponent, type CardVariant } from './lib/card/card.component';
+export {
+  DialogShellComponent,
+  type DialogRole,
+  type DialogSize,
+} from './lib/dialog-shell/dialog-shell.component';
 export { FormFieldComponent } from './lib/form-field/form-field.component';
 export {
   MessageBannerComponent,

--- a/client/libs/ui/src/lib/card/card.component.html
+++ b/client/libs/ui/src/lib/card/card.component.html
@@ -1,0 +1,9 @@
+<div [class]="cardClass()">
+  @if (title(); as titleKey) {
+    <h1>{{ titleKey | transloco }}</h1>
+  }
+  @if (subtitle(); as subtitleKey) {
+    <p class="subtitle">{{ subtitleKey | transloco }}</p>
+  }
+  <ng-content />
+</div>

--- a/client/libs/ui/src/lib/card/card.component.scss
+++ b/client/libs/ui/src/lib/card/card.component.scss
@@ -1,0 +1,5 @@
+@use 'cards';
+
+yn-card {
+  display: contents;
+}

--- a/client/libs/ui/src/lib/card/card.component.spec.ts
+++ b/client/libs/ui/src/lib/card/card.component.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { CardComponent } from './card.component';
+
+const en = {
+  auth: {
+    register: {
+      title: 'Create your account',
+      subtitle: 'Sign up in 30 seconds',
+    },
+  },
+};
+
+describe('CardComponent', () => {
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CardComponent);
+  });
+
+  // ── Variant class ──────────────────────────────────────────────────────────
+
+  it('should apply the auth-card class for the auth variant', () => {
+    fixture.detectChanges();
+
+    const card = fixture.nativeElement.querySelector('div');
+    expect(card.classList.contains('auth-card')).toBe(true);
+  });
+
+  // ── Title / subtitle rendering ────────────────────────────────────────────
+
+  it('should not render an h1 when title is omitted', () => {
+    fixture.detectChanges();
+
+    const heading = fixture.nativeElement.querySelector('h1');
+    expect(heading).toBeFalsy();
+  });
+
+  it('should not render a subtitle when subtitle is omitted', () => {
+    fixture.detectChanges();
+
+    const subtitle = fixture.nativeElement.querySelector('.subtitle');
+    expect(subtitle).toBeFalsy();
+  });
+
+  it('should translate the title input as an h1', () => {
+    fixture.componentRef.setInput('title', 'auth.register.title');
+
+    fixture.detectChanges();
+
+    const heading = fixture.nativeElement.querySelector('h1');
+    expect(heading.textContent.trim()).toBe('Create your account');
+  });
+
+  it('should translate the subtitle input as a .subtitle paragraph', () => {
+    fixture.componentRef.setInput('title', 'auth.register.title');
+    fixture.componentRef.setInput('subtitle', 'auth.register.subtitle');
+
+    fixture.detectChanges();
+
+    const subtitle = fixture.nativeElement.querySelector('.subtitle');
+    expect(subtitle.textContent.trim()).toBe('Sign up in 30 seconds');
+  });
+});

--- a/client/libs/ui/src/lib/card/card.component.ts
+++ b/client/libs/ui/src/lib/card/card.component.ts
@@ -1,0 +1,20 @@
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+
+export type CardVariant = 'auth';
+
+@Component({
+  selector: 'yn-card',
+  imports: [TranslocoPipe],
+  templateUrl: './card.component.html',
+  styleUrl: './card.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CardComponent {
+  variant = input<CardVariant>('auth');
+  title = input<string | undefined>(undefined);
+  subtitle = input<string | undefined>(undefined);
+
+  protected readonly cardClass = computed(() => `${this.variant()}-card`);
+}

--- a/client/libs/ui/src/lib/card/card.stories.ts
+++ b/client/libs/ui/src/lib/card/card.stories.ts
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { CardComponent } from './card.component';
+
+const meta: Meta<CardComponent> = {
+  title: 'Components/Card',
+  component: CardComponent,
+  argTypes: {
+    variant: { control: 'select', options: ['auth'] },
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<div class="auth-container">
+      <yn-card [variant]="variant" [title]="title" [subtitle]="subtitle">
+        <p>Card body content goes here.</p>
+      </yn-card>
+    </div>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<CardComponent>;
+
+export const Default: Story = {
+  args: {
+    variant: 'auth',
+    title: 'auth.register.title',
+    subtitle: 'auth.register.subtitle',
+  },
+};
+
+export const Untitled: Story = {
+  args: { variant: 'auth' },
+};

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.html
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.html
@@ -1,9 +1,7 @@
-<div class="confirm-overlay" (click)="onOverlayClick($event)">
-  <div class="confirm-dialog" role="alertdialog" aria-modal="true" aria-labelledby="confirm-msg">
-    <p id="confirm-msg" class="confirm-message">{{ message() }}</p>
-    <div class="confirm-actions">
-      <button class="btn-secondary" (click)="onCancel()">{{ cancelLabel() }}</button>
-      <button class="btn-danger-filled" (click)="onConfirm()">{{ confirmLabel() }}</button>
-    </div>
+<yn-dialog-shell size="sm" role="alertdialog" labelledBy="confirm-msg" (cancelled)="onCancel()">
+  <p id="confirm-msg" class="confirm-message">{{ message() }}</p>
+  <div class="confirm-actions">
+    <yn-button variant="secondary" (click)="onCancel()">{{ cancelLabel() }}</yn-button>
+    <yn-button variant="danger-filled" (click)="onConfirm()">{{ confirmLabel() }}</yn-button>
   </div>
-</div>
+</yn-dialog-shell>

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
@@ -1,34 +1,5 @@
-@use 'buttons';
-@use 'glass';
-
-.confirm-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--yn-z-modal);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--yn-overlay);
-  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
-}
-
-.confirm-dialog {
-  @include glass.glass-dialog;
-  padding: var(--yn-space-7);
-  max-width: 400px;
-  width: 90%;
-  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .confirm-overlay,
-  .confirm-dialog {
-    animation: none;
-  }
-}
-
 .confirm-message {
-  margin: 0 0 var(--yn-space-7);
+  margin: 0;
   font-size: var(--yn-text-lg);
   line-height: var(--yn-leading-normal);
 }

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
@@ -70,21 +70,21 @@ describe('ConfirmDialogComponent', () => {
   });
 
   it('should emit cancelled on overlay click', () => {
-    const overlay = fixture.nativeElement.querySelector('.confirm-overlay');
+    const overlay = fixture.nativeElement.querySelector('.yn-dialog-overlay');
     overlay.click();
 
     expect(host.cancelledCount).toBe(1);
   });
 
   it('should not emit cancelled when clicking inside dialog', () => {
-    const dialog = fixture.nativeElement.querySelector('.confirm-dialog');
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
     dialog.click();
 
     expect(host.cancelledCount).toBe(0);
   });
 
   it('should have alertdialog role and aria-modal', () => {
-    const dialog = fixture.nativeElement.querySelector('.confirm-dialog');
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
     expect(dialog.getAttribute('role')).toBe('alertdialog');
     expect(dialog.getAttribute('aria-modal')).toBe('true');
   });

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
@@ -1,7 +1,10 @@
-import { Component, ChangeDetectionStrategy, HostListener, input, output } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import { ButtonComponent } from '../button/button.component';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
 
 @Component({
   selector: 'yn-confirm-dialog',
+  imports: [ButtonComponent, DialogShellComponent],
   templateUrl: './confirm-dialog.component.html',
   styleUrl: './confirm-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -14,22 +17,11 @@ export class ConfirmDialogComponent {
   confirmed = output<void>();
   cancelled = output<void>();
 
-  @HostListener('document:keydown.escape')
-  onEscapeKey(): void {
-    this.cancelled.emit();
-  }
-
   onConfirm(): void {
     this.confirmed.emit();
   }
 
   onCancel(): void {
     this.cancelled.emit();
-  }
-
-  onOverlayClick(event: MouseEvent): void {
-    if (event.target === event.currentTarget) {
-      this.cancelled.emit();
-    }
   }
 }

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.html
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.html
@@ -1,0 +1,11 @@
+<div class="yn-dialog-overlay" (click)="onOverlayClick($event)">
+  <div
+    [class]="dialogClass()"
+    [attr.role]="role()"
+    aria-modal="true"
+    [attr.aria-labelledby]="labelledBy() ?? null"
+    [attr.data-testid]="testId() ?? null"
+  >
+    <ng-content />
+  </div>
+</div>

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.scss
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.scss
@@ -1,0 +1,43 @@
+@use 'glass';
+
+.yn-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--yn-z-modal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--yn-space-5);
+  background: var(--yn-overlay);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+}
+
+.yn-dialog {
+  @include glass.glass-dialog;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-6);
+  padding: var(--yn-space-7);
+  animation: yn-scale-up var(--yn-duration-normal) var(--yn-ease-spring) both;
+  overflow: hidden;
+
+  &--sm {
+    width: min(400px, 100%);
+  }
+
+  &--md {
+    width: min(560px, 100%);
+  }
+
+  &--lg {
+    width: min(640px, 100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yn-dialog-overlay,
+  .yn-dialog {
+    animation: none;
+  }
+}

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.spec.ts
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.spec.ts
@@ -1,0 +1,167 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogShellComponent, type DialogRole, type DialogSize } from './dialog-shell.component';
+
+@Component({
+  imports: [DialogShellComponent],
+  template: `<yn-dialog-shell
+    [size]="size()"
+    [role]="role()"
+    [labelledBy]="labelledBy()"
+    [testId]="testId()"
+    [cancelOnBackdrop]="cancelOnBackdrop()"
+    [cancelOnEscape]="cancelOnEscape()"
+    (cancelled)="cancelledCount = cancelledCount + 1"
+  >
+    <h2 [id]="labelledBy() ?? null">Dialog content</h2>
+    <p>Body</p>
+  </yn-dialog-shell>`,
+})
+class HostComponent {
+  size = signal<DialogSize>('md');
+  role = signal<DialogRole>('dialog');
+  labelledBy = signal<string | undefined>(undefined);
+  testId = signal<string | undefined>(undefined);
+  cancelOnBackdrop = signal(true);
+  cancelOnEscape = signal(true);
+  cancelledCount = 0;
+}
+
+describe('DialogShellComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  // ── Variants ───────────────────────────────────────────────────────────────
+
+  it('should apply the medium size class by default', () => {
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.classList.contains('yn-dialog--md')).toBe(true);
+  });
+
+  it('should apply the small size class when size is sm', () => {
+    host.size.set('sm');
+
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.classList.contains('yn-dialog--sm')).toBe(true);
+  });
+
+  it('should apply the large size class when size is lg', () => {
+    host.size.set('lg');
+
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.classList.contains('yn-dialog--lg')).toBe(true);
+  });
+
+  // ── ARIA wiring ────────────────────────────────────────────────────────────
+
+  it('should set role="dialog" and aria-modal="true" by default', () => {
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('should expose role="alertdialog" when role is alertdialog', () => {
+    host.role.set('alertdialog');
+
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.getAttribute('role')).toBe('alertdialog');
+  });
+
+  it('should mirror labelledBy as aria-labelledby on the dialog', () => {
+    host.labelledBy.set('header-title');
+
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.getAttribute('aria-labelledby')).toBe('header-title');
+  });
+
+  it('should mirror testId as data-testid on the dialog', () => {
+    host.testId.set('my-dialog');
+
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.getAttribute('data-testid')).toBe('my-dialog');
+  });
+
+  // ── Backdrop click ─────────────────────────────────────────────────────────
+
+  it('should emit cancelled when the overlay backdrop is clicked', () => {
+    fixture.detectChanges();
+
+    const overlay = fixture.nativeElement.querySelector('.yn-dialog-overlay');
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.cancelledCount).toBe(1);
+  });
+
+  it('should not emit cancelled when clicks bubble from inside the dialog', () => {
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.cancelledCount).toBe(0);
+  });
+
+  it('should suppress backdrop cancellation when cancelOnBackdrop is false', () => {
+    host.cancelOnBackdrop.set(false);
+
+    fixture.detectChanges();
+
+    const overlay = fixture.nativeElement.querySelector('.yn-dialog-overlay');
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.cancelledCount).toBe(0);
+  });
+
+  // ── Escape key ─────────────────────────────────────────────────────────────
+
+  it('should emit cancelled when Escape is pressed on the document', () => {
+    fixture.detectChanges();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(host.cancelledCount).toBe(1);
+  });
+
+  it('should suppress Escape cancellation when cancelOnEscape is false', () => {
+    host.cancelOnEscape.set(false);
+
+    fixture.detectChanges();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(host.cancelledCount).toBe(0);
+  });
+
+  // ── Content projection ────────────────────────────────────────────────────
+
+  it('should project content into the dialog element', () => {
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('.yn-dialog');
+    expect(dialog.textContent).toContain('Dialog content');
+    expect(dialog.textContent).toContain('Body');
+  });
+});

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.ts
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.ts
@@ -1,0 +1,37 @@
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input, output } from '@angular/core';
+
+export type DialogSize = 'sm' | 'md' | 'lg';
+export type DialogRole = 'dialog' | 'alertdialog';
+
+@Component({
+  selector: 'yn-dialog-shell',
+  templateUrl: './dialog-shell.component.html',
+  styleUrl: './dialog-shell.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:keydown.escape)': 'onEscape()',
+  },
+})
+export class DialogShellComponent {
+  size = input<DialogSize>('md');
+  role = input<DialogRole>('dialog');
+  labelledBy = input<string | undefined>(undefined);
+  testId = input<string | undefined>(undefined);
+  cancelOnBackdrop = input(true);
+  cancelOnEscape = input(true);
+
+  cancelled = output<void>();
+
+  protected readonly dialogClass = computed(() => `yn-dialog yn-dialog--${this.size()}`);
+
+  onEscape(): void {
+    if (this.cancelOnEscape()) this.cancelled.emit();
+  }
+
+  onOverlayClick(event: MouseEvent): void {
+    if (this.cancelOnBackdrop() && event.target === event.currentTarget) {
+      this.cancelled.emit();
+    }
+  }
+}

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.stories.ts
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.stories.ts
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { DialogShellComponent } from './dialog-shell.component';
+
+const meta: Meta<DialogShellComponent> = {
+  title: 'Components/Dialog Shell',
+  component: DialogShellComponent,
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    role: { control: 'select', options: ['dialog', 'alertdialog'] },
+    labelledBy: { control: 'text' },
+    testId: { control: 'text' },
+    cancelOnBackdrop: { control: 'boolean' },
+    cancelOnEscape: { control: 'boolean' },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<yn-dialog-shell
+      [size]="size"
+      [role]="role"
+      [labelledBy]="labelledBy"
+      [testId]="testId"
+      [cancelOnBackdrop]="cancelOnBackdrop"
+      [cancelOnEscape]="cancelOnEscape"
+    >
+      <header><h2 id="dialog-title">Dialog title</h2><p>Dialog subtitle</p></header>
+      <p>Dialog body content goes here.</p>
+      <div style="display:flex;gap:.5rem;justify-content:flex-end">
+        <button>Cancel</button>
+        <button>Confirm</button>
+      </div>
+    </yn-dialog-shell>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<DialogShellComponent>;
+
+export const Small: Story = { args: { size: 'sm', labelledBy: 'dialog-title' } };
+export const Medium: Story = { args: { size: 'md', labelledBy: 'dialog-title' } };
+export const Large: Story = { args: { size: 'lg', labelledBy: 'dialog-title' } };
+export const AlertDialog: Story = {
+  args: { size: 'sm', role: 'alertdialog', labelledBy: 'dialog-title' },
+};


### PR DESCRIPTION
## Summary
- New `yn-dialog-shell` in `libs/ui` — overlay + glass-dialog, `size` (sm/md/lg), `role` (dialog/alertdialog), ESC + backdrop click → `cancelled` output (gated by `cancelOnEscape` / `cancelOnBackdrop` inputs), `labelledBy` / `testId` passthrough.
- New `yn-card` in `libs/ui` — wraps the existing `.auth-card` partial with optional transloco-key `title`/`subtitle` inputs and a content slot.
- Migrated 3 modal dialogs (`ConfirmDialog`, `CreateShoppingListDialog`, `MultiRecipePreviewDialog`) to use DialogShell, dropping their per-component overlay SCSS, `HostListener` ESC handlers, and `onOverlayClick` methods.
- Migrated 3 auth pages (login, register, resend-verification) to use Card.

**Stacked on #610** — base is \`feat/ui-button-message-banner\` (the button + message banner PR). When that lands, this PR's base auto-retargets to develop.

## Test plan
- [x] \`yarn nx run-many --target=lint --projects=ui,shell,recipes,shopping,account\` — passes (only pre-existing warnings).
- [x] \`yarn nx run-many --target=test --projects=ui,shell,recipes,shopping,account\` — green (incl. 13 new DialogShell specs and 5 new Card specs; existing dialog specs migrated to dispatch real \`KeyboardEvent\` instead of calling \`onEscapeKey()\` directly, and to query \`.yn-dialog-overlay\` instead of the old per-dialog overlay class).
- [x] \`yarn build:all\` — succeeds (two pre-existing SCSS budget warnings on dashboard.scss / chat-panel.scss, both untouched here).
- [ ] Manual smoke: open the three dialogs (delete recipe → confirm; create shopping list; multi-recipe selection); verify ESC + backdrop click + "creating" gating; load login/register/resend-verification pages.