### PR TITLE
feat(recipes): chat tools for shopping add/remove + meal swap/clear (US-328 + US-329)

### DIFF
--- a/src/Yumney.MealPlan.Client/IMealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/IMealPlanClient.cs
@@ -29,6 +29,22 @@ public interface IMealPlanClient
 	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
 	/// <returns>True on 2xx, false on any error.</returns>
 	Task<bool> ConfirmMealAsync(int year, int weekNumber, ConfirmMealBody body, CancellationToken cancellationToken = default);
+
+	/// <summary>Swap two meal slots. PUT /api/v1/meal-plans/{year}/w/{weekNumber}/slots/swap.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Source day, target day, meal type.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> SwapSlotsAsync(int year, int weekNumber, SwapSlotsBody body, CancellationToken cancellationToken = default);
+
+	/// <summary>Clear a meal slot. DELETE /api/v1/meal-plans/{year}/w/{weekNumber}/slots.</summary>
+	/// <param name="year">ISO year.</param>
+	/// <param name="weekNumber">ISO week number.</param>
+	/// <param name="body">Day + meal type identifying the slot.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> ClearSlotAsync(int year, int weekNumber, ClearSlotBody body, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Trimmed weekly-plan shape returned over the wire.</summary>
@@ -58,3 +74,9 @@ public sealed record AssignRecipeBody(
 
 /// <summary>Body for the confirm-meal PUT.</summary>
 public sealed record ConfirmMealBody(string Day, string MealType, string State);
+
+/// <summary>Body for the swap-slots PUT.</summary>
+public sealed record SwapSlotsBody(string SourceDay, string TargetDay, string MealType);
+
+/// <summary>Body for the clear-slot DELETE.</summary>
+public sealed record ClearSlotBody(string Day, string MealType);

--- a/src/Yumney.MealPlan.Client/MealPlanClient.cs
+++ b/src/Yumney.MealPlan.Client/MealPlanClient.cs
@@ -45,4 +45,38 @@ internal sealed class MealPlanClient(IModuleHttpClientFactory factory) : IMealPl
 			return false;
 		}
 	}
