### PR TITLE
chore(users): split UpdateUserProfile into request DTO + VO command

### DIFF
--- a/src/Yumney.Users.Api/ProfileEndpoints.cs
+++ b/src/Yumney.Users.Api/ProfileEndpoints.cs
@@ -36,14 +36,25 @@ public static class ProfileEndpoints
 		group.MapPut("/", UpdateProfile)
 			.WithName("UpdateUserProfile")
 			.WithTags("Users")
+			.WithValidation<Requests.UpdateUserProfile>()
 			.Produces<UserProfileDto>()
 			.ProducesValidationProblem();
 
 		static async Task<IResult> UpdateProfile(
-			UpdateUserProfileCommand command,
+			Requests.UpdateUserProfile request,
 			ICommandHandler<UpdateUserProfileCommand, Result<UserProfileDto>> handler,
 			CancellationToken cancellationToken)
 		{
+			var (displayName, preferredLanguage, preferredUnitSystem, defaultServings, theme, voiceSettings, notificationPreferences, dietaryProfile) = request;
+			var command = new UpdateUserProfileCommand(
+				displayName,
+				preferredLanguage,
+				preferredUnitSystem,
+				defaultServings,
+				theme,
+				voiceSettings,
+				notificationPreferences,
+				dietaryProfile);
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
 		}

--- a/src/Yumney.Users.Api/Requests/UpdateUserProfile.cs
+++ b/src/Yumney.Users.Api/Requests/UpdateUserProfile.cs
@@ -1,0 +1,47 @@
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
+
+public sealed record UpdateUserProfile(
+	string? DisplayName,
+	string? PreferredLanguage,
+	string? PreferredUnitSystem,
+	int DefaultServings,
+	string? Theme,
+	VoiceSettingsDto? VoiceSettings,
+	NotificationPreferencesDto? NotificationPreferences,
+	string? DietaryType,
+	IReadOnlyList<string> Restrictions,
+	int? MinVeggieMeals,
+	int? MaxRedMeatMeals,
+	string? CookingEffort)
+{
+	public void Deconstruct(
+		out DisplayName? displayName,
+		out PreferredLanguage? preferredLanguage,
+		out PreferredUnitSystem? preferredUnitSystem,
+		out DefaultServings defaultServings,
+		out Theme? theme,
+		out VoiceSettings? voiceSettings,
+		out NotificationPreferences? notificationPreferences,
+		out DietaryProfile dietaryProfile)
+	{
+		displayName = DisplayName is null ? null : Domain.AppUserProfile.DisplayName.From(DisplayName);
+		preferredLanguage = PreferredLanguage is null ? null : Domain.AppUserProfile.PreferredLanguage.From(PreferredLanguage);
+		preferredUnitSystem = PreferredUnitSystem is null ? null : Domain.AppUserProfile.PreferredUnitSystem.From(PreferredUnitSystem);
+		defaultServings = Domain.AppUserProfile.DefaultServings.From(DefaultServings);
+		theme = Theme is null ? null : Domain.AppUserProfile.Theme.From(Theme);
+		voiceSettings = VoiceSettings is null
+			? null
+			: new VoiceSettings(VoiceSettings.Enabled, VoiceSpeed.From(VoiceSettings.Speed), VoiceSettings.AutoReadInCookMode);
+		notificationPreferences = NotificationPreferences is null
+			? null
+			: new NotificationPreferences(NotificationPreferences.TimerHapticFeedback, NotificationPreferences.TimerSoundAlerts);
+		dietaryProfile = Domain.AppUserProfile.DietaryProfile.From(
+			DietaryType is null ? null : Domain.AppUserProfile.DietaryType.From(DietaryType),
+			Restrictions.Select(DietaryRestriction.From).ToList(),
+			WeeklyBalanceGoals.From(MinVeggieMeals, MaxRedMeatMeals),
+			CookingEffort is null ? null : CookingEffortPreference.From(CookingEffort));
+	}
+}

