### PR TITLE
feat(infra): MCP protocol surface — tool listing live, invocation stubbed (Phase 4b of #641)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,9 @@
     <!-- LLM & Scraping -->
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
+    <!-- Model Context Protocol (used by Yumney.Mcp.Server to expose capabilities to external LLM clients per ADR 0002) -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
     <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.31.1" />

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -181,6 +181,16 @@ if (!options.DatabaseOnly)
 	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
 	migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
 
+	// MCP server: aggregates the per-host capability manifests on startup and
+	// exposes them as MCP tools at /mcp (Phase 4b). Tool invocation returns a
+	// stub until the OAuth bridge + REST proxy land in Phase 4c. Declared
+	// outside the run/publish branches because both gateways route to it.
+	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
+		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.WithReference(recipesApi)
+		.WithReference(shoppingApi)
+		.WithReference(mealplanApi);
+
 	if (isRunMode)
 	{
 		// Run mode (including E2E) spawns the Angular dev servers and the gateway
@@ -219,18 +229,10 @@ if (!options.DatabaseOnly)
 			.WithReference(shoppingApi)
 			.WithReference(usersApi)
 			.WithReference(mealplanApi)
+			.WithReference(mcpServer)
 			.WithReference(shell)
 			.WithReference(keycloak)
 			.WaitFor(keycloak);
-
-		// MCP server: aggregates the per-host capability manifests on startup
-		// (Phase 4a). Phase 4b adds the actual ModelContextProtocol surface +
-		// gateway routing. Not yet exposed externally.
-		builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
-			.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-			.WithReference(recipesApi)
-			.WithReference(shoppingApi)
-			.WithReference(mealplanApi);
 	}
 	else if (!isRunMode)
 	{
@@ -246,6 +248,7 @@ if (!options.DatabaseOnly)
 				yarp.AddRoute("/api/v1/shopping-lists/{**catch-all}", shoppingApi);
 				yarp.AddRoute("/api/v1/auth/{**catch-all}", usersApi);
 				yarp.AddRoute("/api/v1/meal-plans/{**catch-all}", mealplanApi);
+				yarp.AddRoute("/mcp/{**catch-all}", mcpServer);
 				yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
 			})
 			.WithExternalHttpEndpoints();

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -41,6 +41,12 @@
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
+      "mcp-route": {
+        "ClusterId": "mcp-server",
+        "Match": {
+          "Path": "/mcp/{**remainder}"
+        }
+      },
       "keycloak-route": {
         "ClusterId": "keycloak",
         "Match": {
@@ -89,6 +95,13 @@
         "Destinations": {
           "primary": {
             "Address": "https+http://mealplan-api"
+          }
+        }
+      },
+      "mcp-server": {
+        "Destinations": {
+          "primary": {
+            "Address": "https+http://mcp-server"
           }
         }
       },

--- a/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
+++ b/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
@@ -1,0 +1,71 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Translates discovered <see cref="CapabilityDescriptor"/>s into MCP
+/// <see cref="Tool"/> descriptors and routes <see cref="CallToolRequestParams"/>
+/// invocations. Phase 4b returns a stub message for invocations because the
+/// REST proxy + Keycloak OAuth bridge land in Phase 4c. List-tools is fully
+/// functional so external MCP clients (Claude Desktop, custom GPTs) can
+/// already enumerate the surface and verify the connection.
+/// </summary>
+#pragma warning disable SA1303
+public static class CapabilityToolRegistration
+{
+	private const string mcpStubInvocationMessage =
+		"The Yumney MCP server is in setup. Tool listing is live, but tool invocation "
+		+ "lands with the Keycloak OAuth bridge + REST proxy in Phase 4c (#641). "
+		+ "Track progress at https://github.com/smartsolutionslab/yumney/issues/641.";
+
+	/// <summary>List the discovered capabilities exposed on the <c>Mcp</c> surface as MCP tools.</summary>
+	/// <param name="registry">Registry populated by <see cref="CapabilityDiscoveryService"/>.</param>
+	/// <returns>The current MCP-surface tools, one per capability with surface flag <c>Mcp</c>.</returns>
+	public static IReadOnlyList<Tool> BuildTools(AggregatedCapabilityRegistry registry) =>
+		[.. registry.AllCapabilities()
+			.Where(capability => capability.Surfaces.HasFlag(CapabilitySurface.Mcp))
+			.Select(ToTool)];
+
+	/// <summary>Stub call-tool result returned in Phase 4b until the REST proxy ships.</summary>
+	/// <param name="toolName">Name the caller asked to invoke.</param>
+	/// <returns>A non-error tool result with the stub message.</returns>
+	public static CallToolResult BuildStubInvocationResult(string toolName) =>
+		new()
+		{
+			Content = [new TextContentBlock { Text = $"[{toolName}] {mcpStubInvocationMessage}" }],
+			IsError = false,
+		};
+
+	/// <summary>The MCP <c>tools/list</c> handler — projects the registry into the protocol shape.</summary>
+	/// <param name="context">Request context (unused — we list everything).</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>The current MCP-surface tools.</returns>
+	public static ValueTask<ListToolsResult> ListToolsAsync(
+		RequestContext<ListToolsRequestParams> context,
+		CancellationToken cancellationToken)
+	{
+		var registry = context.Services!.GetRequiredService<AggregatedCapabilityRegistry>();
+		return ValueTask.FromResult(new ListToolsResult { Tools = [.. BuildTools(registry)] });
+	}
+
+	/// <summary>The MCP <c>tools/call</c> handler — Phase 4b stub; Phase 4c proxies to module REST.</summary>
+	/// <param name="context">Request context with the called tool's name + arguments.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>The stub result.</returns>
+	public static ValueTask<CallToolResult> CallToolAsync(
+		RequestContext<CallToolRequestParams> context,
+		CancellationToken cancellationToken)
+	{
+		var name = context.Params?.Name ?? "<unknown>";
+		return ValueTask.FromResult(BuildStubInvocationResult(name));
+	}
+
+	private static Tool ToTool(CapabilityDescriptor capability) => new()
+	{
+		Name = capability.Name,
+		Description = $"{capability.Description} (proxies {capability.HttpMethod} {capability.RoutePattern})",
+	};
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,19 +18,29 @@ foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
 builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
 builder.Services.AddHostedService<CapabilityDiscoveryService>();
 
+builder.Services.AddMcpServer()
+	.WithHttpTransport()
+	.WithListToolsHandler(CapabilityToolRegistration.ListToolsAsync)
+	.WithCallToolHandler(CapabilityToolRegistration.CallToolAsync);
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
-// Phase 4a debug endpoint: dump everything the discovery service has found so
-// we can verify the cross-host pipeline works before adding the MCP protocol
-// surface in Phase 4b.
+// Debug endpoint: dump everything the discovery service has found so we can
+// verify the cross-host pipeline + MCP-surface filtering at a glance without
+// speaking the full MCP protocol.
 app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) => Results.Ok(new
 {
 	serviceCount = registry.Manifests.Count,
 	capabilityCount = registry.CapabilityCount,
+	mcpToolCount = CapabilityToolRegistration.BuildTools(registry).Count,
 	services = registry.Manifests.Keys.Order().ToArray(),
 	capabilities = registry.AllCapabilities(),
 }));
