### PR TITLE
feat(ui): add EmptyStateComponent and migrate four call sites

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -86,19 +86,18 @@
   }
 
   @if (!isLoading() && recipes().length === 0 && !serverError()) {
-    @if (activeSearch()) {
-      <div class="empty-state">
-        <h2>{{ t('recipes.list.search.noResults') }}</h2>
-        <p>{{ t('recipes.list.search.noResultsMessage', { query: activeSearch() }) }}</p>
-      </div>
+    @if (activeSearch(); as query) {
+      <yn-empty-state
+        title="recipes.list.search.noResults"
+        message="recipes.list.search.noResultsMessage"
+        [messageParams]="{ query }"
+      />
     } @else {
-      <div class="empty-state">
-        <h2>{{ t('recipes.list.empty.title') }}</h2>
-        <p>{{ t('recipes.list.empty.message') }}</p>
-        <a [routerLink]="ROUTES.dashboard" class="cta-button">
+      <yn-empty-state title="recipes.list.empty.title" message="recipes.list.empty.message">
+        <yn-button variant="primary" [routerLink]="ROUTES.dashboard">
           {{ t('recipes.list.empty.cta') }}
-        </a>
-      </div>
+        </yn-button>
+      </yn-empty-state>
     }
   }
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -141,47 +141,6 @@ yn-filter-panel {
   }
 }
 
-// ── Empty state ──
-.empty-state {
-  @include glass.glass-card;
-  text-align: center;
-  padding: 4rem var(--yn-space-8);
-  animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
-
-  h2 {
-    margin: 0 0 var(--yn-space-3);
-    font-size: var(--yn-text-2xl);
-    font-weight: var(--yn-font-semibold);
-  }
-
-  p {
-    margin: 0 0 var(--yn-space-7);
-    color: var(--yn-text-muted);
-    font-size: var(--yn-text-base);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
-}
-
-.cta-button {
-  display: inline-block;
-  padding: var(--yn-button-padding-y) var(--yn-button-padding-x);
-  border-radius: var(--yn-radius-button);
-  background: var(--yn-primary);
-  color: var(--yn-text-inverse);
-  font-size: var(--yn-text-lg);
-  font-weight: var(--yn-font-medium);
-  text-decoration: none;
-  cursor: pointer;
-
-  &:hover {
-    background: var(--yn-primary-hover);
-    box-shadow: var(--yn-shadow-primary-glow);
-  }
-}
-
 // ── Recipe grid ──
 .recipe-grid {
   display: grid;

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
@@ -228,7 +228,7 @@ describe('RecipeListComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const cta = fixture.nativeElement.querySelector('.cta-button');
+    const cta = fixture.nativeElement.querySelector('.empty-state a.btn-primary');
     expect(cta).toBeTruthy();
     expect(cta.textContent).toContain('Import a Recipe');
   }));

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -21,7 +21,9 @@ import {
 } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
 import {
+  ButtonComponent,
   EMPTY_FILTER,
+  EmptyStateComponent,
   FilterPanelComponent,
   InfiniteScrollDirective,
   MessageBannerComponent,
@@ -47,6 +49,8 @@ interface SortOption extends SortMenuOption {
     LucideAngularModule,
     InfiniteScrollDirective,
     StaggerNewItemsDirective,
+    ButtonComponent,
+    EmptyStateComponent,
     FilterPanelComponent,
     MessageBannerComponent,
     RecipeCardComponent,

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -81,8 +81,10 @@
   }
 
   @if (!loading() && totalItems() === 0) {
-    <div class="empty-state" data-testid="shopping-empty-state">
-      <p>{{ t(showPastPurchases() ? 'shopping.history.empty' : 'shopping.empty') }}</p>
-    </div>
+    <yn-empty-state
+      variant="minimal"
+      testId="shopping-empty-state"
+      [message]="showPastPurchases() ? 'shopping.history.empty' : 'shopping.empty'"
+    />
   }
 </div>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.scss
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.scss
@@ -149,8 +149,7 @@
   }
 }
 
