### PR TITLE
feat(recipes): assign_meal + confirm_meal_cooked chat tools (Phase 2c of #639)

### DIFF
--- a/src/Yumney.MealPlan.Client/IMealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/IMealPlanClient.cs
@@ -13,6 +13,22 @@ public interface IMealPlanClient
 	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
 	/// <returns>The weekly plan or null if the week has not been planned.</returns>
 	Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+
+	/// <summary>Assign a recipe to a slot in the given week. POST /api/v1/meal-plans/{year}/w/{weekNumber}/slots.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Day, recipe, meal type, optional servings.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> AssignRecipeAsync(int year, int weekNumber, AssignRecipeBody body, CancellationToken cancellationToken = default);
+
+	/// <summary>Confirm a meal slot's state (cooked / skipped / restored). PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/confirm.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Day, meal type, target state.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> ConfirmMealAsync(int year, int weekNumber, ConfirmMealBody body, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Trimmed weekly-plan shape returned over the wire.</summary>
@@ -31,3 +47,14 @@ public sealed record WeeklyPlanSlotResponse(
 	string? RecipeTitle,
 	int Servings,
 	bool IsEmpty);
+
+/// <summary>Body for the assign-recipe POST.</summary>
+public sealed record AssignRecipeBody(
+	string Day,
+	Guid RecipeIdentifier,
+	string RecipeTitle,
+	string MealType,
+	int? Servings);
+
+/// <summary>Body for the confirm-meal PUT.</summary>
+public sealed record ConfirmMealBody(string Day, string MealType, string State);

--- a/src/Yumney.MealPlan.Client/MealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClient.cs
@@ -11,4 +11,38 @@ internal sealed class MealPlanClient(IModuleHttpClientFactory factory) : IMealPl
 			$"/api/v1/meal-plans/{year}/w/{weekNumber}",
 			"GetWeeklyPlan",
 			cancellationToken);
