### PR TITLE
chore(shopping): drop stale imports + tighten EF Core Query namespace reference

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerProjectionHandler.cs
@@ -1,10 +1,9 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
-using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore.Events;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
@@ -201,7 +200,7 @@ public sealed class ShoppingLedgerProjectionHandler(ShoppingDbContext context)
 		string ownerId,
 		string itemName,
 		string? unit,
-		Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<ShoppingLedgerReadItem>> updateExisting,
+		Action<UpdateSettersBuilder<ShoppingLedgerReadItem>> updateExisting,
 		Action<ShoppingLedgerReadItem> stubFromExisting,
 		CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
## Summary

Tail of the dead-code sweep after the projection-race work. #628 left two using directives in `ShoppingLedgerProjectionHandler` behind that no longer pull anything in:

- `SmartSolutionsLab.Yumney.Shared.Persistence` — was for `ReadModelUpsertExtensions` (`UpsertAsync<T>` / `UpdateAsync<T>`), replaced by `ExecuteUpdateAsync` and EF tracker `Add` in #628. The extensions themselves stay alive — `IngredientBalanceProjectionHandler` still uses them.
- `SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore` — was for the legacy serialiser type; the events now come from the `.Events` sub-namespace which is still imported.

Also pull `Microsoft.EntityFrameworkCore.Query` into the using list so the `UpdateSettersBuilder<T>` parameter type on `UpsertStateAsync` isn't fully qualified at the use site.

## What I checked

Walked the recently-touched modules looking for orphans. Found nothing else to drop:

- `ReadModelUpsertExtensions` (`UpsertAsync` / `UpdateAsync`) — still actively used by `IngredientBalanceProjectionHandler` for the at-home-balance read model.
- `WolverineOutboxEventBus<T>` — used by Recipes and Users infrastructure registrations (#620).
- `ShoppingListProjectionRebuilder` — used by `MigrationWorker` for the dashboard rebuild path.
- `MealPlanProjectionHandler` — already in good shape, uses `INSERT … ON CONFLICT DO NOTHING` for slot upserts and relies on the composite PK to catch racy `WeeklyPlanCreated` redeliveries.
- All e2e page-object selectors checked clean in #623 / #624.
- `dotnet build Yumney.slnx` reports zero warnings — the compiler isn't flagging anything else as unused.

## Test plan

- [x] `dotnet build` clean
- [x] Full Shopping integration suite (91/91) passes locally
- [ ] CI green