### PR TITLE
feat(recipes): get_weekly_plan chat tool + MealPlan cross-module client (Phase 2b of #639)

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -26,6 +26,7 @@
   <Folder Name="/src/MealPlan/">
     <Project Path="src/Yumney.MealPlan.Api/Yumney.MealPlan.Api.csproj" />
     <Project Path="src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj" />
+    <Project Path="src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj" />
     <Project Path="src/Yumney.MealPlan.Domain/Yumney.MealPlan.Domain.csproj" />
     <Project Path="src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj" />
   </Folder>

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -148,6 +148,11 @@ if (!options.DatabaseOnly)
 		.WithReference(shoppingApi)
 		.WithReference(usersApi);
 
+	// Reverse reference: chat tools in Recipes call mealplan-api for get_weekly_plan
+	// (and future planner tools). Cannot inline above because mealplanApi is
+	// declared after recipesApi.
+	recipesApi.WithReference(mealplanApi);
+
 	// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
 	// ACA pulls them via the environment's managed identity, so no registry credentials
 	// are baked into the container app revisions.

--- a/src/Yumney.MealPlan.Client/IMealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/IMealPlanClient.cs
@@ -1,0 +1,33 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+/// <summary>
+/// Slim transport-shaped HTTP client over the MealPlan module's REST endpoints.
+/// Used by sibling modules (Recipes, Shopping, …) per the consumer-defined-contracts
+/// pattern — each consumer wraps relevant calls in its own <c>I*Provider</c> interface.
+/// </summary>
+public interface IMealPlanClient
+{
+	/// <summary>Fetch the weekly plan for the given ISO week.</summary>
+	/// <param name="year">ISO year, e.g. 2026.</param>
+	/// <param name="weekNumber">ISO week number 1-53.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>The weekly plan or null if the week has not been planned.</returns>
+	Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed weekly-plan shape returned over the wire.</summary>
+public sealed record WeeklyPlanResponse(
+	string Week,
+	bool IsExtendedMode,
+	IReadOnlyList<WeeklyPlanSlotResponse> Slots);
+
+/// <summary>One filled or empty slot in the weekly plan.</summary>
+public sealed record WeeklyPlanSlotResponse(
+	string Day,
+	string MealType,
+	string ContentType,
+	string State,
+	Guid? RecipeIdentifier,
+	string? RecipeTitle,
+	int Servings,
+	bool IsEmpty);

--- a/src/Yumney.MealPlan.Client/MealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClient.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+internal sealed class MealPlanClient(IModuleHttpClientFactory factory) : IMealPlanClient
+{
+	private readonly IModuleHttpClient http = factory.For("mealplan-api");
+
+	public Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default) =>
+		http.FindAsync<WeeklyPlanResponse>(
+			$"/api/v1/meal-plans/{year}/w/{weekNumber}",
+			"GetWeeklyPlan",
+			cancellationToken);
+}

--- a/src/Yumney.MealPlan.Client/MealPlanClientServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClientServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+public static class MealPlanClientServiceCollectionExtensions
+{
+	public static IServiceCollection AddMealPlanClient(this IServiceCollection services)
+	{
+		services.AddYumneyServiceClient("mealplan-api");
+		services.AddSingleton<IMealPlanClient, MealPlanClient>();
+		return services;
+	}
+}

--- a/src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj
+++ b/src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Recipes.Application/Interfaces/IWeeklyPlanLookup.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IWeeklyPlanLookup.cs
@@ -1,0 +1,31 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for fetching the user's weekly meal plan from the
+/// MealPlan module. Lives here (not in MealPlan) because the chat surface is the
+/// consumer — see CLAUDE.md "Cross-Module Dependencies" + ADR 0002.
+/// </summary>
+public interface IWeeklyPlanLookup
+{
+	/// <summary>Get the weekly plan for the given ISO week, or null if not yet planned.</summary>
+	/// <param name="year">ISO year, e.g. 2026.</param>
+	/// <param name="weekNumber">ISO week number 1-53.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the lookup.</param>
+	/// <returns>Consumer-flavored weekly plan, or null if the week has not been planned.</returns>
+	Task<WeeklyPlanLookupResult?> GetForWeekAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed weekly-plan shape returned to chat tools.</summary>
+public sealed record WeeklyPlanLookupResult(
+	string Week,
+	bool IsExtendedMode,
+	IReadOnlyList<WeeklyPlanLookupSlot> Slots);
+
+/// <summary>One slot in the consumer-flavored weekly plan.</summary>
+public sealed record WeeklyPlanLookupSlot(
+	string Day,
+	string MealType,
+	Guid? RecipeIdentifier,
+	string? RecipeTitle,
+	int Servings,
+	bool IsEmpty);

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<SearchRecipesTool>();
 		services.AddScoped<GetRecipeTool>();
 		services.AddScoped<GetCookableRecipesTool>();
+		services.AddScoped<GetWeeklyPlanTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -26,6 +26,7 @@ public sealed partial class SemanticKernelChatService(
 	SearchRecipesTool searchRecipesTool,
 	GetRecipeTool getRecipeTool,
 	GetCookableRecipesTool getCookableRecipesTool,
+	GetWeeklyPlanTool getWeeklyPlanTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -125,8 +126,8 @@ public sealed partial class SemanticKernelChatService(
 
 	private const string systemPrompt = """
         You are a friendly, concise cooking assistant for the Yumney recipe app.
-        You can call functions to look up the user's recipes and pantry — prefer
-        calling a function over guessing.
+        You can call functions to look up the user's recipes, pantry, and meal
+        plan — prefer calling a function over guessing.
 
         Tool usage:
         - When the user asks to find or search recipes ("find chicken recipes",
@@ -136,6 +137,10 @@ public sealed partial class SemanticKernelChatService(
           get_cookable_recipes.
         - When the user wants details on a specific recipe (ingredients, steps,
           time), call get_recipe with the identifier from a previous tool call.
+        - When the user asks about their planned meals ("what's for dinner
+          Tuesday?", "show me this week's plan", "was ist nächste Woche
+          geplant?"), call get_weekly_plan. Pass year=0 / weekNumber=0 to
+          mean "this week".
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -156,6 +161,7 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(searchRecipesTool, "recipes_search");
 		requestKernel.Plugins.AddFromObject(getRecipeTool, "recipes_detail");
 		requestKernel.Plugins.AddFromObject(getCookableRecipesTool, "recipes_cookable");
+		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/GetWeeklyPlanTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/GetWeeklyPlanTool.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing the user's weekly meal plan to the chat LLM.
+/// Cross-module call: <see cref="IWeeklyPlanLookup"/> is the consumer-defined
+/// contract owned by Recipes; the HTTP adapter calls the MealPlan module via
+/// <c>IMealPlanClient</c>.
+/// </summary>
+/// <param name="lookup">Consumer-defined weekly-plan lookup.</param>
+/// <param name="context">Per-request collector for downstream suggestion / action emission.</param>
+public sealed class GetWeeklyPlanTool(IWeeklyPlanLookup lookup, ChatToolContext context)
+{
+	/// <summary>Get the user's planned meals for an ISO week. Year + week default to "this week" when omitted.</summary>
+	/// <param name="year">ISO year, e.g. 2026. Pass 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53. Pass 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>The weekly plan or null if nothing planned.</returns>
+	[KernelFunction("get_weekly_plan")]
+	[Description("Fetch the user's planned meals for an ISO week. Use for 'what's for dinner this week?', 'what did I plan for Tuesday?', 'show me next week's plan'. Pass year=0 and weekNumber=0 to mean 'this week'.")]
+	public async Task<WeeklyPlanLookupResult?> GetAsync(
+		[Description("ISO year (e.g. 2026), or 0 for the current year")] int year,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var plan = await lookup.GetForWeekAsync(resolvedYear, resolvedWeek, cancellationToken);
+		if (plan is null) return null;
+
+		foreach (var slot in plan.Slots)
+		{
+			if (slot.RecipeIdentifier is { } id && slot.RecipeTitle is { } title)
+			{
+				context.AppendRecipeMatch(id, title, $"{slot.Day} · {slot.MealType}");
+			}
+		}
+
+		return plan;
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpWeeklyPlanLookup.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpWeeklyPlanLookup.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpWeeklyPlanLookup(IMealPlanClient mealPlan) : IWeeklyPlanLookup
+{
+	public async Task<WeeklyPlanLookupResult?> GetForWeekAsync(int year, int weekNumber, CancellationToken cancellationToken = default)
+	{
+		var response = await mealPlan.GetWeeklyPlanAsync(year, weekNumber, cancellationToken);
+		return response?.ToLookupResult();
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/WeeklyPlanLookupMappingExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/WeeklyPlanLookupMappingExtensions.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+internal static class WeeklyPlanLookupMappingExtensions
+{
+	public static WeeklyPlanLookupResult ToLookupResult(this WeeklyPlanResponse response) =>
+		new(
+			response.Week,
+			response.IsExtendedMode,
+			[.. response.Slots.Select(slot => slot.ToLookupSlot())]);
+
+	public static WeeklyPlanLookupSlot ToLookupSlot(this WeeklyPlanSlotResponse slot) =>
+		new(slot.Day, slot.MealType, slot.RecipeIdentifier, slot.RecipeTitle, slot.Servings, slot.IsEmpty);
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
@@ -40,9 +41,11 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipesUserDataPurger, RecipesUserDataPurger>();
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
+		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();
+		services.AddMealPlanClient();
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
 		return services;

--- a/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
+++ b/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Client\Yumney.MealPlan.Client.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
     <ProjectReference Include="..\Yumney.Users.Client\Yumney.Users.Client.csproj" />
   </ItemGroup>

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpWeeklyPlanLookupTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpWeeklyPlanLookupTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpWeeklyPlanLookupTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task GetForWeekAsync_ClientReturnsResponse_MapsToLookupResult()
+	{
+		var recipe = Guid.NewGuid();
+		client.GetWeeklyPlanAsync(2026, 19, Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanResponse(
+				"2026-W19",
+				IsExtendedMode: true,
+				[new WeeklyPlanSlotResponse("Monday", "Dinner", "Recipe", "Planned", recipe, "Carbonara", 4, IsEmpty: false)]));
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		var result = await lookup.GetForWeekAsync(2026, 19);
+
+		result.Should().NotBeNull();
+		result!.Week.Should().Be("2026-W19");
+		result.IsExtendedMode.Should().BeTrue();
+		result.Slots.Should().ContainSingle();
+		result.Slots[0].RecipeIdentifier.Should().Be(recipe);
+		result.Slots[0].RecipeTitle.Should().Be("Carbonara");
+		result.Slots[0].IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetForWeekAsync_ClientReturnsNull_ReturnsNull()
+	{
+		client.GetWeeklyPlanAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanResponse?)null);
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		var result = await lookup.GetForWeekAsync(2026, 19);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetForWeekAsync_ForwardsYearAndWeekToClient()
+	{
+		client.GetWeeklyPlanAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanResponse?)null);
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		await lookup.GetForWeekAsync(2026, 23);
+
+		await client.Received(1).GetWeeklyPlanAsync(2026, 23, Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetWeeklyPlanToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetWeeklyPlanToolTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class GetWeeklyPlanToolTests
+{
+	private readonly IWeeklyPlanLookup lookup = Substitute.For<IWeeklyPlanLookup>();
+	private readonly ChatToolContext context = new();
+
+	[Fact]
+	public async Task GetAsync_PlanFound_AppendsRecipeMatchesPerSlot()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		lookup.GetForWeekAsync(2026, 19, Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanLookupResult(
+				"2026-W19",
+				IsExtendedMode: false,
+				[
+					new WeeklyPlanLookupSlot("Monday", "Dinner", first, "Carbonara", 4, IsEmpty: false),
+					new WeeklyPlanLookupSlot("Tuesday", "Dinner", second, "Risotto", 4, IsEmpty: false),
+					new WeeklyPlanLookupSlot("Wednesday", "Dinner", null, null, 0, IsEmpty: true),
+				]));
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		var result = await tool.GetAsync(2026, 19);
+
+		result.Should().NotBeNull();
+		result!.Slots.Should().HaveCount(3);
+		context.Matches.Should().HaveCount(2);
+		context.Matches.Select(match => match.Identifier).Should().ContainInOrder(first, second);
+		context.Matches[0].Reason.Should().Be("Monday · Dinner");
+	}
+
+	[Fact]
+	public async Task GetAsync_PlanNotFound_ReturnsNullWithoutAppending()
+	{
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanLookupResult?)null);
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		var result = await tool.GetAsync(2026, 19);
+
+		result.Should().BeNull();
+		context.Matches.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		WeeklyPlanLookupResult? captured = null;
+		int capturedYear = 0;
+		int capturedWeek = 0;
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = new WeeklyPlanLookupResult($"{capturedYear}-W{capturedWeek}", false, []);
+				return captured;
+			});
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		await tool.GetAsync(0, 0);
+
+		capturedYear.Should().BeGreaterThanOrEqualTo(2026);
+		capturedWeek.Should().BeInRange(1, 53);
+	}
+
+	[Fact]
+	public async Task GetAsync_EmptySlot_DoesNotAppendRecipeMatch()
+	{
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanLookupResult(
+				"2026-W19",
+				IsExtendedMode: false,
+				[new WeeklyPlanLookupSlot("Friday", "Dinner", null, null, 0, IsEmpty: true)]));
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		await tool.GetAsync(2026, 19);
+
+		context.Matches.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
Phase 2b of the capability surface epic (#637, [ADR 0002](../blob/develop/docs/adr/0002-capability-surface-for-chat-mcp.md)). Proves the cross-module chat-tool pattern end-to-end with the first read-side tool that requires new HTTP infrastructure. Stacks on #643.

## What this unlocks

- US-185 / US-189 — "what's for dinner Tuesday?", "show me this week's plan", "was ist nächste Woche geplant?" all route through `get_weekly_plan` and surface planned recipes as `OpenRecipe` action chips.

## Architecture (this is the load-bearing part)

This is the first PR that walks Recipes' chat surface across a module boundary using the consumer-defined-contracts pattern. The path of one chat call:

1. LLM picks `get_weekly_plan` (SK kernel function)
2. `GetWeeklyPlanTool` (in Recipes.Extraction) calls `IWeeklyPlanLookup` — a Recipes-Application-owned interface
3. `HttpWeeklyPlanLookup` (Recipes.Infrastructure adapter) calls `IMealPlanClient` — a thin transport-shaped client living in the new `Yumney.MealPlan.Client` project
4. `MealPlanClient` does the actual HTTP via Aspire service discovery (`mealplan-api`)
5. Response maps back through the layers, populating `ChatToolContext` so the chat service emits `OpenRecipe` actions for each planned recipe

This pattern repeats for the rest of Phase 2c: define one `I*Lookup` / `I*Writer` per consumer concern, one `Http*` adapter per concern, one tool per LLM-callable operation, all reusing `IMealPlanClient` (or future `IShoppingClient` extensions).

## What's added

- **`src/Yumney.MealPlan.Client/`** (new project, mirrors `Yumney.Shopping.Client`)
  - `IMealPlanClient.GetWeeklyPlanAsync` + `WeeklyPlanResponse` + `WeeklyPlanSlotResponse`
  - `MealPlanClient` HTTP impl
  - `AddMealPlanClient()` service-collection extension
- **`src/Yumney.Recipes.Application/Interfaces/IWeeklyPlanLookup.cs`** — consumer contract + `WeeklyPlanLookupResult` / `WeeklyPlanLookupSlot` consumer DTOs
- **`src/Yumney.Recipes.Infrastructure/ExternalServices/HttpWeeklyPlanLookup.cs`** + `WeeklyPlanLookupMappingExtensions.cs`
- **`src/Yumney.Recipes.Extraction/Services/Tools/GetWeeklyPlanTool.cs`** — SK kernel function. `year=0`/`weekNumber=0` resolves to the current ISO week.
- **`src/Yumney.AppHost/Program.cs`** — `recipesApi.WithReference(mealplanApi)` reverse reference (declared after `mealplanApi` exists)
- **`Yumney.slnx`** — registers the new project under `/src/MealPlan/`
- Tests:
  - `tests/.../Services/Tools/GetWeeklyPlanToolTests.cs` (4 cases: plan found, plan not found, year/week=0 resolution, empty slots)
  - `tests/.../ExternalServices/HttpWeeklyPlanLookupTests.cs` (3 cases: response mapping, null response, parameter forwarding)

## Out of scope (Phase 2c)

Now that the cross-module pattern is proven, Phase 2c can batch the remaining tools using the same shape:
- `assign_meal` — `IMealPlanScheduler` write contract
- `confirm_meal_cooked` — `IMealConfirmation` write contract
- `get_merged_shopping_list` — extend `IShoppingClient`, `IShoppingListLookup` contract
- `create_shopping_list_from_recipes` — `IShoppingListCreator` contract
- `track_recipe_cooked` (Recipes-owned, no new infra needed)

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Backend tests: Application 184 / Infrastructure 116 (incl. 7 new) / Api 161 / Architecture 140 — all green
- [ ] Manual: chat "what's planned for this week?" → `get_weekly_plan` fires with year/week=0 → resolves to current ISO week, planned recipes render as OpenRecipe chips

## Stacking

Branched from `feat/US-639-sk-function-calling` (PR #643). Targets that branch — base will auto-retarget to develop after #643 merges.

Refs #639
Refs #637