### PR TITLE
feat(recipes): rate_recipe chat tool (US-187)

### DIFF
--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<SearchRecipesTool>();
 		services.AddScoped<GetRecipeTool>();
 		services.AddScoped<GetCookableRecipesTool>();
+		services.AddScoped<RateRecipeTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -26,6 +26,7 @@ public sealed partial class SemanticKernelChatService(
 	SearchRecipesTool searchRecipesTool,
 	GetRecipeTool getRecipeTool,
 	GetCookableRecipesTool getCookableRecipesTool,
+	RateRecipeTool rateRecipeTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -136,6 +137,9 @@ public sealed partial class SemanticKernelChatService(
           get_cookable_recipes.
         - When the user wants details on a specific recipe (ingredients, steps,
           time), call get_recipe with the identifier from a previous tool call.
+        - When the user rates a recipe ("rate the carbonara 5 stars",
+          "I'd give that a 4"), call rate_recipe with the identifier from a
+          previous tool call and the integer rating.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -156,6 +160,7 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(searchRecipesTool, "recipes_search");
 		requestKernel.Plugins.AddFromObject(getRecipeTool, "recipes_detail");
 		requestKernel.Plugins.AddFromObject(getCookableRecipesTool, "recipes_cookable");
+		requestKernel.Plugins.AddFromObject(rateRecipeTool, "recipes_rate");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/RateRecipeTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/RateRecipeTool.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing recipe rating to the chat LLM. Wraps
+/// <see cref="RateRecipeCommand"/> — same Recipes-owned pattern as the other
+/// in-process tools (no cross-module HTTP needed). Closes the chat surface
+/// for US-187.
+/// </summary>
+/// <param name="handler">Command handler that persists the rating.</param>
+public sealed class RateRecipeTool(ICommandHandler<RateRecipeCommand, Result> handler)
+{
+	/// <summary>Rate a recipe 1-5 stars.</summary>
+	/// <param name="recipeIdentifier">Recipe GUID returned by a prior search/get.</param>
+	/// <param name="rating">Integer 1-5.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Confirmation message for the LLM to weave into its reply.</returns>
+	[KernelFunction("rate_recipe")]
+	[Description("Rate a recipe in the user's collection 1-5 stars ('rate the carbonara 5 stars', 'I'd give that pasta a 4'). Requires a recipe identifier from a prior search_recipes / get_recipe call.")]
+	public async Task<string> RateAsync(
+		[Description("Recipe identifier (GUID) returned by search_recipes or get_recipe")] string recipeIdentifier,
+		[Description("Star rating, 1 to 5")] int rating,
+		CancellationToken cancellationToken = default)
+	{
+		if (!Guid.TryParse(recipeIdentifier, out var guid)) return "Invalid recipe identifier — call search_recipes first.";
+		if (rating < Rating.MinValue || rating > Rating.MaxValue) return $"Rating must be between {Rating.MinValue} and {Rating.MaxValue}.";
+
+		var command = new RateRecipeCommand(RecipeIdentifier.From(guid), Rating.From(rating));
+		var result = await handler.HandleAsync(command, cancellationToken);
+		return result.IsSuccess
+			? $"Saved your {rating}-star rating."
+			: "Couldn't save the rating — make sure the recipe is in your collection.";
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/RateRecipeToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/RateRecipeToolTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class RateRecipeToolTests
+{
+	private readonly ICommandHandler<RateRecipeCommand, Result> handler =
+		Substitute.For<ICommandHandler<RateRecipeCommand, Result>>();
+
+	[Fact]
+	public async Task RateAsync_HappyPath_DispatchesAndReturnsConfirmation()
+	{
+		var id = Guid.NewGuid();
+		RateRecipeCommand? captured = null;
+		handler.HandleAsync(Arg.Any<RateRecipeCommand>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<RateRecipeCommand>(0);
+				return Result.Success();
+			});
+
+		var tool = new RateRecipeTool(handler);
+		var reply = await tool.RateAsync(id.ToString(), 5);
+
+		reply.Should().Contain("5-star");
+		captured.Should().NotBeNull();
+		captured!.Identifier.Value.Should().Be(id);
+		captured.Rating.Value.Should().Be(5);
+	}
+
+	[Fact]
+	public async Task RateAsync_InvalidGuid_ReturnsErrorWithoutCallingHandler()
+	{
+		var tool = new RateRecipeTool(handler);
+		var reply = await tool.RateAsync("not-a-guid", 4);
+
+		reply.Should().Contain("Invalid recipe identifier");
+		await handler.DidNotReceiveWithAnyArgs().HandleAsync(default!, default);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(6)]
+	[InlineData(-1)]
+	[InlineData(99)]
+	public async Task RateAsync_OutOfRangeRating_ReturnsErrorWithoutCallingHandler(int rating)
+	{
+		var tool = new RateRecipeTool(handler);
+		var reply = await tool.RateAsync(Guid.NewGuid().ToString(), rating);
+
+		reply.Should().Contain("between 1 and 5");
+		await handler.DidNotReceiveWithAnyArgs().HandleAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task RateAsync_HandlerFailure_ReturnsErrorMessage()
+	{
+		handler.HandleAsync(Arg.Any<RateRecipeCommand>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Failure(new ApiError("ACCESS_DENIED", "Access denied", 403)));
+
+		var tool = new RateRecipeTool(handler);
+		var reply = await tool.RateAsync(Guid.NewGuid().ToString(), 4);
+
+		reply.Should().Contain("Couldn't save");
+	}
+}


### PR DESCRIPTION
Closes the last unwired chat user-story. The handler `RateRecipeCommandHandler` already existed in Recipes.Application — this PR just exposes it as an SK kernel function so chat can call it.

## What's added

**`src/Yumney.Recipes.Extraction/Services/Tools/RateRecipeTool.cs`** — wraps `ICommandHandler<RateRecipeCommand, Result>`:
- Validates GUID before dispatching
- Validates rating against `Rating.MinValue`/`MaxValue` (1-5) before dispatching
- Returns "Saved your N-star rating" on success
- Returns "Couldn't save the rating — make sure the recipe is in your collection" on failure (covers AccessDenied for cross-user attempts, recipe-not-found, etc.)

Same Recipes-owned, in-process pattern as the other Phase 2a tools — no new infrastructure, no cross-module HTTP. The handler enforces the ownership check (`recipe.Owner != currentUser.AsOwner()` → `AccessDenied`) so cross-user rating attempts surface as the failure path.

**Wiring:**
- Registered as scoped in `ExtractionServiceCollectionExtensions`
- Added to `BuildRequestKernel` as `recipes_rate` plugin
- System prompt extended with `rate_recipe` usage hint

## Tests (7)

- Happy path: dispatches command with right identifier + rating, returns "N-star" confirmation
- Invalid GUID: returns error without calling handler
- Out-of-range ratings (0, 6, -1, 99): all return error without calling handler ([Theory])
- Handler failure (e.g. AccessDenied): returns "Couldn't save" error

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] All 7 tests green (~200ms)

## Stacking

Branched from `feat/US-639-sk-function-calling` (PR #643) — needs the SK function calling foundation. Targets that branch — base auto-retargets as the chain merges.

Closes #187
Refs #639