### PR TITLE
refactor(shopping): hybrid EF / raw SQL in ShoppingLedgerProjectionHandler

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerReadItemConfiguration.cs
@@ -21,5 +21,14 @@ internal sealed class ShoppingLedgerReadItemConfiguration : IEntityTypeConfigura
 
 		entity.HasIndex(e => e.OwnerId);
 		entity.HasIndex(e => new { e.OwnerId, e.ItemName, e.Unit });
+
+		// Natural-key uniqueness on (OwnerId, lower(ItemName), COALESCE(Unit, ''))
+		// is enforced by the expression-based unique index added in migration
+		// 20260509125057_AddShoppingLedgerNaturalKeyUniqueIndex. EF Core can't
+		// model an expression-based index without stored generated columns —
+		// more schema bloat than the index is worth — so the migration owns
+		// it directly. ShoppingLedgerProjectionHandler.HandleAsync(Added)
+		// relies on this constraint so two concurrent inserts for the same
+		// logical item collide and fall through to the merge path.
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
@@ -1,10 +1,8 @@
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Npgsql;
-using NpgsqlTypes;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore.Events;
@@ -12,20 +10,27 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore.Ev
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
 /// <summary>
-/// Async projection handler for the <c>ShoppingLedger</c> aggregate. Subscribes
-/// to ledger integration events (<c>ShoppingItemAdded</c>, <c>Bought</c>,
-/// <c>Consumed</c>, <c>Removed</c>, <c>QuantityAdjusted</c>) and maintains the
-/// per-item rolled-up read row exposed via <see cref="MergedShoppingListDto"/>.
+/// Async projection handler for the <c>ShoppingLedger</c> aggregate. Maintains
+/// the per-item rolled-up read row exposed via <see cref="MergedShoppingListDto"/>
+/// from ledger integration events (<c>ShoppingItemAdded</c>, <c>Bought</c>,
+/// <c>Consumed</c>, <c>Removed</c>, <c>QuantityAdjusted</c>).
 /// Distinct from <see cref="ShoppingListProjection"/>, which projects the
-/// ShoppingList aggregate's own event stream.
-/// See PROFILING.md alongside this file for the expected query budget per event.
-/// All five handlers go through INSERT … ON CONFLICT keyed on
-/// (OwnerId, lower(ItemName), COALESCE(Unit, '')) — the unique index added by
-/// migration 20260509125057. That makes them order-independent (Bought arriving
-/// before Added drops a stub instead of silently dropping the bought signal)
-/// and concurrency-safe (two parallel ShoppingItemAdded for the same item
-/// can't fan out to duplicate rows because the second INSERT collides on the
-/// natural key and falls through to the merge UPDATE).
+/// ShoppingList aggregate's own event stream. See PROFILING.md alongside this
+/// file for the expected query budget per event.
+///
+/// All five handlers are race-safe under Wolverine's per-event-type queue
+/// fan-out: the unique index from migration 20260509125057 means a second
+/// concurrent insert for the same (OwnerId, lower(ItemName), Unit) collides
+/// and the catch falls through to the merge UPDATE. They're also order-
+/// independent — a Bought / Consumed / QuantityAdjusted that arrives before
+/// the matching Added drops a stub row so the signal isn't dropped on the
+/// floor.
+///
+/// EF Core does the heavy lifting via tracker INSERTs and ExecuteUpdateAsync /
+/// ExecuteDeleteAsync. The single piece of raw SQL is the <c>jsonb ||</c>
+/// concat in the Added merge path: there's no EF-native equivalent for
+/// appending to a jsonb array column without a deserialise/append/serialise
+/// round-trip that would race.
 /// </summary>
 public sealed class ShoppingLedgerProjectionHandler(ShoppingDbContext context)
 	: IModuleEventHandler<ShoppingItemAddedModuleEvent>,
@@ -39,192 +44,217 @@ public sealed class ShoppingLedgerProjectionHandler(ShoppingDbContext context)
 		var inner = @event.Inner;
 		var quantity = inner.Quantity.Amount.Value;
 		var unit = inner.Quantity.Unit?.Value;
-		var category = (IngredientCategoryResolver.Resolve(inner.ItemName) ?? IngredientCategory.Other).Value;
-		var sourceEntry = SerializeSource(quantity, inner.Source);
+		var ownerId = @event.OwnerId;
+		var itemName = inner.ItemName.Value;
+		var category = (IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other).Value;
+		var sourcesJson = SerializeSources(quantity, inner.Source);
 		var now = DateTime.UtcNow;
 
