### PR TITLE
feat(shopping): expandable source breakdown on merged shopping list (US-313)

### DIFF
--- a/client/apps/shell/public/assets/i18n/shopping/de.json
+++ b/client/apps/shell/public/assets/i18n/shopping/de.json
@@ -81,5 +81,11 @@
   "history": {
     "toggle": "Frühere Einkäufe anzeigen",
     "empty": "Keine früheren Einkäufe vorhanden."
+  },
+  "sources": {
+    "toggle": "Quellen anzeigen",
+    "header": "Quellen",
+    "manual": "Manuell hinzugefügt",
+    "empty": "Keine Quellenangaben verfügbar."
   }
 }

--- a/client/apps/shell/public/assets/i18n/shopping/en.json
+++ b/client/apps/shell/public/assets/i18n/shopping/en.json
@@ -81,5 +81,11 @@
   "history": {
     "toggle": "Show past purchases",
     "empty": "No past purchases to show."
+  },
+  "sources": {
+    "toggle": "Show sources",
+    "header": "Sources",
+    "manual": "Added manually",
+    "empty": "No source breakdown available."
   }
 }

--- a/client/apps/shopping/public/assets/i18n/shopping/de.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/de.json
@@ -81,5 +81,11 @@
   "history": {
     "toggle": "Frühere Einkäufe anzeigen",
     "empty": "Keine früheren Einkäufe vorhanden."
+  },
+  "sources": {
+    "toggle": "Quellen anzeigen",
+    "header": "Quellen",
+    "manual": "Manuell hinzugefügt",
+    "empty": "Keine Quellenangaben verfügbar."
   }
 }

--- a/client/apps/shopping/public/assets/i18n/shopping/en.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/en.json
@@ -81,5 +81,11 @@
   "history": {
     "toggle": "Show past purchases",
     "empty": "No past purchases to show."
+  },
+  "sources": {
+    "toggle": "Show sources",
+    "header": "Sources",
+    "manual": "Added manually",
+    "empty": "No source breakdown available."
   }
 }

--- a/client/apps/shopping/src/app/api.ts
+++ b/client/apps/shopping/src/app/api.ts
@@ -12,5 +12,6 @@ export {
   type CreateShoppingListItem,
   type MergedShoppingList,
   type MergedShoppingItem,
+  type ItemSource,
   type AddedItem,
 } from '@yumney/shared/api-client';

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -62,21 +62,68 @@
       [itemCount]="group.items.length"
       data-testid="shopping-category-group"
     >
