### PR TITLE
refactor(frontend): replace last in-component subscribes with effect/toSignal

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.spec.ts
@@ -1,5 +1,6 @@
-import { DestroyRef, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { TestBed, fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { RecipeApiService, RecipeDetail } from '../api';
 import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
 
@@ -30,7 +31,6 @@ describe('RecipeNotesAutosaveService', () => {
       providers: [
         RecipeNotesAutosaveService,
         { provide: RecipeApiService, useValue: api },
-        { provide: DestroyRef, useValue: { onDestroy: () => () => undefined } },
       ],
     });
     return TestBed.inject(RecipeNotesAutosaveService);
@@ -65,4 +65,26 @@ describe('RecipeNotesAutosaveService', () => {
     expect(service.draft()).toBe('typed');
     expect(service.saved()).toBe(false);
   });
+
+  it('persists once after the debounce interval elapses', fakeAsync(() => {
+    const updateRecipeNotes = vi.fn().mockReturnValue(of(undefined));
+    const service = createService({ updateRecipeNotes });
+    const recipeRef = signal<RecipeDetail | null>(buildRecipe({ notes: null }));
+    service.attach(recipeRef);
+    TestBed.tick();
+
+    service.update('first');
+    TestBed.tick();
+    service.update('second');
+    TestBed.tick();
+    tick(399);
+
+    expect(updateRecipeNotes).not.toHaveBeenCalled();
+
+    tick(1);
+    flushMicrotasks();
+
+    expect(updateRecipeNotes).toHaveBeenCalledTimes(1);
+    expect(updateRecipeNotes).toHaveBeenCalledWith('r1', 'second');
+  }));
 });

--- a/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
@@ -1,6 +1,4 @@
-import { DestroyRef, Injectable, WritableSignal, inject, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { debounceTime, skip } from 'rxjs';
+import { Injectable, WritableSignal, effect, inject, signal } from '@angular/core';
 import { RecipeApiService, RecipeDetail } from '../api';
 
 const NOTES_AUTOSAVE_DEBOUNCE_MS = 400;
@@ -9,7 +7,6 @@ const SAVED_INDICATOR_MS = 2000;
 @Injectable()
 export class RecipeNotesAutosaveService {
   private api = inject(RecipeApiService);
-  private destroyRef = inject(DestroyRef);
 
   readonly draft = signal('');
   readonly saved = signal(false);
@@ -17,9 +14,16 @@ export class RecipeNotesAutosaveService {
   private recipeRef: WritableSignal<RecipeDetail | null> | null = null;
 
   constructor() {
-    toObservable(this.input)
-      .pipe(skip(1), debounceTime(NOTES_AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
-      .subscribe((value) => this.persist(value));
+    let firstRun = true;
+    effect((onCleanup) => {
+      const value = this.input();
+      if (firstRun) {
+        firstRun = false;
+        return;
+      }
+      const timeoutId = setTimeout(() => this.persist(value), NOTES_AUTOSAVE_DEBOUNCE_MS);
+      onCleanup(() => clearTimeout(timeoutId));
+    });
   }
 
   attach(recipeRef: WritableSignal<RecipeDetail | null>): void {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -5,9 +5,10 @@ import {
   inject,
   DestroyRef,
   OnInit,
+  effect,
   viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
@@ -88,12 +89,13 @@ export class DashboardComponent implements OnInit {
   recentActivity = this.suggestionsState.recentActivity;
   suggestionsLoading = this.suggestionsState.loading;
 
-  ngOnInit(): void {
-    this.suggestionsState.load().subscribe(({ initialDataIsEmpty }) => {
-      if (initialDataIsEmpty) this.importSectionExpanded.set(true);
-    });
+  private readonly queryParams = toSignal(this.route.queryParams, {
+    initialValue: {} as Record<string, string>,
+  });
 
-    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
+  constructor() {
+    effect(() => {
+      const params = this.queryParams();
       const urlParam = params['url'] as string | undefined;
       const textParam = params['text'] as string | undefined;
       const sharedText = urlParam || textParam;
@@ -108,6 +110,12 @@ export class DashboardComponent implements OnInit {
         this.serverError.set('dashboard.share.noUrlFound');
         this.importSectionExpanded.set(true);
       }
+    });
+  }
+
+  ngOnInit(): void {
+    this.suggestionsState.load().subscribe(({ initialDataIsEmpty }) => {
+      if (initialDataIsEmpty) this.importSectionExpanded.set(true);
     });
   }
 


### PR DESCRIPTION
## Summary
- \`RecipeNotesAutosaveService\` — drops the \`toObservable(input).pipe(skip, debounceTime, takeUntilDestroyed).subscribe(persist)\` chain in favor of \`effect((onCleanup) => …)\` with a 400ms \`setTimeout\` the cleanup clears. Drops the \`DestroyRef\` injection (no longer used) and the \`takeUntilDestroyed\` / \`toObservable\` / \`skip\` / \`debounceTime\` imports. Spec gains a fakeAsync test that pins the debounce semantics (multiple updates collapse to one persist with the latest value, only after the interval elapses).
- \`DashboardComponent\` — drops the \`route.queryParams.pipe(takeUntilDestroyed).subscribe(...)\` in \`ngOnInit\` for \`toSignal(route.queryParams, { initialValue: {} })\` plus a constructor \`effect(...)\` that runs the same share-target branch. \`DestroyRef\` stays — \`createAsyncState(this.destroyRef)\` still uses it for the import/save flows.

**Stacked on #612** — base is \`feat/ui-click-outside-directive\`. Auto-retargets to develop when that lands.

## Test plan
- [x] \`yarn nx run-many --target=lint --projects=shell,recipes\` — passes (only pre-existing warnings).
- [x] \`yarn nx test recipes\` — 185 tests green (incl. 1 new debounce-semantics test).
- [x] \`yarn nx test shell\` — 233 tests green; the 8 share-target queryParams tests in \`dashboard.component.spec.ts\` keep passing because the spec mock returns the queryParams Observable synchronously via \`of(...)\`, which \`toSignal\` unwraps with the same first-detectChanges timing the old subscribe had.
- [x] \`yarn build:all\` — succeeds.
- [ ] Manual smoke: type into a recipe's notes field (autosave fires once after 400ms idle); open dashboard with \`?url=...\` and \`?text=...\` deep links to confirm share-import still triggers.