-.loading,
-.empty-state {
+.loading {
   text-align: center;
   color: var(--yn-text-muted);
   padding: var(--yn-space-7);

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -12,7 +12,7 @@ import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem } from '../api';
 import { createAsyncState, ERROR_MAPS, groupByCategory, ToastService } from '@yumney/shared/models';
-import { AsyncStateComponent } from '@yumney/ui';
+import { AsyncStateComponent, EmptyStateComponent } from '@yumney/ui';
 
 interface CategoryGroup {
   category: string;
@@ -23,7 +23,7 @@ interface CategoryGroup {
 @Component({
   selector: 'yn-merged-list',
   standalone: true,
-  imports: [FormsModule, TranslocoModule, LucideAngularModule, AsyncStateComponent],
+  imports: [FormsModule, TranslocoModule, LucideAngularModule, AsyncStateComponent, EmptyStateComponent],
   templateUrl: './merged-list.component.html',
   styleUrl: './merged-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
@@ -11,10 +11,7 @@
 
   @if (!isLoading() && !serverError()) {
     @if (lists().length === 0) {
-      <div class="empty-state">
-        <h2>{{ t('shopping.list.empty.title') }}</h2>
-        <p>{{ t('shopping.list.empty.message') }}</p>
-      </div>
+      <yn-empty-state title="shopping.list.empty.title" message="shopping.list.empty.message"/>
     } @else {
       <div class="lists-grid">
         @for (list of lists(); track list.identifier) {

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.scss
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.scss
@@ -17,30 +17,6 @@ h1 {
   padding: 4rem 0;
 }
 
-.empty-state {
-  @include glass.glass-card;
-  text-align: center;
-  padding: 4rem var(--yn-space-5);
-  animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
-
-  h2 {
-    margin: 0 0 var(--yn-space-3);
-    font-size: var(--yn-text-2xl);
-    font-weight: var(--yn-font-semibold);
-    color: var(--yn-text-secondary);
-  }
-
-  p {
-    margin: 0;
-    font-size: var(--yn-text-md);
-    color: var(--yn-text-light);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
-}
-
 .lists-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
@@ -11,11 +11,11 @@ import { DatePipe } from '@angular/common';
 import { TranslocoModule } from '@jsverse/transloco';
 import { ShoppingApiService, ShoppingListSummary } from '../api';
 import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
-import { LoadingSpinnerComponent, MessageBannerComponent } from '@yumney/ui';
+import { EmptyStateComponent, LoadingSpinnerComponent, MessageBannerComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-shopping-list',
-  imports: [TranslocoModule, RouterLink, DatePipe, LoadingSpinnerComponent, MessageBannerComponent],
+  imports: [TranslocoModule, RouterLink, DatePipe, EmptyStateComponent, LoadingSpinnerComponent, MessageBannerComponent],
   templateUrl: './shopping-list.component.html',
   styleUrl: './shopping-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -10,6 +10,10 @@ export {
   type DialogRole,
   type DialogSize,
 } from './lib/dialog-shell/dialog-shell.component';
+export {
+  EmptyStateComponent,
+  type EmptyStateVariant,
+} from './lib/empty-state/empty-state.component';
 export { FormFieldComponent } from './lib/form-field/form-field.component';
 export {
   MessageBannerComponent,

--- a/client/libs/ui/src/lib/empty-state/empty-state.component.html
+++ b/client/libs/ui/src/lib/empty-state/empty-state.component.html
@@ -1,0 +1,7 @@
+<div [class]="containerClass()" [attr.data-testid]="testId() ?? null">
+  @if (title(); as titleKey) {
+    <h2>{{ titleKey | transloco }}</h2>
+  }
+  <p>{{ message() | transloco: messageParams() }}</p>
+  <ng-content />
+</div>

--- a/client/libs/ui/src/lib/empty-state/empty-state.component.scss
+++ b/client/libs/ui/src/lib/empty-state/empty-state.component.scss
@@ -1,0 +1,43 @@
+@use 'glass';
+
+yn-empty-state {
+  display: block;
+}
+
+.empty-state {
+  text-align: center;
+
+  &--card {
+    @include glass.glass-card;
+    display: flex;
+    flex-direction: column;
+    gap: var(--yn-space-5);
+    padding: 4rem var(--yn-space-8);
+    animation: yn-fade-in var(--yn-duration-normal) var(--yn-ease-glass) both;
+
+    h2 {
+      margin: 0;
+      font-size: var(--yn-text-2xl);
+      font-weight: var(--yn-font-semibold);
+    }
+
+    p {
+      margin: 0;
+      color: var(--yn-text-muted);
+      font-size: var(--yn-text-base);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+
+  &--minimal {
+    color: var(--yn-text-muted);
+    padding: var(--yn-space-7);
+
+    p {
+      margin: 0;
+    }
+  }
+}

--- a/client/libs/ui/src/lib/empty-state/empty-state.component.spec.ts
+++ b/client/libs/ui/src/lib/empty-state/empty-state.component.spec.ts
@@ -1,0 +1,111 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { EmptyStateComponent } from './empty-state.component';
+
+const en = {
+  list: {
+    empty: {
+      title: 'Nothing here yet',
+      message: 'Add your first recipe to get started.',
+    },
+    search: {
+      noResults: 'No matches for "{{ query }}"',
+    },
+  },
+};
+
+describe('EmptyStateComponent', () => {
+  let fixture: ComponentFixture<EmptyStateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmptyStateComponent, setupTranslocoTesting(en)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmptyStateComponent);
+  });
+
+  // ── Variant class ──────────────────────────────────────────────────────────
+
+  it('should default to the card variant', () => {
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector('.empty-state');
+    expect(container.classList.contains('empty-state--card')).toBe(true);
+  });
+
+  it('should apply the minimal variant class when requested', () => {
+    fixture.componentRef.setInput('variant', 'minimal');
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector('.empty-state');
+    expect(container.classList.contains('empty-state--minimal')).toBe(true);
+  });
+
+  // ── Title rendering ────────────────────────────────────────────────────────
+
+  it('should not render an h2 when title is omitted', () => {
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const heading = fixture.nativeElement.querySelector('h2');
+    expect(heading).toBeFalsy();
+  });
+
+  it('should translate the title input as an h2', () => {
+    fixture.componentRef.setInput('title', 'list.empty.title');
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const heading = fixture.nativeElement.querySelector('h2');
+    expect(heading.textContent.trim()).toBe('Nothing here yet');
+  });
+
+  // ── Message rendering ─────────────────────────────────────────────────────
+
+  it('should translate the message as a paragraph', () => {
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const message = fixture.nativeElement.querySelector('p');
+    expect(message.textContent.trim()).toBe('Add your first recipe to get started.');
+  });
+
+  it('should interpolate messageParams', () => {
+    fixture.componentRef.setInput('message', 'list.search.noResults');
+    fixture.componentRef.setInput('messageParams', { query: 'pasta' });
+
+    fixture.detectChanges();
+
+    const message = fixture.nativeElement.querySelector('p');
+    expect(message.textContent.trim()).toBe('No matches for "pasta"');
+  });
+
+  // ── Test id passthrough ────────────────────────────────────────────────────
+
+  it('should set data-testid when testId input is provided', () => {
+    fixture.componentRef.setInput('message', 'list.empty.message');
+    fixture.componentRef.setInput('testId', 'recipes-empty');
+
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector('.empty-state');
+    expect(container.getAttribute('data-testid')).toBe('recipes-empty');
+  });
+
+  it('should omit data-testid when testId input is not provided', () => {
+    fixture.componentRef.setInput('message', 'list.empty.message');
+
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector('.empty-state');
+    expect(container.getAttribute('data-testid')).toBeNull();
+  });
+});

--- a/client/libs/ui/src/lib/empty-state/empty-state.component.ts
+++ b/client/libs/ui/src/lib/empty-state/empty-state.component.ts
@@ -1,0 +1,22 @@
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+
+export type EmptyStateVariant = 'card' | 'minimal';
+
+@Component({
+  selector: 'yn-empty-state',
+  imports: [TranslocoPipe],
+  templateUrl: './empty-state.component.html',
+  styleUrl: './empty-state.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EmptyStateComponent {
+  variant = input<EmptyStateVariant>('card');
+  title = input<string | undefined>(undefined);
+  message = input.required<string>();
+  messageParams = input<Record<string, unknown> | undefined>(undefined);
+  testId = input<string | undefined>(undefined);
+
+  protected readonly containerClass = computed(() => `empty-state empty-state--${this.variant()}`);
+}

--- a/client/libs/ui/src/lib/empty-state/empty-state.stories.ts
+++ b/client/libs/ui/src/lib/empty-state/empty-state.stories.ts
@@ -1,0 +1,48 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { provideRouter } from '@angular/router';
+import { ButtonComponent } from '../button/button.component';
+import { EmptyStateComponent } from './empty-state.component';
+
+const meta: Meta<EmptyStateComponent> = {
+  title: 'Components/Empty State',
+  component: EmptyStateComponent,
+  decorators: [moduleMetadata({ imports: [ButtonComponent], providers: [provideRouter([])] })],
+  argTypes: {
+    variant: { control: 'select', options: ['card', 'minimal'] },
+    title: { control: 'text' },
+    message: { control: 'text' },
+    testId: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EmptyStateComponent>;
+
+export const Card: Story = {
+  args: {
+    variant: 'card',
+    title: 'recipes.list.empty.title',
+    message: 'recipes.list.empty.message',
+  },
+};
+
+export const CardWithCta: Story = {
+  args: {
+    variant: 'card',
+    title: 'recipes.list.empty.title',
+    message: 'recipes.list.empty.message',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<yn-empty-state [variant]="variant" [title]="title" [message]="message">
+      <yn-button variant="primary" routerLink="/">Get started</yn-button>
+    </yn-empty-state>`,
+  }),
+};
+
+export const Minimal: Story = {
+  args: {
+    variant: 'minimal',
+    message: 'shopping.empty',
+  },
+};


### PR DESCRIPTION
## Summary
- New \`yn-empty-state\` in \`libs/ui\` with two variants — \`card\` (glass surface, large padding, animated) and \`minimal\` (centered muted text). Optional \`title\` (transloco key), required \`message\` with \`messageParams\` for interpolation, \`testId\` passthrough, and a content slot for an optional CTA.
- Migrated four call sites:
  - \`shopping-list\`: card variant with title + message.
  - \`merged-list\`: minimal variant; ternary inlined into \`[message]\`.
  - \`recipe-list\` "no results" branch: card variant with \`messageParams\` for the search-query interpolation.
  - \`recipe-list\` "empty" branch: card variant with a \`<yn-button variant=\"primary\" [routerLink]>\` projected as CTA, replacing the local \`.cta-button\` (which was a hand-rolled copy of the existing global \`.btn-primary\`).
- Dropped ~50 lines of duplicated \`.empty-state\` SCSS across the three apps and the entire \`.cta-button\` block.

**Stacked on #613** — base is \`feat/signal-migration-autosave-and-queryparams\`. Auto-retargets to develop when that lands.

## Test plan
- [x] \`yarn nx run-many --target=lint --projects=ui,recipes,shopping\` — passes (only pre-existing warnings).
- [x] \`yarn nx run-many --target=test --projects=ui,recipes,shopping\` — green (8 new EmptyStateComponent specs; existing \`.empty-state\` queries in shopping-list/merged-list/recipe-list specs keep working because the component renders \`<div class=\"empty-state empty-state--{variant}\">\`). One spec assertion changed: \`recipe-list\` "should show CTA link" now queries \`.empty-state a.btn-primary\` instead of the dead \`.cta-button\` class.
- [x] \`yarn build:all\` — succeeds.
- [ ] Manual smoke: empty recipe list (with no search), recipe search returning zero results, empty shopping-lists page, merged shopping list with no items.