-		// New row gets the full set; on conflict we merge into the existing row —
-		// summing TotalQuantity and concatenating SourcesJson via jsonb || .
-		// IsBought / BoughtAt are LEFT ALONE so an out-of-order Bought event
-		// that already created a stub doesn't have its bought-state stomped.
-		const string sql = """
-			INSERT INTO "ShoppingListReadItems"
-				("Id", "OwnerId", "ItemName", "TotalQuantity", "Unit", "Category", "IsBought", "BoughtAt", "SourcesJson", "LastUpdated")
-			VALUES (@id, @ownerId, @itemName, @quantity, @unit, @category, FALSE, NULL, @sourceEntry, @now)
-			ON CONFLICT ("OwnerId", lower("ItemName"), COALESCE("Unit", ''))
-			DO UPDATE SET
-				"TotalQuantity" = "ShoppingListReadItems"."TotalQuantity" + EXCLUDED."TotalQuantity",
-				"SourcesJson" = "ShoppingListReadItems"."SourcesJson" || EXCLUDED."SourcesJson",
-				"LastUpdated" = EXCLUDED."LastUpdated"
-			""";
+		// Optimistic insert via the EF tracker. The natural-key unique index
+		// turns a duplicate into a DbUpdateException that the catch routes to
+		// the merge path; on the happy fresh-row path no extra round-trip.
+		context.Set<ShoppingLedgerReadItem>().Add(new ShoppingLedgerReadItem
+		{
+			Id = Guid.CreateVersion7(),
+			OwnerId = ownerId,
+			ItemName = itemName,
+			TotalQuantity = quantity,
+			Unit = unit,
+			Category = category,
+			IsBought = false,
+			BoughtAt = null,
+			SourcesJson = sourcesJson,
+			LastUpdated = now,
+		});
 
-		await context.Database.ExecuteSqlRawAsync(
-			sql,
-			[
-				new NpgsqlParameter("id", NpgsqlDbType.Uuid) { Value = Guid.CreateVersion7() },
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("quantity", NpgsqlDbType.Numeric) { Value = quantity },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-				new NpgsqlParameter("category", NpgsqlDbType.Text) { Value = category },
-				new NpgsqlParameter("sourceEntry", NpgsqlDbType.Jsonb) { Value = sourceEntry },
-				new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now },
-			],
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+			return;
+		}
+		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+		{
+			// Existing row — drop the staged insert and fall through to merge.
+			context.ChangeTracker.Clear();
+		}
+
+		// Sum the quantity in EF (atomic via ExecuteUpdate's row lock) and
+		// concatenate the new source onto the jsonb array via raw SQL — EF
+		// can't model jsonb || jsonb without a deserialise round-trip. The
+		// two statements share the implicit Wolverine handler transaction, so
+		// the merge is atomic from a downstream reader's perspective.
+		await context.Set<ShoppingLedgerReadItem>()
+			.Where(row => row.OwnerId == ownerId
+				&& EF.Functions.ILike(row.ItemName, itemName)
+				&& row.Unit == unit)
+			.ExecuteUpdateAsync(
+				setters =>
+				{
+					setters.SetProperty(row => row.TotalQuantity, row => row.TotalQuantity + quantity);
+					setters.SetProperty(row => row.LastUpdated, _ => now);
+				},
+				cancellationToken);
+
+		await context.Database.ExecuteSqlInterpolatedAsync(
+			$"""
+			UPDATE "ShoppingListReadItems"
+			SET "SourcesJson" = "SourcesJson" || {sourcesJson}::jsonb
+			WHERE "OwnerId" = {ownerId}
+			  AND lower("ItemName") = lower({itemName})
+			  AND COALESCE("Unit", '') = COALESCE({unit}, '')
+			""",
 			cancellationToken);
 	}
 
