### PR TITLE
feat(infra): MCP REST proxy + Keycloak JWT bearer (Phase 4c of #641)

### DIFF
--- a/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
+++ b/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+
+/// <summary>
+/// JWT bearer wiring against Keycloak — mirrors the pattern in
+/// <c>Yumney.Shared.Web.HostBuilderExtensions.AddYumneyDefaults</c> but
+/// inlined here to keep the MCP server's dependency footprint small (no
+/// Wolverine, no Persistence, no EF Core).
+/// </summary>
+#pragma warning disable SA1303
+public static class KeycloakAuthExtensions
+{
+	private const string realmConfigKey = "Keycloak:Realm";
+	private const string keycloakConnectionStringName = "keycloak";
+	private const string defaultRealm = "yumney";
+	private const string defaultUrl = "http://localhost:8080";
+	private const string audience = "yumney-api";
+
+	/// <summary>Add JWT bearer auth pointing at the Aspire-provisioned Keycloak realm.</summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="configuration">Configuration source.</param>
+	/// <param name="environment">Host environment — controls dev-mode laxity.</param>
+	/// <returns>The service collection for chaining.</returns>
+	public static IServiceCollection AddKeycloakBearerAuthentication(
+		this IServiceCollection services,
+		IConfiguration configuration,
+		IHostEnvironment environment)
+	{
+		var isDevelopment = environment.IsDevelopment();
+
+		services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+			.AddJwtBearer(options =>
+			{
+				options.Authority = RealmUrl(configuration);
+				options.Audience = audience;
+				options.RequireHttpsMetadata = !isDevelopment;
+				options.TokenValidationParameters.ValidateIssuer = !isDevelopment;
+				if (!isDevelopment)
+				{
+					options.TokenValidationParameters.ValidIssuer = RealmUrl(configuration);
+				}
+			});
+
+		services.AddAuthorization();
+		return services;
+	}
+
+	private static string GetBaseUrl(IConfiguration configuration) =>
+		configuration.GetConnectionString(keycloakConnectionStringName)
+			?? configuration[$"services:{keycloakConnectionStringName}:http:0"]
+			?? defaultUrl;
+
+	private static string GetRealm(IConfiguration configuration) =>
+		configuration.GetValue<string>(realmConfigKey) ?? defaultRealm;
+
+	private static string RealmUrl(IConfiguration configuration) =>
+		$"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}";
+}

--- a/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
+++ b/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
@@ -32,4 +32,28 @@ public sealed class AggregatedCapabilityRegistry
 	/// <returns>Flat list of every capability descriptor across every discovered service.</returns>
 	public IReadOnlyList<CapabilityDescriptor> AllCapabilities() =>
 		[.. manifestsByService.Values.SelectMany(manifest => manifest.Capabilities)];
+
+	/// <summary>Find the Aspire service name that owns a tool by name.</summary>
+	/// <param name="toolName">Capability name (e.g. <c>search_recipes</c>).</param>
+	/// <returns>Owning service name, or null if no discovered manifest contains it.</returns>
+	public string? ServiceNameForTool(string toolName)
+	{
+		foreach (var (serviceName, manifest) in manifestsByService)
+		{
+			if (manifest.Capabilities.Any(capability => capability.Name == toolName))
+			{
+				return serviceName;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>Find a capability descriptor by name across all discovered services.</summary>
+	/// <param name="toolName">Capability name.</param>
+	/// <returns>Descriptor with the given name, or null if not found.</returns>
+	public CapabilityDescriptor? DescriptorForTool(string toolName) =>
+		manifestsByService.Values
+			.SelectMany(manifest => manifest.Capabilities)
+			.FirstOrDefault(capability => capability.Name == toolName);
 }

--- a/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Translates an MCP <c>tools/call</c> into an HTTP call against the module
+/// endpoint that owns the named capability, forwarding the caller's bearer
+/// token. Returns the upstream response body as a <see cref="CallToolResult"/>.
+/// </summary>
+/// <param name="registry">Discovered capability registry.</param>
+/// <param name="httpClientFactory">Factory keyed by Aspire service name.</param>
+/// <param name="httpContextAccessor">Source of the caller's bearer token.</param>
+/// <param name="logger">Logger for proxy diagnostics.</param>
+public sealed partial class RestProxyService(
+	AggregatedCapabilityRegistry registry,
+	IHttpClientFactory httpClientFactory,
+	IHttpContextAccessor httpContextAccessor,
+	ILogger<RestProxyService> logger)
+{
+	/// <summary>Invoke the module endpoint behind <paramref name="toolName"/>.</summary>
+	/// <param name="toolName">Capability name from a <c>tools/list</c> response.</param>
+	/// <param name="arguments">Tool argument bag (placeholder values + body fields / query params).</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>Upstream response as a tool result, or an error result on failure.</returns>
+	public async Task<CallToolResult> InvokeAsync(
+		string toolName,
+		IDictionary<string, JsonElement>? arguments,
+		CancellationToken cancellationToken)
+	{
+		var descriptor = registry.DescriptorForTool(toolName);
+		if (descriptor is null) return Error($"Unknown tool '{toolName}'.");
+
+		var serviceName = registry.ServiceNameForTool(toolName);
+		if (serviceName is null) return Error($"Tool '{toolName}' is not bound to a discovered service.");
+
+		var built = RouteUrlBuilder.Build(descriptor.HttpMethod, descriptor.RoutePattern, arguments);
+		if (built.MissingPlaceholders.Count > 0)
+		{
+			return Error($"Tool '{toolName}' is missing required argument(s): {string.Join(", ", built.MissingPlaceholders)}.");
+		}
+
+		var bearer = ExtractBearer();
+		if (bearer is null) return Error("No bearer token forwarded with the MCP request — caller must authenticate.");
+
+		var client = httpClientFactory.CreateClient(serviceName);
+		using var request = new HttpRequestMessage(new HttpMethod(descriptor.HttpMethod), built.Url);
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+		if (built.Body is not null)
+		{
+			request.Content = new StringContent(built.Body, Encoding.UTF8, "application/json");
+		}
+
+		try
+		{
+			using var response = await client.SendAsync(request, cancellationToken);
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			if (!response.IsSuccessStatusCode)
+			{
+				LogUpstreamFailure(toolName, serviceName, (int)response.StatusCode);
+				return Error($"Upstream {serviceName} returned {(int)response.StatusCode}: {body}");
+			}
+
+			return new CallToolResult
+			{
+				Content = [new TextContentBlock { Text = body }],
+				IsError = false,
+			};
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogProxyException(toolName, serviceName, ex.Message);
+			return Error($"Proxy call to {serviceName} failed: {ex.Message}");
+		}
+	}
+
+	private static CallToolResult Error(string message) => new()
+	{
+		Content = [new TextContentBlock { Text = message }],
+		IsError = true,
+	};
+
+	private string? ExtractBearer()
+	{
+		var header = httpContextAccessor.HttpContext?.Request.Headers.Authorization.ToString();
+		if (string.IsNullOrEmpty(header)) return null;
+		const string prefix = "Bearer ";
+		return header.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+			? header[prefix.Length..].Trim()
+			: null;
+	}
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Proxy call for tool {ToolName} to {ServiceName} returned non-success status {StatusCode}.")]
+	private partial void LogUpstreamFailure(string toolName, string serviceName, int statusCode);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Proxy call for tool {ToolName} to {ServiceName} threw: {Reason}")]
+	private partial void LogProxyException(string toolName, string serviceName, string reason);
+}

--- a/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Substitutes <c>{name:type}</c> route placeholders with values pulled from
+/// the MCP tool argument bag, and assembles the remaining arguments into a
+/// query string (for GET) or returns them as the JSON body (for POST/PUT).
+/// </summary>
+public static partial class RouteUrlBuilder
+{
+	/// <summary>The result of building a request from a route pattern + tool arguments.</summary>
+	/// <param name="Url">Final URL with placeholders substituted and query string appended where applicable.</param>
+	/// <param name="Body">JSON body for POST/PUT, or null for GET/DELETE.</param>
+	/// <param name="MissingPlaceholders">Placeholder names that didn't have a matching argument — caller should fail the call.</param>
+	public sealed record BuiltRequest(string Url, string? Body, IReadOnlyList<string> MissingPlaceholders);
+
+	/// <summary>Build a request URL + body for an HTTP call to a module endpoint.</summary>
+	/// <param name="httpMethod">HTTP method (case-insensitive).</param>
+	/// <param name="routePattern">Route pattern from a <c>CapabilityDescriptor</c>.</param>
+	/// <param name="arguments">Tool arguments by name. Supports null arguments dictionary.</param>
+	/// <returns>Built request — caller must check <c>MissingPlaceholders</c> before sending.</returns>
+	public static BuiltRequest Build(
+		string httpMethod,
+		string routePattern,
+		IDictionary<string, JsonElement>? arguments)
+	{
+		arguments ??= new Dictionary<string, JsonElement>();
+		var consumedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var missing = new List<string>();
+
+		var path = PlaceholderPattern().Replace(routePattern, match =>
+		{
+			var placeholderName = match.Groups["name"].Value;
+			if (!arguments.TryGetValue(placeholderName, out var value))
+			{
+				missing.Add(placeholderName);
+				return match.Value;
+			}
+
+			consumedKeys.Add(placeholderName);
+			return Uri.EscapeDataString(JsonElementToString(value));
+		});
+
+		var unconsumed = arguments
+			.Where(pair => !consumedKeys.Contains(pair.Key))
+			.ToList();
+
+		if (UsesBody(httpMethod))
+		{
+			var body = unconsumed.Count == 0
+				? null
+				: JsonSerializer.Serialize(unconsumed.ToDictionary(pair => pair.Key, pair => pair.Value));
+			return new BuiltRequest(path, body, missing);
+		}
+
+		var url = unconsumed.Count == 0 ? path : $"{path}?{BuildQueryString(unconsumed)}";
+		return new BuiltRequest(url, Body: null, missing);
+	}
+
+	private static bool UsesBody(string httpMethod) =>
+		HttpMethod.Post.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase)
+		|| HttpMethod.Put.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase)
+		|| HttpMethod.Patch.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase);
+
+	private static string BuildQueryString(IReadOnlyList<KeyValuePair<string, JsonElement>> pairs)
+	{
+		var query = new StringBuilder();
+		var first = true;
+		foreach (var (key, value) in pairs)
+		{
+			if (!first) query.Append('&');
+			query.Append(Uri.EscapeDataString(key));
+			query.Append('=');
+			query.Append(Uri.EscapeDataString(JsonElementToString(value)));
+			first = false;
+		}
+
+		return query.ToString();
+	}
+
+	private static string JsonElementToString(JsonElement value) => value.ValueKind switch
+	{
+		JsonValueKind.String => value.GetString() ?? string.Empty,
+		JsonValueKind.Number => value.GetRawText(),
+		JsonValueKind.True => "true",
+		JsonValueKind.False => "false",
+		JsonValueKind.Null => string.Empty,
+		_ => value.GetRawText(),
+	};
+
+	[GeneratedRegex(@"\{(?<name>[a-zA-Z_][a-zA-Z0-9_]*)(?::[^}]+)?\}")]
+	private static partial Regex PlaceholderPattern();
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,3 +1,4 @@
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
@@ -5,6 +6,9 @@ using SmartSolutionsLab.Yumney.ServiceDefaults;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+builder.Services.AddKeycloakBearerAuthentication(builder.Configuration, builder.Environment);
+builder.Services.AddHttpContextAccessor();
 
 // Register an HttpClient per known module host. Service discovery resolves
 // the http://<service-name> base address via Aspire.
@@ -17,13 +21,22 @@ foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
 
 builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
 builder.Services.AddHostedService<CapabilityDiscoveryService>();
+builder.Services.AddScoped<RestProxyService>();
 
 builder.Services.AddMcpServer()
 	.WithHttpTransport()
 	.WithListToolsHandler(CapabilityToolRegistration.ListToolsAsync)
-	.WithCallToolHandler(CapabilityToolRegistration.CallToolAsync);
+	.WithCallToolHandler(async (context, cancellationToken) =>
+	{
+		var proxy = context.Services!.GetRequiredService<RestProxyService>();
+		var name = context.Params?.Name ?? "<unknown>";
+		return await proxy.InvokeAsync(name, context.Params?.Arguments, cancellationToken);
+	});
 
 var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapDefaultEndpoints();
 
@@ -37,10 +50,11 @@ app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) =
 	mcpToolCount = CapabilityToolRegistration.BuildTools(registry).Count,
 	services = registry.Manifests.Keys.Order().ToArray(),
 	capabilities = registry.AllCapabilities(),
