### PR TITLE
refactor(shared): extract cross-module events into Yumney.Shared.Events.Contracts (#634)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -32,6 +32,8 @@ jobs:
             display: Shared
           - project: Yumney.Shared.Guards.Tests
             display: Shared.Guards
+          - project: Yumney.Shared.Events.Contracts.Tests
+            display: Shared.Events.Contracts
           # Yumney.Shared.Events.Tests excluded: the test project references
           # *.Events.InProcess and *.Events.Wolverine but never *.Events
           # itself, so Stryker's "find a mutable assembly from project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ yumney/
 │   ├── Yumney.Shared.Paging/        # Page, PageSize, PagedResult, SortingOptions
 │   ├── Yumney.Shared.Quantities/    # IngredientCategory, Freshness, ShelfLife, QuantityRounder
 │   ├── Yumney.Shared.Persistence/   # IUnitOfWork, EF event-store + inbox helpers
-│   ├── Yumney.Shared.Events/        # IEventBus, IIntegrationEvent / IModuleEvent / IDomainEvent + handler interfaces
+│   ├── Yumney.Shared.Events/        # IEventBus, IIntegrationEvent / IModuleEvent / IDomainEvent + handler interfaces (abstractions only)
+│   ├── Yumney.Shared.Events.Contracts/ # Concrete cross-module integration event records (RecipeImported, RecipeDeleted, MealConfirmed, …)
 │   ├── Yumney.Shared.Events.InProcess/ # InProcessDomainEventDispatcher (single-host swap-in)
 │   ├── Yumney.Shared.Events.Wolverine/ # Wolverine + RabbitMQ implementation of IEventBus / consumers
 │   ├── Yumney.Shared.CQRS/          # ICommandHandler / IQueryHandler + logging decorators
@@ -190,7 +191,7 @@ Rules:
 Three event types with distinct purposes:
 
 - **Domain Events** (`IDomainEvent` → `IDomainEventHandler<T>`) — within a module, dispatched by `IDomainEventDispatcher` after EF Core `SaveChanges`. Example: `RecipeImportedEvent` triggers side effects inside the Recipes module.
-- **Integration Events** (`IIntegrationEvent` → `IIntegrationEventHandler<T>`) — **cross-module** public contract, published via `IEventBus`. Live in `Yumney.Shared.Events.CrossModule`. Fields must be primitives or shared types only — never a module's Domain types. Example: Recipes publishes `RecipeDeletedIntegrationEvent` → Shopping subscribes.
+- **Integration Events** (`IIntegrationEvent` → `IIntegrationEventHandler<T>`) — **cross-module** public contract, published via `IEventBus`. Concrete event records live in `Yumney.Shared.Events.Contracts` (namespace `SmartSolutionsLab.Yumney.Shared.Events.Contracts`); the `IIntegrationEvent` / `IntegrationEvent` base + handler interfaces stay in `Yumney.Shared.Events`. Fields must be primitives or shared types only — never a module's Domain types. Producer + consumer projects (`*.Application`, `*.Infrastructure`) reference `Yumney.Shared.Events.Contracts` directly; `*.Domain` MUST NOT (enforced by `LayerDependencyTests.Domain_ShouldNotDependOn_EventsContracts`). Example: Recipes publishes `RecipeDeletedIntegrationEvent` → Shopping subscribes.
 - **Module Events** (`IModuleEvent` → `IModuleEventHandler<T>`) — **in-module** bus envelope wrapping a Domain event so projection handlers can subscribe asynchronously. Live in `Yumney.{Module}.Infrastructure/Persistence/EventStore/Events/` and named `*ModuleEvent`. They MUST NOT cross module boundaries; the wrapper exists so the read-model pipeline can ride the same bus as integration events. Example: `EfCoreShoppingEventStore` publishes `ShoppingItemConsumedModuleEvent` → `ShoppingLedgerProjectionHandler` updates the read model.
 
 Both `IIntegrationEvent` and `IModuleEvent` extend `IBusEvent`, the common tag carried by anything `IEventBus.PublishAsync(...)` accepts. Use the specialised marker on concrete types — never `IBusEvent` directly.

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -56,6 +56,7 @@
     <Project Path="tests/Yumney.Shared.Tests/Yumney.Shared.Tests.csproj" />
     <Project Path="tests/Yumney.Shared.Guards.Tests/Yumney.Shared.Guards.Tests.csproj" />
     <Project Path="tests/Yumney.Shared.Events.Tests/Yumney.Shared.Events.Tests.csproj" />
+    <Project Path="tests/Yumney.Shared.Events.Contracts.Tests/Yumney.Shared.Events.Contracts.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/MealPlan/">
     <Project Path="tests/Yumney.MealPlan.Application.Tests/Yumney.MealPlan.Application.Tests.csproj" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -15,6 +15,7 @@
     <Project Path="src/Yumney.Shared.CQRS/Yumney.Shared.CQRS.csproj" />
     <Project Path="src/Yumney.Shared.Events.Wolverine/Yumney.Shared.Events.Wolverine.csproj" />
     <Project Path="src/Yumney.Shared.Events/Yumney.Shared.Events.csproj" />
+    <Project Path="src/Yumney.Shared.Events.Contracts/Yumney.Shared.Events.Contracts.csproj" />
     <Project Path="src/Yumney.Shared.Events.InProcess/Yumney.Shared.Events.InProcess.csproj" />
     <Project Path="src/Yumney.Shared.Guards/Yumney.Shared.Guards.csproj" />
     <Project Path="src/Yumney.Shared.Hosting/Yumney.Shared.Hosting.csproj" />

--- a/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.IntegrationEventHandlers;
 

--- a/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
+++ b/src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Modules\Yumney.Shared.Modules.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/CrossModule/MealConfirmedMapper.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/CrossModule/MealConfirmedMapper.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.Events;
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore.CrossModule;

--- a/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
+++ b/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
     <ProjectReference Include="..\Yumney.Recipes.Client\Yumney.Recipes.Client.csproj" />

--- a/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -3,7 +3,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;

--- a/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListCreatedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListCreatedHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListRecipeReferenceClearedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/ShoppingListRecipeReferenceClearedHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 

--- a/src/Yumney.Recipes.Application/Yumney.Recipes.Application.csproj
+++ b/src/Yumney.Recipes.Application/Yumney.Recipes.Application.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Modules\Yumney.Shared.Modules.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.Recipes.Infrastructure/Services/CachedRecipeViewTracker.cs
+++ b/src/Yumney.Recipes.Infrastructure/Services/CachedRecipeViewTracker.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
 

--- a/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
+++ b/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Yumney.Recipes.Application\Yumney.Recipes.Application.csproj" />
     <ProjectReference Include="..\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />

--- a/src/Yumney.Shared.Events.Contracts/MealConfirmedIngredient.cs
+++ b/src/Yumney.Shared.Events.Contracts/MealConfirmedIngredient.cs
@@ -1,3 +1,3 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 public sealed record MealConfirmedIngredient(string Name, decimal Quantity, string? Unit);

--- a/src/Yumney.Shared.Events.Contracts/MealConfirmedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/MealConfirmedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the MealPlan module when a planned meal transitions to the

--- a/src/Yumney.Shared.Events.Contracts/RecipeCookedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/RecipeCookedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Recipes module when the user finishes cook mode for a

--- a/src/Yumney.Shared.Events.Contracts/RecipeDeletedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/RecipeDeletedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Recipes module after a recipe has been deleted.

--- a/src/Yumney.Shared.Events.Contracts/RecipeImportedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/RecipeImportedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Recipes module after a recipe is saved (manually or via

--- a/src/Yumney.Shared.Events.Contracts/RecipeViewedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/RecipeViewedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Recipes module when a user opens a recipe's detail view

--- a/src/Yumney.Shared.Events.Contracts/ShoppingListCreatedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/ShoppingListCreatedCrossModuleIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Shopping module when a new <c>ShoppingList</c> aggregate

--- a/src/Yumney.Shared.Events.Contracts/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Shopping module when a list's recipe-reference link is

--- a/src/Yumney.Shared.Events.Contracts/UserAccountDeletedIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events.Contracts/UserAccountDeletedIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
 /// <summary>
 /// Published by the Users module when a user erases their account (US-101 / GDPR Art. 17).

--- a/src/Yumney.Shared.Events.Contracts/Yumney.Shared.Events.Contracts.csproj
+++ b/src/Yumney.Shared.Events.Contracts/Yumney.Shared.Events.Contracts.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Shared.Events/IIntegrationEvent.cs
+++ b/src/Yumney.Shared.Events/IIntegrationEvent.cs
@@ -3,7 +3,7 @@ namespace SmartSolutionsLab.Yumney.Shared.Events;
 /// <summary>
 /// Marker for a cross-module integration event. These are the public contracts
 /// between modules — fields must be primitive / shared types only, never a
-/// module's Domain types. They live in <c>Yumney.Shared.Events.CrossModule</c>.
+/// module's Domain types. They live in <c>Yumney.Shared.Events.Contracts</c>.
 /// In-module bus envelopes use <see cref="IModuleEvent"/> instead.
 /// </summary>
 public interface IIntegrationEvent : IBusEvent

--- a/src/Yumney.Shared.Events/IModuleEvent.cs
+++ b/src/Yumney.Shared.Events/IModuleEvent.cs
@@ -5,7 +5,7 @@ namespace SmartSolutionsLab.Yumney.Shared.Events;
 /// routing metadata (at minimum the owner) so projection handlers in the same
 /// module can subscribe via the bus. They MUST NOT cross module boundaries —
 /// cross-module contracts use <see cref="IIntegrationEvent"/> and live in
-/// <c>Yumney.Shared.Events.CrossModule</c>.
+/// <c>Yumney.Shared.Events.Contracts</c>.
 /// </summary>
 public interface IModuleEvent : IBusEvent
 {

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/MealConfirmedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/MealConfirmedHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/RecipeDeletedHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;

--- a/src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj
+++ b/src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Modules\Yumney.Shared.Modules.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/CrossModule/ShoppingListCreatedMapper.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/CrossModule/ShoppingListCreatedMapper.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/CrossModule/ShoppingListRecipeReferenceClearedMapper.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/CrossModule/ShoppingListRecipeReferenceClearedMapper.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 

--- a/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
+++ b/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
     <ProjectReference Include="..\Yumney.Recipes.Client\Yumney.Recipes.Client.csproj" />

--- a/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeCookedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeCookedActivityHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeDeletedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeDeletedActivityHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeImportedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeImportedActivityHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;

--- a/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeViewedActivityHandler.cs
+++ b/src/Yumney.Users.Application/IntegrationEventHandlers/RecipeViewedActivityHandler.cs
@@ -1,5 +1,5 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 
 namespace SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;

--- a/src/Yumney.Users.Application/Yumney.Users.Application.csproj
+++ b/src/Yumney.Users.Application/Yumney.Users.Application.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\Yumney.Users.Domain\Yumney.Users.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Modules\Yumney.Shared.Modules.csproj" />
   </ItemGroup>
 

--- a/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
+++ b/tests/Yumney.Architecture.Tests/EventConsumerRegistrationTests.cs
@@ -118,7 +118,11 @@ public class EventConsumerRegistrationTests
 
 	private static (List<Assembly> EventAssemblies, List<Assembly> HandlerAssemblies) LoadAssemblies()
 	{
-		List<Assembly> eventAssemblies = [Assembly.Load("Yumney.Shared.Events")];
+		List<Assembly> eventAssemblies =
+		[
+			Assembly.Load("Yumney.Shared.Events"),
+			Assembly.Load("Yumney.Shared.Events.Contracts"),
+		];
 		eventAssemblies.AddRange(Modules.Select(module => Assembly.Load($"Yumney.{module}.Infrastructure")));
 
 		List<Assembly> handlerAssemblies = [];

--- a/tests/Yumney.Architecture.Tests/LayerDependencyTests.cs
+++ b/tests/Yumney.Architecture.Tests/LayerDependencyTests.cs
@@ -271,6 +271,24 @@ public class LayerDependencyTests
 			$"{sourceModule}.Api must not depend on {targetModule}.Application");
 	}
 
+	[Theory]
+	[InlineData("Recipes")]
+	[InlineData("Shopping")]
+	[InlineData("Users")]
+	[InlineData("MealPlan")]
+	public void Domain_ShouldNotDependOn_EventsContracts(string module)
+	{
+		var domainAssembly = GetAssembly($"Yumney.{module}.Domain");
+
+		var result = Types.InAssembly(domainAssembly)
+			.ShouldNot()
+			.HaveDependencyOn("SmartSolutionsLab.Yumney.Shared.Events.Contracts")
+			.GetResult();
+
+		result.IsSuccessful.Should().BeTrue(
+			$"{module}.Domain must not author cross-module integration events — that's an Application-layer concern (#634)");
+	}
+
 	private static System.Reflection.Assembly GetAssembly(string name)
 	{
 		return System.Reflection.Assembly.Load(name);

--- a/tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj
+++ b/tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Api\Yumney.MealPlan.Api.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
   </ItemGroup>

--- a/tests/Yumney.Integration.Tests/CrossModule/CachedRecipeViewTrackerCrossInstanceTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/CachedRecipeViewTrackerCrossInstanceTests.cs
@@ -11,7 +11,7 @@ using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Services;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.CrossModule;

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\Yumney.Recipes.Infrastructure\Yumney.Recipes.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shopping.Infrastructure\Yumney.Shopping.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Users.Infrastructure\Yumney.Users.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Shared.Events.Contracts.Tests/IntegrationEventWireFormatTests.cs
+++ b/tests/Yumney.Shared.Events.Contracts.Tests/IntegrationEventWireFormatTests.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Contracts.Tests;
+
+/// <summary>
+/// Wolverine envelopes serialize integration events via System.Text.Json, so
+/// the contract surface here is the STJ round-trip — not just the C# type.
+/// IntegrationEvent.EventIdentifier and OccurredOn use init setters
+/// specifically so the deserialized instance preserves them; without that,
+/// the inbox-dedup key would regenerate on every redelivery and exactly-once
+/// semantics would silently break (per the comment on IntegrationEvent.cs).
+/// These tests pin both the field-shape and the property-survival contracts
+/// so any accidental change to a record signature or to the base type fails
+/// loudly.
+/// </summary>
+public class IntegrationEventWireFormatTests
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNameCaseInsensitive = true,
+	};
+
+	[Fact]
+	public void RecipeImported_RoundTripsThroughJson_PreservingAllFields()
+	{
+		var original = new RecipeImportedIntegrationEvent("user-123", Guid.NewGuid(), "Lasagne");
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void RecipeViewed_RoundTripsThroughJson_PreservingAllFields()
+	{
+		var original = new RecipeViewedIntegrationEvent("user-123", Guid.NewGuid(), "Tomato Soup");
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void RecipeCooked_RoundTripsThroughJson_PreservingAllFields()
+	{
+		var original = new RecipeCookedIntegrationEvent("user-123", Guid.NewGuid(), "Chocolate Cake");
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void RecipeDeleted_RoundTripsThroughJson_PreservingAllFields()
+	{
+		var original = new RecipeDeletedIntegrationEvent("user-123", Guid.NewGuid());
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void MealConfirmed_RoundTripsThroughJson_IncludingNestedIngredients()
+	{
+		var original = new MealConfirmedIntegrationEvent(
+			"user-123",
+			Guid.NewGuid(),
+			Servings: 4,
+			Ingredients:
+			[
+				new MealConfirmedIngredient("Pasta", 500m, "g"),
+				new MealConfirmedIngredient("Tomatoes", 800m, "g"),
+				new MealConfirmedIngredient("Garlic", 3m, null),
+			]);
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void ShoppingListCreated_RoundTripsThroughJson_PreservingNullableRecipeIdentifier()
+	{
+		var withRecipe = new ShoppingListCreatedCrossModuleIntegrationEvent(
+			"user-123",
+			Guid.NewGuid(),
+			"Weekly groceries",
+			Guid.NewGuid(),
+			DateTime.UtcNow);
+		var withoutRecipe = withRecipe with { RecipeIdentifier = null };
+
+		RoundTrip(withRecipe).Should().BeEquivalentTo(withRecipe);
+		RoundTrip(withoutRecipe).Should().BeEquivalentTo(withoutRecipe);
+	}
+
+	[Fact]
+	public void ShoppingListRecipeReferenceCleared_RoundTripsThroughJson_PreservingAllFields()
+	{
+		var original = new ShoppingListRecipeReferenceClearedCrossModuleIntegrationEvent(
+			"user-123",
+			Guid.NewGuid());
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void UserAccountDeleted_RoundTripsThroughJson_PreservingKeycloakUserId()
+	{
+		var original = new UserAccountDeletedIntegrationEvent("keycloak-user-456");
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.Should().BeEquivalentTo(original);
+	}
+
+	[Fact]
+	public void EventIdentifier_SurvivesJsonRoundTrip_NotRegeneratedOnDeserialize()
+	{
+		// Pins the dedup contract: IntegrationEvent's EventIdentifier uses init,
+		// not auto-property — System.Text.Json must round-trip the original Guid,
+		// not generate a fresh one on deserialize. If this regresses, Wolverine's
+		// inbox dedup key would change on every redelivery and exactly-once
+		// processing would silently break.
+		var original = new RecipeViewedIntegrationEvent("user-123", Guid.NewGuid(), "Test");
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.EventIdentifier.Should().Be(original.EventIdentifier);
+	}
+
+	[Fact]
+	public void OccurredOn_SurvivesJsonRoundTrip_NotResetToNow()
+	{
+		// Pins the audit contract: OccurredOn must reflect when the event was
+		// raised, not when the envelope happened to be deserialized. Same init
+		// mechanism as EventIdentifier.
+		var fixedTime = new DateTime(2026, 4, 1, 12, 30, 0, DateTimeKind.Utc);
+		var original = new RecipeViewedIntegrationEvent("user-123", Guid.NewGuid(), "Test")
+		{
+			OccurredOn = fixedTime,
+		};
+
+		var roundTripped = RoundTrip(original);
+
+		roundTripped.OccurredOn.Should().Be(fixedTime);
+	}
+
+	private static T RoundTrip<T>(T value)
+		where T : IIntegrationEvent
+	{
+		var json = JsonSerializer.Serialize(value, JsonOptions);
+		var deserialized = JsonSerializer.Deserialize<T>(json, JsonOptions);
+		deserialized.Should().NotBeNull();
+		return deserialized!;
+	}
+}

--- a/tests/Yumney.Shared.Events.Contracts.Tests/Yumney.Shared.Events.Contracts.Tests.csproj
+++ b/tests/Yumney.Shared.Events.Contracts.Tests/Yumney.Shared.Events.Contracts.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events\Yumney.Shared.Events.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Yumney.Shared.Events.Contracts.Tests/stryker-config.json
+++ b/tests/Yumney.Shared.Events.Contracts.Tests/stryker-config.json
@@ -1,0 +1,12 @@
+{
+  "stryker-config": {
+    "project": "Yumney.Shared.Events.Contracts.csproj",
+    "reporters": ["html", "json", "progress", "cleartext"],
+    "thresholds": {
+      "high": 85,
+      "low": 75,
+      "break": 75
+    },
+    "coverage-analysis": "perTest"
+  }
+}

--- a/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Users.Application.Commands;
 using SmartSolutionsLab.Yumney.Users.Application.Commands.Handlers;

--- a/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeCookedActivityHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeCookedActivityHandlerTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
-using SmartSolutionsLab.Yumney.Shared.Events.CrossModule;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
 using Xunit;

--- a/tests/Yumney.Users.Application.Tests/Yumney.Users.Application.Tests.csproj
+++ b/tests/Yumney.Users.Application.Tests/Yumney.Users.Application.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Users.Application\Yumney.Users.Application.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #634.

## Summary

Splits `Yumney.Shared.Events` into:

- **`Yumney.Shared.Events`** (kept) — abstractions: `IBusEvent`, `IIntegrationEvent`/`IModuleEvent`/`IDomainEvent` base records, `IEventBus`, dispatcher / handler / inbox interfaces, `NoOpInboxStore`.
- **`Yumney.Shared.Events.Contracts`** (new) — the 9 concrete cross-module event records: `RecipeImported`, `RecipeViewed`, `RecipeCooked`, `RecipeDeleted`, `MealConfirmed` (+ `MealConfirmedIngredient`), `ShoppingListCreatedCrossModule…`, `ShoppingListRecipeReferenceClearedCrossModule…`, `UserAccountDeleted`. Single ProjectReference back to `.Events` for the `IntegrationEvent` base.

The contract surface (what crosses module boundaries) now lives in a focused project. Reviewing or evolving the wire format means opening one folder.

## Producer/consumer reference rule

| Layer | References |
|---|---|
| `*.Domain` | NEITHER `.Events` NOR `.Contracts` (enforced by `LayerDependencyTests.Domain_ShouldNotDependOn_EventsContracts`) |
| `*.Application` | both `.Events` (handler interfaces) + `.Contracts` (concrete types it produces or consumes) |
| `*.Infrastructure` | `.Contracts` if it directly publishes (e.g. `CachedRecipeViewTracker`); transitively gets `.Events` via Application or Persistence |

## Files touched

- New: `src/Yumney.Shared.Events.Contracts/` (csproj + 9 event records moved with namespace bump).
- Removed: `src/Yumney.Shared.Events/CrossModule/` folder.
- Modified: 22 source/test consumer files (namespace bump on `using` line); 9 csproj files gain a `ProjectReference` to `.Contracts`; `Yumney.slnx` registers the new project; `IIntegrationEvent.cs` / `IModuleEvent.cs` doc comments updated; `LayerDependencyTests.cs` adds the new `Domain_ShouldNotDependOn_EventsContracts` `[Theory]`; `EventConsumerRegistrationTests.LoadAssemblies` extended to include the new assembly so the existing "every event has at least one handler" check still finds the events post-move.
- `CLAUDE.md`: monorepo tree gains the new project line; Event Communication section's Integration Events bullet documents the .Events vs .Contracts split, the producer/consumer reference rule, and the Domain-must-not-depend-on-Contracts enforcement.

## Test plan

- [ ] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors) ✓ verified locally
- [ ] All unit tests across all projects (filter `!~Integration.Tests`) — green ✓ verified locally
- [ ] `Yumney.Architecture.Tests` 140/140 including the new `Domain_ShouldNotDependOn_EventsContracts` theory ✓ verified locally
- [ ] CI's integration-tests step exercises the `CachedRecipeViewTrackerCrossInstanceTests` against the moved `RecipeViewedIntegrationEvent` — the test was updated as part of this refactor

## Out of scope

- **Per-module contract packages** — considered, rejected for now per #634; revisit if/when an external consumer wants only one module's events.
- **Wolverine/RabbitMQ topology** — pure source-organization refactor; the bus, the dispatcher, and the wire format are unchanged.
- **Event versioning strategy** — worth its own ADR; this PR doesn't design it.