--- a/src/Yumney.Users.Api/Requests/UpdateUserProfileValidator.cs
+++ b/src/Yumney.Users.Api/Requests/UpdateUserProfileValidator.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Api.Requests;
+
+public sealed class UpdateUserProfileValidator : AbstractValidator<UpdateUserProfile>
+{
+	public UpdateUserProfileValidator()
+	{
+		RuleFor(request => request.DefaultServings)
+			.InclusiveBetween(DefaultServings.MinValue, DefaultServings.MaxValue)
+			.WithMessage($"DefaultServings must be between {DefaultServings.MinValue} and {DefaultServings.MaxValue}.");
+
+		RuleFor(request => request.DisplayName!)
+			.MaximumLength(DisplayName.MaxLength)
+			.When(request => request.DisplayName is not null);
+
+		RuleFor(request => request.PreferredLanguage!)
+			.MaximumLength(PreferredLanguage.MaxLength)
+			.When(request => request.PreferredLanguage is not null);
+
+		RuleFor(request => request.PreferredUnitSystem!)
+			.MaximumLength(PreferredUnitSystem.MaxLength)
+			.When(request => request.PreferredUnitSystem is not null);
+
+		RuleFor(request => request.Theme!)
+			.MaximumLength(Theme.MaxLength)
+			.When(request => request.Theme is not null);
+
+		RuleFor(request => request.CookingEffort!)
+			.MaximumLength(CookingEffortPreference.MaxLength)
+			.When(request => request.CookingEffort is not null);
+
+		RuleFor(request => request.MinVeggieMeals!.Value)
+			.InclusiveBetween(WeeklyBalanceGoals.MinMeals, WeeklyBalanceGoals.MaxMeals)
+			.When(request => request.MinVeggieMeals.HasValue);
+
+		RuleFor(request => request.MaxRedMeatMeals!.Value)
+			.InclusiveBetween(WeeklyBalanceGoals.MinMeals, WeeklyBalanceGoals.MaxMeals)
+			.When(request => request.MaxRedMeatMeals.HasValue);
+	}
+}

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -14,61 +14,17 @@ public sealed class UpdateUserProfileCommandHandler(IUsersUnitOfWork unitOfWork,
 		var keycloakId = KeycloakUserId.From(currentUser.UserId);
 		var profile = await unitOfWork.Profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
 
-		ApplyIdentity(profile, command);
-		ApplyPreferences(profile, command);
-		profile.AdjustDefaultServingsTo(DefaultServings.From(command.DefaultServings));
-		profile.UpdateDietaryProfile(BuildDietaryProfile(command));
+		if (command.DisplayName is not null) profile.RenameAs(command.DisplayName);
+		if (command.PreferredLanguage is not null) profile.SwitchLanguageTo(command.PreferredLanguage);
+		if (command.PreferredUnitSystem is not null) profile.SwitchUnitSystemTo(command.PreferredUnitSystem);
+		if (command.Theme is not null) profile.SwitchThemeTo(command.Theme);
+		if (command.VoiceSettings is not null) profile.UpdateVoiceSettings(command.VoiceSettings);
+		if (command.NotificationPreferences is not null) profile.UpdateNotificationPreferences(command.NotificationPreferences);
+		profile.AdjustDefaultServingsTo(command.DefaultServings);
+		profile.UpdateDietaryProfile(command.DietaryProfile);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return profile.ToDto(currentUser.Email);
-	}
-
-	private static void ApplyIdentity(AppUserProfile profile, UpdateUserProfileCommand command)
-	{
-		if (command.DisplayName is not null)
-		{
-			profile.RenameAs(DisplayName.From(command.DisplayName));
-		}
-	}
-
-	private static void ApplyPreferences(AppUserProfile profile, UpdateUserProfileCommand command)
-	{
-		if (command.PreferredLanguage is not null)
-		{
-			profile.SwitchLanguageTo(PreferredLanguage.From(command.PreferredLanguage));
-		}
-
-		if (command.PreferredUnitSystem is not null)
-		{
-			profile.SwitchUnitSystemTo(PreferredUnitSystem.From(command.PreferredUnitSystem));
-		}
-
-		if (command.Theme is not null)
-		{
-			profile.SwitchThemeTo(Theme.From(command.Theme));
-		}
-
-		if (command.VoiceSettings is not null)
-		{
-			var (enabled, speed, autoRead) = command.VoiceSettings;
-			profile.UpdateVoiceSettings(new VoiceSettings(enabled, VoiceSpeed.From(speed), autoRead));
-		}
-
-		if (command.NotificationPreferences is not null)
-		{
-			var (haptic, sound) = command.NotificationPreferences;
-			profile.UpdateNotificationPreferences(new NotificationPreferences(haptic, sound));
-		}
-	}
-
-	private static DietaryProfile BuildDietaryProfile(UpdateUserProfileCommand command)
-	{
-		var dietaryType = command.DietaryType is not null ? DietaryType.From(command.DietaryType) : null;
-		var restrictions = command.Restrictions.Select(DietaryRestriction.From).ToList();
-		var balanceGoals = WeeklyBalanceGoals.From(command.MinVeggieMeals, command.MaxRedMeatMeals);
-		var cookingEffort = command.CookingEffort is not null ? CookingEffortPreference.From(command.CookingEffort) : null;
-
-		return DietaryProfile.From(dietaryType, restrictions, balanceGoals, cookingEffort);
 	}
 }