-}));
+})).AllowAnonymous();
 
 // MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
-// connect here once OAuth ships in Phase 4c.
-app.MapMcp("/mcp");
+// authenticate via the standard Authorization: Bearer header — the bearer is
+// forwarded to the module endpoint by RestProxyService when the LLM calls a tool.
+app.MapMcp("/mcp").RequireAuthorization();
 
 app.Run();

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Keycloak.Authentication" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/RestProxyServiceTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/RestProxyServiceTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class RestProxyServiceTests
+{
+	[Fact]
+	public async Task InvokeAsync_UnknownTool_ReturnsErrorResult()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: "abc");
+
+		var result = await service.InvokeAsync("nonexistent_tool", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("Unknown tool");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_NoBearer_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: null);
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("No bearer token");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_MissingPlaceholder_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("get_recipe", "GET", "/api/v1/recipes/{identifier:guid}"));
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: "abc");
+
+		var result = await service.InvokeAsync("get_recipe", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("identifier");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_HappyPath_ForwardsBearerAndReturnsResponseBody()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		HttpRequestMessage? capturedRequest = null;
+		var service = BuildService(
+			registry,
+			BuildClientFactory(captured =>
+			{
+				capturedRequest = captured;
+				return SuccessClient("[{\"id\":\"abc\"}]");
+			}),
+			bearer: "the-bearer");
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("\"id\":\"abc\"");
+		capturedRequest.Should().NotBeNull();
+		capturedRequest!.Headers.Authorization!.Scheme.Should().Be("Bearer");
+		capturedRequest.Headers.Authorization.Parameter.Should().Be("the-bearer");
+		capturedRequest.Method.Method.Should().Be("GET");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UpstreamReturnsNonSuccess_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		var service = BuildService(
+			registry,
+			BuildClientFactory(_ => FailingClient(HttpStatusCode.InternalServerError, "boom")),
+			bearer: "abc");
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		var text = result.Content.OfType<TextContentBlock>().Single().Text;
+		text.Should().Contain("500");
+		text.Should().Contain("boom");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_PostBodyForwardedAsJson()
+	{
+		var registry = BuildRegistryWith(Descriptor(
+			"create_shopping_list_from_recipes",
+			"POST",
+			"/api/v1/shopping-lists/from-recipes"));
+		string? capturedMethod = null;
+		string? capturedBody = null;
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+			new HttpClient(new BodyCapturingHandler(async (request, ct) =>
+			{
+				capturedMethod = request.Method.Method;
+				capturedBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("{\"id\":\"new-list\"}", Encoding.UTF8, "application/json"),
+				};
+			}))
+			{
+				BaseAddress = new Uri("http://stub"),
+			});
+		var service = BuildService(registry, factory, bearer: "abc");
+
+		var arguments = new Dictionary<string, JsonElement>
+		{
+			["title"] = JsonSerializer.SerializeToElement("This week"),
+		};
+		var result = await service.InvokeAsync("create_shopping_list_from_recipes", arguments, CancellationToken.None);
+
+		result.IsError.Should().BeFalse();
+		capturedMethod.Should().Be("POST");
+		capturedBody.Should().NotBeNull().And.Subject.Should().Contain("\"title\"");
+	}
+
+	private static AggregatedCapabilityRegistry BuildRegistryWith(CapabilityDescriptor descriptor)
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [descriptor]));
+		return registry;
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, string method, string route) =>
+		new(name, $"description for {name}", CapabilitySurface.Mcp, method, route);
+
+	private static RestProxyService BuildService(
+		AggregatedCapabilityRegistry registry,
+		IHttpClientFactory factory,
+		string? bearer)
+	{
+		var contextAccessor = Substitute.For<IHttpContextAccessor>();
+		if (bearer is not null)
+		{
+			var context = new DefaultHttpContext();
+			context.Request.Headers.Authorization = $"Bearer {bearer}";
+			contextAccessor.HttpContext.Returns(context);
+		}
+
+		return new RestProxyService(registry, factory, contextAccessor, NullLogger<RestProxyService>.Instance);
+	}
+
+	private static IHttpClientFactory BuildClientFactory(Func<HttpRequestMessage, HttpClient> handler)
+	{
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient(Arg.Any<string>())
+			.Returns(callInfo => new HttpClient(new CapturingHandler(captured => handler(captured)))
+			{
+				BaseAddress = new Uri("http://stub"),
+			});
+		return factory;
+	}
+
+	private static HttpClient SuccessClient(string body) =>
+		new(new StubHandler(HttpStatusCode.OK, body))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient FailingClient(HttpStatusCode status, string body) =>
+		new(new StubHandler(status, body))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(status)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			});
+	}
+
+	private sealed class CapturingHandler(Func<HttpRequestMessage, HttpClient> upstream) : HttpMessageHandler
+	{
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			using var client = upstream(request);
+			using var inner = await client.SendAsync(new HttpRequestMessage(request.Method, "/"), cancellationToken);
+			var body = await inner.Content.ReadAsStringAsync(cancellationToken);
+			return new HttpResponseMessage(inner.StatusCode)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			};
+		}
+	}
+
+	private sealed class BodyCapturingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			respond(request, cancellationToken);
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/RouteUrlBuilderTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/RouteUrlBuilderTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class RouteUrlBuilderTests
+{
+	[Fact]
+	public void Build_GetWithoutPlaceholders_NoArgs_ReturnsBareRoute()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/", arguments: null);
+
+		built.Url.Should().Be("/api/v1/recipes/");
+		built.Body.Should().BeNull();
+		built.MissingPlaceholders.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Build_GetWithExtraArgs_AppendsQueryString()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/", BuildArgs(("search", "chicken"), ("page", 2)));
+
+		built.Url.Should().Contain("search=chicken").And.Contain("page=2");
+		built.Url.Should().StartWith("/api/v1/recipes/?");
+		built.Body.Should().BeNull();
+	}
+
+	[Fact]
+	public void Build_GetWithPlaceholder_SubstitutesAndOmitsFromQuery()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier:guid}", BuildArgs(("identifier", "abc-123")));
+
+		built.Url.Should().Be("/api/v1/recipes/abc-123");
+		built.Body.Should().BeNull();
+	}
+
+	[Fact]
+	public void Build_PostWithExtraArgs_PutsArgsInJsonBody()
+	{
+		var built = RouteUrlBuilder.Build("POST", "/api/v1/shopping-lists/from-recipes", BuildArgs(("title", "This week"), ("recipes", "[]")));
+
+		built.Url.Should().Be("/api/v1/shopping-lists/from-recipes");
+		built.Body.Should().NotBeNull();
+		built.Body!.Should().Contain("\"title\"");
+		built.Body.Should().Contain("\"recipes\"");
+	}
+
+	[Fact]
+	public void Build_PostWithPlaceholderAndBody_SubstitutesPathArgsAndKeepsBodyArgs()
+	{
+		var built = RouteUrlBuilder.Build(
+			"POST",
+			"/api/v1/meal-plans/{year:int}/w/{weekNumber:int}/slots",
+			BuildArgs(("year", 2026), ("weekNumber", 19), ("day", "Wednesday"), ("recipeIdentifier", "abc-123")));
+
+		built.Url.Should().Be("/api/v1/meal-plans/2026/w/19/slots");
+		built.Body.Should().Contain("\"day\"");
+		built.Body.Should().Contain("\"recipeIdentifier\"");
+		built.Body.Should().NotContain("\"year\"");
+		built.Body.Should().NotContain("\"weekNumber\"");
+	}
+
+	[Fact]
+	public void Build_MissingRequiredPlaceholder_ReportsIt()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier:guid}", arguments: null);
+
+		built.MissingPlaceholders.Should().BeEquivalentTo(["identifier"]);
+	}
+
+	[Fact]
+	public void Build_PutMethod_UsesBody()
+	{
+		var built = RouteUrlBuilder.Build(
+			"PUT",
+			"/api/v1/meal-plans/{year:int}/w/{weekNumber:int}/slots/confirm",
+			BuildArgs(("year", 2026), ("weekNumber", 19), ("day", "Wednesday"), ("state", "Cooked")));
+
+		built.Url.Should().Be("/api/v1/meal-plans/2026/w/19/slots/confirm");
+		built.Body.Should().NotBeNull();
+		built.Body!.Should().Contain("\"day\"");
+		built.Body.Should().Contain("\"state\"");
+	}
+
+	[Fact]
+	public void Build_UrlEscapesPlaceholderValuesAndQueryArgs()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier}", BuildArgs(("identifier", "with space"), ("search", "chicken & rice")));
+
+		built.Url.Should().StartWith("/api/v1/recipes/with%20space?");
+		built.Url.Should().Contain("search=chicken%20%26%20rice");
+	}
+
+	private static Dictionary<string, JsonElement> BuildArgs(params (string Key, object Value)[] pairs)
+	{
+		var dict = new Dictionary<string, JsonElement>();
+		foreach (var (key, value) in pairs)
+		{
+			var json = value switch
+			{
+				int number => JsonSerializer.SerializeToElement(number),
+				string text => JsonSerializer.SerializeToElement(text),
+				_ => JsonSerializer.SerializeToElement(value),
+			};
+			dict[key] = json;
+		}
+
+		return dict;
+	}
+}