+
+	public async Task<bool> SwapSlotsAsync(int year, int weekNumber, SwapSlotsBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.PutAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots/swap",
+				body,
+				"SwapMealSlots",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
+
+	public async Task<bool> ClearSlotAsync(int year, int weekNumber, ClearSlotBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.DeleteAsync(
+				$"/api/v1/meal-plans/{year}/w/{weekNumber}/slots",
+				body,
+				"ClearMealSlot",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/src/Yumney.Recipes.Application/Interfaces/IMealSlotClearer.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealSlotClearer.cs
@@ -1,0 +1,18 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>Consumer-defined contract for clearing a meal slot from the weekly plan.</summary>
+public interface IMealSlotClearer
+{
+	/// <summary>Clear (cancel) the meal planned for a given day + meal type.</summary>
+	/// <param name="request">Year, week, day, meal type.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> ClearAsync(ClearMealSlotRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a clear-meal-slot request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="Day">English weekday name.</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+public sealed record ClearMealSlotRequest(int Year, int WeekNumber, string Day, string MealType);

--- a/src/Yumney.Recipes.Application/Interfaces/IMealSlotSwapper.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IMealSlotSwapper.cs
@@ -1,0 +1,19 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>Consumer-defined contract for swapping two meal slots in the weekly plan.</summary>
+public interface IMealSlotSwapper
+{
+	/// <summary>Swap the meals planned for two days within the same week.</summary>
+	/// <param name="request">Year, week, source / target days, meal type.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> SwapAsync(SwapMealSlotsRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a swap-meal-slots request.</summary>
+/// <param name="Year">ISO year.</param>
+/// <param name="WeekNumber">ISO week number 1-53.</param>
+/// <param name="SourceDay">English weekday name to swap from.</param>
+/// <param name="TargetDay">English weekday name to swap to.</param>
+/// <param name="MealType">One of "Breakfast", "Lunch", "Dinner", "Snack".</param>
+public sealed record SwapMealSlotsRequest(int Year, int WeekNumber, string SourceDay, string TargetDay, string MealType);

--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListItemAdder.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListItemAdder.cs
@@ -1,0 +1,21 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for adding a manual item to the user's active
+/// shopping list. Owned by Recipes (chat surface is the consumer) per
+/// CLAUDE.md cross-module rule + ADR 0002.
+/// </summary>
+public interface IShoppingListItemAdder
+{
+	/// <summary>Add an item to the user's active shopping list.</summary>
+	/// <param name="request">Item name + optional quantity / unit.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> AddAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of an add-shopping-item request.</summary>
+/// <param name="Name">Ingredient name.</param>
+/// <param name="Quantity">Optional quantity; defaults applied upstream when null.</param>
+/// <param name="Unit">Optional unit (g, ml, etc.).</param>
+public sealed record AddShoppingItemRequest(string Name, decimal? Quantity, string? Unit);

--- a/src/Yumney.Recipes.Application/Interfaces/IShoppingListItemRemover.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IShoppingListItemRemover.cs
@@ -1,0 +1,21 @@
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+/// <summary>
+/// Consumer-defined contract for removing an item from the user's active
+/// shopping list. Owned by Recipes (chat surface is the consumer).
+/// </summary>
+public interface IShoppingListItemRemover
+{
+	/// <summary>Remove an item from the user's active shopping list.</summary>
+	/// <param name="request">Item name + optional quantity / reason.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the call.</param>
+	/// <returns>True on success, false if the upstream rejected the request.</returns>
+	Task<bool> RemoveAsync(RemoveShoppingItemRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Consumer-flavored shape of a remove-shopping-item request.</summary>
+/// <param name="Name">Ingredient name.</param>
+/// <param name="Quantity">Optional quantity; null removes the entire entry.</param>
+/// <param name="Unit">Optional unit (g, ml, etc.).</param>
+/// <param name="Reason">Optional removal reason ("bought", "skipped", etc.).</param>
+public sealed record RemoveShoppingItemRequest(string Name, decimal? Quantity, string? Unit, string? Reason);

--- a/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Extraction/ExtractionServiceCollectionExtensions.cs
@@ -49,6 +49,10 @@ public static class ExtractionServiceCollectionExtensions
 		services.AddScoped<ConfirmMealTool>();
 		services.AddScoped<GetMergedShoppingListTool>();
 		services.AddScoped<CreateShoppingListTool>();
+		services.AddScoped<AddShoppingItemTool>();
+		services.AddScoped<RemoveShoppingItemTool>();
+		services.AddScoped<SwapMealSlotsTool>();
+		services.AddScoped<ClearMealSlotTool>();
 
 		var skOptions = configuration
 			.GetSection(SemanticKernelOptions.SectionName)

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -32,6 +32,10 @@ public sealed partial class SemanticKernelChatService(
 	ConfirmMealTool confirmMealTool,
 	GetMergedShoppingListTool getMergedShoppingListTool,
 	CreateShoppingListTool createShoppingListTool,
+	AddShoppingItemTool addShoppingItemTool,
+	RemoveShoppingItemTool removeShoppingItemTool,
+	SwapMealSlotsTool swapMealSlotsTool,
+	ClearMealSlotTool clearMealSlotTool,
 	ChatToolContext toolContext,
 	ILogger<SemanticKernelChatService> logger)
 	: IChatService
@@ -166,6 +170,16 @@ public sealed partial class SemanticKernelChatService(
           search_recipes if needed, then call
           create_shopping_list_from_recipes with the identifiers
           comma-separated.
+        - When the user wants to add an item to the shopping list ("add
+          milk", "add 2kg potatoes"), call add_to_shopping_list. Pass
+          quantity + unit when stated; omit otherwise.
+        - When the user wants to remove an item from the shopping list
+          ("remove eggs", "I don't need milk anymore"), call
+          remove_from_shopping_list.
+        - When the user wants to swap two planned meals ("swap Thursday
+          and Friday"), call swap_meal_slots.
+        - When the user wants to cancel a planned meal ("cancel
+          Wednesday", "clear Friday's dinner"), call clear_meal_slot.
         - For general cooking questions or chit-chat, just reply directly
           without calling tools.
 
@@ -192,6 +206,10 @@ public sealed partial class SemanticKernelChatService(
 		requestKernel.Plugins.AddFromObject(confirmMealTool, "mealplan_confirm");
 		requestKernel.Plugins.AddFromObject(getMergedShoppingListTool, "shopping_merged");
 		requestKernel.Plugins.AddFromObject(createShoppingListTool, "shopping_create");
+		requestKernel.Plugins.AddFromObject(addShoppingItemTool, "shopping_add");
+		requestKernel.Plugins.AddFromObject(removeShoppingItemTool, "shopping_remove");
+		requestKernel.Plugins.AddFromObject(swapMealSlotsTool, "mealplan_swap");
+		requestKernel.Plugins.AddFromObject(clearMealSlotTool, "mealplan_clear");
 		return requestKernel;
 	}
 }

--- a/src/Yumney.Recipes.Extraction/Services/Tools/AddShoppingItemTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/AddShoppingItemTool.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing "add to shopping list" to the chat LLM. Closes
+/// the add-via-chat half of US-328.
+/// </summary>
+/// <param name="adder">Consumer-defined add contract.</param>
+public sealed class AddShoppingItemTool(IShoppingListItemAdder adder)
+{
+	/// <summary>Add an item to the user's shopping list.</summary>
+	/// <param name="name">Item name (e.g. "milk", "potatoes").</param>
+	/// <param name="quantity">Optional numeric quantity. Default 1 if omitted.</param>
+	/// <param name="unit">Optional unit ("kg", "g", "ml", "L", etc.). Omit for count-based items.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Confirmation message for the LLM to weave into its reply.</returns>
+	[KernelFunction("add_to_shopping_list")]
+	[Description("Add an item to the user's shopping list. Use for 'add milk', 'add 2kg potatoes', 'put eggs on the list'. The shopping list will deduplicate / sum quantities for items already present.")]
+	public async Task<string> AddAsync(
+		[Description("Item name, e.g. 'milk' or 'potatoes'")] string name,
+		[Description("Optional numeric quantity, e.g. 2 or 500. Omit for count-based items defaulting to 1.")] decimal? quantity = null,
+		[Description("Optional unit, e.g. 'kg', 'g', 'ml', 'L'. Omit for count-based items.")] string? unit = null,
+		CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace(name)) return "Item name is required.";
+
+		var success = await adder.AddAsync(new AddShoppingItemRequest(name.Trim(), quantity, unit), cancellationToken);
+		if (!success) return $"Couldn't add {name} — please try again.";
+
+		var qtyText = quantity.HasValue ? $"{quantity}{(string.IsNullOrEmpty(unit) ? string.Empty : unit)} " : string.Empty;
+		return $"Added {qtyText}{name} to your shopping list.";
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/ClearMealSlotTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/ClearMealSlotTool.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal-slot clearing to the chat LLM. Closes
+/// the cancel-via-chat half of US-329.
+/// </summary>
+/// <param name="clearer">Consumer-defined clearer contract.</param>
+public sealed class ClearMealSlotTool(IMealSlotClearer clearer)
+{
+	/// <summary>Clear (cancel) the meal planned for a given day + meal type.</summary>
+	/// <param name="day">Weekday name to clear.</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Confirmation message for the LLM.</returns>
+	[KernelFunction("clear_meal_slot")]
+	[Description("Cancel / clear a planned meal ('cancel Wednesday', 'remove Friday's dinner', 'clear lunch on Monday'). Pass year=0 / weekNumber=0 to mean 'this week'.")]
+	public async Task<string> ClearAsync(
+		[Description("Weekday name to clear: Monday..Sunday")] string day,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new ClearMealSlotRequest(resolvedYear, resolvedWeek, day, mealType);
+
+		var success = await clearer.ClearAsync(request, cancellationToken);
+		return success
+			? $"Cleared {day} {mealType.ToLowerInvariant()}."
+			: $"Couldn't clear that slot — it may already be empty.";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/RemoveShoppingItemTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/RemoveShoppingItemTool.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing "remove from shopping list" to the chat LLM.
+/// Closes the remove-via-chat half of US-328.
+/// </summary>
+/// <param name="remover">Consumer-defined remove contract.</param>
+public sealed class RemoveShoppingItemTool(IShoppingListItemRemover remover)
+{
+	/// <summary>Remove an item from the user's shopping list.</summary>
+	/// <param name="name">Item name to remove.</param>
+	/// <param name="quantity">Optional quantity to remove. Omit to remove the entire entry.</param>
+	/// <param name="unit">Optional unit.</param>
+	/// <param name="reason">Optional removal reason ("bought", "skipped", "no_longer_needed").</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Confirmation message for the LLM.</returns>
+	[KernelFunction("remove_from_shopping_list")]
+	[Description("Remove an item from the user's shopping list. Use for 'remove eggs', 'I don't need milk anymore', 'cross off the bread'. Omit quantity to remove the entire entry.")]
+	public async Task<string> RemoveAsync(
+		[Description("Item name to remove from the list")] string name,
+		[Description("Optional numeric quantity. Omit to remove the entire entry.")] decimal? quantity = null,
+		[Description("Optional unit, e.g. 'kg', 'g', 'ml'.")] string? unit = null,
+		[Description("Optional removal reason: 'bought', 'skipped', 'no_longer_needed'.")] string? reason = null,
+		CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace(name)) return "Item name is required.";
+
+		var success = await remover.RemoveAsync(new RemoveShoppingItemRequest(name.Trim(), quantity, unit, reason), cancellationToken);
+		return success
+			? $"Removed {name} from your shopping list."
+			: $"Couldn't find {name} on your list.";
+	}
+}

--- a/src/Yumney.Recipes.Extraction/Services/Tools/SwapMealSlotsTool.cs
+++ b/src/Yumney.Recipes.Extraction/Services/Tools/SwapMealSlotsTool.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+
+/// <summary>
+/// SK kernel function exposing meal-slot swapping to the chat LLM. Closes
+/// the swap-via-chat half of US-329.
+/// </summary>
+/// <param name="swapper">Consumer-defined swapper contract.</param>
+public sealed class SwapMealSlotsTool(IMealSlotSwapper swapper)
+{
+	/// <summary>Swap the meals planned for two days within the same ISO week.</summary>
+	/// <param name="sourceDay">Source weekday name.</param>
+	/// <param name="targetDay">Target weekday name.</param>
+	/// <param name="mealType">Meal type. Defaults to Dinner.</param>
+	/// <param name="year">ISO year, or 0 for the current year.</param>
+	/// <param name="weekNumber">ISO week number 1-53, or 0 for the current week.</param>
+	/// <param name="cancellationToken">Cancellation propagated from the LLM call.</param>
+	/// <returns>Confirmation message for the LLM.</returns>
+	[KernelFunction("swap_meal_slots")]
+	[Description("Swap two meals in the user's weekly plan ('swap Thursday and Friday', 'move Monday's dinner to Tuesday'). Pass year=0 / weekNumber=0 to mean 'this week'.")]
+	public async Task<string> SwapAsync(
+		[Description("Source weekday name: Monday..Sunday")] string sourceDay,
+		[Description("Target weekday name: Monday..Sunday")] string targetDay,
+		[Description("Meal type: Breakfast, Lunch, Dinner, or Snack. Defaults to Dinner.")] string mealType = "Dinner",
+		[Description("ISO year, or 0 for the current year")] int year = 0,
+		[Description("ISO week number 1-53, or 0 for the current week")] int weekNumber = 0,
+		CancellationToken cancellationToken = default)
+	{
+		var (resolvedYear, resolvedWeek) = ResolveWeek(year, weekNumber);
+		var request = new SwapMealSlotsRequest(resolvedYear, resolvedWeek, sourceDay, targetDay, mealType);
+
+		var success = await swapper.SwapAsync(request, cancellationToken);
+		return success
+			? $"Swapped {sourceDay} and {targetDay} {mealType.ToLowerInvariant()}."
+			: $"Couldn't swap those meals — one or both slots may be empty.";
+	}
+
+	private static (int Year, int Week) ResolveWeek(int year, int weekNumber)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var resolvedYear = year > 0 ? year : ISOWeek.GetYear(now.DateTime);
+		var resolvedWeek = weekNumber > 0 ? weekNumber : ISOWeek.GetWeekOfYear(now.DateTime);
+		return (resolvedYear, resolvedWeek);
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealSlotClearer.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealSlotClearer.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealSlotClearer(IMealPlanClient mealPlan) : IMealSlotClearer
+{
+	public Task<bool> ClearAsync(ClearMealSlotRequest request, CancellationToken cancellationToken = default) =>
+		mealPlan.ClearSlotAsync(
+			request.Year,
+			request.WeekNumber,
+			new ClearSlotBody(request.Day, request.MealType),
+			cancellationToken);
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealSlotSwapper.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpMealSlotSwapper.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpMealSlotSwapper(IMealPlanClient mealPlan) : IMealSlotSwapper
+{
+	public Task<bool> SwapAsync(SwapMealSlotsRequest request, CancellationToken cancellationToken = default) =>
+		mealPlan.SwapSlotsAsync(
+			request.Year,
+			request.WeekNumber,
+			new SwapSlotsBody(request.SourceDay, request.TargetDay, request.MealType),
+			cancellationToken);
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListItemAdder.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListItemAdder.cs
@@ -1,0 +1,25 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using ShoppingClient = SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+#pragma warning disable SA1303
+public sealed class HttpShoppingListItemAdder(ShoppingClient.IShoppingClient shopping) : IShoppingListItemAdder
+{
+	private const string chatSourceLabel = "chat";
+
+	public async Task<bool> AddAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await shopping.AddItemAsync(
+				new ShoppingClient.AddShoppingItemRequest(request.Name, request.Quantity ?? 1m, request.Unit, chatSourceLabel),
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
+}

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListItemRemover.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpShoppingListItemRemover.cs
@@ -1,0 +1,12 @@
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+
+public sealed class HttpShoppingListItemRemover(IShoppingClient shopping) : IShoppingListItemRemover
+{
+	public Task<bool> RemoveAsync(RemoveShoppingItemRequest request, CancellationToken cancellationToken = default) =>
+		shopping.RemoveItemAsync(
+			new RemoveShoppingItemBody(request.Name, request.Quantity, request.Unit, request.Reason),
+			cancellationToken);
+}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -46,6 +46,10 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddScoped<IMealConfirmation, HttpMealConfirmation>();
 		services.AddScoped<IShoppingListLookup, HttpShoppingListLookup>();
 		services.AddScoped<IShoppingListCreator, HttpShoppingListCreator>();
+		services.AddScoped<IShoppingListItemAdder, HttpShoppingListItemAdder>();
+		services.AddScoped<IShoppingListItemRemover, HttpShoppingListItemRemover>();
+		services.AddScoped<IMealSlotSwapper, HttpMealSlotSwapper>();
+		services.AddScoped<IMealSlotClearer, HttpMealSlotClearer>();
 		services.AddScoped<IRecipeViewTracker, CachedRecipeViewTracker>();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.Shared.Web/IModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClient.cs
@@ -25,6 +25,17 @@ public interface IModuleHttpClient
 		TBody body,
 		string operation,
 		CancellationToken cancellationToken = default);
+
+	Task DeleteAsync(
+		string url,
+		string operation,
+		CancellationToken cancellationToken = default);
+
+	Task DeleteAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default);
 }
 
 public interface IModuleHttpClientFactory

--- a/src/Yumney.Shared.Web/ModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/ModuleHttpClient.cs
@@ -93,6 +93,45 @@ internal sealed partial class ModuleHttpClient(
 		}
 	}
 
+	public async Task DeleteAsync(
+		string url,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await httpClient.DeleteAsync(url, cancellationToken);
+			response.EnsureSuccessStatusCode();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogDeleteFailed(operation, upstreamName, ex.Message);
+			throw;
+		}
+	}
+
+	public async Task DeleteAsync<TBody>(
+		string url,
+		TBody body,
+		string operation,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var request = new HttpRequestMessage(HttpMethod.Delete, url)
+			{
+				Content = JsonContent.Create(body, options: jsonOptions),
+			};
+			using var response = await httpClient.SendAsync(request, cancellationToken);
+			response.EnsureSuccessStatusCode();
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogDeleteFailed(operation, upstreamName, ex.Message);
+			throw;
+		}
+	}
+
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{Operation} GET against {Upstream} failed ({Reason}); returning fallback.")]
 	private partial void LogGetFailed(string operation, string upstream, string reason);
 
@@ -104,4 +143,7 @@ internal sealed partial class ModuleHttpClient(
 
 	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} PUT to {Upstream} failed ({Reason}).")]
 	private partial void LogPutFailed(string operation, string upstream, string reason);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "{Operation} DELETE to {Upstream} failed ({Reason}).")]
+	private partial void LogDeleteFailed(string operation, string upstream, string reason);
 }

--- a/src/Yumney.Shopping.Client/IShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/IShoppingClient.cs
@@ -19,6 +19,12 @@ public interface IShoppingClient
 	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
 	/// <returns>True on 2xx, false on any error.</returns>
 	Task<bool> CreateListFromRecipesAsync(CreateListFromRecipesBody body, CancellationToken cancellationToken = default);
+
+	/// <summary>Remove an item from the user's active shopping list. DELETE /api/v1/shopping-lists/items.</summary>
+	/// <param name="body">Item name + optional quantity / reason.</param>
+	/// <param name="cancellationToken">Cancellation propagated to the HTTP call.</param>
+	/// <returns>True on 2xx, false on any error.</returns>
+	Task<bool> RemoveItemAsync(RemoveShoppingItemBody body, CancellationToken cancellationToken = default);
 }
 
 public sealed record ShoppingBalanceResponse(IReadOnlyList<ShoppingBalanceItem> Items);
@@ -43,3 +49,6 @@ public sealed record CreateListFromRecipesBody(string Title, IReadOnlyList<Creat
 
 /// <summary>One recipe selection inside a create-list-from-recipes body.</summary>
 public sealed record CreateListRecipeBody(Guid RecipeIdentifier, int? Servings);
+
+/// <summary>Body for remove-item DELETE.</summary>
+public sealed record RemoveShoppingItemBody(string Name, decimal? Quantity = null, string? Unit = null, string? Reason = null);

--- a/src/Yumney.Shopping.Client/ShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClient.cs
@@ -41,4 +41,21 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 			return false;
 		}
 	}
+
+	public async Task<bool> RemoveItemAsync(RemoveShoppingItemBody body, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await http.DeleteAsync(
+				"/api/v1/shopping-lists/items",
+				body,
+				"RemoveShoppingItem",
+				cancellationToken);
+			return true;
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			return false;
+		}
+	}
 }

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceFunctionCallingTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/SemanticKernelChatServiceFunctionCallingTests.cs
@@ -269,6 +269,14 @@ public sealed class SemanticKernelChatServiceFunctionCallingTests
 			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListLookup>());
 		var createShoppingListTool = new CreateShoppingListTool(
 			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListCreator>());
+		var addShoppingItemTool = new AddShoppingItemTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListItemAdder>());
+		var removeShoppingItemTool = new RemoveShoppingItemTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IShoppingListItemRemover>());
+		var swapMealSlotsTool = new SwapMealSlotsTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IMealSlotSwapper>());
+		var clearMealSlotTool = new ClearMealSlotTool(
+			Substitute.For<SmartSolutionsLab.Yumney.Recipes.Application.Interfaces.IMealSlotClearer>());
 
 		var kernelBuilder = Kernel.CreateBuilder();
 		kernelBuilder.Services.AddSingleton<IChatCompletionService>(fake);
