### PR TITLE
chore(infra): upgrade Aspire 13.2.2 → 13.3.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.4",
+      "version": "10.0.7",
       "commands": [
         "dotnet-ef"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,22 +4,23 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.2.2-preview.1.26207.2" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.3.0-preview.1.26256.5" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.3.0-preview.1.26256.5" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.2.2-preview.1.26207.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.3.0-preview.1.26256.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.5.0" />
@@ -32,11 +33,11 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <!-- Persistence -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <!-- LLM & Scraping -->
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
@@ -48,14 +49,14 @@
     <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.31.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
     <!-- DI, Configuration & Logging Abstractions -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <!-- Analyzers -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Testing -->

--- a/client/apps/account/src/app/activity/activity.component.spec.ts
+++ b/client/apps/account/src/app/activity/activity.component.spec.ts
@@ -1,11 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
-import {
-  ActivityTimelineComponent,
-  AsyncStateComponent,
-  provideYumneyIcons,
-} from '@yumney/ui';
+import { ActivityTimelineComponent, AsyncStateComponent, provideYumneyIcons } from '@yumney/ui';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 import { ActivityComponent } from './activity.component';
 import { ActivityApiService, type UserActivityPage } from '../api';

--- a/client/apps/account/src/app/activity/activity.component.spec.ts
+++ b/client/apps/account/src/app/activity/activity.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
-import { provideYumneyIcons } from '@yumney/ui';
+import {
+  ActivityTimelineComponent,
+  AsyncStateComponent,
+  provideYumneyIcons,
+} from '@yumney/ui';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 import { ActivityComponent } from './activity.component';
 import { ActivityApiService, type UserActivityPage } from '../api';
@@ -48,9 +53,62 @@ const secondPage: UserActivityPage = {
   nextCursor: null,
 };
 
+const cookedPage: UserActivityPage = {
+  items: [
+    {
+      type: 'recipe_cooked',
+      recipeIdentifier: 'recipe-cooked-1',
+      recipeTitle: 'Cooked recipe',
+      occurredAt: new Date(2026, 4, 8).toISOString(),
+    },
+  ],
+  nextCursor: null,
+};
+
+// Filter chip order matches FILTER_OPTIONS in activity.component.ts.
+const ChipIndex = {
+  all: 0,
+  imported: 1,
+  viewed: 2,
+  cooked: 3,
+  edited: 4,
+  deleted: 5,
+} as const;
+
 describe('ActivityComponent', () => {
   let fixture: ComponentFixture<ActivityComponent>;
   let apiMock: { getActivity: ReturnType<typeof vi.fn> };
+
+  function chips() {
+    return fixture.debugElement.queryAll(By.css('.activity-page__chip'));
+  }
+
+  function clickChip(index: number) {
+    chips()[index].nativeElement.click();
+    fixture.detectChanges();
+  }
+
+  function loadMoreButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector('.activity-page__load-more');
+  }
+
+  function clickLoadMore() {
+    const button = loadMoreButton();
+    if (button === null) throw new Error('load-more button not rendered');
+    button.click();
+    fixture.detectChanges();
+  }
+
+  function timelineEntries() {
+    const debugEl = fixture.debugElement.query(By.directive(ActivityTimelineComponent));
+    return (debugEl.componentInstance as ActivityTimelineComponent).entries();
+  }
+
+  function emitRetry() {
+    const debugEl = fixture.debugElement.query(By.directive(AsyncStateComponent));
+    (debugEl.componentInstance as AsyncStateComponent).retry.emit();
+    fixture.detectChanges();
+  }
 
   beforeEach(async () => {
     apiMock = {
@@ -66,41 +124,107 @@ describe('ActivityComponent', () => {
     fixture.detectChanges();
   });
 
-  it('loads the first page on init with limit=20 and no cursor', () => {
-    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20 });
+  describe('initial load', () => {
+    it('should call the API with limit=20 and no cursor on init', () => {
+      expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20 });
+    });
+
+    it('should pass the first page to the timeline', () => {
+      expect(timelineEntries()).toHaveLength(20);
+    });
+
+    it('should mark the all-filter chip as active by default', () => {
+      expect(chips()[ChipIndex.all].nativeElement.getAttribute('aria-pressed')).toBe('true');
+    });
   });
 
-  it('renders the load-more button when nextCursor is present', () => {
-    const button = fixture.nativeElement.querySelector('.activity-page__load-more');
-    expect(button).toBeTruthy();
-    expect(button.textContent).toContain('Load older');
+  describe('load more', () => {
+    it('should render the load-more button when next cursor is present', () => {
+      expect(loadMoreButton()).not.toBeNull();
+    });
+
+    it('should pass the current cursor to the API when clicked', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+
+      clickLoadMore();
+
+      expect(apiMock.getActivity).toHaveBeenLastCalledWith({
+        limit: 20,
+        cursor: 'cursor-page-2',
+      });
+    });
+
+    it('should append the next page to the timeline', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+
+      clickLoadMore();
+
+      expect(timelineEntries()).toHaveLength(21);
+    });
+
+    it('should hide the load-more button after the final page exhausts the cursor', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+
+      clickLoadMore();
+
+      expect(loadMoreButton()).toBeNull();
+    });
   });
 
-  it('appends entries and forwards the cursor on load-more', () => {
-    apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+  describe('filter chips', () => {
+    it('should call the API with the selected type when a non-active chip is clicked', () => {
+      apiMock.getActivity.mockClear();
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
 
-    fixture.componentInstance['onLoadMore']();
+      clickChip(ChipIndex.cooked);
 
-    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, cursor: 'cursor-page-2' });
-    expect(fixture.componentInstance['entries']().length).toBe(21);
+      expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, type: 'recipe_cooked' });
+    });
+
+    it('should reset the timeline to the new first page after switching filters', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
+
+      clickChip(ChipIndex.cooked);
+
+      expect(timelineEntries()).toHaveLength(1);
+    });
+
+    it('should reset the cursor (and hide load-more) after switching to a single-page filter', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
+
+      clickChip(ChipIndex.cooked);
+
+      expect(loadMoreButton()).toBeNull();
+    });
+
+    it('should move the active aria-pressed state when filter changes', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
+
+      clickChip(ChipIndex.cooked);
+
+      expect(chips()[ChipIndex.all].nativeElement.getAttribute('aria-pressed')).toBe('false');
+      expect(chips()[ChipIndex.cooked].nativeElement.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('should not refetch when the active chip is clicked again', () => {
+      apiMock.getActivity.mockClear();
+
+      clickChip(ChipIndex.all);
+
+      expect(apiMock.getActivity).not.toHaveBeenCalled();
+    });
   });
 
