### PR TITLE
feat(recipes): recover Phase 2b/2c/2d cross-module chat tools

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -26,6 +26,7 @@
   <Folder Name="/src/MealPlan/">
     <Project Path="src/Yumney.MealPlan.Api/Yumney.MealPlan.Api.csproj" />
     <Project Path="src/Yumney.MealPlan.Application/Yumney.MealPlan.Application.csproj" />
+    <Project Path="src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj" />
     <Project Path="src/Yumney.MealPlan.Domain/Yumney.MealPlan.Domain.csproj" />
     <Project Path="src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj" />
   </Folder>

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -148,6 +148,11 @@ if (!options.DatabaseOnly)
 		.WithReference(shoppingApi)
 		.WithReference(usersApi);
 
+	// Reverse reference: chat tools in Recipes call mealplan-api for get_weekly_plan
+	// (and future planner tools). Cannot inline above because mealplanApi is
+	// declared after recipesApi.
+	recipesApi.WithReference(mealplanApi);
+
 	// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
 	// ACA pulls them via the environment's managed identity, so no registry credentials
 	// are baked into the container app revisions.

--- a/src/Yumney.MealPlan.Client/IMealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/IMealPlanClient.cs
@@ -13,6 +13,22 @@ public interface IMealPlanClient
 	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
 	/// <returns>The weekly plan or null if the week has not been planned.</returns>
 	Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+
+	/// <summary>Assign a recipe to a slot in the given week. POST /api/v1/meal-plans/{year}/w/{weekNumber}/slots.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Day, recipe, meal type, optional servings.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> AssignRecipeAsync(int year, int weekNumber, AssignRecipeBody body, CancellationToken cancellationToken = default);
+
+	/// <summary>Confirm a meal slot's state (cooked / skipped / restored). PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/confirm.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Day, meal type, target state.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> ConfirmMealAsync(int year, int weekNumber, ConfirmMealBody body, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Trimmed weekly-plan shape returned over the wire.</summary>
@@ -31,3 +47,14 @@ public sealed record WeeklyPlanSlotResponse(
 	string? RecipeTitle,
 	int Servings,
 	bool IsEmpty);
+
+/// <summary>Body for the assign-recipe POST.</summary>
+public sealed record AssignRecipeBody(
+	string Day,
+	Guid RecipeIdentifier,
+	string RecipeTitle,
+	string MealType,
+	int? Servings);
+
+/// <summary>Body for the confirm-meal PUT.</summary>
+public sealed record ConfirmMealBody(string Day, string MealType, string State);

--- a/src/Yumney.MealPlan.Client/IMealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/IMealPlanClient.cs
@@ -1,0 +1,33 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+/// <summary>
+/// Slim transport-shaped HTTP client over the MealPlan module's REST endpoints.
+/// Used by sibling modules (Recipes, Shopping, …) per the consumer-defined-contracts
+/// pattern — each consumer wraps relevant calls in its own <c>I*Provider</c> interface.
+/// </summary>
+public interface IMealPlanClient
+{
+	/// <summary>Fetch the weekly plan for the given ISO week.</summary>
+	/// <param name="year">ISO year, e.g. 2026.</param>
+	/// <param name="weekNumber">ISO week number 1-53.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>The weekly plan or null if the week has not been planned.</returns>
+	Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed weekly-plan shape returned over the wire.</summary>
+public sealed record WeeklyPlanResponse(
+	string Week,
+	bool IsExtendedMode,
+	IReadOnlyList<WeeklyPlanSlotResponse> Slots);
+
+/// <summary>One filled or empty slot in the weekly plan.</summary>
+public sealed record WeeklyPlanSlotResponse(
+	string Day,
+	string MealType,
+	string ContentType,
+	string State,
+	Guid? RecipeIdentifier,
+	string? RecipeTitle,
+	int Servings,
+	bool IsEmpty);

--- a/src/Yumney.MealPlan.Client/MealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClient.cs
@@ -11,4 +11,38 @@ internal sealed class MealPlanClient(IModuleHttpClientFactory factory) : IMealPl
 			$"/api/v1/meal-plans/{year}/w/{weekNumber}",
 			"GetWeeklyPlan",
 			cancellationToken);