-	public async Task HandleAsync(ShoppingItemBoughtModuleEvent @event, CancellationToken cancellationToken = default)
+	public Task HandleAsync(ShoppingItemBoughtModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var unit = inner.Quantity.Unit?.Value;
-		var category = (IngredientCategoryResolver.Resolve(inner.ItemName) ?? IngredientCategory.Other).Value;
 		var now = DateTime.UtcNow;
-
-		// Bought-on-stub-or-real: insert a stub row with TotalQuantity=0 if
-		// nothing exists yet (so the bought-state survives Added arriving later)
-		// or flip IsBought / BoughtAt on the existing row. Quantity / sources
-		// are deliberately untouched on conflict — they belong to Added /
-		// Removed / QuantityAdjusted events.
-		const string sql = """
-			INSERT INTO "ShoppingListReadItems"
-				("Id", "OwnerId", "ItemName", "TotalQuantity", "Unit", "Category", "IsBought", "BoughtAt", "SourcesJson", "LastUpdated")
-			VALUES (@id, @ownerId, @itemName, 0, @unit, @category, TRUE, @now, '[]'::jsonb, @now)
-			ON CONFLICT ("OwnerId", lower("ItemName"), COALESCE("Unit", ''))
-			DO UPDATE SET
-				"IsBought" = TRUE,
-				"BoughtAt" = EXCLUDED."BoughtAt",
-				"LastUpdated" = EXCLUDED."LastUpdated"
-			""";
-
-		await context.Database.ExecuteSqlRawAsync(
-			sql,
-			[
-				new NpgsqlParameter("id", NpgsqlDbType.Uuid) { Value = Guid.CreateVersion7() },
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-				new NpgsqlParameter("category", NpgsqlDbType.Text) { Value = category },
-				new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now },
-			],
+		return UpsertStateAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			updateExisting: setters =>
+			{
+				setters.SetProperty(row => row.IsBought, true);
+				setters.SetProperty(row => row.BoughtAt, _ => now);
+				setters.SetProperty(row => row.LastUpdated, _ => now);
+			},
+			stubFromExisting: stub =>
+			{
+				stub.IsBought = true;
+				stub.BoughtAt = now;
+			},
 			cancellationToken);
 	}
 
-	public async Task HandleAsync(ShoppingItemConsumedModuleEvent @event, CancellationToken cancellationToken = default)
+	public Task HandleAsync(ShoppingItemConsumedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var unit = inner.Quantity.Unit?.Value;
-		var category = (IngredientCategoryResolver.Resolve(inner.ItemName) ?? IngredientCategory.Other).Value;
 		var now = DateTime.UtcNow;
-
-		// Consume is a touch-only signal in the ledger projection (the legacy
-		// Update-with-empty-mutate path). If the item isn't projected yet we
-		// still drop a stub so a later Added doesn't surprise a downstream
-		// reader that already saw the consumed event flow through; on conflict
-		// we just bump LastUpdated.
-		const string sql = """
-			INSERT INTO "ShoppingListReadItems"
-				("Id", "OwnerId", "ItemName", "TotalQuantity", "Unit", "Category", "IsBought", "BoughtAt", "SourcesJson", "LastUpdated")
-			VALUES (@id, @ownerId, @itemName, 0, @unit, @category, FALSE, NULL, '[]'::jsonb, @now)
-			ON CONFLICT ("OwnerId", lower("ItemName"), COALESCE("Unit", ''))
-			DO UPDATE SET "LastUpdated" = EXCLUDED."LastUpdated"
-			""";
-
-		await context.Database.ExecuteSqlRawAsync(
-			sql,
-			[
-				new NpgsqlParameter("id", NpgsqlDbType.Uuid) { Value = Guid.CreateVersion7() },
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-				new NpgsqlParameter("category", NpgsqlDbType.Text) { Value = category },
-				new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now },
-			],
+		return UpsertStateAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.Quantity.Unit?.Value,
+			updateExisting: setters =>
+			{
+				setters.SetProperty(row => row.LastUpdated, _ => now);
+			},
+			stubFromExisting: _ => { },
 			cancellationToken);
 	}
 
 	public async Task HandleAsync(ShoppingItemRemovedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
+		var ownerId = @event.OwnerId;
+		var itemName = inner.ItemName.Value;
 		var unit = inner.Quantity.Unit?.Value;
 		var quantity = inner.Quantity.Amount.Value;
 		var now = DateTime.UtcNow;
 
-		// Decrement first via UPDATE (no UPSERT — removing nothing is a no-op,
-		// not a reason to invent a stub row). Then DELETE the row if the total
-		// dropped to <= 0; this matches the previous EF tracker semantics where
-		// Remove was called when TotalQuantity went non-positive.
-		await context.Database.ExecuteSqlRawAsync(
-			"""
-			UPDATE "ShoppingListReadItems"
-			SET "TotalQuantity" = GREATEST(0, "TotalQuantity" - @quantity),
-				"LastUpdated" = @now
-			WHERE "OwnerId" = @ownerId
-			  AND lower("ItemName") = lower(@itemName)
-			  AND COALESCE("Unit", '') = COALESCE(@unit, '');
-			""",
-			[
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-				new NpgsqlParameter("quantity", NpgsqlDbType.Numeric) { Value = quantity },
-				new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now },
-			],
-			cancellationToken);
+		// Decrement first; if the running total drops to <=0 the second pass
+		// deletes the row. No UPSERT — removing nothing is a no-op, not a
+		// reason to invent a stub.
+		await context.Set<ShoppingLedgerReadItem>()
+			.Where(row => row.OwnerId == ownerId
+				&& EF.Functions.ILike(row.ItemName, itemName)
+				&& row.Unit == unit)
+			.ExecuteUpdateAsync(
+				setters =>
+				{
+					setters.SetProperty(row => row.TotalQuantity, row => row.TotalQuantity > quantity ? row.TotalQuantity - quantity : 0);
+					setters.SetProperty(row => row.LastUpdated, _ => now);
+				},
+				cancellationToken);
 
