### PR TITLE
feat(infra): recover Phase 3 capability manifest + Phase 4 MCP server stack

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,9 @@
     <!-- LLM & Scraping -->
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
+    <!-- Model Context Protocol (used by Yumney.Mcp.Server to expose capabilities to external LLM clients per ADR 0002) -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
     <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.31.1" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -9,6 +9,7 @@
   <Folder Name="/src/Shared/">
     <Project Path="src/Yumney.Shared/Yumney.Shared.csproj" />
     <Project Path="src/Yumney.Shared.Abstractions/Yumney.Shared.Abstractions.csproj" />
+    <Project Path="src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj" />
     <Project Path="src/Yumney.Shared.Outcomes/Yumney.Shared.Outcomes.csproj" />
     <Project Path="src/Yumney.Shared.Paging/Yumney.Shared.Paging.csproj" />
     <Project Path="src/Yumney.Shared.Quantities/Yumney.Shared.Quantities.csproj" />

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -3,6 +3,7 @@
   <Folder Name="/src/Host/">
     <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
     <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
+    <Project Path="src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj" />
     <Project Path="src/Yumney.ServiceDefaults/Yumney.ServiceDefaults.csproj" />
     <Project Path="src/Yumney.MigrationRunner/Yumney.MigrationRunner.csproj" />
   </Folder>
@@ -86,5 +87,6 @@
   <Folder Name="/tests/Cross-Cutting/">
     <Project Path="tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj" />
     <Project Path="tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj" />
+    <Project Path="tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -227,6 +227,15 @@ if (!options.DatabaseOnly)
 			.WithReference(shell)
 			.WithReference(keycloak)
 			.WaitFor(keycloak);
+
+		// MCP server: aggregates the per-host capability manifests on startup
+		// (Phase 4a). Phase 4b adds the actual ModelContextProtocol surface +
+		// gateway routing. Not yet exposed externally.
+		builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
+			.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+			.WithReference(recipesApi)
+			.WithReference(shoppingApi)
+			.WithReference(mealplanApi);
 	}
 	else if (!isRunMode)
 	{

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -186,6 +186,16 @@ if (!options.DatabaseOnly)
 	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
 	migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
 
+	// MCP server: aggregates the per-host capability manifests on startup and
+	// exposes them as MCP tools at /mcp (Phase 4b). Tool invocation returns a
+	// stub until the OAuth bridge + REST proxy land in Phase 4c. Declared
+	// outside the run/publish branches because both gateways route to it.
+	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
+		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.WithReference(recipesApi)
+		.WithReference(shoppingApi)
+		.WithReference(mealplanApi);
+
 	if (isRunMode)
 	{
 		// Run mode (including E2E) spawns the Angular dev servers and the gateway
@@ -224,18 +234,10 @@ if (!options.DatabaseOnly)
 			.WithReference(shoppingApi)
 			.WithReference(usersApi)
 			.WithReference(mealplanApi)
+			.WithReference(mcpServer)
 			.WithReference(shell)
 			.WithReference(keycloak)
 			.WaitFor(keycloak);
-
-		// MCP server: aggregates the per-host capability manifests on startup
-		// (Phase 4a). Phase 4b adds the actual ModelContextProtocol surface +
-		// gateway routing. Not yet exposed externally.
-		builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
-			.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-			.WithReference(recipesApi)
-			.WithReference(shoppingApi)
-			.WithReference(mealplanApi);
 	}
 	else if (!isRunMode)
 	{
@@ -251,6 +253,7 @@ if (!options.DatabaseOnly)
 				yarp.AddRoute("/api/v1/shopping-lists/{**catch-all}", shoppingApi);
 				yarp.AddRoute("/api/v1/auth/{**catch-all}", usersApi);
 				yarp.AddRoute("/api/v1/meal-plans/{**catch-all}", mealplanApi);
+				yarp.AddRoute("/mcp/{**catch-all}", mcpServer);
 				yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
 			})
 			.WithExternalHttpEndpoints();

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Yumney.Users.Api\Yumney.Users.Api.csproj" />
     <ProjectReference Include="..\Yumney.MealPlan.Api\Yumney.MealPlan.Api.csproj" />
     <ProjectReference Include="..\Yumney.Gateway\Yumney.Gateway.csproj" />
+    <ProjectReference Include="..\Yumney.Mcp.Server\Yumney.Mcp.Server.csproj" />
     <ProjectReference Include="..\Yumney.MigrationRunner\Yumney.MigrationRunner.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -41,6 +41,12 @@
           "Path": "/api/v1/meal-plans/{**remainder}"
         }
       },
+      "mcp-route": {
+        "ClusterId": "mcp-server",
+        "Match": {
+          "Path": "/mcp/{**remainder}"
+        }
+      },
       "keycloak-route": {
         "ClusterId": "keycloak",
         "Match": {
@@ -89,6 +95,13 @@
         "Destinations": {
           "primary": {
             "Address": "https+http://mealplan-api"
+          }
+        }
+      },
+      "mcp-server": {
+        "Destinations": {
+          "primary": {
+            "Address": "https+http://mcp-server"
           }
         }
       },

--- a/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
+++ b/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+
+/// <summary>
+/// JWT bearer wiring against Keycloak — mirrors the pattern in
+/// <c>Yumney.Shared.Web.HostBuilderExtensions.AddYumneyDefaults</c> but
+/// inlined here to keep the MCP server's dependency footprint small (no
+/// Wolverine, no Persistence, no EF Core).
+/// </summary>
+#pragma warning disable SA1303
+public static class KeycloakAuthExtensions
+{
+	private const string realmConfigKey = "Keycloak:Realm";
+	private const string keycloakConnectionStringName = "keycloak";
+	private const string defaultRealm = "yumney";
+	private const string defaultUrl = "http://localhost:8080";
+	private const string audience = "yumney-api";
+
+	/// <summary>Add JWT bearer auth pointing at the Aspire-provisioned Keycloak realm.</summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="configuration">Configuration source.</param>
+	/// <param name="environment">Host environment — controls dev-mode laxity.</param>
+	/// <returns>The service collection for chaining.</returns>
+	public static IServiceCollection AddKeycloakBearerAuthentication(
+		this IServiceCollection services,
+		IConfiguration configuration,
+		IHostEnvironment environment)
+	{
+		var isDevelopment = environment.IsDevelopment();
+
+		services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+			.AddJwtBearer(options =>
+			{
+				options.Authority = RealmUrl(configuration);
+				options.Audience = audience;
+				options.RequireHttpsMetadata = !isDevelopment;
+				options.TokenValidationParameters.ValidateIssuer = !isDevelopment;
+				if (!isDevelopment)
+				{
+					options.TokenValidationParameters.ValidIssuer = RealmUrl(configuration);
+				}
+			});
+
+		services.AddAuthorization();
+		return services;
+	}
+
+	private static string GetBaseUrl(IConfiguration configuration) =>
+		configuration.GetConnectionString(keycloakConnectionStringName)
+			?? configuration[$"services:{keycloakConnectionStringName}:http:0"]
+			?? defaultUrl;
+
+	private static string GetRealm(IConfiguration configuration) =>
+		configuration.GetValue<string>(realmConfigKey) ?? defaultRealm;
+
+	private static string RealmUrl(IConfiguration configuration) =>
+		$"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}";
+}

--- a/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
+++ b/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Thread-safe singleton holding the union of capability manifests fetched
+/// from every known module host. Phase 4b will project this into MCP tool
+/// descriptors; Phase 4a only exposes it via a debug endpoint.
+/// </summary>
+public sealed class AggregatedCapabilityRegistry
+{
+	private readonly ConcurrentDictionary<string, CapabilityManifest> manifestsByService = new(StringComparer.Ordinal);
+
+	/// <summary>Gets all currently-discovered manifests, keyed by Aspire service name.</summary>
+	public IReadOnlyDictionary<string, CapabilityManifest> Manifests => manifestsByService;
+
+	/// <summary>Gets the total count of capabilities across every discovered manifest.</summary>
+	public int CapabilityCount => manifestsByService.Values.Sum(manifest => manifest.Capabilities.Count);
+
+	/// <summary>Replace the manifest entry for a service. Called by the discovery service after a successful fetch.</summary>
+	/// <param name="serviceName">Aspire service name (e.g. <c>recipes-api</c>).</param>
+	/// <param name="manifest">Manifest just fetched from that service.</param>
+	public void SetManifest(string serviceName, CapabilityManifest manifest) =>
+		manifestsByService[serviceName] = manifest;
+
+	/// <summary>Clear the manifest entry for a service (called when a fetch fails so the registry doesn't serve stale data).</summary>
+	/// <param name="serviceName">Aspire service name.</param>
+	public void RemoveManifest(string serviceName) => manifestsByService.TryRemove(serviceName, out _);
+
+	/// <summary>Return the union of all discovered capabilities across services.</summary>
+	/// <returns>Flat list of every capability descriptor across every discovered service.</returns>
+	public IReadOnlyList<CapabilityDescriptor> AllCapabilities() =>
+		[.. manifestsByService.Values.SelectMany(manifest => manifest.Capabilities)];
+}

--- a/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
+++ b/src/Yumney.Mcp.Server/Discovery/AggregatedCapabilityRegistry.cs
@@ -32,4 +32,28 @@ public sealed class AggregatedCapabilityRegistry
 	/// <returns>Flat list of every capability descriptor across every discovered service.</returns>
 	public IReadOnlyList<CapabilityDescriptor> AllCapabilities() =>
 		[.. manifestsByService.Values.SelectMany(manifest => manifest.Capabilities)];
+
+	/// <summary>Find the Aspire service name that owns a tool by name.</summary>
+	/// <param name="toolName">Capability name (e.g. <c>search_recipes</c>).</param>
+	/// <returns>Owning service name, or null if no discovered manifest contains it.</returns>
+	public string? ServiceNameForTool(string toolName)
+	{
+		foreach (var (serviceName, manifest) in manifestsByService)
+		{
+			if (manifest.Capabilities.Any(capability => capability.Name == toolName))
+			{
+				return serviceName;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>Find a capability descriptor by name across all discovered services.</summary>
+	/// <param name="toolName">Capability name.</param>
+	/// <returns>Descriptor with the given name, or null if not found.</returns>
+	public CapabilityDescriptor? DescriptorForTool(string toolName) =>
+		manifestsByService.Values
+			.SelectMany(manifest => manifest.Capabilities)
+			.FirstOrDefault(capability => capability.Name == toolName);
 }

--- a/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
+++ b/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Background service that fetches the capability manifest from each module
+/// host on startup and pokes the result into <see cref="AggregatedCapabilityRegistry"/>.
+/// Failures are logged and skipped — a transient outage on one module must not
+/// stop the MCP server from booting.
+/// </summary>
+#pragma warning disable SA1303
+internal sealed partial class CapabilityDiscoveryService(
+	IHttpClientFactory httpClientFactory,
+	AggregatedCapabilityRegistry registry,
+	ILogger<CapabilityDiscoveryService> logger) : BackgroundService
+{
+	private const string wellKnownPath = "/.well-known/yumney-capabilities";
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			if (stoppingToken.IsCancellationRequested) return;
+			await DiscoverFromServiceAsync(serviceName, stoppingToken);
+		}
+
+		LogDiscoveryComplete(registry.Manifests.Count, registry.CapabilityCount);
+	}
+
+	private async Task DiscoverFromServiceAsync(string serviceName, CancellationToken cancellationToken)
+	{
+		try
+		{
+			var client = httpClientFactory.CreateClient(serviceName);
+			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, cancellationToken);
+			if (manifest is null)
+			{
+				LogManifestNullFor(serviceName);
+				registry.RemoveManifest(serviceName);
+				return;
+			}
+
+			registry.SetManifest(serviceName, manifest);
+			LogManifestFor(serviceName, manifest.Capabilities.Count);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogManifestFetchFailed(serviceName, ex.Message);
+			registry.RemoveManifest(serviceName);
+		}
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "Discovery complete: {ServiceCount} services, {CapabilityCount} total capabilities.")]
+	private partial void LogDiscoveryComplete(int serviceCount, int capabilityCount);
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "Discovered {CapabilityCount} capabilities from {ServiceName}.")]
+	private partial void LogManifestFor(string serviceName, int capabilityCount);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Manifest endpoint at {ServiceName} returned null payload.")]
+	private partial void LogManifestNullFor(string serviceName);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch capability manifest from {ServiceName}: {Reason}")]
+	private partial void LogManifestFetchFailed(string serviceName, string reason);
+}