### PR DESCRIPTION
Phase 4c finishes the Phase 4 epic server-side. The MCP server now authenticates external clients with Keycloak JWT bearer and proxies tool invocations to the discovered module endpoints, forwarding the caller's bearer all the way through. Stacks on #649.

## End-to-end flow now working

1. External client (Claude Desktop, custom GPT, …) does Keycloak OAuth → receives bearer
2. Client connects to `https://yumney/mcp` with `Authorization: Bearer <token>` → JWT validated against Keycloak realm
3. Client calls `tools/list` → registry returns discovered MCP-surface capabilities
4. Client calls `tools/call` with `{ name, arguments }` →
   - `RestProxyService` looks up the `CapabilityDescriptor` by name
   - Substitutes `{name:type}` route placeholders from arguments
   - Routes remaining args to query string (GET) or JSON body (POST/PUT/PATCH)
   - Calls the owning module endpoint with the same bearer
   - Returns the upstream response body as `CallToolResult`

## What's added

**`src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs`** — `AddKeycloakBearerAuthentication(configuration, environment)` mirrors the JWT wiring from `Yumney.Shared.Web.HostBuilderExtensions`, but **inlined here** to keep the MCP server's dependency footprint small (no Wolverine, no Persistence, no EF Core — those would all come in transitively if I referenced `Yumney.Shared.Web`).