+
+	public async Task<bool> AssignRecipeAsync(int year, int weekNumber, AssignRecipeBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PostAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots",
+				body,
+				"AssignRecipe",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
+
+	public async Task<bool> ConfirmMealAsync(int year, int weekNumber, ConfirmMealBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PutAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots/confirm",
+				body,
+				"ConfirmMeal",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/src/Yumney.MealPlan.Client/MealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClient.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+internal sealed class MealPlanClient(IModuleHttpClientFactory factory) : IMealPlanClient
+{
+	private readonly IModuleHttpClient http = factory.For("mealplan-api");
+
+	public Task<WeeklyPlanResponse?> GetWeeklyPlanAsync(int year, int weekNumber, CancellationToken cancellationToken = default) =>
+		http.FindAsync<WeeklyPlanResponse>(
+			$"/api/v1/meal-plans/{year}/w/{weekNumber}",
+			"GetWeeklyPlan",
+			cancellationToken);
+}

--- a/src/Yumney.MealPlan.Client/MealPlanClientServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClientServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Web;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Client;
+
+public static class MealPlanClientServiceCollectionExtensions
+{
+	public static IServiceCollection AddMealPlanClient(this IServiceCollection services)
+	{
+		services.AddYumneyServiceClient("mealplan-api");
+		services.AddSingleton<IMealPlanClient, MealPlanClient>();
+		return services;
+	}
+}

--- a/src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj
+++ b/src/Yumney.MealPlan.Client/Yumney.MealPlan.Client.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Recipes.Application/Interfaces/IMealConfirmation.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealConfirmation.cs
@@ -1,0 +1,23 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for confirming a planned meal's state (cooked,
+/// skipped, restored to planned) in the user's weekly meal plan. Owned by
+/// Recipes (the chat surface is the consumer) per CLAUDE.md cross-module rule.
+/// </summary>
+public interface IMealConfirmation
+{
+	/// <summary>Confirm a meal slot's state.</summary>
+	/// <param name="request">Year, week, day, meal type, target state.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True if the confirmation succeeded, false if the upstream rejected it.</returns>
+	Task<bool> ConfirmAsync(ConfirmMealRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a confirm-meal request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="Day">English weekday name (Monday..Sunday).</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+/// <param name="State">One of "Planned", "Cooked", "Skipped".</param>
+public sealed record ConfirmMealRequest(int Year, int WeekNumber, string Day, string MealType, string State);

--- a/src/Yumney.Recipes.Application/Interfaces/IMealPlanScheduler.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealPlanScheduler.cs
@@ -1,0 +1,32 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for assigning recipes to slots in the user's
+/// weekly meal plan. Owned by Recipes (the chat surface is the consumer)
+/// per CLAUDE.md cross-module rule + ADR 0002.
+/// </summary>
+public interface IMealPlanScheduler
+{
+	/// <summary>Assign a recipe to a meal slot in the given week.</summary>
+	/// <param name="request">Year, week, day, recipe, meal type, optional servings.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True if the assignment succeeded, false if the upstream rejected it.</returns>
+	Task<bool> AssignAsync(AssignMealRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of an assign-meal request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="Day">English weekday name (Monday..Sunday).</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+/// <param name="RecipeIdentifier">Recipe identifier resolved from a prior search/get.</param>
+/// <param name="RecipeTitle">Recipe title for downstream display.</param>
+/// <param name="Servings">Optional override for slot servings; null = use recipe default.</param>
+public sealed record AssignMealRequest(
+	int Year,
+	int WeekNumber,
+	string Day,
+	string MealType,
+	Guid RecipeIdentifier,
+	string RecipeTitle,
+	int? Servings);

--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListCreator.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListCreator.cs
@@ -1,0 +1,25 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for creating a shopping list from one or more
+/// recipes. Owned by Recipes (the chat surface is the consumer) per CLAUDE.md
+/// cross-module rule + ADR 0002.
+/// </summary>
+public interface IShoppingListCreator
+{
+	/// <summary>Create a shopping list named <paramref name="request"/>.Title sourced from the given recipes.</summary>
+	/// <param name="request">Title plus the list of recipes (with optional servings overrides).</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> CreateAsync(CreateShoppingListRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a create-shopping-list-from-recipes request.</summary>
+/// <param name="Title">List title (e.g. "This week's dinners").</param>
+/// <param name="Recipes">Recipes to draw from.</param>
+public sealed record CreateShoppingListRequest(string Title, IReadOnlyList<CreateShoppingListRecipe> Recipes);
+
+/// <summary>One recipe selection inside a create-shopping-list request.</summary>
+/// <param name="RecipeIdentifier">Recipe identifier resolved from a prior search/get.</param>
+/// <param name="Servings">Optional override for servings; null = use recipe default.</param>
+public sealed record CreateShoppingListRecipe(Guid RecipeIdentifier, int? Servings);

--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListLookup.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListLookup.cs
@@ -1,0 +1,31 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for fetching the user's merged active shopping
+/// list from the Shopping module. Owned by Recipes (the chat surface is the
+/// consumer) per CLAUDE.md cross-module rule + ADR 0002.
+/// </summary>
+public interface IShoppingListLookup
+{
+	/// <summary>Get the merged shopping list across all active lists.</summary>
+	/// <param name="includePastBought">Whether to include items already bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>Consumer-flavored merged list, or null if the upstream call fails.</returns>
+	Task<ShoppingListLookupResult?> GetMergedAsync(bool includePastBought = false, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed merged-list shape returned to chat tools.</summary>
+public sealed record ShoppingListLookupResult(IReadOnlyList<ShoppingListLookupItem> Items);
+
+/// <summary>One merged item across all active shopping lists.</summary>
+/// <param name="Name">Ingredient name.</param>
+/// <param name="Quantity">Display quantity.</param>
+/// <param name="Unit">Unit, if any.</param>
+/// <param name="Category">Aisle / category label.</param>
+/// <param name="IsBought">Whether the item is already checked off.</param>
+public sealed record ShoppingListLookupItem(
+	string Name,
+	decimal Quantity,
+	string? Unit,
+	string Category,
+	bool IsBought);

--- a/src/Yumney.Recipes.Application/Interfaces/IWeeklyPlanLookup.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IWeeklyPlanLookup.cs
@@ -1,0 +1,31 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for fetching the user's weekly meal plan from the
+/// MealPlan module. Lives here (not in MealPlan) because the chat surface is the
+/// consumer — see CLAUDE.md "Cross-Module Dependencies" + ADR 0002.
+/// </summary>
+public interface IWeeklyPlanLookup
+{
+	/// <summary>Get the weekly plan for the given ISO week, or null if not yet planned.</summary>
+	/// <param name="year">ISO year, e.g. 2026.</param>
+	/// <param name="weekNumber">ISO week number 1-53.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the lookup.</param>
+	/// <returns>Consumer-flavored weekly plan, or null if the week has not been planned.</returns>
+	Task<WeeklyPlanLookupResult?> GetForWeekAsync(int year, int weekNumber, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Trimmed weekly-plan shape returned to chat tools.</summary>
+public sealed record WeeklyPlanLookupResult(
+	string Week,
+	bool IsExtendedMode,
+	IReadOnlyList<WeeklyPlanLookupSlot> Slots);
+
+/// <summary>One slot in the consumer-flavored weekly plan.</summary>
+public sealed record WeeklyPlanLookupSlot(
+	string Day,
+	string MealType,
+	Guid? RecipeIdentifier,
+	string? RecipeTitle,
+	int Servings,
+	bool IsEmpty);

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -45,6 +45,8 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<GetCookableRecipesTool>();
 		services.AddScoped<RateRecipeTool>();
 		services.AddScoped<GetWeeklyPlanTool>();
+		services.AddScoped<AssignMealTool>();
+		services.AddScoped<ConfirmMealTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<GetRecipeTool>();
 		services.AddScoped<GetCookableRecipesTool>();
 		services.AddScoped<RateRecipeTool>();
+		services.AddScoped<GetWeeklyPlanTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<GetWeeklyPlanTool>();
 		services.AddScoped<AssignMealTool>();
 		services.AddScoped<ConfirmMealTool>();
+		services.AddScoped<GetMergedShoppingListTool>();
+		services.AddScoped<CreateShoppingListTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -27,6 +27,7 @@ public sealed partial class SemanticKernelChatService(
 	GetRecipeTool getRecipeTool,
 	GetCookableRecipesTool getCookableRecipesTool,
 	RateRecipeTool rateRecipeTool,
+	GetWeeklyPlanTool getWeeklyPlanTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -126,8 +127,8 @@ public sealed partial class SemanticKernelChatService(
 
 	private const string systemPrompt = """
         You are a friendly, concise cooking assistant for the Yumney recipe app.
-        You can call functions to look up the user's recipes and pantry — prefer
-        calling a function over guessing.
+        You can call functions to look up the user's recipes, pantry, and meal
+        plan — prefer calling a function over guessing.
 
         Tool usage:
         - When the user asks to find or search recipes ("find chicken recipes",
@@ -140,6 +141,10 @@ public sealed partial class SemanticKernelChatService(
         - When the user rates a recipe ("rate the carbonara 5 stars",
           "I'd give that a 4"), call rate_recipe with the identifier from a
           previous tool call and the integer rating.
+        - When the user asks about their planned meals ("what's for dinner
+          Tuesday?", "show me this week's plan", "was ist nächste Woche
+          geplant?"), call get_weekly_plan. Pass year=0 / weekNumber=0 to
+          mean "this week".
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -161,6 +166,7 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(getRecipeTool, "recipes_detail");
 		requestKernel.Plugins.AddFromObject(getCookableRecipesTool, "recipes_cookable");
 		requestKernel.Plugins.AddFromObject(rateRecipeTool, "recipes_rate");
+		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -30,6 +30,8 @@ public sealed partial class SemanticKernelChatService(
 	GetWeeklyPlanTool getWeeklyPlanTool,
 	AssignMealTool assignMealTool,
 	ConfirmMealTool confirmMealTool,
+	GetMergedShoppingListTool getMergedShoppingListTool,
+	CreateShoppingListTool createShoppingListTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -155,6 +157,15 @@ public sealed partial class SemanticKernelChatService(
           meal ("I made the spaghetti on Wednesday", "skip Friday's
           dinner"), call confirm_meal_cooked with state Cooked/Skipped/
           Planned.
+        - When the user asks about their shopping list ("what's on my
+          shopping list?", "do I still need eggs?"), call
+          get_merged_shopping_list.
+        - When the user asks to build a shopping list from recipes
+          ("make a list for spaghetti and risotto", "shopping list for
+          this week's dinners"), first resolve recipe identifiers via
+          search_recipes if needed, then call
+          create_shopping_list_from_recipes with the identifiers
+          comma-separated.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -179,6 +190,8 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
 		requestKernel.Plugins.AddFromObject(assignMealTool, "mealplan_assign");
 		requestKernel.Plugins.AddFromObject(confirmMealTool, "mealplan_confirm");
+		requestKernel.Plugins.AddFromObject(getMergedShoppingListTool, "shopping_merged");
+		requestKernel.Plugins.AddFromObject(createShoppingListTool, "shopping_create");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -28,6 +28,8 @@ public sealed partial class SemanticKernelChatService(
 	GetCookableRecipesTool getCookableRecipesTool,
 	RateRecipeTool rateRecipeTool,
 	GetWeeklyPlanTool getWeeklyPlanTool,
+	AssignMealTool assignMealTool,
+	ConfirmMealTool confirmMealTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -145,6 +147,14 @@ public sealed partial class SemanticKernelChatService(
           Tuesday?", "show me this week's plan", "was ist nächste Woche
           geplant?"), call get_weekly_plan. Pass year=0 / weekNumber=0 to
           mean "this week".
+        - When the user wants to plan a recipe ("plan carbonara for
+          Wednesday", "add risotto to Friday lunch"), first resolve the
+          recipe identifier via search_recipes if you don't already have
+          one, then call assign_meal.
+        - When the user reports cooking, skipping, or undoing a planned
+          meal ("I made the spaghetti on Wednesday", "skip Friday's
+          dinner"), call confirm_meal_cooked with state Cooked/Skipped/
+          Planned.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -167,6 +177,8 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(getCookableRecipesTool, "recipes_cookable");
 		requestKernel.Plugins.AddFromObject(rateRecipeTool, "recipes_rate");
 		requestKernel.Plugins.AddFromObject(getWeeklyPlanTool, "mealplan_weekly");
+		requestKernel.Plugins.AddFromObject(assignMealTool, "mealplan_assign");
+		requestKernel.Plugins.AddFromObject(confirmMealTool, "mealplan_confirm");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/AssignMealTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/AssignMealTool.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal assignment to the chat LLM. Cross-module:
+/// <see cref="IMealPlanScheduler"/> is the consumer-defined contract owned by
+/// Recipes; the HTTP adapter calls MealPlan via <c>IMealPlanClient</c>.
+/// </summary>
+/// <param name="scheduler">Consumer-defined scheduler.</param>
+/// <param name="context">Per-request collector for downstream suggestion / action emission.</param>
+public sealed class AssignMealTool(IMealPlanScheduler scheduler, ChatToolContext context)
+{
+	/// <summary>Plan a recipe into a meal slot for an ISO week.</summary>
+	/// <param name="day">English weekday name (Monday..Sunday).</param>
+	/// <param name="recipeIdentifier">Recipe GUID resolved from a prior search/get.</param>
+	/// <param name="recipeTitle">Recipe title for downstream display.</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="servings">Optional override for slot servings; null = use recipe default.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("assign_meal")]
+	[Description("Plan a recipe into a meal slot ('plan carbonara for Wednesday', 'add risotto to Friday lunch'). Pass year=0 / weekNumber=0 to mean 'this week'. Requires a recipe identifier from a previous search_recipes / get_recipe call.")]
+	public async Task<string> AssignAsync(
+		[Description("English weekday name: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, or Sunday")] string day,
+		[Description("Recipe identifier (GUID) returned by search_recipes or get_recipe")] string recipeIdentifier,
+		[Description("Recipe title for display")] string recipeTitle,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		[Description("Optional override for slot servings; omit to use the recipe default")] int? servings = null,
+		CancellationToken cancellationToken = default)
+	{
+		if (!Guid.TryParse(recipeIdentifier, out var recipe)) return "Invalid recipe identifier — call search_recipes first.";
+
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new AssignMealRequest(
+			resolvedYear,
+			resolvedWeek,
+			day,
+			mealType,
+			recipe,
+			recipeTitle,
+			servings);
+
+		var success = await scheduler.AssignAsync(request, cancellationToken);
+		if (!success) return $"Couldn't plan {recipeTitle} for {day} — please try again.";
+
+		context.AppendRecipeMatch(recipe, recipeTitle, $"Planned for {day} · {mealType}");
+		return $"Planned {recipeTitle} for {day} ({mealType}).";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/ConfirmMealTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/ConfirmMealTool.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal-state confirmation to the chat LLM. Used
+/// for "I made the carbonara on Wednesday" / "skip Friday's planned dinner".
+/// Cross-module via <see cref="IMealConfirmation"/>.
+/// </summary>
+/// <param name="confirmation">Consumer-defined confirmation contract.</param>
+public sealed class ConfirmMealTool(IMealConfirmation confirmation)
+{
+	/// <summary>Mark a planned meal as cooked, skipped, or restored to planned.</summary>
+	/// <param name="day">English weekday name (Monday..Sunday).</param>
+	/// <param name="state">"Cooked", "Skipped", or "Planned".</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("confirm_meal_cooked")]
+	[Description("Update a planned meal's state. Use for 'I made the spaghetti on Wednesday' (state=Cooked), 'skip Friday lunch' (state=Skipped), or 'I haven't cooked it yet' (state=Planned). Pass year=0 / weekNumber=0 to mean 'this week'.")]
+	public async Task<string> ConfirmAsync(
+		[Description("English weekday name: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, or Sunday")] string day,
+		[Description("Target state: Cooked, Skipped, or Planned")] string state,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new ConfirmMealRequest(resolvedYear, resolvedWeek, day, mealType, state);
+
+		var success = await confirmation.ConfirmAsync(request, cancellationToken);
+		if (!success) return $"Couldn't update {day}'s {mealType.ToLowerInvariant()} — the slot may not exist.";
+
+		return $"Marked {day} {mealType.ToLowerInvariant()} as {state.ToLowerInvariant()}.";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/CreateShoppingListTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/CreateShoppingListTool.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing "create a shopping list from these recipes" to
+/// the chat LLM. Cross-module via <see cref="IShoppingListCreator"/>.
+/// </summary>
+/// <param name="creator">Consumer-defined creator contract.</param>
+public sealed class CreateShoppingListTool(IShoppingListCreator creator)
+{
+	/// <summary>Create a shopping list named <paramref name="title"/> from the given comma-separated recipe identifiers.</summary>
+	/// <param name="title">List title (e.g. "This week's dinners").</param>
+	/// <param name="recipeIdentifiers">Comma-separated list of recipe GUIDs from prior search/get calls.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Human-readable confirmation string for the LLM to weave into its reply.</returns>
+	[KernelFunction("create_shopping_list_from_recipes")]
+	[Description("Create a new shopping list sourced from one or more recipes. Use for 'make a shopping list for spaghetti and risotto', 'create a list for this week's dinners'. Pass comma-separated recipe identifiers from prior search_recipes / get_recipe calls.")]
+	public async Task<string> CreateAsync(
+		[Description("List title, e.g. 'This week's dinners'")] string title,
+		[Description("Comma-separated recipe GUIDs (e.g. '8d4d…, c2f7…') from prior search_recipes calls")] string recipeIdentifiers,
+		CancellationToken cancellationToken = default)
+	{
+		var parsed = ParseGuids(recipeIdentifiers);
+		if (parsed.Count == 0) return "Need at least one valid recipe identifier — call search_recipes first.";
+
+		var request = new CreateShoppingListRequest(
+			title,
+			[.. parsed.Select(id => new CreateShoppingListRecipe(id, Servings: null))]);
+
+		var success = await creator.CreateAsync(request, cancellationToken);
+		return success
+			? $"Created '{title}' with {parsed.Count} recipe(s)."
+			: $"Couldn't create '{title}' — please try again.";
+	}
+
+	private static List<Guid> ParseGuids(string commaSeparated)
+	{
+		List<Guid> result = [];
+		foreach (var token in commaSeparated.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (Guid.TryParse(token, out var guid)) result.Add(guid);
+		}
+
+		return result;
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/GetMergedShoppingListTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/GetMergedShoppingListTool.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing the user's merged active shopping list to the
+/// chat LLM. Cross-module via <see cref="IShoppingListLookup"/>.
+/// </summary>
+/// <param name="lookup">Consumer-defined merged-list lookup.</param>
+public sealed class GetMergedShoppingListTool(IShoppingListLookup lookup)
+{
+	/// <summary>Get the user's merged active shopping list.</summary>
+	/// <param name="includePastBought">Whether to include items already bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>The merged list or null if nothing on the list.</returns>
+	[KernelFunction("get_merged_shopping_list")]
+	[Description("Fetch the user's active shopping list, merged across all open lists. Use for 'what's on my shopping list?', 'do I need to buy anything for chicken?', 'was steht auf meiner Einkaufsliste?'. Defaults to unbought items only.")]
+	public Task<ShoppingListLookupResult?> GetAsync(
+		[Description("If true, also include items already bought (for review). Defaults to false.")] bool includePastBought = false,
+		CancellationToken cancellationToken = default) =>
+		lookup.GetMergedAsync(includePastBought, cancellationToken);
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/GetWeeklyPlanTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/GetWeeklyPlanTool.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing the user's weekly meal plan to the chat LLM.
+/// Cross-module call: <see cref="IWeeklyPlanLookup"/> is the consumer-defined
+/// contract owned by Recipes; the HTTP adapter calls the MealPlan module via
+/// <c>IMealPlanClient</c>.
+/// </summary>
+/// <param name="lookup">Consumer-defined weekly-plan lookup.</param>
+/// <param name="context">Per-request collector for downstream suggestion / action emission.</param>
+public sealed class GetWeeklyPlanTool(IWeeklyPlanLookup lookup, ChatToolContext context)
+{
+	/// <summary>Get the user's planned meals for an ISO week. Year + week default to "this week" when omitted.</summary>
+	/// <param name="year">ISO year, e.g. 2026. Pass 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53. Pass 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>The weekly plan or null if nothing planned.</returns>
+	[KernelFunction("get_weekly_plan")]
+	[Description("Fetch the user's planned meals for an ISO week. Use for 'what's for dinner this week?', 'what did I plan for Tuesday?', 'show me next week's plan'. Pass year=0 and weekNumber=0 to mean 'this week'.")]
+	public async Task<WeeklyPlanLookupResult?> GetAsync(
+		[Description("ISO year (e.g. 2026), or 0 for the current year")] int year,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var plan = await lookup.GetForWeekAsync(resolvedYear, resolvedWeek, cancellationToken);
+		if (plan is null) return null;
+
+		foreach (var slot in plan.Slots)
+		{
+			if (slot.RecipeIdentifier is { } id && slot.RecipeTitle is { } title)
+			{
+				context.AppendRecipeMatch(id, title, $"{slot.Day} · {slot.MealType}");
+			}
+		}
+
+		return plan;
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealConfirmation.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealConfirmation.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealConfirmation(IMealPlanClient mealPlan) : IMealConfirmation
+{
+	public Task<bool> ConfirmAsync(ConfirmMealRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new ConfirmMealBody(request.Day, request.MealType, request.State);
+		return mealPlan.ConfirmMealAsync(request.Year, request.WeekNumber, body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealPlanScheduler.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealPlanScheduler.cs
@@ -1,0 +1,18 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealPlanScheduler(IMealPlanClient mealPlan) : IMealPlanScheduler
+{
+	public Task<bool> AssignAsync(AssignMealRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new AssignRecipeBody(
+			request.Day,
+			request.RecipeIdentifier,
+			request.RecipeTitle,
+			request.MealType,
+			request.Servings);
+		return mealPlan.AssignRecipeAsync(request.Year, request.WeekNumber, body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListCreator.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListCreator.cs
@@ -1,0 +1,15 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpShoppingListCreator(IShoppingClient shopping) : IShoppingListCreator
+{
+	public Task<bool> CreateAsync(CreateShoppingListRequest request, CancellationToken cancellationToken = default)
+	{
+		var body = new CreateListFromRecipesBody(
+			request.Title,
+			[.. request.Recipes.Select(recipe => new CreateListRecipeBody(recipe.RecipeIdentifier, recipe.Servings))]);
+		return shopping.CreateListFromRecipesAsync(body, cancellationToken);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListLookup.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListLookup.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpShoppingListLookup(IShoppingClient shopping) : IShoppingListLookup
+{
+	public async Task<ShoppingListLookupResult?> GetMergedAsync(bool includePastBought = false, CancellationToken cancellationToken = default)
+	{
+		var response = await shopping.GetMergedListAsync(includePastBought, cancellationToken);
+		return response?.ToLookupResult();
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpWeeklyPlanLookup.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpWeeklyPlanLookup.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpWeeklyPlanLookup(IMealPlanClient mealPlan) : IWeeklyPlanLookup
+{
+	public async Task<WeeklyPlanLookupResult?> GetForWeekAsync(int year, int weekNumber, CancellationToken cancellationToken = default)
+	{
+		var response = await mealPlan.GetWeeklyPlanAsync(year, weekNumber, cancellationToken);
+		return response?.ToLookupResult();
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/ShoppingListLookupMappingExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/ShoppingListLookupMappingExtensions.cs
@@ -1,0 +1,13 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+internal static class ShoppingListLookupMappingExtensions
+{
+	public static ShoppingListLookupResult ToLookupResult(this MergedShoppingListResponse response) =>
+		new([.. response.Items.Select(item => item.ToLookupItem())]);
+
+	public static ShoppingListLookupItem ToLookupItem(this MergedShoppingListItemResponse item) =>
+		new(item.ItemName, item.DisplayQuantity, item.Unit, item.Category, item.IsBought);
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/WeeklyPlanLookupMappingExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/WeeklyPlanLookupMappingExtensions.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+internal static class WeeklyPlanLookupMappingExtensions
+{
+	public static WeeklyPlanLookupResult ToLookupResult(this WeeklyPlanResponse response) =>
+		new(
+			response.Week,
+			response.IsExtendedMode,
+			[.. response.Slots.Select(slot => slot.ToLookupSlot())]);
+
+	public static WeeklyPlanLookupSlot ToLookupSlot(this WeeklyPlanSlotResponse slot) =>
+		new(slot.Day, slot.MealType, slot.RecipeIdentifier, slot.RecipeTitle, slot.Servings, slot.IsEmpty);
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
 		services.AddScoped<IMealPlanScheduler, HttpMealPlanScheduler>();
 		services.AddScoped<IMealConfirmation, HttpMealConfirmation>();
+		services.AddScoped<IShoppingListLookup, HttpShoppingListLookup>();
+		services.AddScoped<IShoppingListCreator, HttpShoppingListCreator>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -42,6 +42,8 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
 		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
+		services.AddScoped<IMealPlanScheduler, HttpMealPlanScheduler>();
+		services.AddScoped<IMealConfirmation, HttpMealConfirmation>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
@@ -40,9 +41,11 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IRecipesUserDataPurger, RecipesUserDataPurger>();
 		services.AddScoped<IIngredientBalanceProvider, HttpIngredientBalanceProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
+		services.AddScoped<IWeeklyPlanLookup, HttpWeeklyPlanLookup>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();
+		services.AddMealPlanClient();
 		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
 
 		return services;

--- a/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
+++ b/src/Yumney.Recipes.Infrastructure/Yumney.Recipes.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
+    <ProjectReference Include="..\Yumney.MealPlan.Client\Yumney.MealPlan.Client.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
     <ProjectReference Include="..\Yumney.Users.Client\Yumney.Users.Client.csproj" />
   </ItemGroup>

--- a/src/Yumney.Shared.Web/IModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClient.cs
@@ -19,6 +19,12 @@ public interface IModuleHttpClient
 		TBody body,
 		string operation,
 		CancellationToken cancellationToken = default);
+
+	Task PutAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default);
 }
 
 public interface IModuleHttpClientFactory

--- a/src/Yumney.Shared.Web/ModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/ModuleHttpClient.cs
@@ -75,6 +75,24 @@ internal sealed partial class ModuleHttpClient(
 		}
 	}
 
+	public async Task PutAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await httpClient.PutAsJsonAsync(url, body, jsonOptions, cancellationToken);
+			response.EnsureSuccessStatusCode();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogPutFailed(operation, upstreamName, ex.Message);
+			throw;
+		}
+	}
+
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{Operation} GET against {Upstream} failed ({Reason}); returning fallback.")]
 	private partial void LogGetFailed(string operation, string upstream, string reason);
 
@@ -83,4 +101,7 @@ internal sealed partial class ModuleHttpClient(
 
 	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} POST to {Upstream} failed ({Reason}).")]
 	private partial void LogPostFailed(string operation, string upstream, string reason);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} PUT to {Upstream} failed ({Reason}).")]
+	private partial void LogPutFailed(string operation, string upstream, string reason);
 }

--- a/src/Yumney.Shopping.Client/IShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/IShoppingClient.cs
@@ -7,6 +7,18 @@ public interface IShoppingClient
 	Task<ShoppingBalanceResponse?> GetBalanceAsync(CancellationToken cancellationToken = default);
 
 	Task AddItemAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default);
+
+	/// <summary>Fetch the user's merged active shopping list. GET /api/v1/shopping-lists/merged.</summary>
+	/// <param name="includePastBought">Whether to include items that have been bought.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>The merged list, or null if the upstream call fails / returns 404.</returns>
+	Task<MergedShoppingListResponse?> GetMergedListAsync(bool includePastBought = false, CancellationToken cancellationToken = default);
+
+	/// <summary>Create a shopping list from one or more recipes. POST /api/v1/shopping-lists/from-recipes.</summary>
+	/// <param name="body">Title plus the list of recipes to include.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> CreateListFromRecipesAsync(CreateListFromRecipesBody body, CancellationToken cancellationToken = default);
 }
 
 public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> Items);
@@ -14,3 +26,20 @@ public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> 
 public sealed record ShoppingBalanceItem(string ItemName, Freshness Freshness);
 
 public sealed record AddShoppingItemRequest(string Name, decimal Quantity, string? Unit, string Source);
+
+/// <summary>Trimmed merged-list shape returned over the wire.</summary>
+public sealed record MergedShoppingListResponse(IReadOnlyList<MergedShoppingListItemResponse> Items);
+
+/// <summary>One merged item across all of the user's active lists.</summary>
+public sealed record MergedShoppingListItemResponse(
+	string ItemName,
+	decimal DisplayQuantity,
+	string? Unit,
+	string Category,
+	bool IsBought);
+
+/// <summary>Body for create-list-from-recipes POST.</summary>
+public sealed record CreateListFromRecipesBody(string Title, IReadOnlyList<CreateListRecipeBody> Recipes);
+
+/// <summary>One recipe selection inside a create-list-from-recipes body.</summary>
+public sealed record CreateListRecipeBody(Guid RecipeIdentifier, int? Servings);

--- a/src/Yumney.Shopping.Client/ShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClient.cs
@@ -18,4 +18,27 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 			request,
 			"AddShoppingItem",
 			cancellationToken);
+
+	public Task<MergedShoppingListResponse?> GetMergedListAsync(bool includePastBought = false, CancellationToken cancellationToken = default) =>
+		http.FindAsync<MergedShoppingListResponse>(
+			$"/api/v1/shopping-lists/merged?includePastBought={includePastBought.ToString().ToLowerInvariant()}",
+			"GetMergedShoppingList",
+			cancellationToken);
+
+	public async Task<bool> CreateListFromRecipesAsync(CreateListFromRecipesBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PostAsync(
+				"/api/v1/shopping-lists/from-recipes",
+				body,
+				"CreateShoppingListFromRecipes",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealConfirmationTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealConfirmationTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealConfirmationTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task ConfirmAsync_MapsConsumerRequestToClientBody()
+	{
+		ConfirmMealBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.ConfirmMealAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ConfirmMealBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<ConfirmMealBody>(2);
+				return true;
+			});
+
+		var confirmation = new HttpMealConfirmation(client);
+		await confirmation.ConfirmAsync(new ConfirmMealRequest(2026, 19, "Wednesday", "Dinner", "Cooked"));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(19);
+		captured.Should().NotBeNull();
+		captured!.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.State.Should().Be("Cooked");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.ConfirmMealAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ConfirmMealBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var confirmation = new HttpMealConfirmation(client);
+		var result = await confirmation.ConfirmAsync(new ConfirmMealRequest(2026, 19, "Friday", "Lunch", "Skipped"));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealPlanSchedulerTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealPlanSchedulerTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealPlanSchedulerTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task AssignAsync_MapsConsumerRequestToClientBody()
+	{
+		AssignRecipeBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.AssignRecipeAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<AssignRecipeBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<AssignRecipeBody>(2);
+				return true;
+			});
+
+		var scheduler = new HttpMealPlanScheduler(client);
+		var recipe = Guid.NewGuid();
+		await scheduler.AssignAsync(new AssignMealRequest(2026, 19, "Wednesday", "Dinner", recipe, "Carbonara", Servings: 4));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(19);
+		captured.Should().NotBeNull();
+		captured!.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.RecipeIdentifier.Should().Be(recipe);
+		captured.RecipeTitle.Should().Be("Carbonara");
+		captured.Servings.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task AssignAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.AssignRecipeAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<AssignRecipeBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var scheduler = new HttpMealPlanScheduler(client);
+		var result = await scheduler.AssignAsync(new AssignMealRequest(2026, 19, "Friday", "Lunch", Guid.NewGuid(), "Pizza", Servings: null));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListCreatorTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListCreatorTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListCreatorTests
+{
+	private readonly IShoppingClient client = Substitute.For<IShoppingClient>();
+
+	[Fact]
+	public async Task CreateAsync_MapsConsumerRecipesToClientBody()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		CreateListFromRecipesBody? captured = null;
+		client.CreateListFromRecipesAsync(Arg.Any<CreateListFromRecipesBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateListFromRecipesBody>(0);
+				return true;
+			});
+
+		var creator = new HttpShoppingListCreator(client);
+		await creator.CreateAsync(new CreateShoppingListRequest(
+			"This week",
+			[
+				new CreateShoppingListRecipe(first, Servings: 4),
+				new CreateShoppingListRecipe(second, Servings: null),
+			]));
+
+		captured.Should().NotBeNull();
+		captured!.Title.Should().Be("This week");
+		captured.Recipes.Should().HaveCount(2);
+		captured.Recipes[0].RecipeIdentifier.Should().Be(first);
+		captured.Recipes[0].Servings.Should().Be(4);
+		captured.Recipes[1].RecipeIdentifier.Should().Be(second);
+		captured.Recipes[1].Servings.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task CreateAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.CreateListFromRecipesAsync(Arg.Any<CreateListFromRecipesBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var creator = new HttpShoppingListCreator(client);
+		var result = await creator.CreateAsync(new CreateShoppingListRequest("List", [new(Guid.NewGuid(), Servings: null)]));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListLookupTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListLookupTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListLookupTests
+{
+	private readonly IShoppingClient client = Substitute.For<IShoppingClient>();
+
+	[Fact]
+	public async Task GetMergedAsync_ClientReturnsResponse_MapsToLookupResult()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(new MergedShoppingListResponse([
+				new MergedShoppingListItemResponse("Eggs", 6m, "pcs", "Dairy", IsBought: false),
+				new MergedShoppingListItemResponse("Flour", 500m, "g", "Pantry", IsBought: true),
+			]));
+
+		var lookup = new HttpShoppingListLookup(client);
+		var result = await lookup.GetMergedAsync();
+
+		result.Should().NotBeNull();
+		result!.Items.Should().HaveCount(2);
+		result.Items[0].Name.Should().Be("Eggs");
+		result.Items[0].Quantity.Should().Be(6m);
+		result.Items[0].Unit.Should().Be("pcs");
+		result.Items[0].Category.Should().Be("Dairy");
+		result.Items[0].IsBought.Should().BeFalse();
+		result.Items[1].IsBought.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task GetMergedAsync_ClientReturnsNull_ReturnsNull()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((MergedShoppingListResponse?)null);
+
+		var lookup = new HttpShoppingListLookup(client);
+		var result = await lookup.GetMergedAsync();
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetMergedAsync_ForwardsIncludePastBoughtFlag()
+	{
+		client.GetMergedListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((MergedShoppingListResponse?)null);
+
+		var lookup = new HttpShoppingListLookup(client);
+		await lookup.GetMergedAsync(includePastBought: true);
+
+		await client.Received(1).GetMergedListAsync(true, Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpWeeklyPlanLookupTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpWeeklyPlanLookupTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpWeeklyPlanLookupTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task GetForWeekAsync_ClientReturnsResponse_MapsToLookupResult()
+	{
+		var recipe = Guid.NewGuid();
+		client.GetWeeklyPlanAsync(2026, 19, Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanResponse(
+				"2026-W19",
+				IsExtendedMode: true,
+				[new WeeklyPlanSlotResponse("Monday", "Dinner", "Recipe", "Planned", recipe, "Carbonara", 4, IsEmpty: false)]));
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		var result = await lookup.GetForWeekAsync(2026, 19);
+
+		result.Should().NotBeNull();
+		result!.Week.Should().Be("2026-W19");
+		result.IsExtendedMode.Should().BeTrue();
+		result.Slots.Should().ContainSingle();
+		result.Slots[0].RecipeIdentifier.Should().Be(recipe);
+		result.Slots[0].RecipeTitle.Should().Be("Carbonara");
+		result.Slots[0].IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetForWeekAsync_ClientReturnsNull_ReturnsNull()
+	{
+		client.GetWeeklyPlanAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanResponse?)null);
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		var result = await lookup.GetForWeekAsync(2026, 19);
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetForWeekAsync_ForwardsYearAndWeekToClient()
+	{
+		client.GetWeeklyPlanAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanResponse?)null);
+
+		var lookup = new HttpWeeklyPlanLookup(client);
+		await lookup.GetForWeekAsync(2026, 23);
+
+		await client.Received(1).GetWeeklyPlanAsync(2026, 23, Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceFunctionCallingTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceFunctionCallingTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
@@ -255,6 +256,19 @@ public sealed class SemanticKernelChatServiceFunctionCallingTests
 		var searchTool = new SearchRecipesTool(searchHandler, context);
 		var getTool = new GetRecipeTool(getHandler, context);
 		var cookableTool = new GetCookableRecipesTool(cookableHandler, context);
+		var rateTool = new RateRecipeTool(Substitute.For<ICommandHandler<RateRecipeCommand, Result>>());
+		var weeklyPlanTool = new GetWeeklyPlanTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IWeeklyPlanLookup>(),
+			context);
+		var assignMealTool = new AssignMealTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IMealPlanScheduler>(),
+			context);
+		var confirmMealTool = new ConfirmMealTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IMealConfirmation>());
+		var mergedShoppingListTool = new GetMergedShoppingListTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListLookup>());
+		var createShoppingListTool = new CreateShoppingListTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListCreator>());
 
 		var kernelBuilder = Kernel.CreateBuilder();
 		kernelBuilder.Services.AddSingleton<IChatCompletionService>(fake);
@@ -265,6 +279,12 @@ public sealed class SemanticKernelChatServiceFunctionCallingTests
 			searchTool,
 			getTool,
 			cookableTool,
+			rateTool,
+			weeklyPlanTool,
+			assignMealTool,
+			confirmMealTool,
+			mergedShoppingListTool,
+			createShoppingListTool,
 			context,
 			NullLogger<SemanticKernelChatService>.Instance);
 

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AssignMealToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AssignMealToolTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class AssignMealToolTests
+{
+	private readonly IMealPlanScheduler scheduler = Substitute.For<IMealPlanScheduler>();
+	private readonly ChatToolContext context = new();
+
+	[Fact]
+	public async Task AssignAsync_HappyPath_ForwardsRequestAndAppendsContext()
+	{
+		var recipe = Guid.NewGuid();
+		AssignMealRequest? captured = null;
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AssignMealRequest>(0);
+				return true;
+			});
+
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Wednesday", recipe.ToString(), "Carbonara", "Dinner", 2026, 19, servings: 4);
+
+		reply.Should().Contain("Carbonara");
+		reply.Should().Contain("Wednesday");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.RecipeIdentifier.Should().Be(recipe);
+		captured.RecipeTitle.Should().Be("Carbonara");
+		captured.Servings.Should().Be(4);
+		context.Matches.Should().ContainSingle();
+		context.Matches[0].Identifier.Should().Be(recipe);
+		context.Matches[0].Reason.Should().Be("Planned for Wednesday · Dinner");
+	}
+
+	[Fact]
+	public async Task AssignAsync_InvalidGuid_ReturnsErrorWithoutCallingScheduler()
+	{
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Wednesday", "not-a-guid", "Carbonara");
+
+		reply.Should().Contain("Invalid recipe identifier");
+		context.Matches.Should().BeEmpty();
+		await scheduler.DidNotReceiveWithAnyArgs().AssignAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task AssignAsync_SchedulerReturnsFalse_ReturnsErrorWithoutAppendingContext()
+	{
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new AssignMealTool(scheduler, context);
+		var reply = await tool.AssignAsync("Friday", Guid.NewGuid().ToString(), "Pizza");
+
+		reply.Should().Contain("Couldn't plan");
+		context.Matches.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task AssignAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		AssignMealRequest? captured = null;
+		scheduler.AssignAsync(Arg.Any<AssignMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AssignMealRequest>(0);
+				return true;
+			});
+
+		var tool = new AssignMealTool(scheduler, context);
+		await tool.AssignAsync("Monday", Guid.NewGuid().ToString(), "Stew", year: 0, weekNumber: 0);
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ConfirmMealToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ConfirmMealToolTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class ConfirmMealToolTests
+{
+	private readonly IMealConfirmation confirmation = Substitute.For<IMealConfirmation>();
+
+	[Fact]
+	public async Task ConfirmAsync_HappyPath_ForwardsRequest()
+	{
+		ConfirmMealRequest? captured = null;
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ConfirmMealRequest>(0);
+				return true;
+			});
+
+		var tool = new ConfirmMealTool(confirmation);
+		var reply = await tool.ConfirmAsync("Wednesday", "Cooked", "Dinner", 2026, 19);
+
+		reply.Should().Contain("Wednesday");
+		reply.Should().Contain("cooked");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+		captured.State.Should().Be("Cooked");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_ConfirmationReturnsFalse_ReturnsErrorMessage()
+	{
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new ConfirmMealTool(confirmation);
+		var reply = await tool.ConfirmAsync("Friday", "Skipped");
+
+		reply.Should().Contain("Couldn't update");
+	}
+
+	[Fact]
+	public async Task ConfirmAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		ConfirmMealRequest? captured = null;
+		confirmation.ConfirmAsync(Arg.Any<ConfirmMealRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ConfirmMealRequest>(0);
+				return true;
+			});
+
+		var tool = new ConfirmMealTool(confirmation);
+		await tool.ConfirmAsync("Monday", "Cooked", year: 0, weekNumber: 0);
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/CreateShoppingListToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/CreateShoppingListToolTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class CreateShoppingListToolTests
+{
+	private readonly IShoppingListCreator creator = Substitute.For<IShoppingListCreator>();
+
+	[Fact]
+	public async Task CreateAsync_HappyPath_BuildsRequestAndReturnsConfirmation()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		CreateShoppingListRequest? captured = null;
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateShoppingListRequest>(0);
+				return true;
+			});
+
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("This week's dinners", $"{first}, {second}");
+
+		reply.Should().Contain("This week's dinners");
+		reply.Should().Contain("2");
+		captured.Should().NotBeNull();
+		captured!.Title.Should().Be("This week's dinners");
+		captured.Recipes.Should().HaveCount(2);
+		captured.Recipes.Select(recipe => recipe.RecipeIdentifier).Should().ContainInOrder(first, second);
+		captured.Recipes.Should().AllSatisfy(recipe => recipe.Servings.Should().BeNull());
+	}
+
+	[Fact]
+	public async Task CreateAsync_NoValidGuids_ReturnsErrorWithoutCallingCreator()
+	{
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("Foo", "not-a-guid, also-not-one");
+
+		reply.Should().Contain("Need at least one valid recipe identifier");
+		await creator.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task CreateAsync_MixedValidAndInvalid_KeepsOnlyValid()
+	{
+		var valid = Guid.NewGuid();
+		CreateShoppingListRequest? captured = null;
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<CreateShoppingListRequest>(0);
+				return true;
+			});
+
+		var tool = new CreateShoppingListTool(creator);
+		await tool.CreateAsync("Mix", $"not-a-guid, {valid}, also-not-one");
+
+		captured.Should().NotBeNull();
+		captured!.Recipes.Should().ContainSingle();
+		captured.Recipes[0].RecipeIdentifier.Should().Be(valid);
+	}
+
+	[Fact]
+	public async Task CreateAsync_CreatorReturnsFalse_ReturnsErrorMessage()
+	{
+		creator.CreateAsync(Arg.Any<CreateShoppingListRequest>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var tool = new CreateShoppingListTool(creator);
+		var reply = await tool.CreateAsync("List", Guid.NewGuid().ToString());
+
+		reply.Should().Contain("Couldn't create");
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetMergedShoppingListToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetMergedShoppingListToolTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class GetMergedShoppingListToolTests
+{
+	private readonly IShoppingListLookup lookup = Substitute.For<IShoppingListLookup>();
+
+	[Fact]
+	public async Task GetAsync_DefaultCall_ExcludesPastBought()
+	{
+		bool capturedFlag = true;
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedFlag = callInfo.ArgAt<bool>(0);
+				return new ShoppingListLookupResult([]);
+			});
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		await tool.GetAsync();
+
+		capturedFlag.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task GetAsync_ReturnsLookupResultDirectly()
+	{
+		var expected = new ShoppingListLookupResult([
+			new ShoppingListLookupItem("Eggs", 6m, "pcs", "Dairy", IsBought: false),
+			new ShoppingListLookupItem("Flour", 500m, "g", "Pantry", IsBought: false),
+		]);
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(expected);
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		var result = await tool.GetAsync();
+
+		result.Should().BeSameAs(expected);
+	}
+
+	[Fact]
+	public async Task GetAsync_LookupReturnsNull_ReturnsNull()
+	{
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns((ShoppingListLookupResult?)null);
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		var result = await tool.GetAsync();
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetAsync_IncludePastBoughtTrue_ForwardsFlag()
+	{
+		bool capturedFlag = false;
+		lookup.GetMergedAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedFlag = callInfo.ArgAt<bool>(0);
+				return new ShoppingListLookupResult([]);
+			});
+
+		var tool = new GetMergedShoppingListTool(lookup);
+		await tool.GetAsync(includePastBought: true);
+
+		capturedFlag.Should().BeTrue();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetWeeklyPlanToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/GetWeeklyPlanToolTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class GetWeeklyPlanToolTests
+{
+	private readonly IWeeklyPlanLookup lookup = Substitute.For<IWeeklyPlanLookup>();
+	private readonly ChatToolContext context = new();
+
+	[Fact]
+	public async Task GetAsync_PlanFound_AppendsRecipeMatchesPerSlot()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		lookup.GetForWeekAsync(2026, 19, Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanLookupResult(
+				"2026-W19",
+				IsExtendedMode: false,
+				[
+					new WeeklyPlanLookupSlot("Monday", "Dinner", first, "Carbonara", 4, IsEmpty: false),
+					new WeeklyPlanLookupSlot("Tuesday", "Dinner", second, "Risotto", 4, IsEmpty: false),
+					new WeeklyPlanLookupSlot("Wednesday", "Dinner", null, null, 0, IsEmpty: true),
+				]));
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		var result = await tool.GetAsync(2026, 19);
+
+		result.Should().NotBeNull();
+		result!.Slots.Should().HaveCount(3);
+		context.Matches.Should().HaveCount(2);
+		context.Matches.Select(match => match.Identifier).Should().ContainInOrder(first, second);
+		context.Matches[0].Reason.Should().Be("Monday · Dinner");
+	}
+
+	[Fact]
+	public async Task GetAsync_PlanNotFound_ReturnsNullWithoutAppending()
+	{
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns((WeeklyPlanLookupResult?)null);
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		var result = await tool.GetAsync(2026, 19);
+
+		result.Should().BeNull();
+		context.Matches.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task GetAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		WeeklyPlanLookupResult? captured = null;
+		int capturedYear = 0;
+		int capturedWeek = 0;
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = new WeeklyPlanLookupResult($"{capturedYear}-W{capturedWeek}", false, []);
+				return captured;
+			});
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		await tool.GetAsync(0, 0);
+
+		capturedYear.Should().BeGreaterThanOrEqualTo(2026);
+		capturedWeek.Should().BeInRange(1, 53);
+	}
+
+	[Fact]
+	public async Task GetAsync_EmptySlot_DoesNotAppendRecipeMatch()
+	{
+		lookup.GetForWeekAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new WeeklyPlanLookupResult(
+				"2026-W19",
+				IsExtendedMode: false,
+				[new WeeklyPlanLookupSlot("Friday", "Dinner", null, null, 0, IsEmpty: true)]));
+
+		var tool = new GetWeeklyPlanTool(lookup, context);
+		await tool.GetAsync(2026, 19);
+
+		context.Matches.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
PRs #644 / #645 / #646 were marked merged on GitHub but their commits never reached develop — they merged into their stacked-branch parents instead of cascading up. This PR re-applies the three commits cleanly on top of develop, plus a small fix to the SK function-calling integration test (#654) so it passes the now-9-tool constructor.

Content is identical to the original PRs — just rebased.

## Recovered

- `feat(recipes): get_weekly_plan chat tool + cross-module MealPlan client` (was #644)
- `feat(recipes): assign_meal + confirm_meal_cooked chat tools` (was #645)
- `feat(recipes): get_merged_shopping_list + create_shopping_list_from_recipes chat tools` (was #646)

## Test fix

`SemanticKernelChatServiceFunctionCallingTests.BuildChatService` now constructs the service with all 9 tools (substituted handlers for the 6 it doesn't directly exercise — they're not the SUT for those tests).

## Closes

- #644
- #645
- #646