-		await context.Database.ExecuteSqlRawAsync(
-			"""
-			DELETE FROM "ShoppingListReadItems"
-			WHERE "OwnerId" = @ownerId
-			  AND lower("ItemName") = lower(@itemName)
-			  AND COALESCE("Unit", '') = COALESCE(@unit, '')
-			  AND "TotalQuantity" <= 0;
-			""",
-			[
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-			],
+		await context.Set<ShoppingLedgerReadItem>()
+			.Where(row => row.OwnerId == ownerId
+				&& EF.Functions.ILike(row.ItemName, itemName)
+				&& row.Unit == unit
+				&& row.TotalQuantity <= 0)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+
+	public Task HandleAsync(ShoppingItemQuantityAdjustedModuleEvent @event, CancellationToken cancellationToken = default)
+	{
+		var inner = @event.Inner;
+		var newQuantity = inner.NewQuantity.Amount.Value;
+		var now = DateTime.UtcNow;
+		return UpsertStateAsync(
+			@event.OwnerId,
+			inner.ItemName,
+			inner.NewQuantity.Unit?.Value,
+			updateExisting: setters =>
+			{
+				setters.SetProperty(row => row.TotalQuantity, _ => newQuantity);
+				setters.SetProperty(row => row.LastUpdated, _ => now);
+			},
+			stubFromExisting: stub =>
+			{
+				stub.TotalQuantity = newQuantity;
+			},
 			cancellationToken);
 	}
 
-	public async Task HandleAsync(ShoppingItemQuantityAdjustedModuleEvent @event, CancellationToken cancellationToken = default)
+	private async Task UpsertStateAsync(
+		string ownerId,
+		string itemName,
+		string? unit,
+		Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<ShoppingLedgerReadItem>> updateExisting,
+		Action<ShoppingLedgerReadItem> stubFromExisting,
+		CancellationToken cancellationToken)
 	{
-		var inner = @event.Inner;
-		var unit = inner.NewQuantity.Unit?.Value;
-		var category = (IngredientCategoryResolver.Resolve(inner.ItemName) ?? IngredientCategory.Other).Value;
-		var quantity = inner.NewQuantity.Amount.Value;
-		var now = DateTime.UtcNow;
+		// Try to update an existing row first. ExecuteUpdate is a single
+		// SQL UPDATE: race-safe against concurrent updates of the same row
+		// (Postgres row-level locks serialise them) and idempotent against
+		// redelivery (running it twice produces the same end state).
+		var rowsAffected = await context.Set<ShoppingLedgerReadItem>()
+			.Where(row => row.OwnerId == ownerId
+				&& EF.Functions.ILike(row.ItemName, itemName)
+				&& row.Unit == unit)
+			.ExecuteUpdateAsync(updateExisting, cancellationToken);
 
-		// QuantityAdjusted overwrites TotalQuantity rather than incrementing —
-		// it carries the new absolute value, not a delta. On conflict we set
-		// the absolute value too. If the row didn't exist yet we still drop a
-		// stub at the new value so a later Added merges correctly.
-		const string sql = """
-			INSERT INTO "ShoppingListReadItems"
-				("Id", "OwnerId", "ItemName", "TotalQuantity", "Unit", "Category", "IsBought", "BoughtAt", "SourcesJson", "LastUpdated")
-			VALUES (@id, @ownerId, @itemName, @quantity, @unit, @category, FALSE, NULL, '[]'::jsonb, @now)
-			ON CONFLICT ("OwnerId", lower("ItemName"), COALESCE("Unit", ''))
-			DO UPDATE SET
-				"TotalQuantity" = EXCLUDED."TotalQuantity",
-				"LastUpdated" = EXCLUDED."LastUpdated"
-			""";
+		if (rowsAffected > 0) return;
 
-		await context.Database.ExecuteSqlRawAsync(
-			sql,
-			[
-				new NpgsqlParameter("id", NpgsqlDbType.Uuid) { Value = Guid.CreateVersion7() },
-				new NpgsqlParameter("ownerId", NpgsqlDbType.Text) { Value = @event.OwnerId },
-				new NpgsqlParameter("itemName", NpgsqlDbType.Text) { Value = inner.ItemName.Value },
-				new NpgsqlParameter("quantity", NpgsqlDbType.Numeric) { Value = quantity },
-				new NpgsqlParameter("unit", NpgsqlDbType.Text) { Value = (object?)unit ?? DBNull.Value },
-				new NpgsqlParameter("category", NpgsqlDbType.Text) { Value = category },
-				new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now },
-			],
-			cancellationToken);
+		// No matching row — drop a stub keyed by the natural key so the
+		// state isn't dropped if Added arrives later. The unique constraint
+		// catches the race against another concurrent stub-insert; on
+		// collision we fall back to the UPDATE we just did, which now has
+		// a row to land on.
+		var stub = new ShoppingLedgerReadItem
+		{
+			Id = Guid.CreateVersion7(),
+			OwnerId = ownerId,
+			ItemName = itemName,
+			TotalQuantity = 0,
+			Unit = unit,
+			Category = (IngredientCategoryResolver.Resolve(itemName) ?? IngredientCategory.Other).Value,
+			IsBought = false,
+			BoughtAt = null,
+			SourcesJson = "[]",
+			LastUpdated = DateTime.UtcNow,
+		};
+		stubFromExisting(stub);
+		context.Set<ShoppingLedgerReadItem>().Add(stub);
+
+		try
+		{
+			await context.SaveChangesAsync(cancellationToken);
+		}
+		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+		{
+			context.ChangeTracker.Clear();
+			await context.Set<ShoppingLedgerReadItem>()
+				.Where(row => row.OwnerId == ownerId
+					&& EF.Functions.ILike(row.ItemName, itemName)
+					&& row.Unit == unit)
+				.ExecuteUpdateAsync(updateExisting, cancellationToken);
+		}
 	}
 
 #pragma warning disable SA1204
