### PR TITLE
feat(infra): Yumney.Mcp.Server bootstrap with capability discovery (Phase 4a of #641)

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -3,6 +3,7 @@
   <Folder Name="/src/Host/">
     <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
     <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
+    <Project Path="src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj" />
     <Project Path="src/Yumney.ServiceDefaults/Yumney.ServiceDefaults.csproj" />
     <Project Path="src/Yumney.MigrationRunner/Yumney.MigrationRunner.csproj" />
   </Folder>
@@ -85,5 +86,6 @@
   <Folder Name="/tests/Cross-Cutting/">
     <Project Path="tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj" />
     <Project Path="tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj" />
+    <Project Path="tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -222,6 +222,15 @@ if (!options.DatabaseOnly)
 			.WithReference(shell)
 			.WithReference(keycloak)
 			.WaitFor(keycloak);
+
+		// MCP server: aggregates the per-host capability manifests on startup
+		// (Phase 4a). Phase 4b adds the actual ModelContextProtocol surface +
+		// gateway routing. Not yet exposed externally.
+		builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
+			.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+			.WithReference(recipesApi)
+			.WithReference(shoppingApi)
+			.WithReference(mealplanApi);
 	}
 	else if (!isRunMode)
 	{

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Yumney.Users.Api\Yumney.Users.Api.csproj" />
     <ProjectReference Include="..\Yumney.MealPlan.Api\Yumney.MealPlan.Api.csproj" />
     <ProjectReference Include="..\Yumney.Gateway\Yumney.Gateway.csproj" />
+    <ProjectReference Include="..\Yumney.Mcp.Server\Yumney.Mcp.Server.csproj" />
     <ProjectReference Include="..\Yumney.MigrationRunner\Yumney.MigrationRunner.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
+++ b/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Thread-safe singleton holding the union of capability manifests fetched
+/// from every known module host. Phase 4b will project this into MCP tool
+/// descriptors; Phase 4a only exposes it via a debug endpoint.
+/// </summary>
+public sealed class AggregatedCapabilityRegistry
+{
+	private readonly ConcurrentDictionary<string, CapabilityManifest> manifestsByService = new(StringComparer.Ordinal);
+
+	/// <summary>Gets all currently-discovered manifests, keyed by Aspire service name.</summary>
+	public IReadOnlyDictionary<string, CapabilityManifest> Manifests => manifestsByService;
+
+	/// <summary>Gets the total count of capabilities across every discovered manifest.</summary>
+	public int CapabilityCount => manifestsByService.Values.Sum(manifest => manifest.Capabilities.Count);
+
+	/// <summary>Replace the manifest entry for a service. Called by the discovery service after a successful fetch.</summary>
+	/// <param name="serviceName">Aspire service name (e.g. <c>recipes-api</c>).</param>
+	/// <param name="manifest">Manifest just fetched from that service.</param>
+	public void SetManifest(string serviceName, CapabilityManifest manifest) =>
+		manifestsByService[serviceName] = manifest;
+
+	/// <summary>Clear the manifest entry for a service (called when a fetch fails so the registry doesn't serve stale data).</summary>
+	/// <param name="serviceName">Aspire service name.</param>
+	public void RemoveManifest(string serviceName) => manifestsByService.TryRemove(serviceName, out _);
+
+	/// <summary>Return the union of all discovered capabilities across services.</summary>
+	/// <returns>Flat list of every capability descriptor across every discovered service.</returns>
+	public IReadOnlyList<CapabilityDescriptor> AllCapabilities() =>
+		[.. manifestsByService.Values.SelectMany(manifest => manifest.Capabilities)];
+}

--- a/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
+++ b/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Background service that fetches the capability manifest from each module
+/// host on startup and pokes the result into <see cref="AggregatedCapabilityRegistry"/>.
+/// Failures are logged and skipped — a transient outage on one module must not
+/// stop the MCP server from booting.
+/// </summary>
+#pragma warning disable SA1303
+internal sealed partial class CapabilityDiscoveryService(
+	IHttpClientFactory httpClientFactory,
+	AggregatedCapabilityRegistry registry,
+	ILogger<CapabilityDiscoveryService> logger) : BackgroundService
+{
+	private const string wellKnownPath = "/.well-known/yumney-capabilities";
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			if (stoppingToken.IsCancellationRequested) return;
+			await DiscoverFromServiceAsync(serviceName, stoppingToken);
+		}
+
+		LogDiscoveryComplete(registry.Manifests.Count, registry.CapabilityCount);
+	}
+
+	private async Task DiscoverFromServiceAsync(string serviceName, CancellationToken cancellationToken)
+	{
+		try
+		{
+			var client = httpClientFactory.CreateClient(serviceName);
+			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, cancellationToken);
+			if (manifest is null)
+			{
+				LogManifestNullFor(serviceName);
+				registry.RemoveManifest(serviceName);
+				return;
+			}
+
+			registry.SetManifest(serviceName, manifest);
+			LogManifestFor(serviceName, manifest.Capabilities.Count);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogManifestFetchFailed(serviceName, ex.Message);
+			registry.RemoveManifest(serviceName);
+		}
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "Discovery complete: {ServiceCount} services, {CapabilityCount} total capabilities.")]
+	private partial void LogDiscoveryComplete(int serviceCount, int capabilityCount);
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "Discovered {CapabilityCount} capabilities from {ServiceName}.")]
+	private partial void LogManifestFor(string serviceName, int capabilityCount);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Manifest endpoint at {ServiceName} returned null payload.")]
+	private partial void LogManifestNullFor(string serviceName);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch capability manifest from {ServiceName}: {Reason}")]
+	private partial void LogManifestFetchFailed(string serviceName, string reason);
+}