-  it('hides the load-more button after the final page exhausts the cursor', () => {
-    apiMock.getActivity.mockReturnValueOnce(of(secondPage));
+  describe('retry', () => {
+    it('should reload the first page with the active filter when retry is emitted', () => {
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
+      clickChip(ChipIndex.cooked);
+      apiMock.getActivity.mockClear();
+      apiMock.getActivity.mockReturnValueOnce(of(cookedPage));
 
-    fixture.componentInstance['onLoadMore']();
-    fixture.detectChanges();
+      emitRetry();
 
-    expect(fixture.componentInstance['nextCursor']()).toBeNull();
-    expect(fixture.nativeElement.querySelector('.activity-page__load-more')).toBeFalsy();
-  });
-
-  it('resets pagination when filter changes', () => {
-    apiMock.getActivity.mockClear();
-    apiMock.getActivity.mockReturnValueOnce(of(firstPage));
-
-    fixture.componentInstance['onFilterChange']('recipe_cooked');
-
-    expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, type: 'recipe_cooked' });
+      expect(apiMock.getActivity).toHaveBeenCalledWith({ limit: 20, type: 'recipe_cooked' });
+    });
   });
 });

--- a/client/apps/account/src/app/api.ts
+++ b/client/apps/account/src/app/api.ts
@@ -8,5 +8,6 @@ export {
   type UserProfile,
   type UpdateProfileRequest,
   type UserActivityItem,
+  type UserActivityPage,
   type ActivityTypeKey,
 } from '@yumney/shared/api-client';

