### PR TITLE
test(test): integration tests for Phase 1 chat actions + Phase 2 cross-module clients

### DIFF
--- a/src/Yumney.Recipes.Extraction/TestStubs/StubIntentParserService.cs
+++ b/src/Yumney.Recipes.Extraction/TestStubs/StubIntentParserService.cs
@@ -4,8 +4,36 @@ using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction.TestStubs;
 
+/// <summary>
+/// E2E / integration test stub. Recognises a small fixed set of navigate
+/// phrases deterministically so chat-action tests can assert the Actions
+/// channel without needing a real LLM. Falls back to <c>general_chat</c> for
+/// every other input — that's the same behaviour the previous version had
+/// for all inputs.
+/// </summary>
 internal sealed class StubIntentParserService : IIntentParserService
 {
-	public Task<Result<ParsedIntentDto>> ParseAsync(string userInput, string? pageContext, CancellationToken cancellationToken = default) =>
-		Task.FromResult(Result<ParsedIntentDto>.Success(new ParsedIntentDto("general_chat", [], null)));
+	public Task<Result<ParsedIntentDto>> ParseAsync(string userInput, string? pageContext, CancellationToken cancellationToken = default)
+	{
+		var target = ResolveNavigateTarget(userInput);
+		if (target is not null)
+		{
+			return Task.FromResult(Result<ParsedIntentDto>.Success(new ParsedIntentDto(
+				"navigate",
+				new Dictionary<string, string> { ["target"] = target },
+				null)));
+		}
+
+		return Task.FromResult(Result<ParsedIntentDto>.Success(new ParsedIntentDto("general_chat", [], null)));
+	}
+
+	private static string? ResolveNavigateTarget(string input)
+	{
+		var normalized = input.Trim().ToLowerInvariant();
+		if (normalized.Contains("shopping list", StringComparison.Ordinal)) return "shopping-list";
+		if (normalized.Contains("meal planner", StringComparison.Ordinal)) return "meal-planner";
+		if (normalized.Contains("settings", StringComparison.Ordinal)) return "settings";
+		if (normalized.Contains("recipes page", StringComparison.Ordinal) || normalized.Contains("open recipes", StringComparison.Ordinal)) return "recipes";
+		return null;
+	}
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/CrossModuleClientContractTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/CrossModuleClientContractTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.CrossModule;
+
+/// <summary>
+/// Phase 2b/2c/2d (#644-#646) coverage: validates that the URLs Yumney.MealPlan.Client
+/// and Yumney.Shopping.Client emit actually exist on the live module APIs and that
+/// the JSON shapes match the response records the clients deserialize against.
+///
+/// The unit tests for the chat tools and HTTP adapters all use stubbed
+/// IMealPlanClient / IShoppingClient — so a wrong URL ("/api/v1/meal-plan"
+/// instead of "/api/v1/meal-plans") would slip through. These tests exercise
+/// the actual endpoint contract.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class CrossModuleClientContractTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task MealPlanWeeklyEndpoint_AtClientUrl_ReturnsParseableWeeklyPlanResponse()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+		var response = await client.GetAsync("/api/v1/meal-plans/2026/w/19");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var parsed = await response.Content.ReadFromJsonAsync<WeeklyPlanResponse>();
+		parsed.Should().NotBeNull();
+		parsed!.Slots.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task MealPlanAssignSlotsEndpoint_AcceptsAssignRecipeBody()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+		var body = new AssignRecipeBody(
+			Day: "Monday",
+			RecipeIdentifier: Guid.NewGuid(),
+			RecipeTitle: "Carbonara",
+			MealType: "Dinner",
+			Servings: 4);
+
+		var response = await client.PostAsJsonAsync("/api/v1/meal-plans/2026/w/19/slots", body);
+
+		// We don't require 2xx — the recipe doesn't exist, MealPlan may reject
+		// with 400/404. The point is: the endpoint binds AssignRecipeBody (the
+		// shape my MealPlanClient sends) — anything other than 415 / 405 / 404
+		// route-not-found proves the URL + body shape match.
+		response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+		response.StatusCode.Should().NotBe(HttpStatusCode.MethodNotAllowed);
+		response.StatusCode.Should().NotBe(HttpStatusCode.UnsupportedMediaType);
+	}
+
+	[Fact]
+	public async Task MealPlanConfirmEndpoint_AcceptsConfirmMealBody()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+		var body = new ConfirmMealBody(Day: "Monday", MealType: "Dinner", State: "Cooked");
+
+		var response = await client.PutAsJsonAsync("/api/v1/meal-plans/2026/w/19/slots/confirm", body);
+
+		response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+		response.StatusCode.Should().NotBe(HttpStatusCode.MethodNotAllowed);
+		response.StatusCode.Should().NotBe(HttpStatusCode.UnsupportedMediaType);
+	}
+
+	[Fact]
+	public async Task ShoppingMergedEndpoint_AtClientUrl_ReturnsParseableMergedShoppingListResponse()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+
+		var response = await client.GetAsync("/api/v1/shopping-lists/merged?includePastBought=false");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		var parsed = await response.Content.ReadFromJsonAsync<MergedShoppingListResponse>();
+		parsed.Should().NotBeNull();
+		parsed!.Items.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
+		var body = new CreateListFromRecipesBody(
+			Title: "Integration test list",
+			Recipes: [new CreateListRecipeBody(Guid.NewGuid(), Servings: null)]);
+
+		var response = await client.PostAsJsonAsync("/api/v1/shopping-lists/from-recipes", body);
+
+		// Same logic as MealPlan write tests — UnprocessableEntity / BadRequest
+		// is fine (recipe doesn't exist), but route-not-found / wrong-shape
+		// failures would prove the contract is broken.
+		response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+		response.StatusCode.Should().NotBe(HttpStatusCode.MethodNotAllowed);
+		response.StatusCode.Should().NotBe(HttpStatusCode.UnsupportedMediaType);
+	}
+
+	[Fact]
+	public async Task MealPlanWeeklyEndpoint_RouteShapeMatchesClientPattern()
+	{
+		// Belt-and-braces: the MealPlanClient builds the URL via
+		// $"/api/v1/meal-plans/{year}/w/{weekNumber}". Any drift in the route
+		// template (e.g. someone renames {year} → {y}) would break this.
+		var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
+
+		var goodResponse = await client.GetAsync("/api/v1/meal-plans/2026/w/19");
+		goodResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var badResponse = await client.GetAsync("/api/v1/meal-plans/2026/19");
+		badResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Recipes/RecipesChatActionsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipesChatActionsContractTests.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes;
+
+/// <summary>
+/// Phase 1 (#642) coverage: the chat endpoint emits ChatResponseDto.Actions[]
+/// driven by the intent parser. Verifies the HTTP contract end-to-end —
+/// request through Keycloak auth, command handler, intent parser, mapper, and
+/// back through the Result→IResult pipeline.
+///
+/// Relies on StubIntentParserService recognising specific navigate phrases
+/// deterministically (E2ETests=true mode); a real LLM is not invoked.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class RecipesChatActionsContractTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task Chat_OpenShoppingListMessage_ReturnsNavigateActionToShopping()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		var request = new ChatRequestDto("open shopping list", []);
+
+		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
+
+		response.IsSuccessStatusCode.Should().BeTrue();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		dto.Should().NotBeNull();
+		dto!.Actions.Should().ContainSingle();
+		dto.Actions[0].Type.Should().Be(ChatActionType.Navigate);
+		dto.Actions[0].Route.Should().Be("/shopping");
+	}
+
+	[Fact]
+	public async Task Chat_OpenMealPlannerMessage_ReturnsNavigateActionToMealPlanner()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		var request = new ChatRequestDto("open meal planner please", []);
+
+		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
+
+		response.IsSuccessStatusCode.Should().BeTrue();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		dto!.Actions.Should().ContainSingle();
+		dto.Actions[0].Route.Should().Be("/meal-planner");
+	}
+
+	[Fact]
+	public async Task Chat_GenericQuestion_ReturnsEmptyActions()
+	{
+		var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
+		var request = new ChatRequestDto("what's a good way to poach an egg?", []);
+
+		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
+
+		response.IsSuccessStatusCode.Should().BeTrue();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		dto!.Actions.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task Chat_WithoutBearer_IsUnauthorized()
+	{
+		var request = new ChatRequestDto("anything", []);
+
+		var response = await fixture.RecipesApi.PostAsJsonAsync("/api/v1/recipes/chat", request);
+
+		response.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -11,6 +11,9 @@
     <ProjectReference Include="..\..\src\Yumney.Shopping.Infrastructure\Yumney.Shopping.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Users.Infrastructure\Yumney.Users.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Recipes.Application\Yumney.Recipes.Application.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.MealPlan.Client\Yumney.MealPlan.Client.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Plugs the integration-coverage gap from PRs #642-#646. Counterpart to PR #651 (which covers Phase 3 + 4). Together these two test PRs close the integration-test gap I flagged in the audit.

## What's tested

**Phase 1 (#642): chat endpoint emits `Actions[]`**

The unit tests stubbed `IIntentParserService` directly. Integration goes through the real handler → stub intent parser → mapper → `ChatResponseDto` pipeline, plus Keycloak auth.

**Phase 2b/c/d (#644-#646): cross-module client URL + shape contracts**

Unit tests for chat tools and HTTP adapters all used stubbed `IMealPlanClient` / `IShoppingClient` with hand-built bodies. A wrong URL like `/api/v1/meal-plan` (singular) instead of `/api/v1/meal-plans` (plural) would have slipped through. These tests exercise the actual endpoint contract by:
1. POSTing my client's wire-shape body to the route my client builds
2. Asserting NOT-`NotFound` / NOT-`MethodNotAllowed` / NOT-`UnsupportedMediaType` (those would prove the contract is broken)
3. For reads: deserializing the response as my client's expected response record

## Production change (small, scoped to test stub)

`StubIntentParserService` now recognises a small fixed set of navigate phrases:
- `"open shopping list"` → `target=shopping-list`
- `"open meal planner"` → `target=meal-planner`
- `"settings"` → `target=settings`
- `"open recipes"` / `"recipes page"` → `target=recipes`

Falls back to `general_chat` for everything else, matching the previous behaviour. Lets E2E + integration tests assert action emission without needing a real LLM.

## New tests (11)

**`Recipes/RecipesChatActionsContractTests` (4)** — Phase 1
- `"open shopping list"` → `ChatResponseDto.Actions` has `Navigate /shopping`
- `"open meal planner please"` → `Navigate /meal-planner`
- Generic message → empty `Actions`
- No bearer → 401

**`CrossModule/CrossModuleClientContractTests` (6)** — Phase 2b/c/d
- MealPlan `GET /meal-plans/{year}/w/{week}` returns parseable `WeeklyPlanResponse`
- MealPlan `POST /slots` accepts `AssignRecipeBody` (route + shape match)
- MealPlan `PUT /slots/confirm` accepts `ConfirmMealBody`
- Shopping `GET /merged` returns parseable `MergedShoppingListResponse`
- Shopping `POST /from-recipes` accepts `CreateListFromRecipesBody`
- Belt-and-braces route-template drift check (good URL vs intentionally wrong URL)

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [ ] CI integration suite (8-min Aspire fixture)

## Out of scope

- Full read-result-payload assertions on writes (e.g. `assign_meal` sets up a recipe + asserts the `WeeklyPlanDto` reflects it). That's deeper integration work — these tests assert the contract, not the business behavior.
- Phase 2a SK function calling end-to-end — needs a real LLM, intentionally out of scope (`StubChatService` returns `"Stub reply."`).

## Stacking

Branched from `feat/US-639d-shopping-tools` (PR #646) since these tests need every Phase 1 + Phase 2 production change in scope. Targets that branch — base auto-retargets as the chain merges.

Refs #642
Refs #644
Refs #645
Refs #646