--- a/src/Yumney.Mcp.Server/Discovery/KnownCapabilityHosts.cs
+++ b/src/Yumney.Mcp.Server/Discovery/KnownCapabilityHosts.cs
@@ -1,0 +1,17 @@
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Aspire service names of every module host that publishes a capability
+/// manifest. Discovery walks this list at startup. Adding a new module is a
+/// one-line change here.
+/// </summary>
+public static class KnownCapabilityHosts
+{
+	/// <summary>The Aspire service names this server discovers manifests from.</summary>
+	public static readonly IReadOnlyList<string> ServiceNames =
+	[
+		"recipes-api",
+		"mealplan-api",
+		"shopping-api",
+	];
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,0 +1,35 @@
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+// Register an HttpClient per known module host. Service discovery resolves
+// the http://<service-name> base address via Aspire.
+foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+{
+	builder.Services.AddHttpClient(serviceName, client => client.BaseAddress = new Uri($"http://{serviceName}"))
+		.AddServiceDiscovery()
+		.AddStandardResilienceHandler();
+}
+
+builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
+builder.Services.AddHostedService<CapabilityDiscoveryService>();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+// Phase 4a debug endpoint: dump everything the discovery service has found so
+// we can verify the cross-host pipeline works before adding the MCP protocol
+// surface in Phase 4b.
+app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) => Results.Ok(new
+{
+	serviceCount = registry.Manifests.Count,
+	capabilityCount = registry.CapabilityCount,
+	services = registry.Manifests.Keys.Order().ToArray(),
+	capabilities = registry.AllCapabilities(),
+}));
+
+app.Run();

--- a/src/Yumney.Mcp.Server/Properties/launchSettings.json
+++ b/src/Yumney.Mcp.Server/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Yumney.Mcp.Server.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.ServiceDefaults\Yumney.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Mcp.Server/appsettings.Development.json
+++ b/src/Yumney.Mcp.Server/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "SmartSolutionsLab.Yumney.Mcp.Server": "Debug"
+    }
+  }
+}