-	private static string SerializeSource(decimal quantity, string source)
+	private static string SerializeSources(decimal quantity, string source)
 	{
 		var entry = new SourceEntry(quantity, source, DateTime.UtcNow);
 		return JsonSerializer.Serialize<List<SourceEntry>>([entry]);


### PR DESCRIPTION
## Summary

#627 closed the ledger projection race by routing every handler through raw `INSERT … ON CONFLICT`. That worked but gave up EF's compile-time property checks, change tracker, and migration awareness in places where EF could have done the job. This pull pulls each handler back into EF Core where it can do the work, and reserves raw SQL only for the seam where EF has no equivalent.

## Where each handler lands

- **`ShoppingItemRemoved`** — pure EF. `ExecuteUpdateAsync` to decrement, `ExecuteDeleteAsync` for rows whose total dropped to ≤0.
- **`Bought` / `Consumed` / `QuantityAdjusted`** — `ExecuteUpdateAsync` first, EF tracker `INSERT` fallback if zero rows matched. The unique index catches the racy concurrent-stub-insert; a `DbUpdateException` on `23505` retries the `UPDATE` which now has a row to land on. All `SetProperty` calls are EF expressions, so property names are compile-time-checked against `ShoppingLedgerReadItem`.
- **`ShoppingItemAdded`** — tracker `INSERT` first (fast happy path). On conflict, clear the staged insert via `ChangeTracker.Clear`, sum the quantity via `ExecuteUpdateAsync`, and run one `ExecuteSqlInterpolatedAsync` that does the `jsonb ||` concat. That last query is the only piece of raw SQL left; EF can't model appending to a jsonb array column without a deserialise round-trip that would race.

## Schema

The natural-key unique index stays in migration `20260509125057`. EF Core can't express an expression-based unique index (`lower` / `COALESCE` on a nullable column) without stored generated columns, which is more schema bloat than the index is worth. The entity config now carries a comment pointing at the migration so the constraint is discoverable from the model.

## Test plan

- [x] `dotnet build` clean
- [x] Shopping integration tests (91) pass
- [x] Full integration suite — **253/253 pass locally**
- [ ] CI green