### PR TITLE
refactor(shared): extract debouncedEffect helper and adopt at three sites

### DIFF
--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -9,10 +9,9 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { debounceTime, skip } from 'rxjs';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import {
   createAsyncState,
+  debouncedEffect,
   ERROR_MAPS,
   ThemeService,
   UI,
@@ -40,7 +39,6 @@ export class ProfileSettingsComponent {
   private loadState = createAsyncState(this.destroyRef);
   private saveState = createAsyncState(this.destroyRef);
   private autosaveTick = signal(0);
-  private autosave$ = toObservable(this.autosaveTick);
 
   protected profile = signal<UserProfile | null>(null);
   protected loading = this.loadState.isLoading;
@@ -100,9 +98,7 @@ export class ProfileSettingsComponent {
   protected readonly cookingEfforts = ['quick-weekdays', 'balanced', 'elaborate-weekends'];
 
   constructor() {
-    this.autosave$
-      .pipe(skip(1), debounceTime(AUTOSAVE_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.persist());
+    debouncedEffect(this.autosaveTick, AUTOSAVE_DEBOUNCE_MS, () => this.persist());
 
     effect(() => {
       // Push theme + voice settings into local services so the change is

--- a/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-notes-autosave.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, WritableSignal, effect, inject, signal } from '@angular/core';
+import { Injectable, WritableSignal, inject, signal } from '@angular/core';
+import { debouncedEffect } from '@yumney/shared/models';
 import { RecipeApiService, RecipeDetail } from '../api';
 
 const NOTES_AUTOSAVE_DEBOUNCE_MS = 400;
@@ -14,16 +15,7 @@ export class RecipeNotesAutosaveService {
   private recipeRef: WritableSignal<RecipeDetail | null> | null = null;
 
   constructor() {
-    let firstRun = true;
-    effect((onCleanup) => {
-      const value = this.input();
-      if (firstRun) {
-        firstRun = false;
-        return;
-      }
-      const timeoutId = setTimeout(() => this.persist(value), NOTES_AUTOSAVE_DEBOUNCE_MS);
-      onCleanup(() => clearTimeout(timeoutId));
-    });
+    debouncedEffect(this.input, NOTES_AUTOSAVE_DEBOUNCE_MS, (value) => this.persist(value));
   }
 
   attach(recipeRef: WritableSignal<RecipeDetail | null>): void {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -7,13 +7,12 @@ import {
   DestroyRef,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { debounceTime, skip } from 'rxjs';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
 import {
   createAsyncState,
+  debouncedEffect,
   ERROR_MAPS,
   ROUTES,
   UI,
@@ -88,8 +87,14 @@ export class RecipeListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
   private searchInput = signal('');
-  private searchInput$ = toObservable(this.searchInput);
   private loadRequestId = 0;
+
+  constructor() {
+    debouncedEffect(this.searchInput, UI.SEARCH_DEBOUNCE_MS, (value) => {
+      this.activeSearch.set(value.trim());
+      this.resetAndReload();
+    });
+  }
 
   protected assignment = inject(RecipeAssignmentService);
   protected multiSelect = inject(MultiRecipeShoppingListService);
@@ -132,13 +137,6 @@ export class RecipeListComponent implements OnInit {
     this.assignment.initFromRoute();
     this.multiSelect.initFromRoute();
     this.loadRecipes(false);
-
-    this.searchInput$
-      .pipe(skip(1), debounceTime(UI.SEARCH_DEBOUNCE_MS), takeUntilDestroyed(this.destroyRef))
-      .subscribe((value) => {
-        this.activeSearch.set(value.trim());
-        this.resetAndReload();
-      });
   }
 
   onSearchInput(event: Event): void {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './lib/merge-recipe-ingredients';
 export { UI } from './lib/ui-constants';
 export { createAsyncState, type AsyncState } from './lib/async-state';
+export { debouncedEffect } from './lib/debounced-effect';
 export { ensureFormValid } from './lib/form-helpers';
 export { optimisticSignalUpdate } from './lib/optimistic-update';
 export { toggleFavoriteOnItem, toggleFavoriteInList } from './lib/favorite-toggle';

--- a/client/libs/shared/models/src/lib/debounced-effect.spec.ts
+++ b/client/libs/shared/models/src/lib/debounced-effect.spec.ts
@@ -1,0 +1,80 @@
+import { Component, signal } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { debouncedEffect } from './debounced-effect';
+
+@Component({ template: '' })
+class HostComponent {
+  readonly source = signal('');
+  readonly callbackInvocations: string[] = [];
+
+  constructor() {
+    debouncedEffect(this.source, 400, (value) => {
+      this.callbackInvocations.push(value);
+    });
+  }
+}
+
+describe('debouncedEffect', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+  });
+
+  it('does not invoke the callback on the first effect run', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    TestBed.tick();
+    tick(1000);
+
+    expect(fixture.componentInstance.callbackInvocations).toEqual([]);
+  }));
+
+  it('invokes the callback once after the debounce window elapses', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    TestBed.tick();
+
+    fixture.componentInstance.source.set('hello');
+    TestBed.tick();
+    tick(399);
+    expect(fixture.componentInstance.callbackInvocations).toEqual([]);
+
+    tick(1);
+    expect(fixture.componentInstance.callbackInvocations).toEqual(['hello']);
+  }));
+
+  it('collapses successive changes into a single fire with the latest value', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    TestBed.tick();
+
+    fixture.componentInstance.source.set('first');
+    TestBed.tick();
+    tick(200);
+    fixture.componentInstance.source.set('second');
+    TestBed.tick();
+    tick(200);
+    fixture.componentInstance.source.set('third');
+    TestBed.tick();
+    tick(200);
+
+    expect(fixture.componentInstance.callbackInvocations).toEqual([]);
+
+    tick(200);
+    expect(fixture.componentInstance.callbackInvocations).toEqual(['third']);
+  }));
+
+  it('cancels the pending callback when the host is destroyed', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    TestBed.tick();
+
+    fixture.componentInstance.source.set('hello');
+    TestBed.tick();
+    tick(200);
+
+    fixture.destroy();
+    tick(1000);
+
+    expect(fixture.componentInstance.callbackInvocations).toEqual([]);
+  }));
+});