--- a/src/Yumney.Mcp.Server/appsettings.json
+++ b/src/Yumney.Mcp.Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/Yumney.Mcp.Server.Tests/Discovery/AggregatedCapabilityRegistryTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Discovery/AggregatedCapabilityRegistryTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Discovery;
+
+public class AggregatedCapabilityRegistryTests
+{
+	[Fact]
+	public void SetManifest_NewService_AddsManifest()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var manifest = new CapabilityManifest("recipes-api", [
+			Descriptor("search_recipes", "GET", "/recipes"),
+			Descriptor("get_recipe", "GET", "/recipes/{id}"),
+		]);
+
+		registry.SetManifest("recipes-api", manifest);
+
+		registry.Manifests.Should().ContainKey("recipes-api");
+		registry.Manifests["recipes-api"].Should().BeSameAs(manifest);
+		registry.CapabilityCount.Should().Be(2);
+	}
+
+	[Fact]
+	public void SetManifest_OverwritesExistingManifestForSameService()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+		var newer = new CapabilityManifest("recipes-api", [
+			Descriptor("a", "GET", "/a"),
+			Descriptor("b", "POST", "/b"),
+		]);
+
+		registry.SetManifest("recipes-api", newer);
+
+		registry.Manifests.Should().HaveCount(1);
+		registry.CapabilityCount.Should().Be(2);
+	}
+
+	[Fact]
+	public void RemoveManifest_DropsExistingService()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+
+		registry.RemoveManifest("recipes-api");
+
+		registry.Manifests.Should().BeEmpty();
+		registry.CapabilityCount.Should().Be(0);
+	}
+
+	[Fact]
+	public void RemoveManifest_UnknownService_IsNoOp()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+
+		registry.RemoveManifest("not-here");
+
+		registry.Manifests.Should().HaveCount(1);
+	}
+
+	[Fact]
+	public void AllCapabilities_ReturnsUnionAcrossServices()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [
+			Descriptor("search_recipes", "GET", "/recipes"),
+			Descriptor("get_recipe", "GET", "/recipes/{id}"),
+		]));
+		registry.SetManifest("shopping-api", new CapabilityManifest("shopping-api", [
+			Descriptor("get_merged_shopping_list", "GET", "/shopping-lists/merged"),
+		]));
+
+		var all = registry.AllCapabilities();
+
+		all.Should().HaveCount(3);
+		all.Select(descriptor => descriptor.Name).Should().Contain(["search_recipes", "get_recipe", "get_merged_shopping_list"]);
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, string method, string route) =>
+		new(name, $"description for {name}", CapabilitySurface.All, method, route);
+}