--- a/src/Yumney.Mcp.Server/Discovery/KnownCapabilityHosts.cs
+++ b/src/Yumney.Mcp.Server/Discovery/KnownCapabilityHosts.cs
@@ -1,0 +1,17 @@
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+/// <summary>
+/// Aspire service names of every module host that publishes a capability
+/// manifest. Discovery walks this list at startup. Adding a new module is a
+/// one-line change here.
+/// </summary>
+public static class KnownCapabilityHosts
+{
+	/// <summary>The Aspire service names this server discovers manifests from.</summary>
+	public static readonly IReadOnlyList<string> ServiceNames =
+	[
+		"recipes-api",
+		"mealplan-api",
+		"shopping-api",
+	];
+}

--- a/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
+++ b/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
@@ -1,0 +1,71 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Translates discovered <see cref="CapabilityDescriptor"/>s into MCP
+/// <see cref="Tool"/> descriptors and routes <see cref="CallToolRequestParams"/>
+/// invocations. Phase 4b returns a stub message for invocations because the
+/// REST proxy + Keycloak OAuth bridge land in Phase 4c. List-tools is fully
+/// functional so external MCP clients (Claude Desktop, custom GPTs) can
+/// already enumerate the surface and verify the connection.
+/// </summary>
+#pragma warning disable SA1303
+public static class CapabilityToolRegistration
+{
+	private const string mcpStubInvocationMessage =
+		"The Yumney MCP server is in setup. Tool listing is live, but tool invocation "
+		+ "lands with the Keycloak OAuth bridge + REST proxy in Phase 4c (#641). "
+		+ "Track progress at https://github.com/smartsolutionslab/yumney/issues/641.";
+
+	/// <summary>List the discovered capabilities exposed on the <c>Mcp</c> surface as MCP tools.</summary>
+	/// <param name="registry">Registry populated by <see cref="CapabilityDiscoveryService"/>.</param>
+	/// <returns>The current MCP-surface tools, one per capability with surface flag <c>Mcp</c>.</returns>
+	public static IReadOnlyList<Tool> BuildTools(AggregatedCapabilityRegistry registry) =>
+		[.. registry.AllCapabilities()
+			.Where(capability => capability.Surfaces.HasFlag(CapabilitySurface.Mcp))
+			.Select(ToTool)];
+
+	/// <summary>Stub call-tool result returned in Phase 4b until the REST proxy ships.</summary>
+	/// <param name="toolName">Name the caller asked to invoke.</param>
+	/// <returns>A non-error tool result with the stub message.</returns>
+	public static CallToolResult BuildStubInvocationResult(string toolName) =>
+		new()
+		{
+			Content = [new TextContentBlock { Text = $"[{toolName}] {mcpStubInvocationMessage}" }],
+			IsError = false,
+		};
+
+	/// <summary>The MCP <c>tools/list</c> handler — projects the registry into the protocol shape.</summary>
+	/// <param name="context">Request context (unused — we list everything).</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>The current MCP-surface tools.</returns>
+	public static ValueTask<ListToolsResult> ListToolsAsync(
+		RequestContext<ListToolsRequestParams> context,
+		CancellationToken cancellationToken)
+	{
+		var registry = context.Services!.GetRequiredService<AggregatedCapabilityRegistry>();
+		return ValueTask.FromResult(new ListToolsResult { Tools = [.. BuildTools(registry)] });
+	}
+
+	/// <summary>The MCP <c>tools/call</c> handler — Phase 4b stub; Phase 4c proxies to module REST.</summary>
+	/// <param name="context">Request context with the called tool's name + arguments.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>The stub result.</returns>
+	public static ValueTask<CallToolResult> CallToolAsync(
+		RequestContext<CallToolRequestParams> context,
+		CancellationToken cancellationToken)
+	{
+		var name = context.Params?.Name ?? "<unknown>";
+		return ValueTask.FromResult(BuildStubInvocationResult(name));
+	}
+
+	private static Tool ToTool(CapabilityDescriptor capability) => new()
+	{
+		Name = capability.Name,
+		Description = $"{capability.Description} (proxies {capability.HttpMethod} {capability.RoutePattern})",
+	};
+}

--- a/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Translates an MCP <c>tools/call</c> into an HTTP call against the module
+/// endpoint that owns the named capability, forwarding the caller's bearer
+/// token. Returns the upstream response body as a <see cref="CallToolResult"/>.
+/// </summary>
+/// <param name="registry">Discovered capability registry.</param>
+/// <param name="httpClientFactory">Factory keyed by Aspire service name.</param>
+/// <param name="httpContextAccessor">Source of the caller's bearer token.</param>
+/// <param name="logger">Logger for proxy diagnostics.</param>
+public sealed partial class RestProxyService(
+	AggregatedCapabilityRegistry registry,
+	IHttpClientFactory httpClientFactory,
+	IHttpContextAccessor httpContextAccessor,
+	ILogger<RestProxyService> logger)
+{
+	/// <summary>Invoke the module endpoint behind <paramref name="toolName"/>.</summary>
+	/// <param name="toolName">Capability name from a <c>tools/list</c> response.</param>
+	/// <param name="arguments">Tool argument bag (placeholder values + body fields / query params).</param>
+	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
+	/// <returns>Upstream response as a tool result, or an error result on failure.</returns>
+	public async Task<CallToolResult> InvokeAsync(
+		string toolName,
+		IDictionary<string, JsonElement>? arguments,
+		CancellationToken cancellationToken)
+	{
+		var descriptor = registry.DescriptorForTool(toolName);
+		if (descriptor is null) return Error($"Unknown tool '{toolName}'.");
+
+		var serviceName = registry.ServiceNameForTool(toolName);
+		if (serviceName is null) return Error($"Tool '{toolName}' is not bound to a discovered service.");
+
+		var built = RouteUrlBuilder.Build(descriptor.HttpMethod, descriptor.RoutePattern, arguments);
+		if (built.MissingPlaceholders.Count > 0)
+		{
+			return Error($"Tool '{toolName}' is missing required argument(s): {string.Join(", ", built.MissingPlaceholders)}.");
+		}
+
+		var bearer = ExtractBearer();
+		if (bearer is null) return Error("No bearer token forwarded with the MCP request — caller must authenticate.");
+
+		var client = httpClientFactory.CreateClient(serviceName);
+		using var request = new HttpRequestMessage(new HttpMethod(descriptor.HttpMethod), built.Url);
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+		if (built.Body is not null)
+		{
+			request.Content = new StringContent(built.Body, Encoding.UTF8, "application/json");
+		}
+
+		try
+		{
+			using var response = await client.SendAsync(request, cancellationToken);
+			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			if (!response.IsSuccessStatusCode)
+			{
+				LogUpstreamFailure(toolName, serviceName, (int)response.StatusCode);
+				return Error($"Upstream {serviceName} returned {(int)response.StatusCode}: {body}");
+			}
+
+			return new CallToolResult
+			{
+				Content = [new TextContentBlock { Text = body }],
+				IsError = false,
+			};
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogProxyException(toolName, serviceName, ex.Message);
+			return Error($"Proxy call to {serviceName} failed: {ex.Message}");
+		}
+	}
+
+	private static CallToolResult Error(string message) => new()
+	{
+		Content = [new TextContentBlock { Text = message }],
+		IsError = true,
+	};
+
+	private string? ExtractBearer()
+	{
+		var header = httpContextAccessor.HttpContext?.Request.Headers.Authorization.ToString();
+		if (string.IsNullOrEmpty(header)) return null;
+		const string prefix = "Bearer ";
+		return header.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+			? header[prefix.Length..].Trim()
+			: null;
+	}
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Proxy call for tool {ToolName} to {ServiceName} returned non-success status {StatusCode}.")]
+	private partial void LogUpstreamFailure(string toolName, string serviceName, int statusCode);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Proxy call for tool {ToolName} to {ServiceName} threw: {Reason}")]
+	private partial void LogProxyException(string toolName, string serviceName, string reason);
+}