**`src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs`**:
- Substitutes `{name:type}` route placeholders with values pulled from the MCP argument bag
- Assembles remaining args into a query string for GET / body for POST/PUT/PATCH
- Reports missing placeholder names so the proxy can fail with a useful message
- URL-escapes both placeholder values and query args (`with space` → `with%20space`, `chicken & rice` → `chicken%20%26%20rice`)

**`src/Yumney.Mcp.Server/Mcp/RestProxyService.cs`**:
- Looks up the `CapabilityDescriptor` + owning service name from `AggregatedCapabilityRegistry`
- Builds the request via `RouteUrlBuilder`
- Forwards `Authorization: Bearer …` via `IHttpContextAccessor`
- Translates upstream response into `CallToolResult` (success body verbatim, non-success → error result with status + body)

**`src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs`**:
- `ServiceNameForTool(name)` — find the Aspire service that owns a tool
- `DescriptorForTool(name)` — find the descriptor across services

**`src/Yumney.Mcp.Server/Program.cs`**:
- `AddKeycloakBearerAuthentication` + `AddHttpContextAccessor` + `AddScoped<RestProxyService>()`
- The MCP `CallToolHandler` now resolves `RestProxyService` from the per-request `IServiceProvider` and dispatches to it
- `app.MapMcp("/mcp").RequireAuthorization()` — anonymous calls now 401
- `/discovered-capabilities` stays `AllowAnonymous` (debug-only)

