### PR TITLE
fix(infra): close dual-write hole on Recipes/Users state-based handlers

### DIFF
--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipesUnitOfWork.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipesUnitOfWork.cs
@@ -1,14 +1,29 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
+using Wolverine.EntityFrameworkCore;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 
-public sealed class RecipesUnitOfWork(RecipesDbContext context) : IRecipesUnitOfWork
+public sealed class RecipesUnitOfWork(
+	RecipesDbContext context,
+	IDbContextOutbox<RecipesDbContext> outbox) : IRecipesUnitOfWork
 {
 	public IRecipeRepository Recipes => field ??= new RecipeRepository(context);
 
 	public IRecipeFavoriteRepository Favorites => field ??= new RecipeFavoriteRepository(context);
 
-	public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-		=> context.SaveChangesAsync(cancellationToken);
+	// Save first so Wolverine's EF interceptor captures any messages staged via
+	// IDbContextOutbox<RecipesDbContext>.PublishAsync into the outbox table inside
+	// the same Postgres transaction. FlushOutgoingMessagesAsync then nudges the
+	// Wolverine relay to deliver immediately — without the flush the rows sit
+	// waiting on the polling relay (~5s+) and time-sensitive cross-module flows
+	// like RecipeDeletedIntegrationEvent → ShoppingList projection lag noticeably.
+	// A flush failure leaves the staged rows in the outbox for retry by the
+	// background relay, so the at-least-once guarantee is preserved.
+	public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		var rowCount = await context.SaveChangesAsync(cancellationToken);
+		await outbox.FlushOutgoingMessagesAsync();
+		return rowCount;
+	}
 }

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Client;
@@ -24,16 +25,14 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 			"wolverine_recipes",
 			typeof(DomainEventDispatchInterceptor));
 
-		// State-based handlers (SaveRecipe / DeleteRecipe / TrackRecipeCooked) keep
-		// the default WolverineEventBus from AddYumneyDefaults. Wolverine's typed
-		// IDbContextOutbox<T> only flushes captured messages when the handler
-		// itself calls outbox.SaveChangesAndFlushMessagesAsync — a plain
-		// DbContext.SaveChangesAsync stages but never delivers, so cross-module
-		// integration events (e.g. RecipeDeletedIntegrationEvent) silently
-		// disappear. Wolverine's PersistMessagesWithPostgresql still gives the
-		// regular bus durable at-least-once delivery; closing the strict
-		// publish-before-save dual-write hole is a follow-up that needs the
-		// handlers to use the outbox API directly.
+		// State-based handlers stage cross-module integration events on the typed
+		// outbox (last AddScoped<IEventBus> wins, so this overrides the default
+		// WolverineEventBus from AddYumneyDefaults). RecipesUnitOfWork.SaveChangesAsync
+		// calls outbox.FlushOutgoingMessagesAsync after persisting the entity changes,
+		// which is what actually delivers the staged messages — without the flush
+		// they sit in the outbox table waiting on the polling relay.
+		services.AddScoped<IEventBus, WolverineOutboxEventBus<RecipesDbContext>>();
+
 		services.AddScoped<RecipesUnitOfWork>();
 		services.AddScoped<IRecipesUnitOfWork>(sp => sp.GetRequiredService<RecipesUnitOfWork>());
 		services.AddScoped<IRecipeRepository>(sp => sp.GetRequiredService<RecipesUnitOfWork>().Recipes);

--- a/src/Yumney.Users.Infrastructure/Persistence/UsersUnitOfWork.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UsersUnitOfWork.cs
@@ -1,10 +1,13 @@
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Wolverine.EntityFrameworkCore;
 
 namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence;
 