-      @for (item of group.items; track item.itemName) {
-        <div class="item-row" [class.bought]="item.isBought">
-          <div class="item-info">
-            <span class="item-quantity"
-              >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
-            >
-            <span class="item-name">{{ item.itemName }}</span>
-          </div>
+      @for (item of group.items; track item.itemName + '|' + item.unit) {
+        <div class="item-card" data-testid="shopping-item-card">
           <button
-            class="remove-btn"
-            (click)="onRemoveItem(item.itemName)"
-            [attr.aria-label]="t('shopping.remove')"
+            type="button"
+            class="item-row"
+            [class.bought]="item.isBought"
+            [class.expanded]="isExpanded(item)"
+            (click)="onToggleExpanded(item)"
+            [attr.aria-expanded]="isExpanded(item)"
+            [attr.aria-label]="t('shopping.sources.toggle')"
+            data-testid="shopping-item-row"
           >
-            <lucide-icon name="x" [size]="14" />
+            <span class="item-info">
+              <span class="item-quantity"
+                >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
+              >
+              <span class="item-name">{{ item.itemName }}</span>
+            </span>
+            <span class="item-actions">
+              <span class="source-count" [attr.aria-hidden]="true">{{
+                item.sources.length || 1
+              }}</span>
+              <lucide-icon
+                name="chevron-down"
+                [size]="16"
+                class="chevron"
+                [attr.aria-hidden]="true"
+              />
+              <span
+                class="remove-btn"
+                role="button"
+                tabindex="0"
+                (click)="$event.stopPropagation(); onRemoveItem(item.itemName)"
+                (keydown.enter)="$event.stopPropagation(); onRemoveItem(item.itemName)"
+                [attr.aria-label]="t('shopping.remove')"
+              >
+                <lucide-icon name="x" [size]="14" />
+              </span>
+            </span>
           </button>
+          @if (isExpanded(item)) {
+            <div class="sources-panel" data-testid="shopping-sources-panel">
+              <div class="sources-header">{{ t('shopping.sources.header') }}</div>
+              @if (item.sources.length === 0) {
+                <p class="sources-empty">{{ t('shopping.sources.empty') }}</p>
+              } @else {
+                <ul class="sources-list">
+                  @for (source of item.sources; track source.occurredAt + '|' + source.source) {
+                    <li class="source-row" data-testid="shopping-source-row">
+                      <span class="source-quantity">{{ formatSourceQuantity(source, item) }}</span>
+                      @if (sourceTranslationKey(source); as key) {
+                        <span class="source-name">{{ t(key) }}</span>
+                      } @else {
+                        <span class="source-name">{{ sourceLiteral(source) }}</span>
+                      }
+                      <span class="source-date">{{ source.occurredAt | date: 'shortDate' }}</span>
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+          }
         </div>
       }
     </yn-category-section>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.scss
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.scss
@@ -93,18 +93,41 @@
   }
 }
 
+.item-card {
+  margin-bottom: var(--yn-space-2);
+}
+
 .item-row {
   @include glass.glass-surface(0);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   padding: var(--yn-space-3) var(--yn-space-4);
+  border: none;
   border-radius: var(--yn-radius-card);
-  margin-bottom: var(--yn-space-2);
+  text-align: left;
+  cursor: pointer;
+  color: var(--yn-text);
+  font: inherit;
+
+  &:focus-visible {
+    outline: 2px solid var(--yn-primary);
+    outline-offset: 2px;
+  }
 
   &.bought {
     opacity: 0.5;
     text-decoration: line-through;
+  }
+
+  &.expanded {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+
+    .chevron {
+      transform: rotate(180deg);
+    }
   }
 }
 
@@ -123,7 +146,28 @@
   color: var(--yn-text);
 }
 
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.source-count {
+  font-size: var(--yn-text-xs);
+  color: var(--yn-text-muted);
+  min-width: 16px;
+  text-align: right;
+}
+
+.chevron {
+  color: var(--yn-text-muted);
+  transition: transform var(--yn-duration-fast) var(--yn-ease-glass);
+}
+
 .remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: none;
   color: var(--yn-text-muted);
@@ -131,9 +175,72 @@
   opacity: 0;
   transition: opacity var(--yn-duration-fast);
 