--- a/tests/Yumney.Mcp.Server.Tests/Discovery/CapabilityDiscoveryServiceTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Discovery/CapabilityDiscoveryServiceTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Discovery;
+
+public class CapabilityDiscoveryServiceTests
+{
+	[Fact]
+	public async Task ExecuteAsync_FetchesManifestForEveryKnownHost()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = BuildFactoryReturningManifestForEveryHost();
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Keys.Should().BeEquivalentTo(KnownCapabilityHosts.ServiceNames);
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_OneHostFails_OthersStillRecorded()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			factory.CreateClient(serviceName).Returns(serviceName == "shopping-api"
+				? FailingClient()
+				: SuccessClient(new CapabilityManifest(serviceName, [Descriptor("tool_a", serviceName)])));
+		}
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Should().ContainKeys("recipes-api", "mealplan-api");
+		registry.Manifests.Should().NotContainKey("shopping-api");
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_NullManifestPayload_DoesNotRecordEntry()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			factory.CreateClient(serviceName).Returns(NullPayloadClient());
+		}
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Should().BeEmpty();
+	}
+
+	private static IHttpClientFactory BuildFactoryReturningManifestForEveryHost()
+	{
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			var manifest = new CapabilityManifest(serviceName, [Descriptor("tool_a", serviceName), Descriptor("tool_b", serviceName)]);
+			factory.CreateClient(serviceName).Returns(SuccessClient(manifest));
+		}
+
+		return factory;
+	}
+
+	private static HttpClient SuccessClient(CapabilityManifest manifest) =>
+		new(new StubHandler(HttpStatusCode.OK, JsonSerializer.Serialize(manifest)))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient FailingClient() =>
+		new(new StubHandler(HttpStatusCode.InternalServerError, "boom"))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient NullPayloadClient() =>
+		new(new StubHandler(HttpStatusCode.OK, "null"))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static CapabilityDescriptor Descriptor(string name, string serviceName) =>
+		new(name, $"{name} on {serviceName}", CapabilitySurface.All, "GET", $"/{name}");
+
+	private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(status)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			});
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
+++ b/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.Mcp.Server\Yumney.Mcp.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Phase 4a of the capability surface epic (#637, [ADR 0002](../blob/develop/docs/adr/0002-capability-surface-for-chat-mcp.md)). Stands up the new MCP server host project with capability-manifest discovery as its foundation. Stacks on #647 (Phase 3) which introduced the per-host manifest endpoints this server consumes.

## Why intentionally pre-MCP-protocol

The full MCP server epic (#641) is large enough that I'm shipping it in slices. **Phase 4a proves the cross-host manifest pipeline works end-to-end** before adding the MCP SDK + tool registration in Phase 4b. The split keeps each PR reviewable and lets us catch any service-discovery / Aspire wiring issues with a known-quantity payload (the manifest JSON) before the more complex protocol layer rides on top.

## Surface

```
GET http://mcp-server/discovered-capabilities
→ {
    "serviceCount": 3,
    "capabilityCount": 9,
    "services": ["mealplan-api", "recipes-api", "shopping-api"],
    "capabilities": [{ "name": "search_recipes", … }, …]
  }
```

This is a **Phase 4a debug endpoint only**. Phase 4b replaces it with the actual MCP protocol surface mounted at `/mcp`.

## What's added

**`src/Yumney.Mcp.Server/`** (new ASP.NET Core 10 host):
- `Discovery/KnownCapabilityHosts.cs` — list of Aspire service names (`recipes-api`, `mealplan-api`, `shopping-api`) the server walks at startup. Adding a new module is one line.
- `Discovery/AggregatedCapabilityRegistry.cs` — thread-safe singleton holding the union of fetched manifests. Exposes `Manifests`, `CapabilityCount`, `AllCapabilities()`. `ConcurrentDictionary` keyed by service name; `SetManifest` is overwrite-by-default so refresh is straightforward.
- `Discovery/CapabilityDiscoveryService.cs` — `BackgroundService` that fetches `/.well-known/yumney-capabilities` from each known host on startup. **Failures are logged and skipped** — one module being down must not stop the MCP server from booting (especially relevant for partial outages and ordered-startup scenarios).
- `Program.cs` — `WebApplication` with `AddServiceDefaults`, an `HttpClient` per known host (Aspire service discovery + standard resilience handler), and the debug endpoint above.
- `appsettings.json` / `appsettings.Development.json` / `Properties/launchSettings.json` — minimal host plumbing.

**`src/Yumney.AppHost/Program.cs`** — registers the new project as `mcp-server` with `WithReference` to the three module APIs. No external endpoint exposed yet — Gateway routing comes in Phase 4b.

**`Yumney.slnx`** — registers `src/Yumney.Mcp.Server/` under `/src/Host/` and `tests/Yumney.Mcp.Server.Tests/` under `/tests/Cross-Cutting/`.

## Tests

- 5 `AggregatedCapabilityRegistryTests` — set/overwrite/remove/unknown-removal/union
- 3 `CapabilityDiscoveryServiceTests` — every host fetched, partial failure tolerated (one host's 500 doesn't drop the others), `null` payload not recorded

Tests use a stub `HttpMessageHandler` to fake the manifest endpoint without needing a live server.

All 8 new tests green; no existing tests touched.

## What's deferred

- **Phase 4b** — `ModelContextProtocol.AspNetCore` SDK (1.3.0 is GA on NuGet), tool registration from the registry, MCP protocol surface at `/mcp`, Gateway routing
- **Phase 4c** — Keycloak OAuth bridge (per the MCP spec's standard auth flow)
- **Phase 4d** — REST proxy that picks up the user's bearer token and calls module endpoints when MCP tools are invoked

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] New tests — 8 / 8 green
- [ ] Manual: `dotnet run --project src/Yumney.AppHost`, hit the new `mcp-server` resource in the dashboard, GET `/discovered-capabilities`, verify all 9 Phase 3 capabilities appear

## Stacking

Branched from `feat/US-640-capability-manifest` (PR #647). Targets that branch — base will auto-retarget to develop after #647 merges.

Refs #641
Refs #637