### PR TITLE
feat(recipes): get_merged_shopping_list + create_shopping_list_from_recipes chat tools (Phase 2d of #639)

### DIFF
--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListCreator.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListCreator.cs
@@ -1,0 +1,25 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for creating a shopping list from one or more
+/// recipes. Owned by Recipes (the chat surface is the consumer) per CLAUDE.md
+/// cross-module rule + ADR 0002.
+/// </summary>
+public interface IShoppingListCreator
+{
+	/// <summary>Create a shopping list named <paramref name="request"/>.Title sourced from the given recipes.</summary>
+	/// <param name="request">Title plus the list of recipes (with optional servings overrides).</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> CreateAsync(CreateShoppingListRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a create-shopping-list-from-recipes request.</summary>
+/// <param name="Title">List title (e.g. "This week's dinners").</param>
+/// <param name="Recipes">Recipes to draw from.</param>
+public sealed record CreateShoppingListRequest(string Title, IReadOnlyList<CreateShoppingListRecipe> Recipes);
+
+/// <summary>One recipe selection inside a create-shopping-list request.</summary>
+/// <param name="RecipeIdentifier">Recipe identifier resolved from a prior search/get.</param>
+/// <param name="Servings">Optional override for servings; null = use recipe default.</param>
+public sealed record CreateShoppingListRecipe(Guid RecipeIdentifier, int? Servings);

--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListLookup.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListLookup.cs
@@ -1,0 +1,31 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for fetching the user's merged active shopping
+/// list from the Shopping module. Owned by Recipes (the chat surface is the
+/// consumer) per CLAUDE.md cross-module rule + ADR 0002.
+/// </summary>
+public interface IShoppingListLookup
+{
+	/// <summary>Get the merged shopping list across all active lists.</summary>
+	/// <param name="includePastBought">Whether to include items already bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>Consumer-flavored merged list, or null if the upstream call fails.</returns>
+	Task<ShoppingListLookupResult?> GetMergedAsync(bool includePastBought = false, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed merged-list shape returned to chat tools.</summary>
+public sealed record ShoppingListLookupResult(IReadOnlyList<ShoppingListLookupItem> Items);
+
+/// <summary>One merged item across all active shopping lists.</summary>
+/// <param name="Name">Ingredient name.</param>
+/// <param name="Quantity">Display quantity.</param>
+/// <param name="Unit">Unit, if any.</param>
+/// <param name="Category">Aisle / category label.</param>
+/// <param name="IsBought">Whether the item is already checked off.</param>
+public sealed record ShoppingListLookupItem(
+	string Name,
+	decimal Quantity,
+	string? Unit,
+	string Category,
+	bool IsBought);

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -46,6 +46,8 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<GetWeeklyPlanTool>();
 		services.AddScoped<AssignMealTool>();
 		services.AddScoped<ConfirmMealTool>();
+		services.AddScoped<GetMergedShoppingListTool>();
+		services.AddScoped<CreateShoppingListTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -29,6 +29,8 @@ public sealed partial class SemanticKernelChatService(
 	GetWeeklyPlanTool getWeeklyPlanTool,
 	AssignMealTool assignMealTool,
 	ConfirmMealTool confirmMealTool,
+	GetMergedShoppingListTool getMergedShoppingListTool,
+	CreateShoppingListTool createShoppingListTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -151,6 +153,15 @@ public sealed partial class SemanticKernelChatService(
           meal ("I made the spaghetti on Wednesday", "skip Friday's
           dinner"), call confirm_meal_cooked with state Cooked/Skipped/
           Planned.
+        - When the user asks about their shopping list ("what's on my
+          shopping list?", "do I still need eggs?"), call
+          get_merged_shopping_list.
+        - When the user asks to build a shopping list from recipes
+          ("make a list for spaghetti and risotto", "shopping list for
+          this week's dinners"), first resolve recipe identifiers via
+          search_recipes if needed, then call
+          create_shopping_list_from_recipes with the identifiers
+          comma-separated.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -174,6 +185,8 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
 		requestKernel.Plugins.AddFromObject(assignMealTool, "mealplan_assign");
 		requestKernel.Plugins.AddFromObject(confirmMealTool, "mealplan_confirm");
+		requestKernel.Plugins.AddFromObject(getMergedShoppingListTool, "shopping_merged");
+		requestKernel.Plugins.AddFromObject(createShoppingListTool, "shopping_create");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/CreateShoppingListTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/CreateShoppingListTool.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing "create a shopping list from these recipes" to
+/// the chat LLM. Cross-module via <see cref="IShoppingListCreator"/>.
+/// </summary>
+/// <param name="creator">Consumer-defined creator contract.</param>
+public sealed class CreateShoppingListTool(IShoppingListCreator creator)
+{
+	/// <summary>Create a shopping list named <paramref name="title"/> from the given comma-separated recipe identifiers.</summary>
+	/// <param name="title">List title (e.g. "This week's dinners").</param>
+	/// <param name="recipeIdentifiers">Comma-separated list of recipe GUIDs from prior search/get calls.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("create_shopping_list_from_recipes")]
+	[Description("Create a new shopping list sourced from one or more recipes. Use for 'make a shopping list for spaghetti and risotto', 'create a list for this week's dinners'. Pass comma-separated recipe identifiers from prior search_recipes / get_recipe calls.")]
+	public async Task<string> CreateAsync(
+		[Description("List title, e.g. 'This week's dinners'")] string title,
+		[Description("Comma-separated recipe GUIDs (e.g. '8d4d…, c2f7…') from prior search_recipes calls")] string recipeIdentifiers,
+		CancellationToken cancellationToken = default)
+	{
+		var parsed = ParseGuids(recipeIdentifiers);
+		if (parsed.Count == 0) return "Need at least one valid recipe identifier — call search_recipes first.";
+
+		var request = new CreateShoppingListRequest(
+			title,
+			[.. parsed.Select(id => new CreateShoppingListRecipe(id, Servings: null))]);
+
+		var success = await creator.CreateAsync(request, cancellationToken);
+		return success
+			? $"Created '{title}' with {parsed.Count} recipe(s)."
+			: $"Couldn't create '{title}' — please try again.";
+	}
+
+	private static List<Guid> ParseGuids(string commaSeparated)
+	{
+		List<Guid> result = [];
+		foreach (var token in commaSeparated.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (Guid.TryParse(token, out var guid)) result.Add(guid);
+		}
+
+		return result;
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/GetMergedShoppingListTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/GetMergedShoppingListTool.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing the user's merged active shopping list to the
+/// chat LLM. Cross-module via <see cref="IShoppingListLookup"/>.
+/// </summary>
+/// <param name="lookup">Consumer-defined merged-list lookup.</param>
+public sealed class GetMergedShoppingListTool(IShoppingListLookup lookup)
+{
+	/// <summary>Get the user's merged active shopping list.</summary>
+	/// <param name="includePastBought">Whether to include items already bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>The merged list or null if nothing on the list.</returns>
+	[KernelFunction("get_merged_shopping_list")]
+	[Description("Fetch the user's active shopping list, merged across all open lists. Use for 'what's on my shopping list?', 'do I need to buy anything for chicken?', 'was steht auf meiner Einkaufsliste?'. Defaults to unbought items only.")]
+	public Task<ShoppingListLookupResult?> GetAsync(
+		[Description("If true, also include items already bought (for review). Defaults to false.")] bool includePastBought = false,
+		CancellationToken cancellationToken = default) =>
+		lookup.GetMergedAsync(includePastBought, cancellationToken);
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListCreator.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListCreator.cs
@@ -1,0 +1,15 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpShoppingListCreator(IShoppingClient shopping) : IShoppingListCreator
+{
+	public Task<bool> CreateAsync(CreateShoppingListRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new CreateListFromRecipesBody(
+			request.Title,
+			[.. request.Recipes.Select(recipe => new CreateListRecipeBody(recipe.RecipeIdentifier, recipe.Servings))]);
+		return shopping.CreateListFromRecipesAsync(body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListLookup.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListLookup.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpShoppingListLookup(IShoppingClient shopping) : IShoppingListLookup
+{
+	public async Task<ShoppingListLookupResult?> GetMergedAsync(bool includePastBought = false, CancellationToken cancellationToken = default)
+	{
+		var response = await shopping.GetMergedListAsync(includePastBought, cancellationToken);
+		return response?.ToLookupResult();
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/ShoppingListLookupMappingExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/ShoppingListLookupMappingExtensions.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+internal static class ShoppingListLookupMappingExtensions
+{
+	public static ShoppingListLookupResult ToLookupResult(this MergedShoppingListResponse response) =>
+		new([.. response.Items.Select(item => item.ToLookupItem())]);
+
+	public static ShoppingListLookupItem ToLookupItem(this MergedShoppingListItemResponse item) =>
+		new(item.ItemName, item.DisplayQuantity, item.Unit, item.Category, item.IsBought);
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
 		services.AddScoped<IMealPlanScheduler, HttpMealPlanScheduler>();
 		services.AddScoped<IMealConfirmation, HttpMealConfirmation>();
+		services.AddScoped<IShoppingListLookup, HttpShoppingListLookup>();
+		services.AddScoped<IShoppingListCreator, HttpShoppingListCreator>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.Shopping.Client/IShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/IShoppingClient.cs
@@ -7,6 +7,18 @@ public interface IShoppingClient
 	Task<ShoppingBalanceResponse?> GetBalanceAsync(CancellationToken cancellationToken = default);
 
 	Task AddItemAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default);
+
+	/// <summary>Fetch the user's merged active shopping list. GET /api/v1/shopping-lists/merged.</summary>
+	/// <param name="includePastBought">Whether to include items that have been bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>The merged list, or null if the upstream call fails / returns 404.</returns>
+	Task<MergedShoppingListResponse?> GetMergedListAsync(bool includePastBought = false, CancellationToken cancellationToken = default);
+
+	/// <summary>Create a shopping list from one or more recipes. POST /api/v1/shopping-lists/from-recipes.</summary>
+	/// <param name="body">Title plus the list of recipes to include.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> CreateListFromRecipesAsync(CreateListFromRecipesBody body, CancellationToken cancellationToken = default);
 }
 
 public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> Items);
@@ -14,3 +26,20 @@ public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> 
 public sealed record ShoppingBalanceItem(string ItemName, Freshness Freshness);
 
 public sealed record AddShoppingItemRequest(string Name, decimal Quantity, string? Unit, string Source);
+
+/// <summary>Trimmed merged-list shape returned over the wire.</summary>
+public sealed record MergedShoppingListResponse(IReadOnlyList<MergedShoppingListItemResponse> Items);
+
+/// <summary>One merged item across all of the user's active lists.</summary>
+public sealed record MergedShoppingListItemResponse(
+	string ItemName,
+	decimal DisplayQuantity,
+	string? Unit,
+	string Category,
+	bool IsBought);
+
+/// <summary>Body for create-list-from-recipes POST.</summary>
+public sealed record CreateListFromRecipesBody(string Title, IReadOnlyList<CreateListRecipeBody> Recipes);
+
+/// <summary>One recipe selection inside a create-list-from-recipes body.</summary>
+public sealed record CreateListRecipeBody(Guid RecipeIdentifier, int? Servings);

--- a/src/Yumney.Shopping.Client/ShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClient.cs
@@ -18,4 +18,27 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 			request,
 			"AddShoppingItem",
 			cancellationToken);
+
+	public Task<MergedShoppingListResponse?> GetMergedListAsync(bool includePastBought = false, CancellationToken cancellationToken = default) =>
+		http.FindAsync<MergedShoppingListResponse>(
+			$"/api/v1/shopping-lists/merged?includePastBought={includePastBought.ToString().ToLowerInvariant()}",
+			"GetMergedShoppingList",
+			cancellationToken);
+
+	public async Task<bool> CreateListFromRecipesAsync(CreateListFromRecipesBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PostAsync(
+				"/api/v1/shopping-lists/from-recipes",
+				body,
+				"CreateShoppingListFromRecipes",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListCreatorTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListCreatorTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListCreatorTests
+{
+	private readonly IShoppingClient client = Substitute.For<IShoppingClient>();
+
+	[Fact]
+	public async Task CreateAsync_MapsConsumerRecipesToClientBody()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		CreateListFromRecipesBody? captured = null;
+		client.CreateListFromRecipesAsync(Arg.Any<CreateListFromRecipesBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateListFromRecipesBody>(0);
+				return true;
+			});
+
+		var creator = new HttpShoppingListCreator(client);
+		await creator.CreateAsync(new CreateShoppingListRequest(
+			"This week",
+			[
+				new CreateShoppingListRecipe(first, Servings: 4),
+				new CreateShoppingListRecipe(second, Servings: null),
+			]));
+
+		captured.Should().NotBeNull();
+		captured!.Title.Should().Be("This week");
+		captured.Recipes.Should().HaveCount(2);
+		captured.Recipes[0].RecipeIdentifier.Should().Be(first);
+		captured.Recipes[0].Servings.Should().Be(4);
+		captured.Recipes[1].RecipeIdentifier.Should().Be(second);
+		captured.Recipes[1].Servings.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task CreateAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.CreateListFromRecipesAsync(Arg.Any<CreateListFromRecipesBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var creator = new HttpShoppingListCreator(client);
+		var result = await creator.CreateAsync(new CreateShoppingListRequest("List", [new(Guid.NewGuid(), Servings: null)]));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListLookupTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListLookupTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListLookupTests
+{
+	private readonly IShoppingClient client = Substitute.For<IShoppingClient>();
+
+	[Fact]
+	public async Task GetMergedAsync_ClientReturnsResponse_MapsToLookupResult()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(new MergedShoppingListResponse([
+				new MergedShoppingListItemResponse("Eggs", 6m, "pcs", "Dairy", IsBought: false),
+				new MergedShoppingListItemResponse("Flour", 500m, "g", "Pantry", IsBought: true),
+			]));
+
+		var lookup = new HttpShoppingListLookup(client);
+		var result = await lookup.GetMergedAsync();
+
+		result.Should().NotBeNull();
+		result!.Items.Should().HaveCount(2);
+		result.Items[0].Name.Should().Be("Eggs");
+		result.Items[0].Quantity.Should().Be(6m);
+		result.Items[0].Unit.Should().Be("pcs");
+		result.Items[0].Category.Should().Be("Dairy");
+		result.Items[0].IsBought.Should().BeFalse();
+		result.Items[1].IsBought.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task GetMergedAsync_ClientReturnsNull_ReturnsNull()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((MergedShoppingListResponse?)null);
+
+		var lookup = new HttpShoppingListLookup(client);
+		var result = await lookup.GetMergedAsync();
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetMergedAsync_ForwardsIncludePastBoughtFlag()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((MergedShoppingListResponse?)null);
+
+		var lookup = new HttpShoppingListLookup(client);
+		await lookup.GetMergedAsync(includePastBought: true);
+
+		await client.Received(1).GetMergedListAsync(true, Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/CreateShoppingListToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/CreateShoppingListToolTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class CreateShoppingListToolTests
+{
+	private readonly IShoppingListCreator creator = Substitute.For<IShoppingListCreator>();
+
+	[Fact]
+	public async Task CreateAsync_HappyPath_BuildsRequestAndReturnsConfirmation()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		CreateShoppingListRequest? captured = null;
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateShoppingListRequest>(0);
+				return true;
+			});
+
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("This week's dinners", $"{first}, {second}");
+
+		reply.Should().Contain("This week's dinners");
+		reply.Should().Contain("2");
+		captured.Should().NotBeNull();
+		captured!.Title.Should().Be("This week's dinners");
+		captured.Recipes.Should().HaveCount(2);
+		captured.Recipes.Select(recipe => recipe.RecipeIdentifier).Should().ContainInOrder(first, second);
+		captured.Recipes.Should().AllSatisfy(recipe => recipe.Servings.Should().BeNull());
+	}
+
+	[Fact]
+	public async Task CreateAsync_NoValidGuids_ReturnsErrorWithoutCallingCreator()
+	{
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("Foo", "not-a-guid, also-not-one");
+
+		reply.Should().Contain("Need at least one valid recipe identifier");
+		await creator.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task CreateAsync_MixedValidAndInvalid_KeepsOnlyValid()
+	{
+		var valid = Guid.NewGuid();
+		CreateShoppingListRequest? captured = null;
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateShoppingListRequest>(0);
+				return true;
+			});
+
+		var tool = new CreateShoppingListTool(creator);
+		await tool.CreateAsync("Mix", $"not-a-guid, {valid}, also-not-one");
+
+		captured.Should().NotBeNull();
+		captured!.Recipes.Should().ContainSingle();
+		captured.Recipes[0].RecipeIdentifier.Should().Be(valid);
+	}
+
+	[Fact]
+	public async Task CreateAsync_CreatorReturnsFalse_ReturnsErrorMessage()
+	{
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("List", Guid.NewGuid().ToString());
+
+		reply.Should().Contain("Couldn't create");
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetMergedShoppingListToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetMergedShoppingListToolTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class GetMergedShoppingListToolTests
+{
+	private readonly IShoppingListLookup lookup = Substitute.For<IShoppingListLookup>();
+
+	[Fact]
+	public async Task GetAsync_DefaultCall_ExcludesPastBought()
+	{
+		bool capturedFlag = true;
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedFlag = callInfo.ArgAt<bool>(0);
+				return new ShoppingListLookupResult([]);
+			});
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		await tool.GetAsync();
+
+		capturedFlag.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetAsync_ReturnsLookupResultDirectly()
+	{
+		var expected = new ShoppingListLookupResult([
+			new ShoppingListLookupItem("Eggs", 6m, "pcs", "Dairy", IsBought: false),
+			new ShoppingListLookupItem("Flour", 500m, "g", "Pantry", IsBought: false),
+		]);
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(expected);
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		var result = await tool.GetAsync();
+
+		result.Should().BeSameAs(expected);
+	}
+
+	[Fact]
+	public async Task GetAsync_LookupReturnsNull_ReturnsNull()
+	{
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((ShoppingListLookupResult?)null);
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		var result = await tool.GetAsync();
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetAsync_IncludePastBoughtTrue_ForwardsFlag()
+	{
+		bool capturedFlag = false;
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedFlag = callInfo.ArgAt<bool>(0);
+				return new ShoppingListLookupResult([]);
+			});
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		await tool.GetAsync(includePastBought: true);
+
+		capturedFlag.Should().BeTrue();
+	}
+}


### PR DESCRIPTION
Phase 2d closes the cross-module Phase 2 work — chat now reaches all four sibling-module surfaces (Recipes / MealPlan read+write / Shopping read+write). Stacks on #645.

## What this unlocks

- US-188 — "what's on my shopping list?", "do I still need eggs?", "was steht auf meiner Einkaufsliste?"
- US-185 / US-188 — "make a shopping list for spaghetti and risotto", "shopping list for this week's dinners"

## Tools added

| Tool | Consumer contract | Upstream call |
|---|---|---|
| `get_merged_shopping_list` | `IShoppingListLookup` | `Shopping GET /api/v1/shopping-lists/merged` |
| `create_shopping_list_from_recipes` | `IShoppingListCreator` | `Shopping POST /api/v1/shopping-lists/from-recipes` |

## Architecture

- **`IShoppingClient`** extended with `GetMergedListAsync` (returns `MergedShoppingListResponse?`) + `CreateListFromRecipesAsync` (returns `bool` per the same Phase 2c convention for write tools).
- **Two consumer-defined contracts** in `Recipes.Application/Interfaces/`:
  - `IShoppingListLookup` + `ShoppingListLookupResult` / `ShoppingListLookupItem`
  - `IShoppingListCreator` + `CreateShoppingListRequest` / `CreateShoppingListRecipe`
- **Two HTTP adapters** in `Recipes.Infrastructure/ExternalServices/` + `ShoppingListLookupMappingExtensions` for the wire→consumer projection.
- **Two SK kernel functions** in `Recipes.Extraction/Services/Tools/`:
  - `GetMergedShoppingListTool.GetAsync` is a passthrough (no transformation needed)
  - `CreateShoppingListTool.CreateAsync` parses comma-separated GUIDs (LLM-friendly), skips invalid tokens, returns "Need at least one valid recipe identifier — call search_recipes first" if no GUIDs parse
- **`SemanticKernelChatService`** gains DI for both tools, registers them on the per-request kernel under plugin names `shopping_merged` / `shopping_create`. System prompt extended with usage hints.

## Files

Production:
- `src/Yumney.Shopping.Client/IShoppingClient.cs` + `ShoppingClient.cs` — merged + create-from-recipes methods + new wire records
- `src/Yumney.Recipes.Application/Interfaces/IShoppingListLookup.cs` (new)
- `src/Yumney.Recipes.Application/Interfaces/IShoppingListCreator.cs` (new)
- `src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListLookup.cs` (new)
- `src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListCreator.cs` (new)
- `src/Yumney.Recipes.Infrastructure/ExternalServices/ShoppingListLookupMappingExtensions.cs` (new)
- `src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs` — register both
- `src/Yumney.Recipes.Extraction/Services/Tools/GetMergedShoppingListTool.cs` (new)
- `src/Yumney.Recipes.Extraction/Services/Tools/CreateShoppingListTool.cs` (new)
- `src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs` — DI + kernel + prompt
- `src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs` — register tools

Tests (13 new):
- `tests/.../Services/Tools/GetMergedShoppingListToolTests.cs` (4 cases)
- `tests/.../Services/Tools/CreateShoppingListToolTests.cs` (4 cases — incl. mixed valid/invalid GUID parsing)
- `tests/.../ExternalServices/HttpShoppingListLookupTests.cs` (3 cases)
- `tests/.../ExternalServices/HttpShoppingListCreatorTests.cs` (2 cases)

## Phase 2 surface summary

After this PR the chat surface covers:

**Read:** `search_recipes`, `get_recipe`, `get_cookable_recipes`, `get_weekly_plan`, `get_merged_shopping_list`

**Write:** `assign_meal`, `confirm_meal_cooked`, `create_shopping_list_from_recipes`

Plus the deterministic intent-driven `Navigate` action from Phase 1.

That covers US-184, US-185, US-186 (cook-mode via OpenRecipe), US-188, US-189, US-190 server-side. US-187 (recipe rating chat) is the only chat user-story still unwired — small follow-up since the handler `RateRecipeCommandHandler` already exists.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Backend tests: Application 184 / Infrastructure 140 (incl. 13 new) / Api 161 / Architecture 140 — all green
- [ ] Manual: chat "what's on my shopping list?" → `get_merged_shopping_list` fires
- [ ] Manual: chat "make a shopping list for spaghetti and risotto" → search_recipes + `create_shopping_list_from_recipes` fires

## Stacking

Branched from `feat/US-639c-mealplan-write-tools` (PR #645). Targets that branch — base will auto-retarget as the chain merges.

Refs #639
Refs #637