### PR TITLE
fix(shopping): close merged-list eventual-consistency gap with optimistic add + retry

### DIFF
--- a/client/apps/shopping/src/app/api.ts
+++ b/client/apps/shopping/src/app/api.ts
@@ -12,4 +12,5 @@ export {
   type CreateShoppingListItem,
   type MergedShoppingList,
   type MergedShoppingItem,
+  type AddedItem,
 } from '@yumney/shared/api-client';

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -63,7 +63,16 @@ describe('MergedListComponent', () => {
   beforeEach(async () => {
     apiMock = {
       getMergedList: vi.fn().mockReturnValue(of(mockList)),
-      addItem: vi.fn().mockReturnValue(of({ itemName: 'Eggs' })),
+      addItem: vi.fn().mockReturnValue(
+        of({
+          itemName: 'Eggs',
+          quantity: 1,
+          unit: null,
+          category: 'other',
+          source: 'manual',
+          ledgerIdentifier: '00000000-0000-0000-0000-000000000001',
+        }),
+      ),
       removeItem: vi.fn().mockReturnValue(of(undefined)),
       exportList: vi.fn().mockReturnValue(of('Shopping list text')),
     };

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -10,7 +10,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem } from '../api';
+import {
+  ShoppingApiService,
+  type MergedShoppingList,
+  type MergedShoppingItem,
+  type AddedItem,
+} from '../api';
 import { createAsyncState, ERROR_MAPS, groupByCategory, ToastService } from '@yumney/shared/models';
 import { AsyncStateComponent, EmptyStateComponent } from '@yumney/ui';
 
@@ -84,7 +89,17 @@ export class MergedListComponent {
     this.mutationState.execute(
       this.api.addItem({ name }),
       ERROR_MAPS.shopping.merged.add,
-      () => this.loadList(),
+      (added) => {
+        // Read-after-write across an async projection: add lands in the
+        // ShoppingLedger event store + Wolverine outbox, then the projection
+        // updates ShoppingLedgerReadItem on its own listener thread. A naive
+        // GET right after POST returns the pre-add state, so the new item
+        // briefly disappears from the UI. Patch the local signal optimistically
+        // first, then re-fetch with backoff until the projection catches up
+        // and we can replace the optimistic state with server truth.
+        this.applyOptimisticAdd(added);
+        this.refreshUntilContains(added);
+      },
       (errorKey) => this.error.set(errorKey),
     );
   }
@@ -166,5 +181,86 @@ export class MergedListComponent {
       .writeText(text)
       .then(() => this.toasts.success('shopping.export.copied'))
       .catch(() => this.error.set('shopping.errors.exportFailed'));
+  }
+
+  private applyOptimisticAdd(added: AddedItem): void {
+    const current = this.list() ?? { items: [] };
+    const matchIndex = current.items.findIndex(
+      (item) =>
+        item.itemName.toLowerCase() === added.itemName.toLowerCase() && item.unit === added.unit,
+    );
+
+    let nextItems: MergedShoppingItem[];
+    if (matchIndex >= 0) {
+      const matched = current.items[matchIndex];
+      const merged: MergedShoppingItem = {
+        ...matched,
+        totalQuantity: matched.totalQuantity + added.quantity,
+        displayQuantity: matched.displayQuantity + added.quantity,
+      };
+      nextItems = current.items.map((item, index) => (index === matchIndex ? merged : item));
+    } else {
+      nextItems = [
+        ...current.items,
+        {
+          itemName: added.itemName,
+          totalQuantity: added.quantity,
+          displayQuantity: added.quantity,
+          unit: added.unit,
+          category: added.category,
+          isBought: false,
+          sources: [],
+        },
+      ];
+    }
+
+    this.list.set({ ...current, items: nextItems });
+  }
+
+  private refreshUntilContains(added: AddedItem, attempt = 0): void {
+    // Capped-backoff poll. Eight attempts at 200/400/.../1600 ms ≈ 7.2s
+    // total — comfortably inside the merged-list test's 60s budget but
+    // well under what a user would notice in normal use, where the
+    // projection typically lands inside one tick.
+    const maxAttempts = 8;
+    const requestId = ++this.loadRequestId;
+
+    this.api
+      .getMergedList(this.showPastPurchases())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (list) => {
+          if (requestId !== this.loadRequestId) return;
+          if (this.containsAddedItem(list, added)) {
+            this.list.set(list);
+            return;
+          }
+
+          if (attempt + 1 >= maxAttempts) {
+            // Give up reconciling, keep the optimistic state so the user
+            // still sees their addition. The next mutation or page load
+            // will pick up the canonical truth.
+            return;
+          }
+
+          setTimeout(
+            () => this.refreshUntilContains(added, attempt + 1),
+            Math.min(1600, 200 * (attempt + 1)),
+          );
+        },
+        error: () => {
+          if (requestId !== this.loadRequestId) return;
+          this.error.set('shopping.errors.loadFailed');
+        },
+      });
+  }
+
+  private containsAddedItem(list: MergedShoppingList, added: AddedItem): boolean {
+    return list.items.some(
+      (item) =>
+        item.itemName.toLowerCase() === added.itemName.toLowerCase() &&
+        item.unit === added.unit &&
+        item.totalQuantity >= added.quantity,
+    );
   }
 }


### PR DESCRIPTION
## Summary

The merged-list view writes through ShoppingLedger event store → Wolverine outbox → `ShoppingLedgerProjectionHandler` → `ShoppingLedgerReadItem`. Adding an item POST-returns immediately, but the projection runs on its own listener thread, so the GET that fires right after returns the pre-add state — the new item briefly disappears from the UI.

The two merged-list e2e tests (`should add a manual item`, `should show progress bar when items exist`) flake on develop because on slow CI runners the projection slips past their 60s / 45s budgets.

## What changed

- `MergedListComponent.onAddItem` patches the local `list` signal optimistically using the `AddedItem` payload (merging by case-insensitive name + unit so duplicates roll up the way the projection would).
- A new `refreshUntilContains` polls `getMergedList` with capped backoff (8 attempts, 200/400/.../1600 ms ≈ 7s total) until the new item is in the response. Once it shows up, the optimistic state is replaced with server truth; if all attempts exhaust, the optimistic state stays in place so the user still sees their addition.

## Why frontend, not backend

The flake is purely a read-after-write timing problem — the data lands in Postgres correctly, just slightly later than the GET. A backend fix would need either (a) a synchronous in-process projection invocation alongside Wolverine's async one (couples handler to projection), or (b) the POST handler computing and returning a full `MergedShoppingListDto` (duplicates the projection's category-resolution + roll-up logic). The optimistic + retry pattern lives in the only component that needs it and falls back gracefully if the projection ever takes longer than 7 seconds.

The shopping-detail page (single-list view) doesn't share this race — its adds run through the `ShoppingList` projection that #621 already made order- and concurrency-safe via `INSERT … ON CONFLICT`.

## Test plan

- [x] `MergedListComponent` unit tests (21) green; mock updated to a realistic `AddedItem` so `applyOptimisticAdd` has the fields it needs
- [x] `prettier --check` clean across the touched files
- [x] `nx run shopping:lint` clean
- [ ] CI green