-  .item-row:hover & {
+  .item-row:hover &,
+  .item-row:focus-within & {
     opacity: 1;
   }
+}
+
+.sources-panel {
+  @include glass.glass-surface(0);
+  margin: 0;
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border-top: 1px solid var(--yn-glass-border-subtle);
+  border-bottom-left-radius: var(--yn-radius-card);
+  border-bottom-right-radius: var(--yn-radius-card);
+  border-left: 3px solid var(--yn-primary);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.sources-header {
+  font-size: var(--yn-text-xs);
+  font-weight: var(--yn-font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--yn-text-muted);
+  margin-bottom: var(--yn-space-2);
+}
+
+.sources-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-1);
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--yn-space-3);
+  align-items: baseline;
+  font-size: var(--yn-text-sm);
+}
+
+.source-quantity {
+  color: var(--yn-primary);
+  font-weight: var(--yn-font-medium);
+}
+
+.source-name {
+  color: var(--yn-text);
+}
+
+.source-date {
+  color: var(--yn-text-muted);
+  font-size: var(--yn-text-xs);
+}
+
+.sources-empty {
+  margin: 0;
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  font-style: italic;
 }
 
 .loading {
@@ -162,7 +269,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .remove-btn {
+  .remove-btn,
+  .chevron {
     transition: none;
   }
 }

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -22,6 +22,12 @@ const en = {
       toggle: 'Show past purchases',
       empty: 'No past purchases to show.',
     },
+    sources: {
+      toggle: 'Show sources',
+      header: 'Sources',
+      manual: 'Added manually',
+      empty: 'No source breakdown available.',
+    },
     remove: 'Remove',
     checked: 'checked',
     retry: 'Retry',
@@ -301,6 +307,121 @@ describe('MergedListComponent', () => {
         kind: 'success',
         messageKey: 'shopping.export.copied',
       });
+    });
+  });
+
+  describe('expandable sources (US-313)', () => {
+    const listWithSources: MergedShoppingList = {
+      items: [
+        {
+          itemName: 'Milk',
+          totalQuantity: 3,
+          displayQuantity: 3,
+          unit: 'L',
+          category: 'dairy',
+          isBought: false,
+          sources: [
+            { quantity: 2, source: 'Lasagne', occurredAt: '2026-05-09T10:00:00Z' },
+            { quantity: 1, source: 'manual', occurredAt: '2026-05-10T08:30:00Z' },
+          ],
+        },
+        {
+          itemName: 'Flour',
+          totalQuantity: 500,
+          displayQuantity: 500,
+          unit: 'g',
+          category: 'pantry',
+          isBought: false,
+          sources: [],
+        },
+      ],
+    };
+
+    beforeEach(async () => {
+      apiMock.getMergedList.mockReturnValue(of(listWithSources));
+      fixture.componentInstance['loadList']();
+      fixture.detectChanges();
+    });
+
+    it('renders the merged total per item', () => {
+      expect(fixture.nativeElement.textContent).toContain('3 L');
+      expect(fixture.nativeElement.textContent).toContain('Milk');
+    });
+
+    it('starts collapsed — no source-breakdown panel visible', () => {
+      const panels = fixture.nativeElement.querySelectorAll(
+        '[data-testid="shopping-sources-panel"]',
+      );
+      expect(panels.length).toBe(0);
+    });
+
+    it('expands the breakdown when an item row is clicked', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      rows[0].click();
+      fixture.detectChanges();
+
+      const panel = fixture.nativeElement.querySelector(
+        '[data-testid="shopping-sources-panel"]',
+      );
+      expect(panel).toBeTruthy();
+      expect(rows[0].getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('collapses the breakdown when the same row is clicked again', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      rows[0].click();
+      fixture.detectChanges();
+      rows[0].click();
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelectorAll('[data-testid="shopping-sources-panel"]').length,
+      ).toBe(0);
+    });
+
+    it('renders one source row per ItemSource entry', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      rows[0].click();
+      fixture.detectChanges();
+
+      const sourceRows = fixture.nativeElement.querySelectorAll(
+        '[data-testid="shopping-source-row"]',
+      );
+      expect(sourceRows.length).toBe(2);
+      const text = fixture.nativeElement.textContent;
+      expect(text).toContain('Lasagne');
+      expect(text).toContain('Added manually');
+    });
+
+    it('shows empty-source message when an item has no sources', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      rows[1].click();
+      fixture.detectChanges();
+
+      const panel = fixture.nativeElement.querySelector(
+        '[data-testid="shopping-sources-panel"]',
+      );
+      expect(panel.textContent).toContain('No source breakdown available');
+    });
+
+    it('expands items independently', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      rows[0].click();
+      fixture.detectChanges();
+
+      expect(rows[0].getAttribute('aria-expanded')).toBe('true');
+      expect(rows[1].getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('clicking the remove button does not toggle expansion', () => {
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
+      const removeButton = rows[0].querySelector('.remove-btn');
+      removeButton.click();
+      fixture.detectChanges();
+
+      // Row stays collapsed; only the remove API call should fire.
+      expect(rows[0].getAttribute('aria-expanded')).toBe('false');
+      expect(apiMock.removeItem).toHaveBeenCalledWith({ name: 'Milk' });
     });
   });
 });

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -7,6 +7,7 @@ import {
   computed,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
@@ -15,6 +16,7 @@ import {
   type MergedShoppingList,
   type MergedShoppingItem,
   type AddedItem,
+  type ItemSource,
 } from '../api';
 import {
   createAsyncState,
@@ -36,6 +38,7 @@ import {
   selector: 'yn-merged-list',
   standalone: true,
   imports: [
+    DatePipe,
     FormsModule,
     TranslocoModule,
     LucideAngularModule,
@@ -58,6 +61,7 @@ export class MergedListComponent {
   protected error = signal<string | null>(null);
   protected newItemName = signal('');
   protected showPastPurchases = signal(false);
+  protected expandedItems = signal<ReadonlySet<string>>(new Set());
 
   private loadRequestId = 0;
 
@@ -150,6 +154,42 @@ export class MergedListComponent {
   protected onTogglePastPurchases(): void {
     this.showPastPurchases.update((current) => !current);
     this.loadList();
+  }
+
+  protected onToggleExpanded(item: MergedShoppingItem): void {
+    const key = expandKey(item);
+    this.expandedItems.update((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+
+      return next;
+    });
+  }
+
+  protected isExpanded(item: MergedShoppingItem): boolean {
+    return this.expandedItems().has(expandKey(item));
+  }
+
+  // Backend source strings: 'manual', 'chat', or a free-text recipe label.
+  // Map the well-known cases to a translation key; pass the rest through
+  // as-is for the template to render literally.
+  protected sourceTranslationKey(source: ItemSource): string | null {
+    const raw = (source.source ?? '').trim().toLowerCase();
+    if (raw.length === 0 || raw === 'manual' || raw === 'chat') return 'shopping.sources.manual';
+    return null;
+  }
+
+  protected sourceLiteral(source: ItemSource): string {
+    return source.source ?? '';
+  }
+
+  protected formatSourceQuantity(source: ItemSource, item: MergedShoppingItem): string {
+    if (item.unit) return `${source.quantity} ${item.unit}`;
+    return `${source.quantity}`;
   }
 
   private loadList(): void {
@@ -260,4 +300,8 @@ export class MergedListComponent {
         item.totalQuantity >= added.quantity,
     );
   }
+}
+
+function expandKey(item: MergedShoppingItem): string {
+  return `${item.itemName.toLowerCase()}|${item.unit ?? ''}`;
 }


### PR DESCRIPTION
Closes **#162** (must-have). The merged list already shipped one row per ingredient with totals; this PR adds the tap-to-expand source breakdown that the must-have acceptance criteria call for.

## Acceptance criteria status

| AC | Status |
|---|---|
| Same ingredient from multiple sources merged into one line | ✅ already shipped (backend merging) |
| Total quantity displayed | ✅ already shipped |
| **Tap to expand: shows breakdown by source** | ✅ this PR |
| **Collapsed by default** | ✅ this PR |
| Merging is case-insensitive | ✅ already shipped |
| Unit-aware: same unit → sum, different units → separate lines | ✅ already shipped (track key uses itemName + unit) |
| **Glass-styled expandable detail panel** | ✅ this PR (`@include glass-surface(0)`, primary-color left border, fade-in animation) |

## What's added

- **Per-item expanded state** tracked via `Set<string>` keyed by `'<itemName-lower>|<unit>'`. Handles same-name-different-unit rows independently (e.g. 2 cups milk vs 500ml milk expand separately).
- **Item rendered as a button** with `aria-expanded`. Chevron rotates 180° on expand. Remove button stops event propagation so "remove" doesn't also toggle expansion.
- **Glass-styled sources panel** below the row showing one line per `ItemSource`: quantity + recipe name (or "Added manually") + date. Backend's `ItemSource.source` string is rendered verbatim for recipe sources; `'manual'` / `'chat'` map to the `shopping.sources.manual` i18n key.
- **Source-count chip** in the collapsed row preview.
- **Empty-state** message for items with zero sources (defensive — not expected in practice but covered).

## i18n

`shopping.sources.{toggle,header,manual,empty}` added in `shopping/en.json` + `shopping/de.json` and auto-mirrored to the shell via `sync-i18n.mjs`.

## Tests (8 new)

In `merged-list.component.spec.ts`:
- merged total renders correctly
- starts collapsed (no source-breakdown panel)
- expand on row click
- collapse on second click
- one source row per `ItemSource` entry
- empty-source message for items with no sources
- expansion is independent per item
- remove-button click does NOT trigger expansion (event propagation guard)

Total: 29 tests pass. Lint clean. Build clean (production). i18n drift check clean.

## Test plan

- [x] `yarn nx build shopping` — clean
- [x] `yarn nx test shopping` — 29/29 green
- [x] `yarn nx lint shopping` — clean
- [x] `node client/scripts/sync-i18n.mjs --check` — clean
- [ ] Manual: hit `/shopping`, verify items collapsed by default, click row → panel opens with per-source breakdown, click again → collapses

Closes #162