### PR TITLE
feat(ui): add ClickOutsideDirective and migrate dropdowns

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
+++ b/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
@@ -1,4 +1,4 @@
-<div class="sort-dropdown" #dropdown *transloco="let t">
+<div class="sort-dropdown" ynClickOutside (clickOutside)="onDismiss()" (escape)="onDismiss()" *transloco="let t">
   <button
     type="button"
     class="sort-toggle"

--- a/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.ts
@@ -1,15 +1,7 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ElementRef,
-  HostListener,
-  input,
-  output,
-  signal,
-  viewChild,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, output, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
+import { ClickOutsideDirective } from '@yumney/ui';
 
 export interface SortMenuOption {
   value: string;
@@ -18,7 +10,7 @@ export interface SortMenuOption {
 
 @Component({
   selector: 'yn-sort-menu',
-  imports: [TranslocoModule, LucideAngularModule],
+  imports: [TranslocoModule, LucideAngularModule, ClickOutsideDirective],
   templateUrl: './sort-menu.component.html',
   styleUrl: './sort-menu.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,14 +22,13 @@ export class SortMenuComponent {
   sortSelect = output<string>();
 
   protected open = signal(false);
-  private dropdown = viewChild<ElementRef>('dropdown');
 
   protected currentLabelKey(): string {
-    return this.options().find((o) => o.value === this.currentValue())?.labelKey ?? '';
+    return this.options().find((option) => option.value === this.currentValue())?.labelKey ?? '';
   }
 
   protected toggle(): void {
-    this.open.update((o) => !o);
+    this.open.update((open) => !open);
   }
 
   protected select(value: string): void {
@@ -45,16 +36,7 @@ export class SortMenuComponent {
     this.sortSelect.emit(value);
   }
 
-  @HostListener('document:keydown.escape')
-  protected onEscape(): void {
+  protected onDismiss(): void {
     if (this.open()) this.open.set(false);
-  }
-
-  @HostListener('document:click', ['$event.target'])
-  protected onDocumentClick(target: EventTarget | null): void {
-    const el = this.dropdown()?.nativeElement;
-    if (this.open() && target instanceof Node && !el?.contains(target)) {
-      this.open.set(false);
-    }
   }
 }

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -70,5 +70,6 @@ export { StarRatingComponent } from './lib/star-rating/star-rating.component';
 export { provideYumneyIcons } from './lib/icons/provide-icons';
 
 // Directives
+export { ClickOutsideDirective } from './lib/directives/click-outside.directive';
 export { InfiniteScrollDirective } from './lib/directives/infinite-scroll.directive';
 export { StaggerNewItemsDirective } from './lib/directives/stagger-new-items.directive';

--- a/client/libs/ui/src/lib/directives/click-outside.directive.spec.ts
+++ b/client/libs/ui/src/lib/directives/click-outside.directive.spec.ts
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClickOutsideDirective } from './click-outside.directive';
+
+@Component({
+  imports: [ClickOutsideDirective],
+  template: `
+    <div ynClickOutside (clickOutside)="outsideCount = outsideCount + 1" (escape)="escapeCount = escapeCount + 1" data-testid="wrapper">
+      <button data-testid="inner-button">click me</button>
+    </div>
+    <button data-testid="external-button">outside</button>
+  `,
+})
+class HostComponent {
+  outsideCount = 0;
+  escapeCount = 0;
+}
+
+describe('ClickOutsideDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ── clickOutside output ────────────────────────────────────────────────────
+
+  it('should not emit clickOutside when a click lands inside the host element', () => {
+    const inner = fixture.nativeElement.querySelector('[data-testid="inner-button"]');
+    inner.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.outsideCount).toBe(0);
+  });
+
+  it('should emit clickOutside when a click lands on a sibling outside the host', () => {
+    const external = fixture.nativeElement.querySelector('[data-testid="external-button"]');
+    external.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.outsideCount).toBe(1);
+  });
+
+  it('should emit clickOutside when a click lands on the document body', () => {
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(host.outsideCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── escape output ──────────────────────────────────────────────────────────
+
+  it('should emit escape when Escape is pressed on the document', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(host.escapeCount).toBe(1);
+  });
+
+  it('should not emit escape on other keys', () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(host.escapeCount).toBe(0);
+  });
+});

--- a/client/libs/ui/src/lib/directives/click-outside.directive.ts
+++ b/client/libs/ui/src/lib/directives/click-outside.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, ElementRef, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[ynClickOutside]',
+  host: {
+    '(document:click)': 'onDocumentClick($event)',
+    '(document:keydown.escape)': 'onEscape()',
+  },
+})
+export class ClickOutsideDirective {
+  clickOutside = output<void>();
+  escape = output<void>();
+
+  private host = inject(ElementRef<HTMLElement>);
+
+  protected onDocumentClick(event: MouseEvent): void {
+    const target = event.target;
+    if (target instanceof Node && !this.host.nativeElement.contains(target)) {
+      this.clickOutside.emit();
+    }
+  }
+
+  protected onEscape(): void {
+    this.escape.emit();
+  }
+}

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -1,4 +1,4 @@
-<header *transloco="let t">
+<header ynClickOutside (clickOutside)="onDismissMenu()" (escape)="onDismissMenu()" *transloco="let t">
   <div class="header-content">
     <a class="brand" routerLink="/">Yumney</a>
 