--- a/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Substitutes <c>{name:type}</c> route placeholders with values pulled from
+/// the MCP tool argument bag, and assembles the remaining arguments into a
+/// query string (for GET) or returns them as the JSON body (for POST/PUT).
+/// </summary>
+public static partial class RouteUrlBuilder
+{
+	/// <summary>The result of building a request from a route pattern + tool arguments.</summary>
+	/// <param name="Url">Final URL with placeholders substituted and query string appended where applicable.</param>
+	/// <param name="Body">JSON body for POST/PUT, or null for GET/DELETE.</param>
+	/// <param name="MissingPlaceholders">Placeholder names that didn't have a matching argument — caller should fail the call.</param>
+	public sealed record BuiltRequest(string Url, string? Body, IReadOnlyList<string> MissingPlaceholders);
+
+	/// <summary>Build a request URL + body for an HTTP call to a module endpoint.</summary>
+	/// <param name="httpMethod">HTTP method (case-insensitive).</param>
+	/// <param name="routePattern">Route pattern from a <c>CapabilityDescriptor</c>.</param>
+	/// <param name="arguments">Tool arguments by name. Supports null arguments dictionary.</param>
+	/// <returns>Built request — caller must check <c>MissingPlaceholders</c> before sending.</returns>
+	public static BuiltRequest Build(
+		string httpMethod,
+		string routePattern,
+		IDictionary<string, JsonElement>? arguments)
+	{
+		arguments ??= new Dictionary<string, JsonElement>();
+		var consumedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var missing = new List<string>();
+
+		var path = PlaceholderPattern().Replace(routePattern, match =>
+		{
+			var placeholderName = match.Groups["name"].Value;
+			if (!arguments.TryGetValue(placeholderName, out var value))
+			{
+				missing.Add(placeholderName);
+				return match.Value;
+			}
+
+			consumedKeys.Add(placeholderName);
+			return Uri.EscapeDataString(JsonElementToString(value));
+		});
+
+		var unconsumed = arguments
+			.Where(pair => !consumedKeys.Contains(pair.Key))
+			.ToList();
+
+		if (UsesBody(httpMethod))
+		{
+			var body = unconsumed.Count == 0
+				? null
+				: JsonSerializer.Serialize(unconsumed.ToDictionary(pair => pair.Key, pair => pair.Value));
+			return new BuiltRequest(path, body, missing);
+		}
+
+		var url = unconsumed.Count == 0 ? path : $"{path}?{BuildQueryString(unconsumed)}";
+		return new BuiltRequest(url, Body: null, missing);
+	}
+
+	private static bool UsesBody(string httpMethod) =>
+		HttpMethod.Post.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase)
+		|| HttpMethod.Put.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase)
+		|| HttpMethod.Patch.Method.Equals(httpMethod, StringComparison.OrdinalIgnoreCase);
+
+	private static string BuildQueryString(IReadOnlyList<KeyValuePair<string, JsonElement>> pairs)
+	{
+		var query = new StringBuilder();
+		var first = true;
+		foreach (var (key, value) in pairs)
+		{
+			if (!first) query.Append('&');
+			query.Append(Uri.EscapeDataString(key));
+			query.Append('=');
+			query.Append(Uri.EscapeDataString(JsonElementToString(value)));
+			first = false;
+		}
+
+		return query.ToString();
+	}
+
+	private static string JsonElementToString(JsonElement value) => value.ValueKind switch
+	{
+		JsonValueKind.String => value.GetString() ?? string.Empty,
+		JsonValueKind.Number => value.GetRawText(),
+		JsonValueKind.True => "true",
+		JsonValueKind.False => "false",
+		JsonValueKind.Null => string.Empty,
+		_ => value.GetRawText(),
+	};
+
+	[GeneratedRegex(@"\{(?<name>[a-zA-Z_][a-zA-Z0-9_]*)(?::[^}]+)?\}")]
+	private static partial Regex PlaceholderPattern();
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,19 +18,29 @@ foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
 builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
 builder.Services.AddHostedService<CapabilityDiscoveryService>();
 
+builder.Services.AddMcpServer()
+	.WithHttpTransport()
+	.WithListToolsHandler(CapabilityToolRegistration.ListToolsAsync)
+	.WithCallToolHandler(CapabilityToolRegistration.CallToolAsync);
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
-// Phase 4a debug endpoint: dump everything the discovery service has found so
-// we can verify the cross-host pipeline works before adding the MCP protocol
-// surface in Phase 4b.
+// Debug endpoint: dump everything the discovery service has found so we can
+// verify the cross-host pipeline + MCP-surface filtering at a glance without
+// speaking the full MCP protocol.
 app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) => Results.Ok(new
 {
 	serviceCount = registry.Manifests.Count,
 	capabilityCount = registry.CapabilityCount,
+	mcpToolCount = CapabilityToolRegistration.BuildTools(registry).Count,
 	services = registry.Manifests.Keys.Order().ToArray(),
 	capabilities = registry.AllCapabilities(),
 }));
+
+// MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
+// connect here once OAuth ships in Phase 4c.
+app.MapMcp("/mcp");
 
 app.Run();

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,0 +1,35 @@
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+// Register an HttpClient per known module host. Service discovery resolves
+// the http://<service-name> base address via Aspire.
+foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+{
+	builder.Services.AddHttpClient(serviceName, client => client.BaseAddress = new Uri($"http://{serviceName}"))
+		.AddServiceDiscovery()
+		.AddStandardResilienceHandler();
+}
+
+builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
+builder.Services.AddHostedService<CapabilityDiscoveryService>();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+// Phase 4a debug endpoint: dump everything the discovery service has found so
+// we can verify the cross-host pipeline works before adding the MCP protocol
+// surface in Phase 4b.
+app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) => Results.Ok(new
+{
+	serviceCount = registry.Manifests.Count,
+	capabilityCount = registry.CapabilityCount,
+	services = registry.Manifests.Keys.Order().ToArray(),
+	capabilities = registry.AllCapabilities(),
+}));
+
+app.Run();

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,3 +1,4 @@
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
@@ -5,6 +6,9 @@ using SmartSolutionsLab.Yumney.ServiceDefaults;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+builder.Services.AddKeycloakBearerAuthentication(builder.Configuration, builder.Environment);
+builder.Services.AddHttpContextAccessor();
 
 // Register an HttpClient per known module host. Service discovery resolves
 // the http://<service-name> base address via Aspire.
@@ -17,13 +21,22 @@ foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
 
 builder.Services.AddSingleton<AggregatedCapabilityRegistry>();
 builder.Services.AddHostedService<CapabilityDiscoveryService>();
+builder.Services.AddScoped<RestProxyService>();
 
 builder.Services.AddMcpServer()
 	.WithHttpTransport()
 	.WithListToolsHandler(CapabilityToolRegistration.ListToolsAsync)
-	.WithCallToolHandler(CapabilityToolRegistration.CallToolAsync);
+	.WithCallToolHandler(async (context, cancellationToken) =>
+	{
+		var proxy = context.Services!.GetRequiredService<RestProxyService>();
+		var name = context.Params?.Name ?? "<unknown>";
+		return await proxy.InvokeAsync(name, context.Params?.Arguments, cancellationToken);
+	});
 
 var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapDefaultEndpoints();
 
@@ -37,10 +50,11 @@ app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) =
 	mcpToolCount = CapabilityToolRegistration.BuildTools(registry).Count,
 	services = registry.Manifests.Keys.Order().ToArray(),
 	capabilities = registry.AllCapabilities(),
-}));
+})).AllowAnonymous();
 
 // MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
-// connect here once OAuth ships in Phase 4c.
-app.MapMcp("/mcp");
+// authenticate via the standard Authorization: Bearer header — the bearer is
+// forwarded to the module endpoint by RestProxyService when the LLM calls a tool.
+app.MapMcp("/mcp").RequireAuthorization();
 
 app.Run();

--- a/src/Yumney.Mcp.Server/Properties/launchSettings.json
+++ b/src/Yumney.Mcp.Server/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Yumney.Mcp.Server.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.ServiceDefaults\Yumney.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
+++ b/src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Keycloak.Authentication" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />

--- a/src/Yumney.Mcp.Server/appsettings.Development.json
+++ b/src/Yumney.Mcp.Server/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "SmartSolutionsLab.Yumney.Mcp.Server": "Debug"
+    }
+  }
+}

--- a/src/Yumney.Mcp.Server/appsettings.json
+++ b/src/Yumney.Mcp.Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore.Ev
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -28,6 +29,7 @@ public sealed class MealPlanApiModule : IEndpointModule
 			.UseYumneyDefaults()
 			.MapApiV1()
 			.MapMealPlanEndpoints();
+		app.MapCapabilityManifest("mealplan-api");
 		return app;
 	}
 }

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -3,10 +3,12 @@ using SmartSolutionsLab.Yumney.MealPlan.Application.Commands;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api;
 
@@ -19,6 +21,10 @@ public static class MealPlanEndpoints
 		group.MapGet("/{year:int}/w/{weekNumber:int}", GetWeeklyPlan)
 			.WithName("GetWeeklyPlan")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "get_weekly_plan",
+				description: "Fetch the user's planned meals for an ISO week. Use for 'what's for dinner this week?' / 'show me next week's plan'.",
+				surfaces: CapabilitySurface.All)
 			.Produces<WeeklyPlanDto>();
 
 		static async Task<IResult> GetWeeklyPlan(
@@ -36,6 +42,10 @@ public static class MealPlanEndpoints
 		group.MapPost("/{year:int}/w/{weekNumber:int}/slots", AssignRecipe)
 			.WithName("AssignRecipe")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "assign_meal",
+				description: "Plan a recipe into a meal slot for an ISO week ('plan carbonara for Wednesday', 'add risotto to Friday lunch'). Requires a recipe identifier from a prior recipe lookup.",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<WeeklyPlanDto>()
 			.ProducesProblem(StatusCodes.Status400BadRequest);
 
@@ -117,6 +127,10 @@ public static class MealPlanEndpoints
 		group.MapPut("/{year:int}/w/{weekNumber:int}/slots/confirm", ConfirmMeal)
 			.WithName("ConfirmMeal")
 			.WithTags("MealPlan")
+			.WithCapability(
+				name: "confirm_meal_cooked",
+				description: "Update a planned meal's state to Cooked, Skipped, or Planned ('I made the spaghetti on Wednesday', 'skip Friday's dinner').",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<WeeklyPlanDto>()
 			.ProducesProblem(StatusCodes.Status404NotFound);
 

--- a/src/Yumney.Recipes.Api/RecipesApiModule.cs
+++ b/src/Yumney.Recipes.Api/RecipesApiModule.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -31,6 +32,7 @@ public sealed class RecipesApiModule : IEndpointModule
 			.UseYumneyDefaults()
 			.MapApiV1()
 			.MapRecipesEndpoints();
+		app.MapCapabilityManifest("recipes-api");
 		return app;
 	}
 }

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -6,11 +6,13 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Common;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -134,6 +136,10 @@ public static partial class RecipesEndpoints
 			.WithName("ImportRecipe")
 			.WithTags("Recipes")
 			.WithValidation<Requests.ImportRecipe>()
+			.WithCapability(
+				name: "import_recipe_from_url",
+				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the parsed recipe (title, ingredients, steps).",
+				surfaces: CapabilitySurface.Mcp | CapabilitySurface.Voice)
 			.Produces<ExtractedRecipeDto>()
 			.ProducesValidationProblem()
 			.ProducesProblem(StatusCodes.Status404NotFound)

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -2,10 +2,12 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Api;
 
@@ -31,6 +33,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/", GetAll)
 			.WithName("GetRecipes")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "search_recipes",
+				description: "Search the user's recipe collection by free text query and optional filters (tags, difficulty, max prep/cook time, favorites). Returns paged recipe summaries.",
+				surfaces: CapabilitySurface.All)
 			.Produces<PagedResult<RecipeListItemDto>>();
 
 		static async Task<IResult> GetAll(
@@ -60,6 +66,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/{identifier:guid}", GetById)
 			.WithName("GetRecipeById")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "get_recipe",
+				description: "Fetch full details (ingredients, steps, timings, servings) of one recipe by its identifier.",
+				surfaces: CapabilitySurface.All)
 			.Produces<RecipeDetailDto>()
 			.ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -163,6 +173,10 @@ public static partial class RecipesEndpoints
 		group.MapGet("/what-can-i-cook", WhatCanICook)
 			.WithName("WhatCanICook")
 			.WithTags("Recipes")