+
+	public async Task<bool> AssignRecipeAsync(int year, int weekNumber, AssignRecipeBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PostAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots",
+				body,
+				"AssignRecipe",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
+
+	public async Task<bool> ConfirmMealAsync(int year, int weekNumber, ConfirmMealBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PutAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots/confirm",
+				body,
+				"ConfirmMeal",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/src/Yumney.Recipes.Application/Interfaces/IMealConfirmation.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealConfirmation.cs
@@ -1,0 +1,23 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for confirming a planned meal's state (cooked,
+/// skipped, restored to planned) in the user's weekly meal plan. Owned by
+/// Recipes (the chat surface is the consumer) per CLAUDE.md cross-module rule.
+/// </summary>
+public interface IMealConfirmation
+{
+	/// <summary>Confirm a meal slot's state.</summary>
+	/// <param name="request">Year, week, day, meal type, target state.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True if the confirmation succeeded, false if the upstream rejected it.</returns>
+	Task<bool> ConfirmAsync(ConfirmMealRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a confirm-meal request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="Day">English weekday name (Monday..Sunday).</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+/// <param name="State">One of "Planned", "Cooked", "Skipped".</param>
+public sealed record ConfirmMealRequest(int Year, int WeekNumber, string Day, string MealType, string State);

--- a/src/Yumney.Recipes.Application/Interfaces/IMealPlanScheduler.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealPlanScheduler.cs
@@ -1,0 +1,32 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for assigning recipes to slots in the user's
+/// weekly meal plan. Owned by Recipes (the chat surface is the consumer)
+/// per CLAUDE.md cross-module rule + ADR 0002.
+/// </summary>
+public interface IMealPlanScheduler
+{
+	/// <summary>Assign a recipe to a meal slot in the given week.</summary>
+	/// <param name="request">Year, week, day, recipe, meal type, optional servings.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True if the assignment succeeded, false if the upstream rejected it.</returns>
+	Task<bool> AssignAsync(AssignMealRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of an assign-meal request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="Day">English weekday name (Monday..Sunday).</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+/// <param name="RecipeIdentifier">Recipe identifier resolved from a prior search/get.</param>
+/// <param name="RecipeTitle">Recipe title for downstream display.</param>
+/// <param name="Servings">Optional override for slot servings; null = use recipe default.</param>
+public sealed record AssignMealRequest(
+	int Year,
+	int WeekNumber,
+	string Day,
+	string MealType,
+	Guid RecipeIdentifier,
+	string RecipeTitle,
+	int? Servings);

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<GetRecipeTool>();
 		services.AddScoped<GetCookableRecipesTool>();
 		services.AddScoped<GetWeeklyPlanTool>();
+		services.AddScoped<AssignMealTool>();
+		services.AddScoped<ConfirmMealTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -27,6 +27,8 @@ public sealed partial class SemanticKernelChatService(
 	GetRecipeTool getRecipeTool,
 	GetCookableRecipesTool getCookableRecipesTool,
 	GetWeeklyPlanTool getWeeklyPlanTool,
+	AssignMealTool assignMealTool,
+	ConfirmMealTool confirmMealTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -141,6 +143,14 @@ public sealed partial class SemanticKernelChatService(
           Tuesday?", "show me this week's plan", "was ist nächste Woche
           geplant?"), call get_weekly_plan. Pass year=0 / weekNumber=0 to
           mean "this week".
+        - When the user wants to plan a recipe ("plan carbonara for
+          Wednesday", "add risotto to Friday lunch"), first resolve the
+          recipe identifier via search_recipes if you don't already have
+          one, then call assign_meal.
+        - When the user reports cooking, skipping, or undoing a planned
+          meal ("I made the spaghetti on Wednesday", "skip Friday's
+          dinner"), call confirm_meal_cooked with state Cooked/Skipped/
+          Planned.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -162,6 +172,8 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(getRecipeTool, "recipes_detail");
 		requestKernel.Plugins.AddFromObject(getCookableRecipesTool, "recipes_cookable");
 		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
+		requestKernel.Plugins.AddFromObject(assignMealTool, "mealplan_assign");
+		requestKernel.Plugins.AddFromObject(confirmMealTool, "mealplan_confirm");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/AssignMealTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/AssignMealTool.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal assignment to the chat LLM. Cross-module:
+/// <see cref="IMealPlanScheduler"/> is the consumer-defined contract owned by
+/// Recipes; the HTTP adapter calls MealPlan via <c>IMealPlanClient</c>.
+/// </summary>
+/// <param name="scheduler">Consumer-defined scheduler.</param>
+/// <param name="context">Per-request collector for downstream suggestion / action emission.</param>
+public sealed class AssignMealTool(IMealPlanScheduler scheduler, ChatToolContext context)
+{
+	/// <summary>Plan a recipe into a meal slot for an ISO week.</summary>
+	/// <param name="day">English weekday name (Monday..Sunday).</param>
+	/// <param name="recipeIdentifier">Recipe GUID resolved from a prior search/get.</param>
+	/// <param name="recipeTitle">Recipe title for downstream display.</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="servings">Optional override for slot servings; null = use recipe default.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("assign_meal")]
+	[Description("Plan a recipe into a meal slot ('plan carbonara for Wednesday', 'add risotto to Friday lunch'). Pass year=0 / weekNumber=0 to mean 'this week'. Requires a recipe identifier from a previous search_recipes / get_recipe call.")]
+	public async Task<string> AssignAsync(
+		[Description("English weekday name: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, or Sunday")] string day,
+		[Description("Recipe identifier (GUID) returned by search_recipes or get_recipe")] string recipeIdentifier,
+		[Description("Recipe title for display")] string recipeTitle,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		[Description("Optional override for slot servings; omit to use the recipe default")] int? servings = null,
+		CancellationToken cancellationToken = default)
+	{
+		if (!Guid.TryParse(recipeIdentifier, out var recipe)) return "Invalid recipe identifier — call search_recipes first.";
+
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new AssignMealRequest(
+			resolvedYear,
+			resolvedWeek,
+			day,
+			mealType,
+			recipe,
+			recipeTitle,
+			servings);
+
+		var success = await scheduler.AssignAsync(request, cancellationToken);
+		if (!success) return $"Couldn't plan {recipeTitle} for {day} — please try again.";
+
+		context.AppendRecipeMatch(recipe, recipeTitle, $"Planned for {day} · {mealType}");
+		return $"Planned {recipeTitle} for {day} ({mealType}).";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/ConfirmMealTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/ConfirmMealTool.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal-state confirmation to the chat LLM. Used
+/// for "I made the carbonara on Wednesday" / "skip Friday's planned dinner".
+/// Cross-module via <see cref="IMealConfirmation"/>.
+/// </summary>
+/// <param name="confirmation">Consumer-defined confirmation contract.</param>
+public sealed class ConfirmMealTool(IMealConfirmation confirmation)
+{
+	/// <summary>Mark a planned meal as cooked, skipped, or restored to planned.</summary>
+	/// <param name="day">English weekday name (Monday..Sunday).</param>
+	/// <param name="state">"Cooked", "Skipped", or "Planned".</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("confirm_meal_cooked")]
+	[Description("Update a planned meal's state. Use for 'I made the spaghetti on Wednesday' (state=Cooked), 'skip Friday lunch' (state=Skipped), or 'I haven't cooked it yet' (state=Planned). Pass year=0 / weekNumber=0 to mean 'this week'.")]
+	public async Task<string> ConfirmAsync(
+		[Description("English weekday name: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, or Sunday")] string day,
+		[Description("Target state: Cooked, Skipped, or Planned")] string state,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new ConfirmMealRequest(resolvedYear, resolvedWeek, day, mealType, state);
+
+		var success = await confirmation.ConfirmAsync(request, cancellationToken);
+		if (!success) return $"Couldn't update {day}'s {mealType.ToLowerInvariant()} — the slot may not exist.";
+
+		return $"Marked {day} {mealType.ToLowerInvariant()} as {state.ToLowerInvariant()}.";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealConfirmation.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealConfirmation.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealConfirmation(IMealPlanClient mealPlan) : IMealConfirmation
+{
+	public Task<bool> ConfirmAsync(ConfirmMealRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new ConfirmMealBody(request.Day, request.MealType, request.State);
+		return mealPlan.ConfirmMealAsync(request.Year, request.WeekNumber, body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealPlanScheduler.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealPlanScheduler.cs
@@ -1,0 +1,18 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealPlanScheduler(IMealPlanClient mealPlan) : IMealPlanScheduler
+{
+	public Task<bool> AssignAsync(AssignMealRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new AssignRecipeBody(
+			request.Day,
+			request.RecipeIdentifier,
+			request.RecipeTitle,
+			request.MealType,
+			request.Servings);
+		return mealPlan.AssignRecipeAsync(request.Year, request.WeekNumber, body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -42,6 +42,8 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
 		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
+		services.AddScoped<IMealPlanScheduler, HttpMealPlanScheduler>();
+		services.AddScoped<IMealConfirmation, HttpMealConfirmation>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.Shared.Web/IModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClient.cs
@@ -19,6 +19,12 @@ public interface IModuleHttpClient
 		TBody body,
 		string operation,
 		CancellationToken cancellationToken = default);
+
+	Task PutAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default);
 }
 
 public interface IModuleHttpClientFactory

--- a/src/Yumney.Shared.Web/ModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/ModuleHttpClient.cs
@@ -75,6 +75,24 @@ internal sealed partial class ModuleHttpClient(
 		}
 	}
 
+	public async Task PutAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await httpClient.PutAsJsonAsync(url, body, jsonOptions, cancellationToken);
+			response.EnsureSuccessStatusCode();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogPutFailed(operation, upstreamName, ex.Message);
+			throw;
+		}
+	}
+
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{Operation} GET against {Upstream} failed ({Reason}); returning fallback.")]
 	private partial void LogGetFailed(string operation, string upstream, string reason);
 
@@ -83,4 +101,7 @@ internal sealed partial class ModuleHttpClient(
 
 	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} POST to {Upstream} failed ({Reason}).")]
 	private partial void LogPostFailed(string operation, string upstream, string reason);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} PUT to {Upstream} failed ({Reason}).")]
+	private partial void LogPutFailed(string operation, string upstream, string reason);
 }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealConfirmationTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealConfirmationTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealConfirmationTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task ConfirmAsync_MapsConsumerRequestToClientBody()
+	{
+		ConfirmMealBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.ConfirmMealAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ConfirmMealBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<ConfirmMealBody>(2);
+				return true;
+			});
+
+		var confirmation = new HttpMealConfirmation(client);
+		await confirmation.ConfirmAsync(new ConfirmMealRequest(2026, 19, "Wednesday", "Dinner", "Cooked"));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(19);
+		captured.Should().NotBeNull();
+		captured!.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.State.Should().Be("Cooked");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.ConfirmMealAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ConfirmMealBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var confirmation = new HttpMealConfirmation(client);
+		var result = await confirmation.ConfirmAsync(new ConfirmMealRequest(2026, 19, "Friday", "Lunch", "Skipped"));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealPlanSchedulerTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealPlanSchedulerTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealPlanSchedulerTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task AssignAsync_MapsConsumerRequestToClientBody()
+	{
+		AssignRecipeBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.AssignRecipeAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<AssignRecipeBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<AssignRecipeBody>(2);
+				return true;
+			});
+
+		var scheduler = new HttpMealPlanScheduler(client);
+		var recipe = Guid.NewGuid();
+		await scheduler.AssignAsync(new AssignMealRequest(2026, 19, "Wednesday", "Dinner", recipe, "Carbonara", Servings: 4));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(19);
+		captured.Should().NotBeNull();
+		captured!.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.RecipeIdentifier.Should().Be(recipe);
+		captured.RecipeTitle.Should().Be("Carbonara");
+		captured.Servings.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task AssignAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.AssignRecipeAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<AssignRecipeBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var scheduler = new HttpMealPlanScheduler(client);
+		var result = await scheduler.AssignAsync(new AssignMealRequest(2026, 19, "Friday", "Lunch", Guid.NewGuid(), "Pizza", Servings: null));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AssignMealToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AssignMealToolTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class AssignMealToolTests
+{
+	private readonly IMealPlanScheduler scheduler = Substitute.For<IMealPlanScheduler>();
+	private readonly ChatToolContext context = new();
+
+	[Fact]
+	public async Task AssignAsync_HappyPath_ForwardsRequestAndAppendsContext()
+	{
+		var recipe = Guid.NewGuid();
+		AssignMealRequest? captured = null;
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AssignMealRequest>(0);
+				return true;
+			});
+
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Wednesday", recipe.ToString(), "Carbonara", "Dinner", 2026, 19, servings: 4);
+
+		reply.Should().Contain("Carbonara");
+		reply.Should().Contain("Wednesday");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.RecipeIdentifier.Should().Be(recipe);
+		captured.RecipeTitle.Should().Be("Carbonara");
+		captured.Servings.Should().Be(4);
+		context.Matches.Should().ContainSingle();
+		context.Matches[0].Identifier.Should().Be(recipe);
+		context.Matches[0].Reason.Should().Be("Planned for Wednesday · Dinner");
+	}
+
+	[Fact]
+	public async Task AssignAsync_InvalidGuid_ReturnsErrorWithoutCallingScheduler()
+	{
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Wednesday", "not-a-guid", "Carbonara");
+
+		reply.Should().Contain("Invalid recipe identifier");
+		context.Matches.Should().BeEmpty();
+		await scheduler.DidNotReceiveWithAnyArgs().AssignAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task AssignAsync_SchedulerReturnsFalse_ReturnsErrorWithoutAppendingContext()
+	{
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Friday", Guid.NewGuid().ToString(), "Pizza");
+
+		reply.Should().Contain("Couldn't plan");
+		context.Matches.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task AssignAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		AssignMealRequest? captured = null;
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AssignMealRequest>(0);
+				return true;
+			});
+
+		var tool = new AssignMealTool(scheduler, context);
+		await tool.AssignAsync("Monday", Guid.NewGuid().ToString(), "Stew", year: 0, weekNumber: 0);
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ConfirmMealToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ConfirmMealToolTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class ConfirmMealToolTests
+{
+	private readonly IMealConfirmation confirmation = Substitute.For<IMealConfirmation>();
+
+	[Fact]
+	public async Task ConfirmAsync_HappyPath_ForwardsRequest()
+	{
+		ConfirmMealRequest? captured = null;
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ConfirmMealRequest>(0);
+				return true;
+			});
+
+		var tool = new ConfirmMealTool(confirmation);
+		var reply = await tool.ConfirmAsync("Wednesday", "Cooked", "Dinner", 2026, 19);
+
+		reply.Should().Contain("Wednesday");
+		reply.Should().Contain("cooked");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.State.Should().Be("Cooked");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_ConfirmationReturnsFalse_ReturnsErrorMessage()
+	{
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new ConfirmMealTool(confirmation);
+		var reply = await tool.ConfirmAsync("Friday", "Skipped");
+
+		reply.Should().Contain("Couldn't update");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		ConfirmMealRequest? captured = null;
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ConfirmMealRequest>(0);
+				return true;
+			});
+
+		var tool = new ConfirmMealTool(confirmation);
+		await tool.ConfirmAsync("Monday", "Cooked", year: 0, weekNumber: 0);
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+}


### PR DESCRIPTION
Phase 2c continues the cross-module chat-tool pattern proven in Phase 2b (#644). Adds the two MealPlan write tools so chat can plan recipes and confirm cooked meals end-to-end. Stacks on #644.

## What this unlocks

- US-185 Planner Mode chat — "plan carbonara for Wednesday", "add risotto to Friday lunch"
- US-189 history chat — "I made the spaghetti on Wednesday", "skip Friday's dinner"

## Tools added

| Tool | Consumer contract | Upstream call |
|---|---|---|
| `assign_meal` | `IMealPlanScheduler` | `MealPlan POST /api/v1/meal-plans/{year}/w/{week}/slots` |
| `confirm_meal_cooked` | `IMealConfirmation` | `MealPlan PUT /api/v1/meal-plans/{year}/w/{week}/slots/confirm` |

Both follow the `year=0` / `weekNumber=0` → current ISO week convention from `get_weekly_plan`. String day / mealType / state for LLM friendliness — no enum coercion needed at the tool boundary.

## Architecture changes

- **`IModuleHttpClient.PutAsync<TBody>`** added (mirrors existing `PostAsync<TBody>` shape). Used by the new write call.
- **`IMealPlanClient`** extended:
  - `AssignRecipeAsync(year, week, AssignRecipeBody, ct) → Task<bool>`
  - `ConfirmMealAsync(year, week, ConfirmMealBody, ct) → Task<bool>`
  - Both return `bool` rather than the upstream `WeeklyPlanDto`. The chat tools only need success/failure for the LLM reply; the LLM can call `get_weekly_plan` again if it needs the new state.
- **Two consumer-defined contracts** in `Recipes.Application/Interfaces/`:
  - `IMealPlanScheduler` + `AssignMealRequest` record
  - `IMealConfirmation` + `ConfirmMealRequest` record
- **Two HTTP adapters** in `Recipes.Infrastructure/ExternalServices/` — both very thin (just request mapping).
- **Two SK kernel functions** in `Recipes.Extraction/Services/Tools/`:
  - `AssignMealTool.AssignAsync` validates the recipe identifier as a GUID before dispatching, appends a context match for downstream `OpenRecipe` action emission.
  - `ConfirmMealTool.ConfirmAsync` is fire-and-forget (no recipe match — the LLM already knows the slot).
- **`SemanticKernelChatService`** gains DI for both tools, registers them on the per-request kernel under plugin names `mealplan_assign` / `mealplan_confirm`. System prompt extended with usage hints for both tools.

## Files

Production:
- `src/Yumney.Shared.Web/IModuleHttpClient.cs` + `ModuleHttpClient.cs` — `PutAsync` API
- `src/Yumney.MealPlan.Client/IMealPlanClient.cs` + `MealPlanClient.cs` — assign + confirm methods
- `src/Yumney.Recipes.Application/Interfaces/IMealPlanScheduler.cs` (new)
- `src/Yumney.Recipes.Application/Interfaces/IMealConfirmation.cs` (new)
- `src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealPlanScheduler.cs` (new)
- `src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealConfirmation.cs` (new)
- `src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs` — register both
- `src/Yumney.Recipes.Extraction/Services/Tools/AssignMealTool.cs` (new)
- `src/Yumney.Recipes.Extraction/Services/Tools/ConfirmMealTool.cs` (new)
- `src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs` — DI + kernel + prompt
- `src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs` — register tools

Tests (11 new):
- `tests/.../Services/Tools/AssignMealToolTests.cs` (4 cases: happy path, invalid GUID, scheduler failure, year=0/week=0 resolution)
- `tests/.../Services/Tools/ConfirmMealToolTests.cs` (3 cases: happy path, confirmation failure, year=0/week=0 resolution)
- `tests/.../ExternalServices/HttpMealPlanSchedulerTests.cs` (2 cases: request mapping, false propagation)
- `tests/.../ExternalServices/HttpMealConfirmationTests.cs` (2 cases: request mapping, false propagation)

## Out of scope (Phase 2d)

Shopping read+write tools using the same shape:
- `get_merged_shopping_list` — extend `IShoppingClient` + `IShoppingListLookup` contract + adapter
- `create_shopping_list_from_recipes` — `IShoppingListCreator` contract + adapter

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Backend tests: Application 184 / Infrastructure 127 (incl. 11 new) / Api 161 / Architecture 140 — all green
- [ ] Manual: chat "plan spaghetti for Wednesday" → search_recipes("spaghetti") → assign_meal fires → success message + OpenRecipe chip
- [ ] Manual: chat "I made the carbonara on Wednesday" → confirm_meal_cooked fires → success message

## Stacking

Branched from `feat/US-639b-cross-module-tools` (PR #644). Targets that branch — base will auto-retarget as the chain merges.

Refs #639
Refs #637