### PR TITLE
fix(e2e): repoint recipe-detail confirm-dialog locator at renamed overlay class

### DIFF
--- a/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
@@ -37,10 +37,13 @@ export class RecipeDetailPage {
       .locator('[data-testid="recipe-create-shopping-list-btn"]')
       .first();
     this.sourceLink = page.locator('.source-link a');
-    // Target the .confirm-overlay child rather than the host yn-confirm-dialog.
-    // The host has 0x0 dimensions because its child is position:fixed, so
-    // Playwright reports the host as hidden even when the dialog is visible.
-    this.confirmDialog = page.locator('yn-confirm-dialog .confirm-overlay');
+    // Target the overlay div inside yn-dialog-shell rather than the host
+    // yn-confirm-dialog. The host has 0x0 dimensions because its child is
+    // position:fixed, so Playwright reports the host as hidden even when the
+    // dialog is visible. The class is `.yn-dialog-overlay` after the dialog
+    // got refactored to share a common shell — the older `.confirm-overlay`
+    // selector silently matched zero nodes and timed out.
+    this.confirmDialog = page.locator('yn-confirm-dialog .yn-dialog-overlay');
     this.confirmCancelButton = this.confirmDialog.getByRole('button', { name: /cancel/i });
     this.confirmDeleteButton = this.confirmDialog.locator('.btn-danger-filled');
     this.errorBanner = page.locator('[role="alert"]');


### PR DESCRIPTION
## Summary

The two recipe-detail delete specs that have been failing on develop's E2E run for a while — `should show and dismiss delete confirmation dialog` and `should delete recipe and navigate to list` — were broken by a stale page-object selector.

After the dialog refactor that introduced `yn-dialog-shell` as the common host, the overlay renders with class `.yn-dialog-overlay` everywhere ([dialog-shell.component.html:1](https://github.com/smartsolutionslab/yumney/blob/develop/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.html)). The recipe-detail page object still pointed at `yn-confirm-dialog .confirm-overlay`, which silently matched zero nodes — Playwright's auto-wait then ran out the 45s clock on every CI run.

Repoint the locator at `.yn-dialog-overlay`. The component itself is fine; the test was looking at a class name that no longer exists.

## Test plan

- [x] `nx run shell-e2e:lint` clean
- [x] `prettier --check` clean
- [ ] CI green