+			.WithCapability(
+				name: "get_cookable_recipes",
+				description: "Find recipes the user can cook now or with at most a couple of missing items, ranked by ingredient freshness in their pantry. Use for 'what can I cook?' / 'was kann ich kochen?'.",
+				surfaces: CapabilitySurface.All)
 			.Produces<PagedResult<CookableRecipeDto>>();
 
 		static async Task<IResult> WhatCanICook(

--- a/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
@@ -1,0 +1,22 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Wire shape of one capability — the projection of <see cref="CapabilityMetadata"/>
+/// plus the route the capability is mounted on.
+/// </summary>
+/// <param name="Name">Stable LLM-facing tool name.</param>
+/// <param name="Description">One-paragraph description for the LLM.</param>
+/// <param name="Surfaces">Bitfield of surfaces this capability is exposed on.</param>
+/// <param name="HttpMethod">HTTP verb (GET, POST, PUT, DELETE, …).</param>
+/// <param name="RoutePattern">Raw route pattern (e.g. <c>/api/v1/recipes/{id:guid}</c>).</param>
+public sealed record CapabilityDescriptor(
+	string Name,
+	string Description,
+	CapabilitySurface Surfaces,
+	string HttpMethod,
+	string RoutePattern);
+
+/// <summary>Wire shape of one host's capability manifest, returned by <c>/.well-known/yumney-capabilities</c>.</summary>
+/// <param name="ServiceName">Aspire service name (e.g. <c>recipes-api</c>).</param>
+/// <param name="Capabilities">All capabilities advertised by this host.</param>
+public sealed record CapabilityManifest(string ServiceName, IReadOnlyList<CapabilityDescriptor> Capabilities);

--- a/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Endpoint metadata marking a route as an LLM-callable capability. Attached
+/// via <c>WithCapability(...)</c>; surfaced by <c>MapCapabilityManifest()</c>
+/// on the well-known manifest endpoint.
+/// </summary>
+/// <param name="Name">Stable LLM-facing tool name (snake_case). Treat as a public contract — renaming breaks installed clients.</param>
+/// <param name="Description">One-paragraph description used by the LLM to decide when to call this capability.</param>
+/// <param name="Surfaces">Bitfield of surfaces this capability is exposed on.</param>
+public sealed record CapabilityMetadata(string Name, string Description, CapabilitySurface Surfaces);

--- a/src/Yumney.Shared.Capabilities/CapabilitySurface.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilitySurface.cs
@@ -1,0 +1,24 @@
+namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+/// <summary>
+/// Flags marking which LLM-callable surfaces an endpoint is exposed on.
+/// Combine with bitwise OR. See ADR 0002 for the surface inventory.
+/// </summary>
+[Flags]
+public enum CapabilitySurface
+{
+	/// <summary>Endpoint is not exposed to any LLM-callable surface.</summary>
+	None = 0,
+
+	/// <summary>Exposed to the in-app chat panel (Semantic Kernel function calling).</summary>
+	Chat = 1,
+
+	/// <summary>Exposed to external Model Context Protocol clients (Claude Desktop, custom GPTs, …).</summary>
+	Mcp = 2,
+
+	/// <summary>Exposed to the future voice-command surface.</summary>
+	Voice = 4,
+
+	/// <summary>Convenience union covering every current surface.</summary>
+	All = Chat | Mcp | Voice,
+}

--- a/src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj
+++ b/src/Yumney.Shared.Capabilities/Yumney.Shared.Capabilities.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+
+/// <summary>
+/// Maps the well-known capability manifest endpoint that exposes every
+/// <see cref="CapabilityMetadata"/>-tagged route on this host.
+/// </summary>
+public static class CapabilityManifestEndpoint
+{
+	/// <summary>The well-known path: <c>/.well-known/yumney-capabilities</c>.</summary>
+	public const string WellKnownPath = "/.well-known/yumney-capabilities";
+
+	/// <summary>Map the capability manifest endpoint on this host.</summary>
+	/// <param name="app">Endpoint route builder.</param>
+	/// <param name="serviceName">Aspire service name (e.g. <c>recipes-api</c>) — surfaced in the manifest.</param>
+	/// <returns>The same builder, for fluent chaining.</returns>
+	public static IEndpointRouteBuilder MapCapabilityManifest(this IEndpointRouteBuilder app, string serviceName)
+	{
+		app.MapGet(WellKnownPath, (HttpContext context) =>
+		{
+			var dataSource = context.RequestServices.GetRequiredService<EndpointDataSource>();
+			var manifest = BuildManifest(serviceName, dataSource);
+			return Results.Ok(manifest);
+		})
+		.AllowAnonymous()
+		.WithName("GetCapabilityManifest")
+		.WithTags("Capabilities");
+		return app;
+	}
+
+	internal static CapabilityManifest BuildManifest(string serviceName, EndpointDataSource dataSource)
+	{
+		var descriptors = dataSource.Endpoints
+			.OfType<RouteEndpoint>()
+			.Select(ProjectDescriptor)
+			.OfType<CapabilityDescriptor>()
+			.ToList();
+		return new CapabilityManifest(serviceName, descriptors);
+	}
+
+	private static CapabilityDescriptor? ProjectDescriptor(RouteEndpoint endpoint)
+	{
+		var meta = endpoint.Metadata.GetMetadata<CapabilityMetadata>();
+		if (meta is null) return null;
+
+		var methods = endpoint.Metadata.GetMetadata<Microsoft.AspNetCore.Routing.HttpMethodMetadata>()?.HttpMethods;
+		var httpMethod = methods is { Count: > 0 } ? methods[0] : "GET";
+		var routePattern = endpoint.RoutePattern.RawText ?? string.Empty;
+
+		return new CapabilityDescriptor(meta.Name, meta.Description, meta.Surfaces, httpMethod, routePattern);
+	}
+}

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+
+/// <summary>
+/// Endpoint-builder extensions for tagging routes with <see cref="CapabilityMetadata"/>.
+/// </summary>
+public static class CapabilityRouteBuilderExtensions
+{
+	/// <summary>Mark an endpoint as an LLM-callable capability.</summary>
+	/// <typeparam name="TBuilder">Concrete endpoint convention builder type.</typeparam>
+	/// <param name="builder">The endpoint builder returned by <c>MapGet</c> / <c>MapPost</c> / etc.</param>
+	/// <param name="name">Stable LLM-facing tool name (snake_case).</param>
+	/// <param name="description">One-paragraph description used by the LLM.</param>
+	/// <param name="surfaces">Surfaces this capability is exposed on. Defaults to Chat | Mcp.</param>
+	/// <returns>The same builder, for fluent chaining.</returns>
+	public static TBuilder WithCapability<TBuilder>(
+		this TBuilder builder,
+		string name,
+		string description,
+		CapabilitySurface surfaces = CapabilitySurface.Chat | CapabilitySurface.Mcp)
+		where TBuilder : IEndpointConventionBuilder =>
+		builder.WithMetadata(new CapabilityMetadata(name, description, surfaces));
+}

--- a/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
+++ b/src/Yumney.Shared.Web/Yumney.Shared.Web.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Yumney.Shared\Yumney.Shared.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Abstractions\Yumney.Shared.Abstractions.csproj" />
+    <ProjectReference Include="..\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Paging\Yumney.Shared.Paging.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Outcomes\Yumney.Shared.Outcomes.csproj" />

--- a/src/Yumney.Shopping.Api/ShoppingApiModule.cs
+++ b/src/Yumney.Shopping.Api/ShoppingApiModule.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 using SmartSolutionsLab.Yumney.Shopping.Api.Requests.Validator;
 using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure;
@@ -28,6 +29,7 @@ public sealed class ShoppingApiModule : IEndpointModule
 	public WebApplication RegisterEndpoints(WebApplication app)
 	{
 		app.UseYumneyDefaults().MapApiV1().MapShoppingEndpoints();
+		app.MapCapabilityManifest("shopping-api");
 		return app;
 	}
 }

--- a/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
+++ b/src/Yumney.Shopping.Api/ShoppingEndpoints.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
 using SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Queries;
@@ -45,6 +47,10 @@ public static partial class ShoppingEndpoints
 			.WithName("CreateShoppingListFromRecipes")
 			.WithTags("Shopping")
 			.WithValidation<Requests.CreateFromRecipes>()
+			.WithCapability(
+				name: "create_shopping_list_from_recipes",
+				description: "Create a new shopping list sourced from one or more recipes ('make a shopping list for spaghetti and risotto').",
+				surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp)
 			.Produces<ShoppingListDetailDto>(StatusCodes.Status201Created)
 			.ProducesValidationProblem();
 
@@ -181,6 +187,10 @@ public static partial class ShoppingEndpoints
 		group.MapGet("/merged", GetMerged)
 			.WithName("GetMergedShoppingList")
 			.WithTags("Shopping")