--- a/client/libs/shared/models/src/lib/debounced-effect.ts
+++ b/client/libs/shared/models/src/lib/debounced-effect.ts
@@ -1,0 +1,27 @@
+import { Signal, effect } from '@angular/core';
+
+/**
+ * Runs `callback` after `ms` of quiet whenever `source` changes. Each new
+ * change resets the timer; the latest value wins. The first run (the value
+ * present at registration time) is skipped, matching `rxjs.skip(1)`.
+ *
+ * Must be called from an injection context — the underlying `effect` ties
+ * its lifetime to the surrounding injector. Pending timeouts are cleared
+ * on each re-run and on teardown.
+ */
+export function debouncedEffect<T>(
+  source: Signal<T>,
+  ms: number,
+  callback: (value: T) => void,
+): void {
+  let firstRun = true;
+  effect((onCleanup) => {
+    const value = source();
+    if (firstRun) {
+      firstRun = false;
+      return;
+    }
+    const timeoutId = setTimeout(() => callback(value), ms);
+    onCleanup(() => clearTimeout(timeoutId));
+  });
+}


### PR DESCRIPTION
## Summary
- New \`debouncedEffect(source, ms, callback)\` in \`@yumney/shared/models\` — wraps \`effect((onCleanup) => setTimeout)\` with skip-first-run semantics and timeout cleanup on each change / on teardown.
- Adopts it at three call sites that all had the same \`toObservable + skip(1) + debounceTime + takeUntilDestroyed + subscribe\` chain:
  - \`RecipeNotesAutosaveService\` — was already on the inline cleanup pattern from #613; collapses to a one-line helper call.
  - \`RecipeListComponent\` — search-input debounce moves from \`ngOnInit\` subscribe to a constructor \`debouncedEffect\`.
  - \`ProfileSettingsComponent\` — autosave-tick subscribe collapses similarly; the \`autosave$ = toObservable(...)\` field is gone.
- Drops \`debounceTime\`, \`skip\`, \`toObservable\`, and \`takeUntilDestroyed\` imports from the three consumers.

**Stacked on #614** — base is \`feat/ui-empty-state-component\`. Auto-retargets to develop when that lands.

## Test plan
- [x] \`yarn nx run-many --target=lint --projects=shared-models,recipes,account\` — passes (only pre-existing warnings).
- [x] \`yarn nx run-many --target=test --projects=shared-models,recipes,account\` — green; 4 new helper specs added (skip-first-run, single fire after window, latest-value-wins, cleanup on destroy). The autosave debounce-semantics test added in #613 still passes against the helper.
- [x] \`yarn build:all\` — green.
- [ ] Manual smoke: type into the recipe-list search bar (results refresh after 400ms idle, not on every keystroke); change a profile setting (toast appears once after 400ms idle).