--- a/client/libs/ui/src/lib/header/header.component.ts
+++ b/client/libs/ui/src/lib/header/header.component.ts
@@ -1,21 +1,14 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  computed,
-  signal,
-  ElementRef,
-  HostListener,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, computed, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { AuthService } from '@yumney/shared/auth';
 import { LanguageService, ThemeService, ChatStateService, ROUTES } from '@yumney/shared/models';
+import { ClickOutsideDirective } from '../directives/click-outside.directive';
 
 @Component({
   selector: 'yn-header',
-  imports: [TranslocoModule, RouterLink, LucideAngularModule],
+  imports: [TranslocoModule, RouterLink, LucideAngularModule, ClickOutsideDirective],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -27,8 +20,6 @@ export class HeaderComponent {
   protected languageService = inject(LanguageService);
   protected themeService = inject(ThemeService);
   protected chatState = inject(ChatStateService);
-
-  private elementRef = inject(ElementRef);
 
   protected menuOpen = signal(false);
   protected isDark = computed(() => this.themeService.theme() === 'dark');
@@ -51,18 +42,8 @@ export class HeaderComponent {
     return this.languageService.nextLanguage;
   });
 
-  @HostListener('document:keydown.escape')
-  onEscapeKey(): void {
-    if (this.menuOpen()) {
-      this.menuOpen.set(false);
-    }
-  }
-
-  @HostListener('document:click', ['$event'])
-  onDocumentClick(event: MouseEvent): void {
-    if (this.menuOpen() && !this.elementRef.nativeElement.contains(event.target)) {
-      this.menuOpen.set(false);
-    }
+  onDismissMenu(): void {
+    if (this.menuOpen()) this.menuOpen.set(false);
   }
 
   onToggleMenu(): void {

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.html
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.html
@@ -1,4 +1,4 @@
-<div class="unit-select" *transloco="let t">
+<div class="unit-select" ynClickOutside (clickOutside)="onDismiss()" (escape)="onDismiss()" *transloco="let t">
   <button
     type="button"
     class="unit-toggle"

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.ts
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.ts
@@ -5,18 +5,17 @@ import {
   input,
   signal,
   forwardRef,
-  ElementRef,
-  inject,
   HostListener,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { type UnitGroupInfo, type KnownUnit, KNOWN_UNITS } from '@yumney/shared/models';
+import { ClickOutsideDirective } from '../directives/click-outside.directive';
 
 @Component({
   selector: 'yn-unit-select',
-  imports: [TranslocoModule, LucideAngularModule],
+  imports: [TranslocoModule, LucideAngularModule, ClickOutsideDirective],
   templateUrl: './unit-select.component.html',
   styleUrl: './unit-select.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -39,7 +38,6 @@ export class UnitSelectComponent implements ControlValueAccessor {
 
   protected flatUnits = computed(() => this.unitGroups().flatMap((group) => group.units));
 
-  private elementRef = inject(ElementRef);
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private onChange: (value: string | null) => void = () => {};
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -48,19 +46,11 @@ export class UnitSelectComponent implements ControlValueAccessor {
   get selectedLabel(): string | null {
     const value = this.selectedValue();
     if (!value) return null;
-    const unit = KNOWN_UNITS.find((u) => u.value === value);
+    const unit = KNOWN_UNITS.find((knownUnit) => knownUnit.value === value);
     return unit?.labelKey ?? value;
   }
 
-  @HostListener('document:click', ['$event'])
-  onDocumentClick(event: MouseEvent): void {
-    if (!this.elementRef.nativeElement.contains(event.target)) {
-      this.isOpen.set(false);
-    }
-  }
-
-  @HostListener('document:keydown.escape')
-  onEscapeKey(): void {
+  onDismiss(): void {
     if (this.isOpen()) {
       this.isOpen.set(false);
       this.focusedIndex.set(-1);


### PR DESCRIPTION
## Summary
- New \`[ynClickOutside]\` directive in \`libs/ui\` with two outputs: \`(clickOutside)\` (fires when a click lands outside the host element) and \`(escape)\` (fires on Escape keydown). Uses \`host: { '(document:click)': '...', '(document:keydown.escape)': '...' }\` instead of \`@HostListener\`.
- Migrated three dropdown components — \`SortMenuComponent\` (recipes), \`UnitSelectComponent\` (libs/ui), \`HeaderComponent\` (libs/ui) — to consume the directive. Each one drops its duplicated pair of HostListeners and (where applicable) its \`ElementRef\` injection. SortMenu also drops the \`#dropdown\` ViewChild it used as the outside-check anchor.
- UnitSelect's third HostListener (arrow-key navigation inside an open menu) is intentionally kept — it's not click-outside concern.

**Stacked on #611** — base is \`feat/ui-dialog-shell-card\`. When that lands, this PR's base auto-retargets to develop.

## Test plan
- [x] \`yarn nx run-many --target=lint --projects=ui,recipes\` — passes (only pre-existing warnings).
- [x] \`yarn nx run-many --target=test --projects=ui,recipes,shell\` — green (incl. 5 new directive specs; existing UnitSelect specs that dispatch real \`document\` events keep working unchanged through the directive's host listeners).
- [x] \`yarn build:all\` — succeeds.
- [ ] Manual smoke: open the recipe list sort menu, an ingredient unit picker, and the header avatar menu; verify each closes on outside click and Escape; verify SortMenu still closes when picking an option.