+			.WithCapability(
+				name: "get_merged_shopping_list",
+				description: "Fetch the user's merged active shopping list across all open lists ('what's on my shopping list?', 'do I still need eggs?').",
+				surfaces: CapabilitySurface.All)
 			.Produces<MergedShoppingListDto>();
 
 		static async Task<IResult> GetMerged(

--- a/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
+++ b/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
@@ -1,0 +1,76 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Architecture.Tests;
+
+#pragma warning disable SA1601
+public partial class CapabilityTaggingTests
+#pragma warning restore SA1601
+{
+	[Fact]
+	public void EveryWithCapabilityCall_HasUniqueName()
+	{
+		var srcRoot = SolutionRoot.Src;
+		var pattern = WithCapabilityNamePattern();
+
+		var allMatches = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.SelectMany(path => MatchesIn(path, pattern))
+			.ToList();
+
+		var duplicates = allMatches
+			.GroupBy(match => match.Name, StringComparer.Ordinal)
+			.Where(group => group.Count() > 1)
+			.ToList();
+
+		duplicates.Should().BeEmpty(
+			"Capability names are LLM-facing tool identifiers and form an external contract — duplicates make the manifest ambiguous. Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, duplicates.Select(group => $"  {group.Key}: {string.Join(", ", group.Select(match => match.Location))}")));
+	}
+
+	[Fact]
+	public void EveryWithCapabilityCall_UsesSnakeCaseName()
+	{
+		var srcRoot = SolutionRoot.Src;
+		var pattern = WithCapabilityNamePattern();
+		var snakeCase = SnakeCasePattern();
+
+		var violations = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.SelectMany(path => MatchesIn(path, pattern))
+			.Where(match => !snakeCase.IsMatch(match.Name))
+			.ToList();
+
+		violations.Should().BeEmpty(
+			"Capability names must be snake_case (e.g. search_recipes, get_weekly_plan). Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation.Name} at {violation.Location}")));
+	}
+
+	[GeneratedRegex(@"WithCapability\s*\(\s*name:\s*""(?<name>[^""]+)""", RegexOptions.Singleline)]
+	private static partial Regex WithCapabilityNamePattern();
+
+	[GeneratedRegex(@"^[a-z][a-z0-9_]*$")]
+	private static partial Regex SnakeCasePattern();
+
+	private static IEnumerable<CapabilityMatch> MatchesIn(string path, Regex pattern)
+	{
+		var content = File.ReadAllText(path);
+		var matches = pattern.Matches(content);
+		foreach (Match match in matches)
+		{
+			yield return new CapabilityMatch(match.Groups["name"].Value, Path.GetRelativePath(SolutionRoot.Path, path));
+		}
+	}
+
+	private static bool IsTrackedSourceFile(string path)
+	{
+		var normalized = path.Replace('\\', '/');
+		return !normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+			&& !normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private sealed record CapabilityMatch(string Name, string Location);
+}

--- a/tests/Yumney.Integration.Tests/Capabilities/CapabilityManifestEndpointIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Capabilities/CapabilityManifestEndpointIntegrationTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Capabilities;
+
+/// <summary>
+/// Phase 3 (#647) coverage: each module's well-known capability manifest endpoint
+/// returns the [WithCapability]-tagged routes. Catches drift between source-tagging
+/// and what the live host actually advertises.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
+{
+	private const string WellKnownPath = "/.well-known/yumney-capabilities";
+
+	[Fact]
+	public async Task RecipesManifest_ContainsExpectedTaggedEndpoints()
+	{
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		manifest.Should().NotBeNull();
+		manifest!.ServiceName.Should().Be("recipes-api");
+		manifest.Capabilities.Select(capability => capability.Name).Should().Contain([
+			"search_recipes",
+			"get_recipe",
+			"get_cookable_recipes",
+			"import_recipe_from_url",
+		]);
+	}
+
+	[Fact]
+	public async Task MealPlanManifest_ContainsExpectedTaggedEndpoints()
+	{
+		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		manifest.Should().NotBeNull();
+		manifest!.ServiceName.Should().Be("mealplan-api");
+		manifest.Capabilities.Select(capability => capability.Name).Should().Contain([
+			"get_weekly_plan",
+			"assign_meal",
+			"confirm_meal_cooked",
+		]);
+	}
+
+	[Fact]
+	public async Task ShoppingManifest_ContainsExpectedTaggedEndpoints()
+	{
+		var manifest = await fixture.ShoppingApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		manifest.Should().NotBeNull();
+		manifest!.ServiceName.Should().Be("shopping-api");
+		manifest.Capabilities.Select(capability => capability.Name).Should().Contain([
+			"get_merged_shopping_list",
+			"create_shopping_list_from_recipes",
+		]);
+	}
+
+	[Fact]
+	public async Task ManifestEndpoint_IsAnonymous_NoBearerNeeded()
+	{
+		fixture.RecipesApi.DefaultRequestHeaders.Authorization = null;
+
+		var response = await fixture.RecipesApi.GetAsync(WellKnownPath);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task EveryDescriptor_HasMcpOrChatSurface_AndPathStartsWithApiV1()
+	{
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		manifest!.Capabilities.Should().NotBeEmpty();
+		manifest.Capabilities.Should().AllSatisfy(capability =>
+		{
+			(capability.Surfaces & (CapabilitySurface.Mcp | CapabilitySurface.Chat | CapabilitySurface.Voice)).Should().NotBe(CapabilitySurface.None);
+			capability.RoutePattern.Should().StartWith("/api/v1/");
+		});
+	}
+
+	[Fact]
+	public async Task SearchRecipesDescriptor_HasGetMethodAndCorrectRoute()
+	{
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		var search = manifest!.Capabilities.Single(capability => capability.Name == "search_recipes");
+		search.HttpMethod.Should().Be("GET");
+		search.RoutePattern.Should().Be("/api/v1/recipes/");
+	}
+
+	[Fact]
+	public async Task AssignMealDescriptor_HasPostMethodAndIncludesPlaceholders()
+	{
+		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+
+		var assign = manifest!.Capabilities.Single(capability => capability.Name == "assign_meal");
+		assign.HttpMethod.Should().Be("POST");
+		assign.RoutePattern.Should().Contain("{year:int}");
+		assign.RoutePattern.Should().Contain("{weekNumber:int}");
+		assign.RoutePattern.Should().EndWith("/slots");
+	}
+}

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -62,6 +62,9 @@ public sealed class AspireFixture : IAsyncLifetime
 	/// <summary>Gets the pre-configured HttpClient targeting the MealPlan API.</summary>
 	public HttpClient MealPlanApi { get; private set; } = null!;
 
+	/// <summary>Gets the pre-configured HttpClient targeting the MCP server.</summary>
+	public HttpClient McpServer { get; private set; } = null!;
+
 	public async Task InitializeAsync()
 	{
 		await CleanupStaleContainersAsync();
@@ -90,7 +93,7 @@ public sealed class AspireFixture : IAsyncLifetime
 			await app.ResourceNotifications.WaitForResourceAsync("keycloak", KnownResourceStates.Running, cts.Token);
 			await app.ResourceNotifications.WaitForResourceAsync("yumney-migrations", KnownResourceStates.Finished, cts.Token);
 
-			string[] apis = ["recipes-api", "shopping-api", "users-api", "mealplan-api"];
+			string[] apis = ["recipes-api", "shopping-api", "users-api", "mealplan-api", "mcp-server"];
 			var apiTasks = apis.Select(api => app.ResourceNotifications.WaitForResourceAsync(api, KnownResourceStates.Running, cts.Token));
 
 			await Task.WhenAll(apiTasks);
@@ -111,6 +114,7 @@ public sealed class AspireFixture : IAsyncLifetime
 		ShoppingApi = app.CreateHttpClient("shopping-api");
 		UsersApi = app.CreateHttpClient("users-api");
 		MealPlanApi = app.CreateHttpClient("mealplan-api");
+		McpServer = app.CreateHttpClient("mcp-server");
 
 		async Task VerifyKeycloak()
 		{
@@ -138,6 +142,7 @@ public sealed class AspireFixture : IAsyncLifetime
 		ShoppingApi.Dispose();
 		UsersApi.Dispose();
 		MealPlanApi.Dispose();
+		McpServer.Dispose();
 
 		if (app is not null)
 		{

--- a/tests/Yumney.Integration.Tests/Mcp/McpAuthIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpAuthIntegrationTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Phase 4c (#650) coverage: the /mcp endpoint requires a Keycloak-issued JWT.
+/// Verifies the route is wired and JWT bearer auth is enforced — without this,
+/// the REST proxy would silently accept any caller and forward an unforwardable
+/// (missing) bearer to the modules.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpAuthIntegrationTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task PostToMcp_WithoutBearer_IsRejectedAsUnauthorized()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp");
+		var response = await fixture.McpServer.SendAsync(request);
+
+		// MCP HTTP transport accepts POST for JSON-RPC; without auth the
+		// JWT bearer middleware short-circuits to 401.
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task PostToMcp_WithInvalidBearer_IsRejectedAsUnauthorized()
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "not-a-real-token");
+
+		var response = await fixture.McpServer.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task PostToMcp_WithValidKeycloakBearer_IsNotUnauthorized()
+	{
+		var token = await fixture.GetAccessTokenAsync("testuser", "Test1234");
+		using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		var response = await fixture.McpServer.SendAsync(request);
+
+		// We don't assert OK here — the body is empty so MCP returns a JSON-RPC
+		// parse-error 400 or 415 depending on transport state. The point of this
+		// test is the AUTH gate: 401 means JWT validation failed against Keycloak,
+		// and that's what we're proving doesn't happen with a valid token.
+		response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetDiscoveredCapabilities_IsAnonymous_NoBearerNeeded()
+	{
+		var response = await fixture.McpServer.GetAsync("/discovered-capabilities");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Mcp/McpDiscoveryIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpDiscoveryIntegrationTests.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Phase 4a (#648) coverage: the MCP server boots, walks every known module
+/// host, and aggregates the per-host capability manifests. Verifies the
+/// cross-host pipeline (HttpClient + Aspire service discovery) wires up at
+/// runtime, which the unit tests can't catch (they stub the HTTP layer).
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpDiscoveryIntegrationTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task DiscoveredCapabilities_FindsAllThreeKnownHosts()
+	{
+		await Eventually.AssertAsync(async () =>
+		{
+			var snapshot = await fixture.McpServer.GetFromJsonAsync<DiscoveredCapabilitiesResponse>("/discovered-capabilities");
+			snapshot.Should().NotBeNull();
+			snapshot!.ServiceCount.Should().Be(3);
+			snapshot.Services.Should().Contain(["recipes-api", "mealplan-api", "shopping-api"]);
+		});
+	}
+
+	[Fact]
+	public async Task DiscoveredCapabilities_ExposesAtLeastNineCapabilities()
+	{
+		// Phase 3 tagged 9 endpoints (4 Recipes + 3 MealPlan + 2 Shopping). The
+		// integration test asserts the lower bound — adding new tagged endpoints
+		// in future PRs won't break this assertion.
+		await Eventually.AssertAsync(async () =>
+		{
+			var snapshot = await fixture.McpServer.GetFromJsonAsync<DiscoveredCapabilitiesResponse>("/discovered-capabilities");
+			snapshot!.CapabilityCount.Should().BeGreaterThanOrEqualTo(9);
+		});
+	}
+
+	[Fact]
+	public async Task DiscoveredCapabilities_McpToolCount_ExcludesChatOnlyAndVoiceOnlyCapabilities()
+	{
+		// Phase 3 tagged import_recipe_from_url with Mcp | Voice only — that's
+		// fine. But every other capability has Mcp surface. So mcpToolCount
+		// must equal capabilityCount as long as no purely-non-MCP tag exists.
+		await Eventually.AssertAsync(async () =>
+		{
+			var snapshot = await fixture.McpServer.GetFromJsonAsync<DiscoveredCapabilitiesResponse>("/discovered-capabilities");
+			snapshot!.McpToolCount.Should().BeGreaterThan(0);
+			snapshot.McpToolCount.Should().BeLessThanOrEqualTo(snapshot.CapabilityCount);
+		});
+	}
+
+	[Fact]
+	public async Task DiscoveredCapabilities_ContainsKnownCapabilityNames()
+	{
+		await Eventually.AssertAsync(async () =>
+		{
+			var snapshot = await fixture.McpServer.GetFromJsonAsync<DiscoveredCapabilitiesResponse>("/discovered-capabilities");
+			var names = snapshot!.Capabilities.Select(capability => capability.Name).ToList();
+			names.Should().Contain("search_recipes");
+			names.Should().Contain("get_weekly_plan");
+			names.Should().Contain("get_merged_shopping_list");
+		});
+	}
+
+	private sealed record DiscoveredCapabilitiesResponse(
+		[property: JsonPropertyName("serviceCount")] int ServiceCount,
+		[property: JsonPropertyName("capabilityCount")] int CapabilityCount,
+		[property: JsonPropertyName("mcpToolCount")] int McpToolCount,
+		[property: JsonPropertyName("services")] IReadOnlyList<string> Services,
+		[property: JsonPropertyName("capabilities")] IReadOnlyList<DiscoveredCapability> Capabilities);
+
+	private sealed record DiscoveredCapability(
+		[property: JsonPropertyName("name")] string Name,
+		[property: JsonPropertyName("description")] string Description,
+		[property: JsonPropertyName("surfaces")] string Surfaces,
+		[property: JsonPropertyName("httpMethod")] string HttpMethod,
+		[property: JsonPropertyName("routePattern")] string RoutePattern);
+}

--- a/tests/Yumney.Integration.Tests/Mcp/McpToolInvocationIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpToolInvocationIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System.Net.Http.Headers;
+using Aspire.Hosting.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Phase 4 closing test: actually drives the MCP protocol end-to-end.
+/// Connects an MCP client (the SDK's <c>HttpClientTransport</c>) to the
+/// running mcp-server with a Keycloak bearer, lists tools, and invokes one
+/// — exercising the full chain from protocol → CallToolHandler →
+/// RestProxyService → real upstream module via Aspire service discovery.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpToolInvocationIntegrationTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task ListToolsAsync_ReturnsDiscoveredMcpSurfaceTools()
+	{
+		await using var client = await CreateClientAsync();
+
+		var tools = await client.ListToolsAsync();
+
+		tools.Should().NotBeEmpty();
+		tools.Select(tool => tool.Name).Should().Contain([
+			"search_recipes",
+			"get_recipe",
+			"get_cookable_recipes",
+			"get_weekly_plan",
+			"get_merged_shopping_list",
+		]);
+	}
+
+	[Fact]
+	public async Task CallToolAsync_SearchRecipes_ProxiesToRecipesApiAndReturnsResponse()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("search_recipes", arguments: new Dictionary<string, object?>());
+
+		// The user has no seeded recipes, so the response is an empty paged
+		// result — but it deserialized, which proves the proxy hit the real
+		// Recipes API with the bearer and got 200 back.
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+		var firstText = result.Content.OfType<TextContentBlock>().First().Text;
+		firstText.Should().Contain("\"items\"");
+	}
+
+	[Fact]
+	public async Task CallToolAsync_GetMergedShoppingList_ProxiesToShoppingApi()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("get_merged_shopping_list", arguments: new Dictionary<string, object?>());
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+		var firstText = result.Content.OfType<TextContentBlock>().First().Text;
+		firstText.Should().Contain("\"items\"");
+	}
+
+	[Fact]
+	public async Task CallToolAsync_GetWeeklyPlan_ProxiesToMealPlanApi()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("get_weekly_plan", arguments: new Dictionary<string, object?>
+		{
+			["year"] = 2026,
+			["weekNumber"] = 19,
+		});
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public async Task CallToolAsync_UnknownTool_ReturnsErrorResult()
+	{
+		await using var client = await CreateClientAsync();
+
+		var result = await client.CallToolAsync("nonexistent_tool", arguments: new Dictionary<string, object?>());
+
+		result.IsError.Should().BeTrue();
+	}
+
+	private async Task<McpClient> CreateClientAsync()
+	{
+		var token = await fixture.GetAccessTokenAsync("testuser", "Test1234");
+		var http = fixture.App.CreateHttpClient("mcp-server");
+		http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		var options = new HttpClientTransportOptions
+		{
+			Endpoint = new Uri(http.BaseAddress!, "/mcp"),
+			Name = "mcp-integration-test",
+		};
+		var transport = new HttpClientTransport(options, http, NullLoggerFactory.Instance, ownsHttpClient: true);
+
+		return await McpClient.CreateAsync(transport, clientOptions: null, loggerFactory: NullLoggerFactory.Instance);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Mcp/McpWriteToolBehaviorTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpWriteToolBehaviorTests.cs
@@ -1,0 +1,172 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Aspire.Hosting.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Phase 4 closing-of-closing test: actually persist via MCP write tools and
+/// then read it back via the read tools. Catches subtle wiring bugs the
+/// contract-only tests miss — e.g. arguments serialized in the wrong shape,
+/// owner not propagated, route placeholder bound to the wrong arg name.
+///
+/// Uses a deliberately-far-future ISO week so the test data never collides
+/// with anything else seeded by the suite.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpWriteToolBehaviorTests(AspireFixture fixture)
+{
+	private const int FutureYear = 2099;
+
+	[Fact]
+	public async Task AssignMeal_ThenGetWeeklyPlan_SlotReflectsAssignment()
+	{
+		await using var client = await CreateClientAsync();
+		var recipeId = Guid.NewGuid();
+		const string recipeTitle = "Test Carbonara (assign)";
+		const int week = 11;
+
+		var assignResult = await client.CallToolAsync("assign_meal", new Dictionary<string, object?>
+		{
+			["day"] = "Wednesday",
+			["recipeIdentifier"] = recipeId.ToString(),
+			["recipeTitle"] = recipeTitle,
+			["mealType"] = "Dinner",
+			["year"] = FutureYear,
+			["weekNumber"] = week,
+		});
+
+		assignResult.IsError.Should().BeFalse(because: GetText(assignResult));
+
+		var planResult = await client.CallToolAsync("get_weekly_plan", new Dictionary<string, object?>
+		{
+			["year"] = FutureYear,
+			["weekNumber"] = week,
+		});
+
+		planResult.IsError.Should().BeFalse();
+		var planText = GetText(planResult);
+		planText.Should().Contain(recipeId.ToString().ToLowerInvariant());
+		planText.Should().Contain(recipeTitle);
+		planText.Should().Contain("Wednesday");
+	}
+
+	[Fact]
+	public async Task ConfirmMealCooked_AfterAssign_StateReflectsCooked()
+	{
+		await using var client = await CreateClientAsync();
+		var recipeId = Guid.NewGuid();
+		const int week = 12;
+
+		await client.CallToolAsync("assign_meal", new Dictionary<string, object?>
+		{
+			["day"] = "Friday",
+			["recipeIdentifier"] = recipeId.ToString(),
+			["recipeTitle"] = "Test Pizza (confirm)",
+			["mealType"] = "Dinner",
+			["year"] = FutureYear,
+			["weekNumber"] = week,
+		});
+
+		var confirmResult = await client.CallToolAsync("confirm_meal_cooked", new Dictionary<string, object?>
+		{
+			["day"] = "Friday",
+			["state"] = "Cooked",
+			["mealType"] = "Dinner",
+			["year"] = FutureYear,
+			["weekNumber"] = week,
+		});
+
+		confirmResult.IsError.Should().BeFalse(because: GetText(confirmResult));
+
+		var planResult = await client.CallToolAsync("get_weekly_plan", new Dictionary<string, object?>
+		{
+			["year"] = FutureYear,
+			["weekNumber"] = week,
+		});
+
+		planResult.IsError.Should().BeFalse();
+		var planJson = JsonDocument.Parse(GetText(planResult));
+		var slots = planJson.RootElement.GetProperty("slots").EnumerateArray();
+		var fridaySlot = slots.Single(slot =>
+			slot.GetProperty("day").GetString() == "Friday"
+			&& slot.GetProperty("mealType").GetString() == "Dinner");
+		fridaySlot.GetProperty("recipeIdentifier").GetGuid().Should().Be(recipeId);
+	}
+
+	[Fact]
+	public async Task CreateShoppingListFromRecipes_PersistsList_VisibleViaMergedRead()
+	{
+		var ownerId = await fixture.GetTestUserIdAsync();
+		var recipe = RecipeFactory.TomatoSoup(owner: ownerId);
+		await fixture.SeedRecipesAsync(recipe);
+
+		await using var client = await CreateClientAsync();
+
+		var createResult = await client.CallToolAsync("create_shopping_list_from_recipes", new Dictionary<string, object?>
+		{
+			["title"] = $"MCP integration list {Guid.NewGuid():N}",
+			["recipeIdentifiers"] = recipe.Id.Value.ToString(),
+		});
+
+		createResult.IsError.Should().BeFalse(because: GetText(createResult));
+
+		await Eventually.AssertAsync(async () =>
+		{
+			var mergedResult = await client.CallToolAsync("get_merged_shopping_list", new Dictionary<string, object?>());
+			mergedResult.IsError.Should().BeFalse();
+			var mergedText = GetText(mergedResult);
+
+			// At least one of the recipe's ingredients should appear in the merged list.
+			mergedText.Should().Contain("Tomatoes");
+		});
+	}
+
+	[Fact]
+	public async Task AssignMealWithMissingRequiredArgument_ReturnsError()
+	{
+		await using var client = await CreateClientAsync();
+
+		// Day omitted — model bound parameter, MealPlan should reject the request.
+		var result = await client.CallToolAsync("assign_meal", new Dictionary<string, object?>
+		{
+			["recipeIdentifier"] = Guid.NewGuid().ToString(),
+			["recipeTitle"] = "Whatever",
+			["mealType"] = "Dinner",
+			["year"] = FutureYear,
+			["weekNumber"] = 13,
+		});
+
+		// The tool's response wraps the upstream failure — IsError or a
+		// "Couldn't plan" message both prove the missing-arg path surfaces.
+		var text = GetText(result);
+		var failed = (result.IsError ?? false) || text.Contains("Couldn't plan", StringComparison.OrdinalIgnoreCase);
+		failed.Should().BeTrue($"expected either IsError=true or a Couldn't-plan message; got: {text}");
+	}
+
+	private static string GetText(CallToolResult result) =>
+		result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text ?? string.Empty;
+
+	private async Task<McpClient> CreateClientAsync()
+	{
+		var token = await fixture.GetAccessTokenAsync("testuser", "Test1234");
+		var http = fixture.App.CreateHttpClient("mcp-server");
+		http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		var options = new HttpClientTransportOptions
+		{
+			Endpoint = new Uri(http.BaseAddress!, "/mcp"),
+			Name = "mcp-write-behavior-test",
+		};
+		var transport = new HttpClientTransport(options, http, NullLoggerFactory.Instance, ownsHttpClient: true);
+
+		return await McpClient.CreateAsync(transport, clientOptions: null, loggerFactory: NullLoggerFactory.Instance);
+	}
+}

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Yumney.Recipes.Application\Yumney.Recipes.Application.csproj" />
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Client\Yumney.MealPlan.Client.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Mcp.Server.Tests/Discovery/AggregatedCapabilityRegistryTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Discovery/AggregatedCapabilityRegistryTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Discovery;
+
+public class AggregatedCapabilityRegistryTests
+{
+	[Fact]
+	public void SetManifest_NewService_AddsManifest()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var manifest = new CapabilityManifest("recipes-api", [
+			Descriptor("search_recipes", "GET", "/recipes"),
+			Descriptor("get_recipe", "GET", "/recipes/{id}"),
+		]);
+
+		registry.SetManifest("recipes-api", manifest);
+
+		registry.Manifests.Should().ContainKey("recipes-api");
+		registry.Manifests["recipes-api"].Should().BeSameAs(manifest);
+		registry.CapabilityCount.Should().Be(2);
+	}
+
+	[Fact]
+	public void SetManifest_OverwritesExistingManifestForSameService()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+		var newer = new CapabilityManifest("recipes-api", [
+			Descriptor("a", "GET", "/a"),
+			Descriptor("b", "POST", "/b"),
+		]);
+
+		registry.SetManifest("recipes-api", newer);
+
+		registry.Manifests.Should().HaveCount(1);
+		registry.CapabilityCount.Should().Be(2);
+	}
+
+	[Fact]
+	public void RemoveManifest_DropsExistingService()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+
+		registry.RemoveManifest("recipes-api");
+
+		registry.Manifests.Should().BeEmpty();
+		registry.CapabilityCount.Should().Be(0);
+	}
+
+	[Fact]
+	public void RemoveManifest_UnknownService_IsNoOp()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [Descriptor("a", "GET", "/a")]));
+
+		registry.RemoveManifest("not-here");
+
+		registry.Manifests.Should().HaveCount(1);
+	}
+
+	[Fact]
+	public void AllCapabilities_ReturnsUnionAcrossServices()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [
+			Descriptor("search_recipes", "GET", "/recipes"),
+			Descriptor("get_recipe", "GET", "/recipes/{id}"),
+		]));
+		registry.SetManifest("shopping-api", new CapabilityManifest("shopping-api", [
+			Descriptor("get_merged_shopping_list", "GET", "/shopping-lists/merged"),
+		]));
+
+		var all = registry.AllCapabilities();
+
+		all.Should().HaveCount(3);
+		all.Select(descriptor => descriptor.Name).Should().Contain(["search_recipes", "get_recipe", "get_merged_shopping_list"]);
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, string method, string route) =>
+		new(name, $"description for {name}", CapabilitySurface.All, method, route);
+}