## Tests (14 new, total 28)

`RouteUrlBuilderTests` (8):
- GET without placeholders / no args → bare route
- GET with extra args → query string
- GET with placeholder → substituted
- POST with extra args → JSON body
- POST with placeholder + body args → both populated
- Missing required placeholder reported
- PUT uses body (matching POST semantics)
- URL-escape both placeholder values and query arg values

`RestProxyServiceTests` (6):
- Unknown tool → error result
- No bearer → error result
- Missing placeholder → error result with placeholder name
- Happy path → bearer forwarded, response body returned
- Upstream non-success → error with status code + body
- POST body forwarded as JSON

## What's deferred

- **Per-tool Keycloak scopes** — single `yumney.api` scope to start; revisit when an integration partner forces it (separate issue).
- **Dynamic client registration** — MCP spec allows it, but installing the Yumney MCP server in Claude Desktop currently requires a pre-registered Keycloak client. Documenting + automating this is a separate small PR.
- **MCP write tools beyond the four currently exposed** — Phase 3 tagged 9 endpoints; the surface adds new tools by tagging more endpoints with `[Capability(... CapabilitySurface.Mcp)]`. No MCP server changes needed.
- **Aspire integration test** for the full MCP-server-to-module round trip — separate test PR.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] All 28 `Yumney.Mcp.Server.Tests` green
- [ ] Manual: `dotnet run --project src/Yumney.AppHost`, register `yumney-mcp` client in Keycloak realm, configure Claude Desktop with the MCP server URL + Keycloak OAuth, verify a search_recipes call returns recipes from the test user

## Stacking

Branched from `feat/US-641b-mcp-protocol-surface` (PR #649). Targets that branch — base auto-retargets as the chain merges.

Refs #641
Refs #637