### PR TITLE
test(e2e): un-fixme three shopping-detail flow tests now that #621 closed the race

### DIFF
--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -74,12 +74,12 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     });
   });
 
-  // The next three tests are fixme'd pending #432: in CI the just-created
-  // list (test 5) doesn't show up at /shopping/lists for reasons we
-  // haven't pinned down — backend contract tests pass, frontend has no
-  // in-memory cache layer, NGSW freshness timeout bump didn't help. Needs
-  // trace artifacts to root-cause.
-  test.fixme('should check off an item with strikethrough', async ({ authenticatedPage }) => {
+  // The next three tests rely on the list created in the previous test
+  // being visible at /shopping/lists. The original symptom traced back to
+  // the ShoppingList projection's out-of-order delivery race that #621
+  // closed via INSERT … ON CONFLICT DO UPDATE in ShoppingListProjection;
+  // un-fixme'd here to let CI confirm the fix held.
+  test('should check off an item with strikethrough', async ({ authenticatedPage }) => {
     const lists = new ShoppingListsPage(authenticatedPage);
     await lists.goto();
     await lists.listCards.first().click();
@@ -94,7 +94,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     await expect(detailPage.checkedItems.first()).toBeVisible();
   });
 
-  test.fixme('should check all items and reset', async ({ authenticatedPage }) => {
+  test('should check all items and reset', async ({ authenticatedPage }) => {
     const lists = new ShoppingListsPage(authenticatedPage);
     await lists.goto();
     await lists.listCards.first().click();
@@ -115,7 +115,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     }
   });
 
-  test.fixme('should show progress counter', async ({ authenticatedPage }) => {
+  test('should show progress counter', async ({ authenticatedPage }) => {
     const lists = new ShoppingListsPage(authenticatedPage);
     await lists.goto();
     await lists.listCards.first().click();


### PR DESCRIPTION
## Summary

Three `test.fixme`s in `shopping-list.spec.ts` were chasing what looked like a hard-to-reproduce list-overview ghost ("the just-created list doesn't show up at /shopping/lists for reasons we haven't pinned down"). The actual cause is the same out-of-order `ListItemAdded` vs `ShoppingListCreated` delivery race that #621 closed: an item landing first hit a no-summary read and silently dropped its increment, then `ShoppingListCreated` materialised the row with stale data.

Both projection halves now use `INSERT … ON CONFLICT DO UPDATE` (#621) so the summary appears reliably regardless of arrival order. The detail page already uses optimistic signal updates for check-off state, so the assertions don't depend on round-tripping through the projection.

Un-fixme'd:
- `should check off an item with strikethrough`
- `should check all items and reset`
- `should show progress counter`

If any flake again, Playwright will retain a trace and we can revisit instead of paving over with a comment.

## Test plan

- [x] `nx run shell-e2e:lint` clean
- [ ] CI E2E green for all three tests