--- a/tests/Yumney.Mcp.Server.Tests/Discovery/CapabilityDiscoveryServiceTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Discovery/CapabilityDiscoveryServiceTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Discovery;
+
+public class CapabilityDiscoveryServiceTests
+{
+	[Fact]
+	public async Task ExecuteAsync_FetchesManifestForEveryKnownHost()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = BuildFactoryReturningManifestForEveryHost();
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Keys.Should().BeEquivalentTo(KnownCapabilityHosts.ServiceNames);
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_OneHostFails_OthersStillRecorded()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			factory.CreateClient(serviceName).Returns(serviceName == "shopping-api"
+				? FailingClient()
+				: SuccessClient(new CapabilityManifest(serviceName, [Descriptor("tool_a", serviceName)])));
+		}
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Should().ContainKeys("recipes-api", "mealplan-api");
+		registry.Manifests.Should().NotContainKey("shopping-api");
+	}
+
+	[Fact]
+	public async Task ExecuteAsync_NullManifestPayload_DoesNotRecordEntry()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			factory.CreateClient(serviceName).Returns(NullPayloadClient());
+		}
+
+		var service = new CapabilityDiscoveryService(factory, registry, NullLogger<CapabilityDiscoveryService>.Instance);
+		await service.StartAsync(CancellationToken.None);
+		await service.ExecuteTask!;
+
+		registry.Manifests.Should().BeEmpty();
+	}
+
+	private static IHttpClientFactory BuildFactoryReturningManifestForEveryHost()
+	{
+		var factory = Substitute.For<IHttpClientFactory>();
+		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		{
+			var manifest = new CapabilityManifest(serviceName, [Descriptor("tool_a", serviceName), Descriptor("tool_b", serviceName)]);
+			factory.CreateClient(serviceName).Returns(SuccessClient(manifest));
+		}
+
+		return factory;
+	}
+
+	private static HttpClient SuccessClient(CapabilityManifest manifest) =>
+		new(new StubHandler(HttpStatusCode.OK, JsonSerializer.Serialize(manifest)))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient FailingClient() =>
+		new(new StubHandler(HttpStatusCode.InternalServerError, "boom"))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient NullPayloadClient() =>
+		new(new StubHandler(HttpStatusCode.OK, "null"))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static CapabilityDescriptor Descriptor(string name, string serviceName) =>
+		new(name, $"{name} on {serviceName}", CapabilitySurface.All, "GET", $"/{name}");
+
+	private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(status)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			});
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class CapabilityToolRegistrationTests
+{
+	[Fact]
+	public void BuildTools_OnlyIncludesCapabilitiesWithMcpSurface()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("search_recipes", CapabilitySurface.All),
+			Descriptor("chat_only_tool", CapabilitySurface.Chat),
+			Descriptor("voice_only_tool", CapabilitySurface.Voice),
+			Descriptor("mcp_only_tool", CapabilitySurface.Mcp),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().HaveCount(2);
+		tools.Select(tool => tool.Name).Should().BeEquivalentTo(["search_recipes", "mcp_only_tool"]);
+	}
+
+	[Fact]
+	public void BuildTools_IncludesRoutePatternInDescription()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			new CapabilityDescriptor(
+				"search_recipes",
+				"Search the user's recipes",
+				CapabilitySurface.All,
+				HttpMethod: "GET",
+				RoutePattern: "/api/v1/recipes/"),
+		]));
+
+		var tool = CapabilityToolRegistration.BuildTools(registry).Single();
+
+		tool.Name.Should().Be("search_recipes");
+		tool.Description.Should().Contain("Search the user's recipes");
+		tool.Description.Should().Contain("GET /api/v1/recipes/");
+	}
+
+	[Fact]
+	public void BuildTools_EmptyRegistry_ReturnsEmptyList()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void BuildTools_NoMcpSurfaceCapabilities_ReturnsEmptyList()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("chat_only", CapabilitySurface.Chat),
+			Descriptor("voice_only", CapabilitySurface.Voice),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void BuildStubInvocationResult_ReferencesRequestedToolName()
+	{
+		var result = CapabilityToolRegistration.BuildStubInvocationResult("search_recipes");
+
+		result.IsError.Should().BeFalse();
+		result.Content.Should().ContainSingle();
+		var text = result.Content.OfType<TextContentBlock>().Single().Text;
+		text.Should().Contain("[search_recipes]");
+		text.Should().Contain("Phase 4c");
+	}
+
+	[Fact]
+	public void BuildTools_UnionsAcrossManifestsFromMultipleServices()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			Descriptor("search_recipes", CapabilitySurface.All),
+		]));
+		registry.SetManifest("shopping-api", new CapabilityManifest(
+			"shopping-api",
+			[
+			Descriptor("get_merged_shopping_list", CapabilitySurface.Mcp),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		tools.Select(tool => tool.Name).Should().BeEquivalentTo(["search_recipes", "get_merged_shopping_list"]);
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, CapabilitySurface surfaces) =>
+		new(name, $"description for {name}", surfaces, "GET", $"/{name}");
+}

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/RestProxyServiceTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/RestProxyServiceTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class RestProxyServiceTests
+{
+	[Fact]
+	public async Task InvokeAsync_UnknownTool_ReturnsErrorResult()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: "abc");
+
+		var result = await service.InvokeAsync("nonexistent_tool", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("Unknown tool");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_NoBearer_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: null);
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("No bearer token");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_MissingPlaceholder_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("get_recipe", "GET", "/api/v1/recipes/{identifier:guid}"));
+		var service = BuildService(registry, BuildClientFactory(_ => SuccessClient("ignored")), bearer: "abc");
+
+		var result = await service.InvokeAsync("get_recipe", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("identifier");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_HappyPath_ForwardsBearerAndReturnsResponseBody()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		HttpRequestMessage? capturedRequest = null;
+		var service = BuildService(
+			registry,
+			BuildClientFactory(captured =>
+			{
+				capturedRequest = captured;
+				return SuccessClient("[{\"id\":\"abc\"}]");
+			}),
+			bearer: "the-bearer");
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeFalse();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("\"id\":\"abc\"");
+		capturedRequest.Should().NotBeNull();
+		capturedRequest!.Headers.Authorization!.Scheme.Should().Be("Bearer");
+		capturedRequest.Headers.Authorization.Parameter.Should().Be("the-bearer");
+		capturedRequest.Method.Method.Should().Be("GET");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_UpstreamReturnsNonSuccess_ReturnsErrorResult()
+	{
+		var registry = BuildRegistryWith(Descriptor("search_recipes", "GET", "/api/v1/recipes/"));
+		var service = BuildService(
+			registry,
+			BuildClientFactory(_ => FailingClient(HttpStatusCode.InternalServerError, "boom")),
+			bearer: "abc");
+
+		var result = await service.InvokeAsync("search_recipes", arguments: null, CancellationToken.None);
+
+		result.IsError.Should().BeTrue();
+		var text = result.Content.OfType<TextContentBlock>().Single().Text;
+		text.Should().Contain("500");
+		text.Should().Contain("boom");
+	}
+
+	[Fact]
+	public async Task InvokeAsync_PostBodyForwardedAsJson()
+	{
+		var registry = BuildRegistryWith(Descriptor(
+			"create_shopping_list_from_recipes",
+			"POST",
+			"/api/v1/shopping-lists/from-recipes"));
+		string? capturedMethod = null;
+		string? capturedBody = null;
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+			new HttpClient(new BodyCapturingHandler(async (request, ct) =>
+			{
+				capturedMethod = request.Method.Method;
+				capturedBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+				return new HttpResponseMessage(HttpStatusCode.OK)
+				{
+					Content = new StringContent("{\"id\":\"new-list\"}", Encoding.UTF8, "application/json"),
+				};
+			}))
+			{
+				BaseAddress = new Uri("http://stub"),
+			});
+		var service = BuildService(registry, factory, bearer: "abc");
+
+		var arguments = new Dictionary<string, JsonElement>
+		{
+			["title"] = JsonSerializer.SerializeToElement("This week"),
+		};
+		var result = await service.InvokeAsync("create_shopping_list_from_recipes", arguments, CancellationToken.None);
+
+		result.IsError.Should().BeFalse();
+		capturedMethod.Should().Be("POST");
+		capturedBody.Should().NotBeNull().And.Subject.Should().Contain("\"title\"");
+	}
+
+	private static AggregatedCapabilityRegistry BuildRegistryWith(CapabilityDescriptor descriptor)
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest("recipes-api", [descriptor]));
+		return registry;
+	}
+
+	private static CapabilityDescriptor Descriptor(string name, string method, string route) =>
+		new(name, $"description for {name}", CapabilitySurface.Mcp, method, route);
+
+	private static RestProxyService BuildService(
+		AggregatedCapabilityRegistry registry,
+		IHttpClientFactory factory,
+		string? bearer)
+	{
+		var contextAccessor = Substitute.For<IHttpContextAccessor>();
+		if (bearer is not null)
+		{
+			var context = new DefaultHttpContext();
+			context.Request.Headers.Authorization = $"Bearer {bearer}";
+			contextAccessor.HttpContext.Returns(context);
+		}
+
+		return new RestProxyService(registry, factory, contextAccessor, NullLogger<RestProxyService>.Instance);
+	}
+
+	private static IHttpClientFactory BuildClientFactory(Func<HttpRequestMessage, HttpClient> handler)
+	{
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient(Arg.Any<string>())
+			.Returns(callInfo => new HttpClient(new CapturingHandler(captured => handler(captured)))
+			{
+				BaseAddress = new Uri("http://stub"),
+			});
+		return factory;
+	}
+
+	private static HttpClient SuccessClient(string body) =>
+		new(new StubHandler(HttpStatusCode.OK, body))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private static HttpClient FailingClient(HttpStatusCode status, string body) =>
+		new(new StubHandler(status, body))
+		{
+			BaseAddress = new Uri("http://stub"),
+		};
+
+	private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(status)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			});
+	}
+
+	private sealed class CapturingHandler(Func<HttpRequestMessage, HttpClient> upstream) : HttpMessageHandler
+	{
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			using var client = upstream(request);
+			using var inner = await client.SendAsync(new HttpRequestMessage(request.Method, "/"), cancellationToken);
+			var body = await inner.Content.ReadAsStringAsync(cancellationToken);
+			return new HttpResponseMessage(inner.StatusCode)
+			{
+				Content = new StringContent(body, Encoding.UTF8, "application/json"),
+			};
+		}
+	}
+
+	private sealed class BodyCapturingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			respond(request, cancellationToken);
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/RouteUrlBuilderTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/RouteUrlBuilderTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class RouteUrlBuilderTests
+{
+	[Fact]
+	public void Build_GetWithoutPlaceholders_NoArgs_ReturnsBareRoute()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/", arguments: null);
+
+		built.Url.Should().Be("/api/v1/recipes/");
+		built.Body.Should().BeNull();
+		built.MissingPlaceholders.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Build_GetWithExtraArgs_AppendsQueryString()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/", BuildArgs(("search", "chicken"), ("page", 2)));
+
+		built.Url.Should().Contain("search=chicken").And.Contain("page=2");
+		built.Url.Should().StartWith("/api/v1/recipes/?");
+		built.Body.Should().BeNull();
+	}
+
+	[Fact]
+	public void Build_GetWithPlaceholder_SubstitutesAndOmitsFromQuery()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier:guid}", BuildArgs(("identifier", "abc-123")));
+
+		built.Url.Should().Be("/api/v1/recipes/abc-123");
+		built.Body.Should().BeNull();
+	}
+
+	[Fact]
+	public void Build_PostWithExtraArgs_PutsArgsInJsonBody()
+	{
+		var built = RouteUrlBuilder.Build("POST", "/api/v1/shopping-lists/from-recipes", BuildArgs(("title", "This week"), ("recipes", "[]")));
+
+		built.Url.Should().Be("/api/v1/shopping-lists/from-recipes");
+		built.Body.Should().NotBeNull();
+		built.Body!.Should().Contain("\"title\"");
+		built.Body.Should().Contain("\"recipes\"");
+	}
+
+	[Fact]
+	public void Build_PostWithPlaceholderAndBody_SubstitutesPathArgsAndKeepsBodyArgs()
+	{
+		var built = RouteUrlBuilder.Build(
+			"POST",
+			"/api/v1/meal-plans/{year:int}/w/{weekNumber:int}/slots",
+			BuildArgs(("year", 2026), ("weekNumber", 19), ("day", "Wednesday"), ("recipeIdentifier", "abc-123")));
+
+		built.Url.Should().Be("/api/v1/meal-plans/2026/w/19/slots");
+		built.Body.Should().Contain("\"day\"");
+		built.Body.Should().Contain("\"recipeIdentifier\"");
+		built.Body.Should().NotContain("\"year\"");
+		built.Body.Should().NotContain("\"weekNumber\"");
+	}
+
+	[Fact]
+	public void Build_MissingRequiredPlaceholder_ReportsIt()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier:guid}", arguments: null);
+
+		built.MissingPlaceholders.Should().BeEquivalentTo(["identifier"]);
+	}
+
+	[Fact]
+	public void Build_PutMethod_UsesBody()
+	{
+		var built = RouteUrlBuilder.Build(
+			"PUT",
+			"/api/v1/meal-plans/{year:int}/w/{weekNumber:int}/slots/confirm",
+			BuildArgs(("year", 2026), ("weekNumber", 19), ("day", "Wednesday"), ("state", "Cooked")));
+
+		built.Url.Should().Be("/api/v1/meal-plans/2026/w/19/slots/confirm");
+		built.Body.Should().NotBeNull();
+		built.Body!.Should().Contain("\"day\"");
+		built.Body.Should().Contain("\"state\"");
+	}
+
+	[Fact]
+	public void Build_UrlEscapesPlaceholderValuesAndQueryArgs()
+	{
+		var built = RouteUrlBuilder.Build("GET", "/api/v1/recipes/{identifier}", BuildArgs(("identifier", "with space"), ("search", "chicken & rice")));
+
+		built.Url.Should().StartWith("/api/v1/recipes/with%20space?");
+		built.Url.Should().Contain("search=chicken%20%26%20rice");
+	}
+
+	private static Dictionary<string, JsonElement> BuildArgs(params (string Key, object Value)[] pairs)
+	{
+		var dict = new Dictionary<string, JsonElement>();
+		foreach (var (key, value) in pairs)
+		{
+			var json = value switch
+			{
+				int number => JsonSerializer.SerializeToElement(number),
+				string text => JsonSerializer.SerializeToElement(text),
+				_ => JsonSerializer.SerializeToElement(value),
+			};
+			dict[key] = json;
+		}
+
+		return dict;
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
+++ b/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.Mcp.Server\Yumney.Mcp.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Yumney.Shared.Tests/Capabilities/CapabilityManifestEndpointTests.cs
+++ b/tests/Yumney.Shared.Tests/Capabilities/CapabilityManifestEndpointTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Primitives;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Capabilities;
+
+public class CapabilityManifestEndpointTests
+{
+	[Fact]
+	public void BuildManifest_OnlyTaggedEndpoints_AppearInDescriptors()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/api/v1/recipes", "GET", "search_recipes", "search the user's recipes", CapabilitySurface.All),
+			TaggedEndpoint("/api/v1/recipes/{id}", "GET", "get_recipe", "fetch one recipe", CapabilitySurface.Chat | CapabilitySurface.Mcp),
+			UntaggedEndpoint("/health", "GET"));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("recipes-api", dataSource);
+
+		manifest.ServiceName.Should().Be("recipes-api");
+		manifest.Capabilities.Should().HaveCount(2);
+		manifest.Capabilities.Select(capability => capability.Name).Should().Contain(["search_recipes", "get_recipe"]);
+		manifest.Capabilities.Select(capability => capability.RoutePattern).Should().NotContain("/health");
+	}
+
+	[Fact]
+	public void BuildManifest_ProjectsHttpMethodFromMetadata()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/post-route", "POST", "post_tool", "creates a thing", CapabilitySurface.Mcp),
+			TaggedEndpoint("/put-route", "PUT", "put_tool", "updates a thing", CapabilitySurface.Mcp));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		manifest.Capabilities.Single(capability => capability.Name == "post_tool").HttpMethod.Should().Be("POST");
+		manifest.Capabilities.Single(capability => capability.Name == "put_tool").HttpMethod.Should().Be("PUT");
+	}
+
+	[Fact]
+	public void BuildManifest_PreservesNameDescriptionAndSurfaces()
+	{
+		var dataSource = new TestEndpointDataSource(
+			TaggedEndpoint("/route", "GET", "tool_name", "long description", CapabilitySurface.Chat | CapabilitySurface.Voice));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		var descriptor = manifest.Capabilities.Single();
+		descriptor.Name.Should().Be("tool_name");
+		descriptor.Description.Should().Be("long description");
+		descriptor.Surfaces.Should().Be(CapabilitySurface.Chat | CapabilitySurface.Voice);
+		descriptor.RoutePattern.Should().Be("/route");
+	}
+
+	[Fact]
+	public void BuildManifest_NoTaggedEndpoints_ReturnsEmptyCapabilityList()
+	{
+		var dataSource = new TestEndpointDataSource(
+			UntaggedEndpoint("/a", "GET"),
+			UntaggedEndpoint("/b", "POST"));
+
+		var manifest = CapabilityManifestEndpoint.BuildManifest("test-api", dataSource);
+
+		manifest.ServiceName.Should().Be("test-api");
+		manifest.Capabilities.Should().BeEmpty();
+	}
+
+	private static RouteEndpoint TaggedEndpoint(string pattern, string method, string name, string description, CapabilitySurface surfaces) =>
+		new(
+			_ => Task.CompletedTask,
+			RoutePatternFactory.Parse(pattern),
+			order: 0,
+			new EndpointMetadataCollection(
+				new HttpMethodMetadata([method]),
+				new CapabilityMetadata(name, description, surfaces)),
+			displayName: name);
+
+	private static RouteEndpoint UntaggedEndpoint(string pattern, string method) =>
+		new(
+			_ => Task.CompletedTask,
+			RoutePatternFactory.Parse(pattern),
+			order: 0,
+			new EndpointMetadataCollection(new HttpMethodMetadata([method])),
+			displayName: pattern);
+
+	private sealed class TestEndpointDataSource(params Endpoint[] endpoints) : EndpointDataSource
+	{
+		public override IReadOnlyList<Endpoint> Endpoints { get; } = endpoints;
+
+		public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Capabilities/CapabilityRouteBuilderExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Capabilities/CapabilityRouteBuilderExtensionsTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Capabilities;
+
+public class CapabilityRouteBuilderExtensionsTests
+{
+	[Fact]
+	public void WithCapability_AttachesCapabilityMetadata()
+	{
+		var builder = new TestConventionBuilder();
+
+		builder.WithCapability("test_tool", "a test", CapabilitySurface.Chat);
+
+		var metadata = builder.AppliedMetadata.OfType<CapabilityMetadata>().Single();
+		metadata.Name.Should().Be("test_tool");
+		metadata.Description.Should().Be("a test");
+		metadata.Surfaces.Should().Be(CapabilitySurface.Chat);
+	}
+
+	[Fact]
+	public void WithCapability_DefaultSurfaces_IsChatPlusMcp()
+	{
+		var builder = new TestConventionBuilder();
+
+		builder.WithCapability("default_tool", "default surfaces");
+
+		var metadata = builder.AppliedMetadata.OfType<CapabilityMetadata>().Single();
+		metadata.Surfaces.Should().Be(CapabilitySurface.Chat | CapabilitySurface.Mcp);
+	}
+
+	private sealed class TestConventionBuilder : IEndpointConventionBuilder
+	{
+		public List<object> AppliedMetadata { get; } = [];
+
+		public void Add(Action<EndpointBuilder> convention)
+		{
+			var endpointBuilder = new TestEndpointBuilder();
+			convention(endpointBuilder);
+			AppliedMetadata.AddRange(endpointBuilder.Metadata);
+		}
+
+		public void Finally(Action<EndpointBuilder> finallyConvention)
+		{
+		}
+	}
+
+	private sealed class TestEndpointBuilder : EndpointBuilder
+	{
+		public override Endpoint Build() => throw new NotSupportedException();
+	}
+}


### PR DESCRIPTION
PRs #647 / #648 / #649 / #650 (Phase 3 + Phase 4a/4b/4c production) plus the integration test PRs #651 / #653 / #655 were marked merged on GitHub but their commits never reached develop — same broken-merge pattern as #644-#646 (recovered via #657). Stacked PRs with rebased merges into intermediate branches don't cascade up.

This PR re-applies all 7 commits cleanly on top of develop. Content is identical — just rebased.

## Recovered

Production:
- `feat(shared): capability surface foundation - manifest endpoint + 9 tagged routes (US-640)` (was #647)
- `feat(infra): Yumney.Mcp.Server bootstrap with capability discovery (US-641 Phase 4a)` (was #648)
- `feat(infra): MCP protocol surface with tool listing + stub invocation (US-641 Phase 4b)` (was #649)
- `feat(infra): MCP REST proxy + Keycloak JWT bearer (US-641 Phase 4c)` (was #650)

Integration tests:
- `test(test): integration tests for Phase 3 manifest + Phase 4 MCP server` (was #651)
- `test(test): MCP tools/call round-trip via SDK client` (was #653)
- `test(test): MCP write-tool round-trips actually persist` (was #655)

## Closes

- #647
- #648
- #649
- #650
- #651
- #653
- #655