### PR TITLE
test(test): MCP tools/call round-trip via SDK client (closes Phase 4 integration gap)

### DIFF
--- a/tests/Yumney.Integration.Tests/Mcp/McpToolInvocationIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpToolInvocationIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System.Net.Http.Headers;
+using Aspire.Hosting.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Phase 4 closing test: actually drives the MCP protocol end-to-end.
+/// Connects an MCP client (the SDK's <c>HttpClientTransport</c>) to the
+/// running mcp-server with a Keycloak bearer, lists tools, and invokes one
+/// — exercising the full chain from protocol → CallToolHandler →
+/// RestProxyService → real upstream module via Aspire service discovery.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpToolInvocationIntegrationTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task ListToolsAsync_ReturnsDiscoveredMcpSurfaceTools()
+	{
+		await using var client = await CreateClientAsync();
+
+		var tools = await client.ListToolsAsync();
+
+		tools.Should().NotBeEmpty();
+		tools.Select(tool => tool.Name).Should().Contain([
+			"search_recipes",
+			"get_recipe",
+			"get_cookable_recipes",
+			"get_weekly_plan",
+			"get_merged_shopping_list",
+		]);
+	}
+
+	[Fact]
+	public async Task CallToolAsync_SearchRecipes_ProxiesToRecipesApiAndReturnsResponse()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("search_recipes", arguments: new Dictionary<string, object?>());
+
+		// The user has no seeded recipes, so the response is an empty paged
+		// result — but it deserialized, which proves the proxy hit the real
+		// Recipes API with the bearer and got 200 back.
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+		var firstText = result.Content.OfType<TextContentBlock>().First().Text;
+		firstText.Should().Contain("\"items\"");
+	}
+
+	[Fact]
+	public async Task CallToolAsync_GetMergedShoppingList_ProxiesToShoppingApi()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("get_merged_shopping_list", arguments: new Dictionary<string, object?>());
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+		var firstText = result.Content.OfType<TextContentBlock>().First().Text;
+		firstText.Should().Contain("\"items\"");
+	}
+
+	[Fact]
+	public async Task CallToolAsync_GetWeeklyPlan_ProxiesToMealPlanApi()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("get_weekly_plan", arguments: new Dictionary<string, object?>
+		{
+			["year"] = 2026,
+			["weekNumber"] = 19,
+		});
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public async Task CallToolAsync_UnknownTool_ReturnsErrorResult()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("nonexistent_tool", arguments: new Dictionary<string, object?>());
+
+		result.IsError.Should().BeTrue();
+	}
+
+	private async Task<McpClient> CreateClientAsync()
+	{
+		var token = await fixture.GetAccessTokenAsync("testuser", "Test1234");
+		var http = fixture.App.CreateHttpClient("mcp-server");
+		http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		var options = new HttpClientTransportOptions
+		{
+			Endpoint = new Uri(http.BaseAddress!, "/mcp"),
+			Name = "mcp-integration-test",
+		};
+		var transport = new HttpClientTransport(options, http, NullLoggerFactory.Instance, ownsHttpClient: true);
+
+		return await McpClient.CreateAsync(transport, clientOptions: null, loggerFactory: NullLoggerFactory.Instance);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
Drives the MCP protocol end-to-end using the official `ModelContextProtocol.Client.HttpClientTransport`. With this PR, every layer of the Phase 4 stack is exercised by an integration test.

## The full chain now under test

```
Claude Desktop equivalent
  → ModelContextProtocol.Client (HttpClientTransport, MCP JSON-RPC over HTTP/SSE)
  → /mcp endpoint with Authorization: Bearer <Keycloak token>
  → MCP server JWT validation against the real Keycloak realm
  → CapabilityToolRegistration ListTools / CallTool handlers
  → RestProxyService → RouteUrlBuilder
  → Aspire service discovery
  → Real module REST endpoint with bearer forwarded
  → Response back through every layer
```

Was previously the biggest remaining unknown — the unit tests stubbed `HttpClient` and the integration tests in #651 only proved the auth gate (401 without bearer, not-401 with). Tool invocation through to upstream was unobservable.

## Tests added (5)

- **`ListToolsAsync_ReturnsDiscoveredMcpSurfaceTools`** — MCP client lists tools, asserts the 5 expected names appear: `search_recipes`, `get_recipe`, `get_cookable_recipes`, `get_weekly_plan`, `get_merged_shopping_list`.
- **`CallToolAsync_SearchRecipes_ProxiesToRecipesApiAndReturnsResponse`** — invokes `search_recipes` via MCP, asserts non-error response with a parseable `"items"` array (proves bearer reached recipes-api and the paged result shape comes back).
- **`CallToolAsync_GetMergedShoppingList_ProxiesToShoppingApi`** — same for shopping-api.
- **`CallToolAsync_GetWeeklyPlan_ProxiesToMealPlanApi`** — same for mealplan-api with `year` / `weekNumber` arguments.
- **`CallToolAsync_UnknownTool_ReturnsErrorResult`** — unknown tool name returns `IsError=true`.

## Package change

`ModelContextProtocol` package added to `Yumney.Integration.Tests`. Already centrally managed at 1.3.0 in `Directory.Packages.props` from PR #649. The `ModelContextProtocol.Core` namespace ships the client API (`McpClient`, `HttpClientTransport`, `HttpClientTransportOptions`).

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [ ] CI integration suite (full Aspire fixture)

## What's still NOT covered

- **Phase 2a SK function calling end-to-end** — needs a real LLM. `StubChatService` short-circuits in E2E mode. Tools themselves are unit-tested + invokable via MCP (this PR), but the LLM-to-SK-tool dispatch in the chat service remains unobservable without spending against OpenAI.
- **Write-tool business behavior** — `assign_meal` / `confirm_meal_cooked` / `create_shopping_list_from_recipes` integration tests would need recipe seeding + state assertions (e.g. assign + then get_weekly_plan returns the assignment). Worth doing as a follow-up but out of scope for this round.

Both are reasonable follow-ups, not regressions in current coverage.

## Stacking

Branched from `test/US-641-mcp-integration` (PR #651). Targets that branch — base auto-retargets as the chain merges.

Refs #641
Refs #637