--- a/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
+++ b/src/Yumney.Users.Application/Commands/UpdateUserProfileCommand.cs
@@ -1,19 +1,16 @@
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.Commands;
 
 public sealed record UpdateUserProfileCommand(
-	string? DisplayName,
-	string? PreferredLanguage,
-	string? PreferredUnitSystem,
-	int DefaultServings,
-	string? Theme,
-	VoiceSettingsDto? VoiceSettings,
-	NotificationPreferencesDto? NotificationPreferences,
-	string? DietaryType,
-	IReadOnlyList<string> Restrictions,
-	int? MinVeggieMeals,
-	int? MaxRedMeatMeals,
-	string? CookingEffort) : ICommand<Result<UserProfileDto>>;
+	DisplayName? DisplayName,
+	PreferredLanguage? PreferredLanguage,
+	PreferredUnitSystem? PreferredUnitSystem,
+	DefaultServings DefaultServings,
+	Theme? Theme,
+	VoiceSettings? VoiceSettings,
+	NotificationPreferences? NotificationPreferences,
+	DietaryProfile DietaryProfile) : ICommand<Result<UserProfileDto>>;

--- a/tests/Yumney.Users.Api.Tests/Requests/UpdateUserProfileValidatorTests.cs
+++ b/tests/Yumney.Users.Api.Tests/Requests/UpdateUserProfileValidatorTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Api.Tests.Requests;
+
+public class UpdateUserProfileValidatorTests
+{
+	private readonly Api.Requests.UpdateUserProfileValidator validator = new();
+
+	[Fact]
+	public void Validate_MinimalValidRequest_IsValid()
+	{
+		var request = MinimalRequest();
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Validate_FullyPopulatedValidRequest_IsValid()
+	{
+		var request = MinimalRequest() with
+		{
+			DisplayName = "Renamed",
+			PreferredLanguage = "de",
+			PreferredUnitSystem = "imperial",
+			Theme = "dark",
+			VoiceSettings = new VoiceSettingsDto(false, "fast", true),
+			NotificationPreferences = new NotificationPreferencesDto(false, false),
+			DietaryType = "vegetarian",
+			Restrictions = ["gluten-free"],
+			MinVeggieMeals = 3,
+			MaxRedMeatMeals = 2,
+			CookingEffort = "balanced",
+		};
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(13)]
+	public void Validate_DefaultServingsOutOfRange_IsNotValid(int servings)
+	{
+		var request = MinimalRequest() with { DefaultServings = servings };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(error => error.PropertyName == nameof(Api.Requests.UpdateUserProfile.DefaultServings));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(8)]
+	public void Validate_MinVeggieMealsOutOfRange_IsNotValid(int minVeggieMeals)
+	{
+		var request = MinimalRequest() with { MinVeggieMeals = minVeggieMeals };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(error => error.PropertyName.Contains("MinVeggieMeals"));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(8)]
+	public void Validate_MaxRedMeatMealsOutOfRange_IsNotValid(int maxRedMeatMeals)
+	{
+		var request = MinimalRequest() with { MaxRedMeatMeals = maxRedMeatMeals };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(error => error.PropertyName.Contains("MaxRedMeatMeals"));
+	}
+
+	[Fact]
+	public void Validate_DisplayNameTooLong_IsNotValid()
+	{
+		var request = MinimalRequest() with { DisplayName = new string('x', 201) };
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(error => error.PropertyName == nameof(Api.Requests.UpdateUserProfile.DisplayName));
+	}
+
+	[Fact]
+	public void Validate_NullOptionalsAreAllowed()
+	{
+		var request = MinimalRequest();
+
+		var result = validator.Validate(request);
+
+		result.IsValid.Should().BeTrue();
+	}
+
+	private static Api.Requests.UpdateUserProfile MinimalRequest() =>
+		new(
+			DisplayName: null,
+			PreferredLanguage: null,
+			PreferredUnitSystem: null,
+			DefaultServings: 4,
+			Theme: null,
+			VoiceSettings: null,
+			NotificationPreferences: null,
+			DietaryType: null,
+			Restrictions: [],
+			MinVeggieMeals: null,
+			MaxRedMeatMeals: null,
+			CookingEffort: null);
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/UpdateUserProfileCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/UpdateUserProfileCommandHandlerTests.cs
@@ -175,18 +175,18 @@ public class UpdateUserProfileCommandHandlerTests
 		int? maxRedMeatMeals = null,
 		string? cookingEffort = null) =>
 		new(
-			displayName,
-			preferredLanguage,
-			preferredUnitSystem,
-			defaultServings,
-			theme,
-			voiceSettings,
-			notificationPreferences,
-			dietaryType,
-			restrictions ?? [],
-			minVeggieMeals,
-			maxRedMeatMeals,
-			cookingEffort);
+			displayName is null ? null : DisplayName.From(displayName),
+			preferredLanguage is null ? null : PreferredLanguage.From(preferredLanguage),
+			preferredUnitSystem is null ? null : PreferredUnitSystem.From(preferredUnitSystem),
+			DefaultServings.From(defaultServings),
+			theme is null ? null : Theme.From(theme),
+			voiceSettings is null ? null : new VoiceSettings(voiceSettings.Enabled, VoiceSpeed.From(voiceSettings.Speed), voiceSettings.AutoReadInCookMode),
+			notificationPreferences is null ? null : new NotificationPreferences(notificationPreferences.TimerHapticFeedback, notificationPreferences.TimerSoundAlerts),
+			DietaryProfile.From(
+				dietaryType is null ? null : DietaryType.From(dietaryType),
+				(restrictions ?? []).Select(DietaryRestriction.From).ToList(),
+				WeeklyBalanceGoals.From(minVeggieMeals, maxRedMeatMeals),
+				cookingEffort is null ? null : CookingEffortPreference.From(cookingEffort)));
 
 	private AppUserProfile CreateProfile()
 	{


### PR DESCRIPTION
## Summary
Found by audit: \`POST /users/me/profile\` was binding \`UpdateUserProfileCommand\` directly as the JSON body, and the command itself was a 13-field primitive bag with all VO conversion crammed into the handler. Two CLAUDE.md rules at once:
- "API endpoints receive request DTOs (primitives), validate via FluentValidation, then map to commands with value objects."
- "Commands and Queries must take value objects for business-meaningful parameters."

Split into the canonical pattern matched by RegisterUser / ResendVerificationEmail.

## What changed
- **New \`Yumney.Users.Api/Requests/UpdateUserProfile\`** — primitive-bag request DTO with a \`Deconstruct\` that maps to \`(DisplayName?, PreferredLanguage?, PreferredUnitSystem?, DefaultServings, Theme?, VoiceSettings?, NotificationPreferences?, DietaryProfile)\`. Arity collapses 12 → 8 because the dietary fields bundle into the existing \`DietaryProfile\` VO.
- **New \`UpdateUserProfileValidator\`** — runs at the API edge with FluentValidation. Range checks for DefaultServings + WeeklyBalanceGoals; length limits for the optional strings.
- **\`UpdateUserProfileCommand\`** rewritten to take the VO bundle.
- **\`UpdateUserProfileCommandHandler\`** drops its three private helpers (\`ApplyIdentity\`, \`ApplyPreferences\`, \`BuildDietaryProfile\`) — every VO arrives pre-built, so the handler is just a sequence of conditional mutator calls plus the always-applied DefaultServings and DietaryProfile assignments. **40 lines net removed.**
- **\`ProfileEndpoints.UpdateProfile\`** wired with \`WithValidation<>()\` and deconstructs the request into VOs before building the command.

Existing \`UpdateUserProfileCommandHandlerTests\` keep their primitive helper signature; the helper now does the VO conversion internally, so the per-test call sites are unchanged. Added \`UpdateUserProfileValidatorTests\` covering range checks and length limits.

**Stacked on #616** — base is \`chore/api-request-suffix-cleanup\`. Auto-retargets to develop when that lands. The two PRs are independent in scope (one renames Recipes API request types, this one fixes a Users architecture leak); stacking is just for clean history.

## Test plan
- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — clean.
- [x] \`dotnet format --verify-no-changes\` — clean.
- [x] \`dotnet test tests/Yumney.Users.Api.Tests\` — 34 pass (incl. 7 new validator tests).
- [x] \`dotnet test tests/Yumney.Users.Application.Tests\` — 53 pass.
- [x] \`dotnet test tests/Yumney.Architecture.Tests\` — 136 pass (incl. the new \`NoApiRequestType_HasRequestSuffixOrInfix\` arch test from #616, which would catch any \`Request\`-suffix slip).
- [ ] Manual smoke: open profile settings page, change a few fields, hit save; verify the round-trip works and the PUT body is the same shape the frontend already sends.