### PR TITLE
chore(e2e): drop dead RecipeListPage.ctaButton locator

### DIFF
--- a/client/apps/shell-e2e/src/pages/recipe-list.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-list.page.ts
@@ -7,7 +7,6 @@ export class RecipeListPage {
   readonly sortToggle: Locator;
   readonly recipeCards: Locator;
   readonly emptyState: Locator;
-  readonly ctaButton: Locator;
   readonly errorBanner: Locator;
   readonly loading: Locator;
   readonly filterToggle: Locator;
@@ -20,7 +19,6 @@ export class RecipeListPage {
     this.sortToggle = page.locator('[data-testid="sort-toggle"]');
     this.recipeCards = page.locator('.recipe-card');
     this.emptyState = page.locator('.empty-state');
-    this.ctaButton = page.locator('.cta-button');
     this.errorBanner = page.locator('[role="alert"]');
     this.loading = page.locator('.loading');
     this.filterToggle = page.locator('[data-testid="recipe-list-filter-toggle"]');


### PR DESCRIPTION
## Summary

`.cta-button` doesn't exist anywhere in `apps/` or `libs/` — no template, SCSS, or component-computed class produces it. The `ctaButton` Locator field on `RecipeListPage` is also referenced by zero specs. Pure dead code from a since-removed empty-state hero CTA.

Removing it shrinks the page object's surface and prevents future tests from silently picking up a no-op locator that just auto-waits to timeout.

## Audit context

Found this while sweeping every e2e selector against the actual component output (templates + SCSS + computed-class outputs). Everything else resolves correctly:

- All other class selectors map to live render output — e.g. `success-banner` via `yn-message-banner`'s `bannerClass` computed, `save-btn` via `yn-submit-button`'s `cssClass` input, `merged-list` / `recipe-card` / etc. directly in templates.
- All `data-testid` selectors resolve to a `[data-testid]` in some component template.
- All ID selectors map to either our own form fields or the Keycloak login page.

So `.cta-button` was the only stale entry. Sister to #623 (which fixed the `.confirm-overlay` → `.yn-dialog-overlay` rename); this one's a dead reference rather than a renamed one.

## Test plan

- [x] `nx run shell-e2e:lint` clean
- [x] `prettier --check` clean
- [ ] CI green