+
+// MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
+// connect here once OAuth ships in Phase 4c.
+app.MapMcp("/mcp");
 
 app.Run();

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class CapabilityToolRegistrationTests
+{
+	[Fact]
+	public void BuildTools_OnlyIncludesCapabilitiesWithMcpSurface()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("search_recipes", CapabilitySurface.All),
+			Descriptor("chat_only_tool", CapabilitySurface.Chat),
+			Descriptor("voice_only_tool", CapabilitySurface.Voice),
+			Descriptor("mcp_only_tool", CapabilitySurface.Mcp),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().HaveCount(2);
+		tools.Select(tool => tool.Name).Should().BeEquivalentTo(["search_recipes", "mcp_only_tool"]);
+	}
+
+	[Fact]
+	public void BuildTools_IncludesRoutePatternInDescription()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			new CapabilityDescriptor(
+				"search_recipes",
+				"Search the user's recipes",
+				CapabilitySurface.All,
+				HttpMethod: "GET",
+				RoutePattern: "/api/v1/recipes/"),
+		]));
+
+		var tool = CapabilityToolRegistration.BuildTools(registry).Single();
+
+		tool.Name.Should().Be("search_recipes");
+		tool.Description.Should().Contain("Search the user's recipes");
+		tool.Description.Should().Contain("GET /api/v1/recipes/");
+	}
+
+	[Fact]
+	public void BuildTools_EmptyRegistry_ReturnsEmptyList()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void BuildTools_NoMcpSurfaceCapabilities_ReturnsEmptyList()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("chat_only", CapabilitySurface.Chat),
+			Descriptor("voice_only", CapabilitySurface.Voice),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void BuildStubInvocationResult_ReferencesRequestedToolName()
+	{
+		var result = CapabilityToolRegistration.BuildStubInvocationResult("search_recipes");
+
+		result.IsError.Should().BeFalse();
+		result.Content.Should().ContainSingle();
+		var text = result.Content.OfType<TextContentBlock>().Single().Text;
+		text.Should().Contain("[search_recipes]");
+		text.Should().Contain("Phase 4c");
+	}
+
+	[Fact]
+	public void BuildTools_UnionsAcrossManifestsFromMultipleServices()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("search_recipes", CapabilitySurface.All),
+		]));
+		registry.SetManifest("shopping-api", new CapabilityManifest(
+			"shopping-api",
+			[
+			Descriptor("get_merged_shopping_list", CapabilitySurface.Mcp),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Select(tool => tool.Name).Should().BeEquivalentTo(["search_recipes", "get_merged_shopping_list"]);
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, CapabilitySurface surfaces) =>
+		new(name, $"description for {name}", surfaces, "GET", $"/{name}");
+}


### PR DESCRIPTION
Phase 4b builds on Phase 4a's discovery foundation (#648). The MCP server now speaks the Model Context Protocol over HTTP/SSE — external clients (Claude Desktop, custom GPTs) can connect, list discovered capabilities as tools, and invoke them. **Invocation returns a stub message** until Phase 4c lands the OAuth bridge + REST proxy.

## Why split listing from invocation

Tool invocation requires a bearer token to call the module REST endpoints (which require Keycloak JWT). Without OAuth, invocation can't actually proxy. So the natural slice is:

- **Phase 4b** (this PR): protocol surface live, list-tools is real, call-tool is a stub message naming the Phase 4c milestone
- **Phase 4c**: OAuth bridge + REST proxy together (one is useless without the other)

This way Claude Desktop can already connect and verify the connection; we get protocol-level validation (handshake, transport, JSON-RPC framing) before the auth complexity rides on top.

## Surface

```
GET  http://mcp-server/discovered-capabilities  (debug — registry dump + mcpToolCount)
*    http://mcp-server/mcp                      (MCP protocol via HTTP/SSE)
```

Both routed through Yumney.Gateway under `/mcp/*`.

## What's added

**`Directory.Packages.props`** — `ModelContextProtocol` + `ModelContextProtocol.AspNetCore` 1.3.0 (GA).

**`src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs`**:
- `BuildTools(registry)` — projects discovered `CapabilityDescriptor`s with `Surface=Mcp` into MCP `Tool` definitions. **Voice-only / chat-only capabilities are not exposed** to MCP clients (per ADR 0002 — MCP is for external clients, chat-only directives like `Navigate` make no sense outside the Yumney shell).
- `ListToolsAsync` handler — passthrough to `BuildTools`, scoped to the request's `IServiceProvider`.
- `CallToolAsync` handler — returns a stub `CallToolResult` naming the tool and pointing at the Phase 4c milestone (#641).

**`src/Yumney.Mcp.Server/Program.cs`**:
- `AddMcpServer().WithHttpTransport()` + `WithListToolsHandler(...)` + `WithCallToolHandler(...)`
- `app.MapMcp("/mcp")` exposes the SSE transport
- `/discovered-capabilities` debug endpoint extended with `mcpToolCount` (count of tools the MCP surface advertises, vs. total `capabilityCount` in the registry)

**`src/Yumney.AppHost/Program.cs`**:
- MCP server registration moved out of the run-mode-only block so publish-mode YARP also routes to it
- `mcp-route` added to gateway YARP config (both run-mode `appsettings.json` and publish-mode `AddYarp` inline config)

## Tests

6 new `CapabilityToolRegistrationTests`:
- Mcp-surface filter (chat-only / voice-only excluded)
- Description includes route pattern (`"GET /api/v1/recipes/"`)
- Empty registry → empty tool list
- No-mcp-surface → empty tool list
- Stub call result names the requested tool + references Phase 4c
- Multi-service union (recipes + shopping → both surfaces appear)

`Yumney.Mcp.Server.Tests` now 14 / 14 green (8 from Phase 4a + 6 new).

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] All Mcp.Server tests green
- [ ] Manual: `dotnet run --project src/Yumney.AppHost`, connect Claude Desktop to `http://localhost:5100/mcp`, verify it lists ~7 tools (the Mcp-surface subset of the 9 tagged endpoints from Phase 3)
- [ ] Manual: invoke any tool from Claude Desktop, verify the stub message comes back with the tool name embedded

## What's deferred

- **Phase 4c** — Keycloak OAuth bridge (MCP standard auth flow) + REST proxy that picks up the user's bearer token and calls module endpoints. These are tightly coupled — proxy is useless without auth, and there's no point exposing OAuth without something to call.
- Per-tool Keycloak scopes — single `yumney.api` scope to start; revisit when an integration partner forces it.
- Stdio MCP transport — Yumney is a hosted PWA; HTTP/SSE is the only transport that makes sense.

## Stacking

Branched from `feat/US-641a-mcp-server-bootstrap` (PR #648). Targets that branch — base will auto-retarget as the chain merges.

Refs #641
Refs #637