### PR TITLE
feat(shared): capability surface foundation — manifest endpoint + 9 tagged routes (US-640, Phase 3 of #637)

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -9,6 +9,7 @@
   <Folder Name="/src/Shared/">
     <Project Path="src/Yumney.Shared/Yumney.Shared.csproj" />
     <Project Path="src/Yumney.Shared.Abstractions/Yumney.Shared.Abstractions.csproj" />
+    <Project Path="src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj" />
     <Project Path="src/Yumney.Shared.Outcomes/Yumney.Shared.Outcomes.csproj" />
     <Project Path="src/Yumney.Shared.Paging/Yumney.Shared.Paging.csproj" />
     <Project Path="src/Yumney.Shared.Quantities/Yumney.Shared.Quantities.csproj" />

--- a/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore.Ev
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -28,6 +29,7 @@ public sealed class MealPlanApiModule : IEndpointModule
 			.UseYumneyDefaults()
 			.MapApiV1()
 			.MapMealPlanEndpoints();
+		app.MapCapabilityManifest("mealplan-api");
 		return app;
 	}
 }

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -3,10 +3,12 @@ using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -19,6 +21,10 @@ public static class MealPlanEndpoints
 		group.MapGet("/{year:int}/w/{weekNumber:int}", GetWeeklyPlan)
 			.WithName("GetWeeklyPlan")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "get_weekly_plan",
+				description: "Fetch the user's planned meals for an ISO week. Use for 'what's for dinner this week?' / 'show me next week's plan'.",
+				surfaces: CapabilitySurface.All)
 			.Produces<WeeklyPlanDto>();
 
 		static async Task<IResult> GetWeeklyPlan(
@@ -36,6 +42,10 @@ public static class MealPlanEndpoints
 		group.MapPost("/{year:int}/w/{weekNumber:int}/slots", AssignRecipe)
 			.WithName("AssignRecipe")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "assign_meal",
+				description: "Plan a recipe into a meal slot for an ISO week ('plan carbonara for Wednesday', 'add risotto to Friday lunch'). Requires a recipe identifier from a prior recipe lookup.",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<WeeklyPlanDto>()
 			.ProducesProblem(StatusCodes.Status400BadRequest);
 
@@ -117,6 +127,10 @@ public static class MealPlanEndpoints
 		group.MapPut("/{year:int}/w/{weekNumber:int}/slots/confirm", ConfirmMeal)
 			.WithName("ConfirmMeal")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "confirm_meal_cooked",
+				description: "Update a planned meal's state to Cooked, Skipped, or Planned ('I made the spaghetti on Wednesday', 'skip Friday's dinner').",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<WeeklyPlanDto>()
 			.ProducesProblem(StatusCodes.Status404NotFound);
 

--- a/src/Yumney.Recipes.Api/RecipesApiModule.cs
+++ b/src/Yumney.Recipes.Api/RecipesApiModule.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -31,6 +32,7 @@ public sealed class RecipesApiModule : IEndpointModule
 			.UseYumneyDefaults()
 			.MapApiV1()
 			.MapRecipesEndpoints();
+		app.MapCapabilityManifest("recipes-api");
 		return app;
 	}
 }

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -6,11 +6,13 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Common;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -134,6 +136,10 @@ public static partial class RecipesEndpoints
 			.WithName("ImportRecipe")
 			.WithTags("Recipes")
 			.WithValidation<Requests.ImportRecipe>()
+			.WithCapability(
+				name: "import_recipe_from_url",
+				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the parsed recipe (title, ingredients, steps).",
+				surfaces: CapabilitySurface.Mcp | CapabilitySurface.Voice)
 			.Produces<ExtractedRecipeDto>()
 			.ProducesValidationProblem()
 			.ProducesProblem(StatusCodes.Status404NotFound)

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -2,10 +2,12 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -31,6 +33,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/", GetAll)
 			.WithName("GetRecipes")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "search_recipes",
+				description: "Search the user's recipe collection by free text query and optional filters (tags, difficulty, max prep/cook time, favorites). Returns paged recipe summaries.",
+				surfaces: CapabilitySurface.All)
 			.Produces<PagedResult<RecipeListItemDto>>();
 
 		static async Task<IResult> GetAll(
@@ -60,6 +66,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/{identifier:guid}", GetById)
 			.WithName("GetRecipeById")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "get_recipe",
+				description: "Fetch full details (ingredients, steps, timings, servings) of one recipe by its identifier.",
+				surfaces: CapabilitySurface.All)
 			.Produces<RecipeDetailDto>()
 			.ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -163,6 +173,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/what-can-i-cook", WhatCanICook)
 			.WithName("WhatCanICook")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "get_cookable_recipes",