--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -32,8 +32,7 @@ internal static class AppHostExtensions
 		IDistributedApplicationBuilder aspireBuilder,
 		AppHostOptions options)
 	{
-		if (options.E2ETests)
-			return builder;
+		if (options.E2ETests) return builder;
 
 		if (options.UseOllama)
 		{

--- a/src/Yumney.AppHost/DashboardResetEntries.cs
+++ b/src/Yumney.AppHost/DashboardResetEntries.cs
@@ -1,6 +1,3 @@
-using Aspire.Hosting;
-using Aspire.Hosting.ApplicationModel;
-
 namespace SmartSolutionsLab.Yumney.AppHost;
 
 /// <summary>

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -188,11 +188,14 @@ if (!options.DatabaseOnly)
 		// flag above still toggles persistent volumes and optional sidecars
 		// (pgAdmin, mailpit); it doesn't affect whether the frontend is registered.
 		var addMfe = (string name, string script, int port) =>
+#pragma warning disable ASPIREBROWSERLOGS001
 			builder.AddJavaScriptApp(name, "../../client", script)
 				.WithYarn()
 				.WithEnvironment("NX_DAEMON", "false")
 				.WithEnvironment("NX_ISOLATE_PLUGINS", "false")
-				.WithHttpEndpoint(targetPort: port);
+				.WithHttpEndpoint(targetPort: port)
+				.WithBrowserLogs();
+#pragma warning restore ASPIREBROWSERLOGS001
 
 		// E2E mode runs against a production build so PWA tests (service
 		// worker, offline cache) and Vite-free fetch behaviour exercise the

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.Browsers" />
     <PackageReference Include="Aspire.Hosting.Keycloak" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDesignTimeDbContextFactory.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDesignTimeDbContextFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+
+public sealed class MealPlanDesignTimeDbContextFactory : IDesignTimeDbContextFactory<MealPlanDbContext>
+{
+	public MealPlanDbContext CreateDbContext(string[] args)
+	{
+		var optionsBuilder = new DbContextOptionsBuilder<MealPlanDbContext>();
+		optionsBuilder.UseNpgsql(
+			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
+			x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
+
+		return new MealPlanDbContext(optionsBuilder.Options);
+	}
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanReadDesignTimeDbContextFactory.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanReadDesignTimeDbContextFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
+
+public sealed class MealPlanReadDesignTimeDbContextFactory : IDesignTimeDbContextFactory<MealPlanReadDbContext>
+{
+	public MealPlanReadDbContext CreateDbContext(string[] args)
+	{
+		var optionsBuilder = new DbContextOptionsBuilder<MealPlanReadDbContext>();
+		optionsBuilder.UseNpgsql(
+			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
+			x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
+
+		return new MealPlanReadDbContext(optionsBuilder.Options);
+	}
+}

--- a/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using SmartSolutionsLab.Yumney.Shared.Events;
 
 namespace SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDesignTimeDbContextFactory.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDesignTimeDbContextFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
+
+public sealed class ShoppingReadDesignTimeDbContextFactory : IDesignTimeDbContextFactory<ShoppingReadDbContext>
+{
+	public ShoppingReadDbContext CreateDbContext(string[] args)
+	{
+		var optionsBuilder = new DbContextOptionsBuilder<ShoppingReadDbContext>();
+		optionsBuilder.UseNpgsql(
+			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
+			x => x.MigrationsHistoryTable("__ShoppingMigrationsHistory"));
+
+		return new ShoppingReadDbContext(optionsBuilder.Options);
+	}
+}


### PR DESCRIPTION
## Summary
- Aspire `13.2.2` → `13.3.0` across all `Aspire.Hosting.*` packages and the AppHost SDK; Keycloak previews bumped to matching `13.3.0-preview.1.26256.5`.
- Bumps `Microsoft.Extensions.*` and `Microsoft.EntityFrameworkCore.*` `10.0.6` → `10.0.7` (transitive requirement of Aspire 13.3; `.NET 10` servicing patch — no schema impact).
- `dotnet-ef` tool `10.0.4` → `10.0.7` so the local tool tracks the EF runtime (the old tool started failing to load `System.Runtime` against the new runtime).
- Adds `IDesignTimeDbContextFactory` for `ShoppingReadDbContext`, `MealPlanDbContext`, and `MealPlanReadDbContext`, completing the convention already used by Recipes/Users/Shopping write contexts. Without these, `dotnet ef` falls back to building the API host's DI graph, which trips `Ensure.That(rabbitConnection)…` in `WolverineEventBusExtensions` because Aspire only injects the `messaging` connection string at runtime.

## Notes
- `CommunityToolkit.Aspire.Hosting.Ollama` is left at `13.1.1` — no 13.3 release published yet.
- Verified `dotnet ef migrations has-pending-model-changes` is clean for `ShoppingDbContext` and `MealPlanDbContext`. Read contexts don't own migrations (single snapshot per module, owned by the write context); their isolated probe report is a tooling artifact.

## Test plan
- [x] `dotnet restore Yumney.slnx`
- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors
- [x] `dotnet format Yumney.slnx --verify-no-changes` → clean
- [x] `dotnet ef migrations has-pending-model-changes` for Shopping & MealPlan write contexts → no changes
- [ ] CI green
- [ ] Aspire dashboard launches locally and all module hosts come up healthy