@@ -285,6 +293,10 @@ public sealed class SemanticKernelChatServiceFunctionCallingTests
 			confirmMealTool,
 			mergedShoppingListTool,
 			createShoppingListTool,
+			addShoppingItemTool,
+			removeShoppingItemTool,
+			swapMealSlotsTool,
+			clearMealSlotTool,
 			context,
 			NullLogger<SemanticKernelChatService>.Instance);
 

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AddShoppingItemToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/AddShoppingItemToolTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class AddShoppingItemToolTests
+{
+	private readonly IShoppingListItemAdder adder = Substitute.For<IShoppingListItemAdder>();
+
+	[Fact]
+	public async Task AddAsync_HappyPath_DispatchesAndReturnsConfirmation()
+	{
+		AddShoppingItemRequest? captured = null;
+		adder.AddAsync(Arg.Any<AddShoppingItemRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AddShoppingItemRequest>(0);
+				return true;
+			});
+
+		var tool = new AddShoppingItemTool(adder);
+		var reply = await tool.AddAsync("milk", quantity: 2m, unit: "L");
+
+		reply.Should().Contain("milk");
+		reply.Should().Contain("2");
+		captured.Should().NotBeNull();
+		captured!.Name.Should().Be("milk");
+		captured.Quantity.Should().Be(2m);
+		captured.Unit.Should().Be("L");
+	}
+
+	[Fact]
+	public async Task AddAsync_NoQuantityOrUnit_StillAdds()
+	{
+		AddShoppingItemRequest? captured = null;
+		adder.AddAsync(Arg.Any<AddShoppingItemRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<AddShoppingItemRequest>(0);
+				return true;
+			});
+
+		var tool = new AddShoppingItemTool(adder);
+		await tool.AddAsync("eggs");
+
+		captured.Should().NotBeNull();
+		captured!.Name.Should().Be("eggs");
+		captured.Quantity.Should().BeNull();
+		captured.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task AddAsync_BlankName_ReturnsErrorWithoutCallingAdder()
+	{
+		var tool = new AddShoppingItemTool(adder);
+		var reply = await tool.AddAsync("   ");
+
+		reply.Should().Contain("Item name is required");
+		await adder.DidNotReceiveWithAnyArgs().AddAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task AddAsync_AdderFails_ReturnsErrorMessage()
+	{
+		adder.AddAsync(Arg.Any<AddShoppingItemRequest>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		var tool = new AddShoppingItemTool(adder);
+		var reply = await tool.AddAsync("milk");
+
+		reply.Should().Contain("Couldn't add");
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ClearMealSlotToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/ClearMealSlotToolTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class ClearMealSlotToolTests
+{
+	private readonly IMealSlotClearer clearer = Substitute.For<IMealSlotClearer>();
+
+	[Fact]
+	public async Task ClearAsync_HappyPath_DispatchesAndReturnsConfirmation()
+	{
+		ClearMealSlotRequest? captured = null;
+		clearer.ClearAsync(Arg.Any<ClearMealSlotRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ClearMealSlotRequest>(0);
+				return true;
+			});
+
+		var tool = new ClearMealSlotTool(clearer);
+		var reply = await tool.ClearAsync("Wednesday", "Dinner", 2026, 19);
+
+		reply.Should().Contain("Cleared Wednesday");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+	}
+
+	[Fact]
+	public async Task ClearAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		ClearMealSlotRequest? captured = null;
+		clearer.ClearAsync(Arg.Any<ClearMealSlotRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<ClearMealSlotRequest>(0);
+				return true;
+			});
+
+		var tool = new ClearMealSlotTool(clearer);
+		await tool.ClearAsync("Monday");
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+
+	[Fact]
+	public async Task ClearAsync_ClearerFails_ReturnsAlreadyEmptyMessage()
+	{
+		clearer.ClearAsync(Arg.Any<ClearMealSlotRequest>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		var tool = new ClearMealSlotTool(clearer);
+		var reply = await tool.ClearAsync("Friday");
+
+		reply.Should().Contain("already be empty");
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/RemoveShoppingItemToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/RemoveShoppingItemToolTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class RemoveShoppingItemToolTests
+{
+	private readonly IShoppingListItemRemover remover = Substitute.For<IShoppingListItemRemover>();
+
+	[Fact]
+	public async Task RemoveAsync_HappyPath_DispatchesAndReturnsConfirmation()
+	{
+		RemoveShoppingItemRequest? captured = null;
+		remover.RemoveAsync(Arg.Any<RemoveShoppingItemRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<RemoveShoppingItemRequest>(0);
+				return true;
+			});
+
+		var tool = new RemoveShoppingItemTool(remover);
+		var reply = await tool.RemoveAsync("eggs", reason: "bought");
+
+		reply.Should().Contain("Removed eggs");
+		captured.Should().NotBeNull();
+		captured!.Name.Should().Be("eggs");
+		captured.Reason.Should().Be("bought");
+	}
+
+	[Fact]
+	public async Task RemoveAsync_BlankName_ReturnsErrorWithoutCallingRemover()
+	{
+		var tool = new RemoveShoppingItemTool(remover);
+		var reply = await tool.RemoveAsync(string.Empty);
+
+		reply.Should().Contain("Item name is required");
+		await remover.DidNotReceiveWithAnyArgs().RemoveAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task RemoveAsync_RemoverFails_ReturnsNotFoundMessage()
+	{
+		remover.RemoveAsync(Arg.Any<RemoveShoppingItemRequest>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		var tool = new RemoveShoppingItemTool(remover);
+		var reply = await tool.RemoveAsync("ghost-item");
+
+		reply.Should().Contain("Couldn't find");
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/SwapMealSlotsToolTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/Services/Tools/SwapMealSlotsToolTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Extraction.Services.Tools;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.Services.Tools;
+
+public class SwapMealSlotsToolTests
+{
+	private readonly IMealSlotSwapper swapper = Substitute.For<IMealSlotSwapper>();
+
+	[Fact]
+	public async Task SwapAsync_HappyPath_DispatchesAndReturnsConfirmation()
+	{
+		SwapMealSlotsRequest? captured = null;
+		swapper.SwapAsync(Arg.Any<SwapMealSlotsRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<SwapMealSlotsRequest>(0);
+				return true;
+			});
+
+		var tool = new SwapMealSlotsTool(swapper);
+		var reply = await tool.SwapAsync("Thursday", "Friday", "Dinner", 2026, 19);
+
+		reply.Should().Contain("Thursday").And.Contain("Friday");
+		captured.Should().NotBeNull();
+		captured!.Year.Should().Be(2026);
+		captured.WeekNumber.Should().Be(19);
+		captured.SourceDay.Should().Be("Thursday");
+		captured.TargetDay.Should().Be("Friday");
+		captured.MealType.Should().Be("Dinner");
+	}
+
+	[Fact]
+	public async Task SwapAsync_YearAndWeekZero_ResolvesToCurrentIsoWeek()
+	{
+		SwapMealSlotsRequest? captured = null;
+		swapper.SwapAsync(Arg.Any<SwapMealSlotsRequest>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<SwapMealSlotsRequest>(0);
+				return true;
+			});
+
+		var tool = new SwapMealSlotsTool(swapper);
+		await tool.SwapAsync("Monday", "Tuesday");
+
+		captured.Should().NotBeNull();
+		captured!.Year.Should().BeGreaterThanOrEqualTo(2026);
+		captured.WeekNumber.Should().BeInRange(1, 53);
+	}
+
+	[Fact]
+	public async Task SwapAsync_SwapperFails_ReturnsErrorMessage()
+	{
+		swapper.SwapAsync(Arg.Any<SwapMealSlotsRequest>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		var tool = new SwapMealSlotsTool(swapper);
+		var reply = await tool.SwapAsync("Monday", "Tuesday");
+
+		reply.Should().Contain("Couldn't swap");
+	}
+}


### PR DESCRIPTION
Closes the remaining acceptance criteria for **US-328 (#176)** and **US-329 (#177)**. The capability surface epic shipped the read tools (`get_merged_shopping_list`, `get_weekly_plan`) and the meal-plan-from-recipes write tool (`assign_meal`); this PR adds the four small write tools that complete the natural-language acceptance criteria.

## Tools added (4)

| Tool | Upstream | Closes |
|---|---|---|
| `add_to_shopping_list` | `Shopping POST /shopping-lists/items` | "Add milk", "Add 2kg potatoes" (#176) |
| `remove_from_shopping_list` | `Shopping DELETE /shopping-lists/items` | "Remove eggs", "I don't need milk anymore" (#176) |
| `swap_meal_slots` | `MealPlan PUT /slots/swap` | "Swap Thursday and Friday" (#177) |
| `clear_meal_slot` | `MealPlan DELETE /slots` | "Cancel Wednesday", "Clear Friday's dinner" (#177) |

All four wrap existing module command handlers — no new backend business logic, just chat-side wiring along the consumer-defined-contracts pattern from Phase 2.

## Architecture changes

- **`IModuleHttpClient.DeleteAsync`** (no body) + `DeleteAsync<TBody>` (with body, used by Shopping's `DELETE /items` pattern). Mirrors the `PostAsync` / `PutAsync` shape from Phase 2c.
- **`IShoppingClient`** extended with `RemoveItemAsync`.
- **`IMealPlanClient`** extended with `SwapSlotsAsync` + `ClearSlotAsync`.
- **Four new consumer-defined contracts** in `Recipes.Application/Interfaces/`:
  - `IShoppingListItemAdder` + `AddShoppingItemRequest`
  - `IShoppingListItemRemover` + `RemoveShoppingItemRequest`
  - `IMealSlotSwapper` + `SwapMealSlotsRequest`
  - `IMealSlotClearer` + `ClearMealSlotRequest`
- **Four new HTTP adapters** in `Recipes.Infrastructure/ExternalServices/`. `HttpShoppingListItemAdder` uses an `extern alias`-style `using ShoppingClient = ...` to avoid name collision (Shopping.Client also exports `AddShoppingItemRequest`).
- **Four new SK kernel functions** in `Recipes.Extraction/Services/Tools/`. Both meal tools follow the `year=0`/`weekNumber=0` → current ISO week convention from Phase 2b/c.
- **DI**: registered scoped in `ExtractionServiceCollectionExtensions`. `SemanticKernelChatService` accepts them via primary constructor and adds them to the per-request kernel under `shopping_add` / `shopping_remove` / `mealplan_swap` / `mealplan_clear`.
- **System prompt** extended with usage hints for all four new commands.

## Tests (13 new)

- `AddShoppingItemToolTests` (4): happy path, no-quantity-or-unit, blank name rejected, adder failure
- `RemoveShoppingItemToolTests` (3): happy path with reason, blank name rejected, remover-fails-not-found-message
- `SwapMealSlotsToolTests` (3): happy path, year=0/week=0 resolution, swapper failure
- `ClearMealSlotToolTests` (3): happy path, year=0/week=0 resolution, clearer-fails-already-empty-message

Plus updated `SemanticKernelChatServiceFunctionCallingTests` to substitute the 4 new dependencies.

## What's still NOT covered for #176/#177

- **"Add milk" repeated → quantity increases** (#176 AC) — handled upstream by `AddManualItemCommandHandler`'s deduplication. Chat doesn't need special logic; the existing handler aggregates.
- **Toast vs chat-panel response distinction** (#176 AC) — frontend-only concern, separate work
- **Context-aware default intent** (#176, #177 AC) — frontend page-context piping, separate work
- **Fuzzy recipe-name matching** for assign_meal (#177 AC) — already handled by chaining: LLM calls `search_recipes` then `assign_meal`. Multi-match disambiguation ("Which one? Spaghetti Bolognese, Penne Arrabiata...") is LLM-driven from the search results.

The remaining AC items are deliberate frontend follow-ups, not backend gaps. This PR closes the chat-tool surface side cleanly.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] All 13 new tests green; existing chat function-calling integration test updated and green

Closes #176
Closes #177