+				description: "Find recipes the user can cook now or with at most a couple of missing items, ranked by ingredient freshness in their pantry. Use for 'what can I cook?' / 'was kann ich kochen?'.",
+				surfaces: CapabilitySurface.All)
 			.Produces<PagedResult<CookableRecipeDto>>();
 
 		static async Task<IResult> WhatCanICook(

--- a/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Wire shape of one capability — the projection of <see cref="CapabilityMetadata"/>
+/// plus the route the capability is mounted on.
+/// </summary>
+/// <param name="Name">Stable LLM-facing tool name.</param>
+/// <param name="Description">One-paragraph description for the LLM.</param>
+/// <param name="Surfaces">Bitfield of surfaces this capability is exposed on.</param>
+/// <param name="HttpMethod">HTTP verb (GET, POST, PUT, DELETE, …).</param>
+/// <param name="RoutePattern">Raw route pattern (e.g. <c>/api/v1/recipes/{id:guid}</c>).</param>
+public sealed record CapabilityDescriptor(
+	string Name,
+	string Description,
+	CapabilitySurface Surfaces,
+	string HttpMethod,
+	string RoutePattern);
+
+/// <summary>Wire shape of one host's capability manifest, returned by <c>/.well-known/yumney-capabilities</c>.</summary>
+/// <param name="ServiceName">Aspire service name (e.g. <c>recipes-api</c>).</param>
+/// <param name="Capabilities">All capabilities advertised by this host.</param>
+public sealed record CapabilityManifest(string ServiceName, IReadOnlyList<CapabilityDescriptor> Capabilities);

--- a/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Endpoint metadata marking a route as an LLM-callable capability. Attached
+/// via <c>WithCapability(...)</c>; surfaced by <c>MapCapabilityManifest()</c>
+/// on the well-known manifest endpoint.
+/// </summary>
+/// <param name="Name">Stable LLM-facing tool name (snake_case). Treat as a public contract — renaming breaks installed clients.</param>
+/// <param name="Description">One-paragraph description used by the LLM to decide when to call this capability.</param>
+/// <param name="Surfaces">Bitfield of surfaces this capability is exposed on.</param>
+public sealed record CapabilityMetadata(string Name, string Description, CapabilitySurface Surfaces);

--- a/src/Yumney.Shared.Capabilities/CapabilitySurface.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilitySurface.cs
@@ -1,0 +1,24 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Flags marking which LLM-callable surfaces an endpoint is exposed on.
+/// Combine with bitwise OR. See ADR 0002 for the surface inventory.
+/// </summary>
+[Flags]
+public enum CapabilitySurface
+{
+	/// <summary>Endpoint is not exposed to any LLM-callable surface.</summary>
+	None = 0,
+
+	/// <summary>Exposed to the in-app chat panel (Semantic Kernel function calling).</summary>
+	Chat = 1,
+
+	/// <summary>Exposed to external Model Context Protocol clients (Claude Desktop, custom GPTs, …).</summary>
+	Mcp = 2,
+
+	/// <summary>Exposed to the future voice-command surface.</summary>
+	Voice = 4,
+
+	/// <summary>Convenience union covering every current surface.</summary>
+	All = Chat | Mcp | Voice,
+}

--- a/src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj
+++ b/src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+
+/// <summary>
+/// Maps the well-known capability manifest endpoint that exposes every
+/// <see cref="CapabilityMetadata"/>-tagged route on this host.
+/// </summary>
+public static class CapabilityManifestEndpoint
+{
+	/// <summary>The well-known path: <c>/.well-known/yumney-capabilities</c>.</summary>
+	public const string WellKnownPath = "/.well-known/yumney-capabilities";
+
+	/// <summary>Map the capability manifest endpoint on this host.</summary>
+	/// <param name="app">Endpoint route builder.</param>
+	/// <param name="serviceName">Aspire service name (e.g. <c>recipes-api</c>) — surfaced in the manifest.</param>
+	/// <returns>The same builder, for fluent chaining.</returns>
+	public static IEndpointRouteBuilder MapCapabilityManifest(this IEndpointRouteBuilder app, string serviceName)
+	{
+		app.MapGet(WellKnownPath, (HttpContext context) =>
+		{
+			var dataSource = context.RequestServices.GetRequiredService<EndpointDataSource>();
+			var manifest = BuildManifest(serviceName, dataSource);
+			return Results.Ok(manifest);
+		})
+		.AllowAnonymous()
+		.WithName("GetCapabilityManifest")
+		.WithTags("Capabilities");
+		return app;
+	}
+
+	internal static CapabilityManifest BuildManifest(string serviceName, EndpointDataSource dataSource)
+	{
+		var descriptors = dataSource.Endpoints
+			.OfType<RouteEndpoint>()
+			.Select(ProjectDescriptor)
+			.OfType<CapabilityDescriptor>()
+			.ToList();
+		return new CapabilityManifest(serviceName, descriptors);
+	}
+
+	private static CapabilityDescriptor? ProjectDescriptor(RouteEndpoint endpoint)
+	{
+		var meta = endpoint.Metadata.GetMetadata<CapabilityMetadata>();
+		if (meta is null) return null;
+
+		var methods = endpoint.Metadata.GetMetadata<Microsoft.AspNetCore.Routing.HttpMethodMetadata>()?.HttpMethods;
+		var httpMethod = methods is { Count: > 0 } ? methods[0] : "GET";
+		var routePattern = endpoint.RoutePattern.RawText ?? string.Empty;
+
+		return new CapabilityDescriptor(meta.Name, meta.Description, meta.Surfaces, httpMethod, routePattern);
+	}
+}

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+
+/// <summary>
+/// Endpoint-builder extensions for tagging routes with <see cref="CapabilityMetadata"/>.
+/// </summary>
+public static class CapabilityRouteBuilderExtensions
+{
+	/// <summary>Mark an endpoint as an LLM-callable capability.</summary>
+	/// <typeparam name="TBuilder">Concrete endpoint convention builder type.</typeparam>
+	/// <param name="builder">The endpoint builder returned by <c>MapGet</c> / <c>MapPost</c> / etc.</param>
+	/// <param name="name">Stable LLM-facing tool name (snake_case).</param>
+	/// <param name="description">One-paragraph description used by the LLM.</param>
+	/// <param name="surfaces">Surfaces this capability is exposed on. Defaults to Chat | Mcp.</param>
+	/// <returns>The same builder, for fluent chaining.</returns>
+	public static TBuilder WithCapability<TBuilder>(
+		this TBuilder builder,
+		string name,
+		string description,
+		CapabilitySurface surfaces = CapabilitySurface.Chat | CapabilitySurface.Mcp)
+		where TBuilder : IEndpointConventionBuilder =>
+		builder.WithMetadata(new CapabilityMetadata(name, description, surfaces));
+}

--- a/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
+++ b/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Shared\Yumney.Shared.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Abstractions\Yumney.Shared.Abstractions.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Paging\Yumney.Shared.Paging.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Outcomes\Yumney.Shared.Outcomes.csproj" />

--- a/src/Yumney.Shopping.Api/ShoppingApiModule.cs
+++ b/src/Yumney.Shopping.Api/ShoppingApiModule.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure;
@@ -28,6 +29,7 @@ public sealed class ShoppingApiModule : IEndpointModule
 	public WebApplication RegisterEndpoints(WebApplication app)
 	{
 		app.UseYumneyDefaults().MapApiV1().MapShoppingEndpoints();
+		app.MapCapabilityManifest("shopping-api");
 		return app;
 	}
 }

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
@@ -45,6 +47,10 @@ public static partial class ShoppingEndpoints
 			.WithName("CreateShoppingListFromRecipes")
 			.WithTags("Shopping")
 			.WithValidation<Requests.CreateFromRecipes>()