-public sealed class UsersUnitOfWork(UsersDbContext context) : IUsersUnitOfWork
+public sealed class UsersUnitOfWork(
+	UsersDbContext context,
+	IDbContextOutbox<UsersDbContext> outbox) : IUsersUnitOfWork
 {
 	public IAppUserProfileRepository Profiles => field ??= new AppUserProfileRepository(context);
 
@@ -12,6 +15,17 @@ public sealed class UsersUnitOfWork(UsersDbContext context) : IUsersUnitOfWork
 
 	public IStaplesListRepository StaplesLists => field ??= new StaplesListRepository(context);
 
-	public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-		=> context.SaveChangesAsync(cancellationToken);
+	// Save first so Wolverine's EF interceptor captures any messages staged via
+	// IDbContextOutbox<UsersDbContext>.PublishAsync into the outbox table inside
+	// the same Postgres transaction. FlushOutgoingMessagesAsync then nudges the
+	// Wolverine relay to deliver immediately — UserAccountDeletedIntegrationEvent
+	// is GDPR-critical and must not sit waiting on the polling relay. A flush
+	// failure leaves the staged rows in the outbox for retry by the background
+	// relay, preserving at-least-once.
+	public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		var rowCount = await context.SaveChangesAsync(cancellationToken);
+		await outbox.FlushOutgoingMessagesAsync();
+		return rowCount;
+	}
 }

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
@@ -27,15 +28,17 @@ public static class UsersInfrastructureServiceCollectionExtensions
 			"wolverine_users",
 			typeof(DomainEventDispatchInterceptor));
 
-		// DeleteAccount keeps the default WolverineEventBus from AddYumneyDefaults.
-		// Wolverine's typed IDbContextOutbox<T> only flushes captured messages when
-		// the handler calls outbox.SaveChangesAndFlushMessagesAsync — a plain
-		// DbContext.SaveChangesAsync stages but never delivers, so cross-module
-		// integration events (UserAccountDeletedIntegrationEvent is GDPR-critical
-		// and must not silently disappear). Wolverine's PersistMessagesWithPostgresql
-		// still gives the regular bus durable at-least-once delivery; closing the
-		// strict publish-before-save dual-write hole here is a follow-up that needs
-		// the handler to use the outbox API directly.
+		// State-based handlers (DeleteAccount, RegisterUser, UpdateUserProfile,
+		// EnsureUserProfile, ResendVerificationEmail) stage cross-module
+		// integration events on the typed outbox (last AddScoped<IEventBus>
+		// wins, so this overrides the default WolverineEventBus from
+		// AddYumneyDefaults). UsersUnitOfWork.SaveChangesAsync calls
+		// outbox.FlushOutgoingMessagesAsync after persisting the entity
+		// changes, which is what actually delivers the staged messages —
+		// UserAccountDeletedIntegrationEvent is GDPR-critical and must not
+		// sit waiting on the polling relay.
+		services.AddScoped<IEventBus, WolverineOutboxEventBus<UsersDbContext>>();
+
 		services.AddScoped<UsersUnitOfWork>();
 		services.AddScoped<IUsersUnitOfWork>(sp => sp.GetRequiredService<UsersUnitOfWork>());
 		services.AddScoped<IAppUserProfileRepository>(sp => sp.GetRequiredService<UsersUnitOfWork>().Profiles);


### PR DESCRIPTION
## Summary

- Reinstates the `WolverineOutboxEventBus<TContext>` binding for Recipes / Users (reverted in #619 while diagnosing CI red) and threads the outbox flush through `RecipesUnitOfWork` / `UsersUnitOfWork`.
- Cross-module integration events from state-based handlers (`SaveRecipe`, `DeleteRecipe`, `TrackRecipeCooked`, `DeleteAccount`) now stage on the outbox in the same Postgres transaction as the entity write, and `FlushOutgoingMessagesAsync` nudges immediate delivery.
- GDPR-critical `UserAccountDeletedIntegrationEvent` is no longer left waiting on Wolverine's polling relay.

## Why this is necessary

`IDbContextOutbox<T>.PublishAsync` only stages — captured into the outbox table during the next `DbContext.SaveChangesAsync`, but the relay polls (~5s+) before delivering. `RecipeDeletedPropagationTests` was timing out at 15s on develop until #619 reverted the binding. This PR keeps the binding and adds the explicit flush, which is what Wolverine's docs prescribe for handlers that call `DbContext.SaveChangesAsync` directly.

A flush failure leaves the staged rows in the outbox for the polling relay to retry, so at-least-once is preserved.

## Test plan

- [x] `dotnet build Yumney.slnx` clean
- [x] `RecipeDeletedPropagationTests` — both cases pass
- [x] Users contract + Recipes contract + CrossModule flows — 130/130 pass
- [x] Full integration suite — 251/253 (two pre-existing flakes that also fail on develop: `OutboxDeliveryTests`, `ShoppingListCreateFlowTests.CreateAndCheckOff_PersistsCheckedState`)
- [ ] CI green