+			.WithCapability(
+				name: "create_shopping_list_from_recipes",
+				description: "Create a new shopping list sourced from one or more recipes ('make a shopping list for spaghetti and risotto').",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<ShoppingListDetailDto>(StatusCodes.Status201Created)
 			.ProducesValidationProblem();
 
@@ -181,6 +187,10 @@ public static partial class ShoppingEndpoints
 		group.MapGet("/merged", GetMerged)
 			.WithName("GetMergedShoppingList")
 			.WithTags("Shopping")
+			.WithCapability(
+				name: "get_merged_shopping_list",
+				description: "Fetch the user's merged active shopping list across all open lists ('what's on my shopping list?', 'do I still need eggs?').",
+				surfaces: CapabilitySurface.All)
 			.Produces<MergedShoppingListDto>();
 
 		static async Task<IResult> GetMerged(

--- a/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
+++ b/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
@@ -1,0 +1,76 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Architecture.Tests;
+
+#pragma warning disable SA1601
+public partial class CapabilityTaggingTests
+#pragma warning restore SA1601
+{
+	[Fact]
+	public void EveryWithCapabilityCall_HasUniqueName()
+	{
+		var srcRoot = SolutionRoot.Src;
+		var pattern = WithCapabilityNamePattern();
+
+		var allMatches = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.SelectMany(path => MatchesIn(path, pattern))
+			.ToList();
+
+		var duplicates = allMatches
+			.GroupBy(match => match.Name, StringComparer.Ordinal)
+			.Where(group => group.Count() > 1)
+			.ToList();
+
+		duplicates.Should().BeEmpty(
+			"Capability names are LLM-facing tool identifiers and form an external contract — duplicates make the manifest ambiguous. Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, duplicates.Select(group => $"  {group.Key}: {string.Join(", ", group.Select(match => match.Location))}")));
+	}
+
+	[Fact]
+	public void EveryWithCapabilityCall_UsesSnakeCaseName()
+	{
+		var srcRoot = SolutionRoot.Src;
+		var pattern = WithCapabilityNamePattern();
+		var snakeCase = SnakeCasePattern();
+
+		var violations = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.SelectMany(path => MatchesIn(path, pattern))
+			.Where(match => !snakeCase.IsMatch(match.Name))
+			.ToList();
+
+		violations.Should().BeEmpty(
+			"Capability names must be snake_case (e.g. search_recipes, get_weekly_plan). Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation.Name} at {violation.Location}")));
+	}
+
+	[GeneratedRegex(@"WithCapability\s*\(\s*name:\s*""(?<name>[^""]+)""", RegexOptions.Singleline)]
+	private static partial Regex WithCapabilityNamePattern();
+
+	[GeneratedRegex(@"^[a-z][a-z0-9_]*$")]
+	private static partial Regex SnakeCasePattern();
+
+	private static IEnumerable<CapabilityMatch> MatchesIn(string path, Regex pattern)
+	{
+		var content = File.ReadAllText(path);
+		var matches = pattern.Matches(content);
+		foreach (Match match in matches)
+		{
+			yield return new CapabilityMatch(match.Groups["name"].Value, Path.GetRelativePath(SolutionRoot.Path, path));
+		}
+	}
+
+	private static bool IsTrackedSourceFile(string path)
+	{
+		var normalized = path.Replace('\\', '/');
+		return !normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+			&& !normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private sealed record CapabilityMatch(string Name, string Location);
+}

--- a/tests/Yumney.Shared.Tests/Capabilities/CapabilityManifestEndpointTests.cs
+++ b/tests/Yumney.Shared.Tests/Capabilities/CapabilityManifestEndpointTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Primitives;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Capabilities;
+
+public class CapabilityManifestEndpointTests
+{
+	[Fact]
+	public void BuildManifest_OnlyTaggedEndpoints_AppearInDescriptors()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/api/v1/recipes", "GET", "search_recipes", "search the user's recipes", CapabilitySurface.All),
+			TaggedEndpoint("/api/v1/recipes/{id}", "GET", "get_recipe", "fetch one recipe", CapabilitySurface.Chat | CapabilitySurface.Mcp),
+			UntaggedEndpoint("/health", "GET"));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("recipes-api", dataSource);
+
+		manifest.ServiceName.Should().Be("recipes-api");
+		manifest.Capabilities.Should().HaveCount(2);
+		manifest.Capabilities.Select(capability => capability.Name).Should().Contain(["search_recipes", "get_recipe"]);
+		manifest.Capabilities.Select(capability => capability.RoutePattern).Should().NotContain("/health");
+	}
+
+	[Fact]
+	public void BuildManifest_ProjectsHttpMethodFromMetadata()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/post-route", "POST", "post_tool", "creates a thing", CapabilitySurface.Mcp),
+			TaggedEndpoint("/put-route", "PUT", "put_tool", "updates a thing", CapabilitySurface.Mcp));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		manifest.Capabilities.Single(capability => capability.Name == "post_tool").HttpMethod.Should().Be("POST");
+		manifest.Capabilities.Single(capability => capability.Name == "put_tool").HttpMethod.Should().Be("PUT");
+	}
+
+	[Fact]
+	public void BuildManifest_PreservesNameDescriptionAndSurfaces()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/route", "GET", "tool_name", "long description", CapabilitySurface.Chat | CapabilitySurface.Voice));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		var descriptor = manifest.Capabilities.Single();
+		descriptor.Name.Should().Be("tool_name");
+		descriptor.Description.Should().Be("long description");
+		descriptor.Surfaces.Should().Be(CapabilitySurface.Chat | CapabilitySurface.Voice);
+		descriptor.RoutePattern.Should().Be("/route");
+	}
+
+	[Fact]
+	public void BuildManifest_NoTaggedEndpoints_ReturnsEmptyCapabilityList()
+	{
+		var dataSource = new TestEndpointDataSource(
+			UntaggedEndpoint("/a", "GET"),
+			UntaggedEndpoint("/b", "POST"));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		manifest.ServiceName.Should().Be("test-api");
+		manifest.Capabilities.Should().BeEmpty();
+	}
+
+	private static RouteEndpoint TaggedEndpoint(string pattern, string method, string name, string description, CapabilitySurface surfaces) =>
+		new(
+			_ => Task.CompletedTask,
+			RoutePatternFactory.Parse(pattern),
+			order: 0,
+			new EndpointMetadataCollection(
+				new HttpMethodMetadata([method]),
+				new CapabilityMetadata(name, description, surfaces)),
+			displayName: name);
+
+	private static RouteEndpoint UntaggedEndpoint(string pattern, string method) =>
+		new(
+			_ => Task.CompletedTask,
+			RoutePatternFactory.Parse(pattern),
+			order: 0,
+			new EndpointMetadataCollection(new HttpMethodMetadata([method])),
+			displayName: pattern);
+
+	private sealed class TestEndpointDataSource(params Endpoint[] endpoints) : EndpointDataSource
+	{
+		public override IReadOnlyList<Endpoint> Endpoints { get; } = endpoints;
+
+		public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Capabilities/CapabilityRouteBuilderExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Capabilities/CapabilityRouteBuilderExtensionsTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Capabilities;
+
+public class CapabilityRouteBuilderExtensionsTests
+{
+	[Fact]
+	public void WithCapability_AttachesCapabilityMetadata()
+	{
+		var builder = new TestConventionBuilder();
+
+		builder.WithCapability("test_tool", "a test", CapabilitySurface.Chat);
+
+		var metadata = builder.AppliedMetadata.OfType<CapabilityMetadata>().Single();
+		metadata.Name.Should().Be("test_tool");
+		metadata.Description.Should().Be("a test");
+		metadata.Surfaces.Should().Be(CapabilitySurface.Chat);
+	}
+
+	[Fact]
+	public void WithCapability_DefaultSurfaces_IsChatPlusMcp()
+	{
+		var builder = new TestConventionBuilder();
+
+		builder.WithCapability("default_tool", "default surfaces");
+
+		var metadata = builder.AppliedMetadata.OfType<CapabilityMetadata>().Single();
+		metadata.Surfaces.Should().Be(CapabilitySurface.Chat | CapabilitySurface.Mcp);
+	}
+
+	private sealed class TestConventionBuilder : IEndpointConventionBuilder
+	{
+		public List<object> AppliedMetadata { get; } = [];
+
+		public void Add(Action<EndpointBuilder> convention)
+		{
+			var endpointBuilder = new TestEndpointBuilder();
+			convention(endpointBuilder);
+			AppliedMetadata.AddRange(endpointBuilder.Metadata);
+		}
+
+		public void Finally(Action<EndpointBuilder> finallyConvention)
+		{
+		}
+	}
+
+	private sealed class TestEndpointBuilder : EndpointBuilder
+	{
+		public override Endpoint Build() => throw new NotSupportedException();
+	}
+}


### PR DESCRIPTION
Phase 3 of the capability surface epic (#637, [ADR 0002](../blob/develop/docs/adr/0002-capability-surface-for-chat-mcp.md)). Adds the single-source-of-truth manifest that Phase 4 (MCP server) will consume. **Branched off develop** — architecturally orthogonal to the Phase 2 chat work (which calls these endpoints in-process via SK function calling) and can ship/merge independently.

## What this unlocks

- **Phase 4 (MCP server)** can now consume `/.well-known/yumney-capabilities` per host instead of hand-rolled tool descriptor lists.
- Future LLM surfaces (voice, CLI) get the same manifest for free.
- The capability set is now self-documenting — adding a new chat tool is one `WithCapability(...)` chained on the route mapping.

## Surface

```
GET {host}/.well-known/yumney-capabilities
→ {
    "serviceName": "recipes-api",
    "capabilities": [
      { "name": "search_recipes", "description": "…", "surfaces": "All", "httpMethod": "GET", "routePattern": "/api/v1/recipes/" },
      …
    ]
  }
```

## What's added

**`src/Yumney.Shared.Capabilities/`** (new project, primitives only — no deps):
- `CapabilitySurface` flags enum (`None` / `Chat` / `Mcp` / `Voice` / `All`)
- `CapabilityMetadata` — endpoint metadata attached via `WithCapability(...)`
- `CapabilityDescriptor` + `CapabilityManifest` — wire shapes returned by the manifest endpoint

**`src/Yumney.Shared.Web/Capabilities/`**:
- `CapabilityRouteBuilderExtensions.WithCapability(name, description, surfaces)` attaches `CapabilityMetadata` to any `IEndpointConventionBuilder` (chains on `MapGet/MapPost/...`)
- `CapabilityManifestEndpoint.MapCapabilityManifest(serviceName)` maps `/.well-known/yumney-capabilities` and enumerates the host's `EndpointDataSource` for tagged routes

## Tagged endpoints (9)

Matching the chat tool surface from the Phase 2 stack:

| Module | Endpoint | Capability | Surfaces |
|---|---|---|---|
| Recipes | `GET /recipes` | `search_recipes` | All |
| Recipes | `GET /recipes/{id}` | `get_recipe` | All |
| Recipes | `GET /recipes/what-can-i-cook` | `get_cookable_recipes` | All |
| Recipes | `POST /recipes/import` | `import_recipe_from_url` | Mcp \| Voice (chat handles URL detection deterministically per Phase 2 design) |
| MealPlan | `GET /meal-plans/{year}/w/{week}` | `get_weekly_plan` | All |
| MealPlan | `POST /meal-plans/{year}/w/{week}/slots` | `assign_meal` | Chat \| Mcp |
| MealPlan | `PUT /meal-plans/{year}/w/{week}/slots/confirm` | `confirm_meal_cooked` | Chat \| Mcp |
| Shopping | `GET /shopping-lists/merged` | `get_merged_shopping_list` | All |
| Shopping | `POST /shopping-lists/from-recipes` | `create_shopping_list_from_recipes` | Chat \| Mcp |

Each module's `*ApiModule.RegisterEndpoints` calls `MapCapabilityManifest("<service-name>")` so each host advertises its own slice. Phase 4 will aggregate at the gateway.

## Tests

- 4 `CapabilityManifestEndpointTests` — only-tagged projection, HTTP method extraction, name/description/surface preservation, empty case (uses a `TestEndpointDataSource` with hand-built `RouteEndpoint`s, no live host needed)
- 2 `CapabilityRouteBuilderExtensionsTests` — metadata attached, default surfaces = `Chat | Mcp`
- 2 `CapabilityTaggingTests` (architecture) scanning src files for `WithCapability(name: "...")`:
  - Every name is unique across the solution (LLM contract — duplicates make the manifest ambiguous)
  - Every name is snake_case (`^[a-z][a-z0-9_]*$`)

Tallies: Shared 297 (+8) / Architecture 142 (+2) / Recipes.Api 161 / Shopping.Api 29 — all green.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Backend impacted tests — all green
- [ ] Manual: hit each module's `/.well-known/yumney-capabilities` from the Aspire dashboard, verify the expected entries appear

## What's deferred to follow-ups

- **Gateway aggregation** — combining per-host manifests at `Yumney.Gateway` so a single endpoint serves the union. Small follow-up; the per-host endpoint is sufficient for Phase 4 (MCP server connects per host or aggregates client-side).
- **OpenAPI vendor extension** — surfacing `x-yumney-capability` inside the OpenAPI document so Scalar / external tooling can see the tagging. Same data, different transport — separate PR.
- **SK tool descriptor regeneration from manifest** — Phase 2's hand-registered SK `KernelFunction`s could read the manifest at startup instead of being wired one-by-one. Deferred until Phase 2 stack lands and we know the maintenance burden.
- **`Yumney.Mcp.Server`** — that's Phase 4 (#641), the consumer of this manifest.

Refs #640
Refs #637