### PR TITLE
feat(recipes): natural-language recipe search via chat (US-231)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -24,11 +24,13 @@
       "cta": "Rezept importieren"
     },
     "search": {
-      "placeholder": "Rezepte suchen...",
+      "placeholder": "Rezepte suchen oder Frage stellen...",
       "label": "Rezepte suchen",
       "noResults": "Keine Rezepte gefunden",
       "noResultsMessage": "Keine Rezepte für \"{{query}}\" gefunden. Versuche einen anderen Suchbegriff.",
-      "clear": "Suche löschen"
+      "clear": "Suche löschen",
+      "aiBadge": "KI",
+      "aiHint": "KI-Vorschläge für deine Frage werden angezeigt"
     },
     "filter": {
       "toggle": "Filter",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -24,11 +24,13 @@
       "cta": "Import a Recipe"
     },
     "search": {
-      "placeholder": "Search recipes...",
+      "placeholder": "Search recipes or ask a question...",
       "label": "Search recipes",
       "noResults": "No recipes found",
       "noResultsMessage": "No recipes match \"{{query}}\". Try a different search term.",
-      "clear": "Clear search"
+      "clear": "Clear search",
+      "aiBadge": "AI",
+      "aiHint": "Showing AI-suggested recipes for your question"
     },
     "filter": {
       "toggle": "Filters",

--- a/client/apps/recipes/src/app/api.ts
+++ b/client/apps/recipes/src/app/api.ts
@@ -7,6 +7,7 @@ export {
   MealPlanApiService,
   ShoppingApiService,
   ActivityApiService,
+  ChatApiService,
   type RecipeListItem,
   type RecipeListResponse,
   type RecipeDetail,
@@ -15,4 +16,6 @@ export {
   type CreateShoppingListItem,
   type ShoppingListDetail,
   type RecipeActivityStats,
+  type ChatResponse,
+  type ChatRecipeSuggestion,
 } from '@yumney/shared/api-client';

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -32,6 +32,11 @@
         [placeholder]="t('recipes.list.search.placeholder')"
         [attr.aria-label]="t('recipes.list.search.label')"
       />
+      @if (isAiPowered()) {
+        <span class="search-ai-badge" data-testid="recipe-list-ai-badge">{{
+          t('recipes.list.search.aiBadge')
+        }}</span>
+      }
       @if (searchQuery()) {
         <button
           class="search-clear"
@@ -79,6 +84,10 @@
       (valueChange)="onFilterChange($event)"
       (closed)="filterPanelOpen.set(false)"
     />
+  }
+
+  @if (isAiPowered() && !isLoading() && !serverError()) {
+    <yn-message-banner tone="success" [message]="t('recipes.list.search.aiHint')" />
   }
 
   @if (serverError(); as error) {

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -116,6 +116,23 @@ yn-filter-panel {
   }
 }
 
+.search-ai-badge {
+  position: absolute;
+  right: var(--yn-space-10);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0 var(--yn-space-2);
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-primary);
+  color: var(--yn-on-primary, white);
+  font-size: var(--yn-text-xs);
+  font-weight: var(--yn-font-semibold);
+  letter-spacing: 0.05em;
+}
+
 .search-input {
   width: 100%;
   padding: var(--yn-space-4) var(--yn-space-5);

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
@@ -4,6 +4,7 @@ import { provideRouter } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { RecipeListComponent } from './recipe-list.component';
 import {
+  ChatApiService,
   RecipeApiService,
   RecipeListResponse,
   ShoppingApiService,
@@ -106,10 +107,13 @@ const en = {
       cookTime: 'Cook {{minutes}} min',
       loading: 'Loading recipes...',
       search: {
-        placeholder: 'Search recipes...',
+        placeholder: 'Search recipes or ask a question...',
         label: 'Search recipes',
         noResults: 'No recipes found',
         noResultsMessage: 'No recipes match "{{query}}". Try a different search term.',
+        clear: 'Clear search',
+        aiBadge: 'AI',
+        aiHint: 'Showing AI-suggested recipes for your question',
       },
       empty: {
         title: 'No recipes yet',
@@ -143,6 +147,9 @@ describe('RecipeListComponent', () => {
   let shoppingApiMock: {
     createShoppingListFromRecipes: ReturnType<typeof vi.fn>;
   };
+  let chatApiMock: {
+    send: ReturnType<typeof vi.fn>;
+  };
 
   beforeAll(() => {
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
@@ -161,6 +168,9 @@ describe('RecipeListComponent', () => {
     shoppingApiMock = {
       createShoppingListFromRecipes: vi.fn(),
     };
+    chatApiMock = {
+      send: vi.fn(),
+    };
 
     TestBed.configureTestingModule({
       imports: [RecipeListComponent, setupTranslocoTesting(en)],
@@ -169,6 +179,7 @@ describe('RecipeListComponent', () => {
         provideRouter([]),
         { provide: RecipeApiService, useValue: recipeApiMock },
         { provide: ShoppingApiService, useValue: shoppingApiMock },
+        { provide: ChatApiService, useValue: chatApiMock },
       ],
     });
 
@@ -944,5 +955,121 @@ describe('RecipeListComponent', () => {
     expect(
       fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-toggle"]'),
     ).toBeNull();
+  }));
+
+  it('should keep keyword path for short single-word search', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(emptyResponse)));
+    fixture.detectChanges();
+    tick();
+
+    recipeApiMock.getRecipes.mockClear();
+    recipeApiMock.getRecipes.mockReturnValue(of(emptyResponse));
+
+    component.onSearchInput({ target: { value: 'pasta' } } as unknown as Event);
+    tick(300);
+
+    expect(chatApiMock.send).not.toHaveBeenCalled();
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'pasta' }),
+    );
+    expect(component.isAiPowered()).toBe(false);
+  }));
+
+  it('should route conversational queries through ChatApiService and hydrate suggestions', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(emptyResponse)));
+    fixture.detectChanges();
+    tick();
+
+    chatApiMock.send.mockReturnValue(
+      of({
+        reply: 'Here you go',
+        suggestions: [
+          { recipeIdentifier: 'abc-123', title: 'Pasta Carbonara', reason: null },
+          { recipeIdentifier: null, title: 'Skipped', reason: null },
+        ],
+        actions: [],
+      }),
+    );
+    recipeApiMock.getRecipeById.mockReturnValue(
+      of({
+        identifier: 'abc-123',
+        title: 'Pasta Carbonara',
+        description: 'A classic',
+        servings: 4,
+        prepTimeMinutes: 10,
+        cookTimeMinutes: 20,
+        difficulty: 'medium',
+        imageUrl: null,
+        createdAt: '2026-03-10T00:00:00Z',
+        tags: [],
+        isFavorite: false,
+        rating: null,
+        notes: null,
+        ingredients: [],
+        steps: [],
+        sourceUrl: null,
+        language: 'en',
+      }),
+    );
+
+    component.onSearchInput({
+      target: { value: 'what can I make with chicken' },
+    } as unknown as Event);
+    tick(300);
+    tick();
+
+    expect(chatApiMock.send).toHaveBeenCalledWith({
+      message: 'what can I make with chicken',
+      history: [],
+    });
+    expect(recipeApiMock.getRecipeById).toHaveBeenCalledWith('abc-123');
+    expect(component.isAiPowered()).toBe(true);
+    expect(component.recipes()).toHaveLength(1);
+    expect(component.recipes()[0].identifier).toBe('abc-123');
+  }));
+
+  it('should fall back to keyword search when chat call fails', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(emptyResponse)));
+    fixture.detectChanges();
+    tick();
+
+    chatApiMock.send.mockReturnValue(throwError(() => new Error('boom')));
+    recipeApiMock.getRecipes.mockClear();
+    recipeApiMock.getRecipes.mockReturnValue(of(emptyResponse));
+
+    component.onSearchInput({
+      target: { value: 'show me something with tomatoes please' },
+    } as unknown as Event);
+    tick(300);
+    tick();
+
+    expect(chatApiMock.send).toHaveBeenCalled();
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'show me something with tomatoes please' }),
+    );
+    expect(component.isAiPowered()).toBe(false);
+  }));
+
+  it('should clear AI flag when search is cleared', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(emptyResponse)));
+    fixture.detectChanges();
+    tick();
+
+    component.isAiPowered.set(true);
+    recipeApiMock.getRecipes.mockReturnValue(of(emptyResponse));
+
+    component.onSearchClear();
+    tick();
+
+    expect(component.isAiPowered()).toBe(false);
+  }));
+
+  it('should disable load-more in AI mode', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
+    fixture.detectChanges();
+    tick();
+
+    component.isAiPowered.set(true);
+    expect(component.hasMore()).toBe(false);
   }));
 });

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -9,7 +9,15 @@ import {
 } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import {
+  RecipeApiService,
+  RecipeListItem,
+  GetRecipesParams,
+  ChatApiService,
+  type ChatRecipeSuggestion,
+} from '../api';
 import {
   createAsyncState,
   debouncedEffect,
@@ -84,6 +92,7 @@ export class RecipeListComponent implements OnInit {
   ];
 
   private recipeApi = inject(RecipeApiService);
+  private chatApi = inject(ChatApiService);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState(this.destroyRef);
   private searchInput = signal('');
@@ -91,8 +100,15 @@ export class RecipeListComponent implements OnInit {
 
   constructor() {
     debouncedEffect(this.searchInput, UI.SEARCH_DEBOUNCE_MS, (value) => {
-      this.activeSearch.set(value.trim());
-      this.resetAndReload();
+      const trimmed = value.trim();
+      this.activeSearch.set(trimmed);
+      if (trimmed === '' || !isConversationalQuery(trimmed)) {
+        this.isAiPowered.set(false);
+        this.resetAndReload();
+        return;
+      }
+
+      this.searchViaChat(trimmed);
     });
   }
 
@@ -109,11 +125,14 @@ export class RecipeListComponent implements OnInit {
   serverError = computed(() => this.multiSelect.serverError() ?? this.asyncState.serverError());
   searchQuery = signal('');
   activeSearch = signal('');
+  isAiPowered = signal(false);
   filter = signal<RecipeFilterValue>({ ...EMPTY_FILTER });
   filterPanelOpen = signal(false);
   availableTags = signal<string[]>([]);
 
-  hasMore = computed(() => this.recipes().length < this.totalCount());
+  // Pagination + load-more disabled in AI mode: chat returns a small fixed
+  // set (top-N suggestions), there's no concept of "next page" to ask for.
+  hasMore = computed(() => !this.isAiPowered() && this.recipes().length < this.totalCount());
 
   currentSort = computed(() => {
     const by = this.sortBy().toLowerCase();
@@ -148,6 +167,7 @@ export class RecipeListComponent implements OnInit {
   onSearchClear(): void {
     this.searchQuery.set('');
     this.activeSearch.set('');
+    this.isAiPowered.set(false);
     this.resetAndReload();
   }
 
@@ -185,6 +205,80 @@ export class RecipeListComponent implements OnInit {
     this.totalCount.set(0);
     this.multiSelect.clearSelection();
     this.loadRecipes(false);
+  }
+
+  // Conversational query path: send the query through the chat service
+  // (which calls the search_recipes SK tool internally) and hydrate each
+  // returned suggestion's identifier into a full RecipeListItem for the
+  // grid. Falls back to keyword search if the chat call fails — a transient
+  // LLM outage must not regress baseline search.
+  private searchViaChat(query: string): void {
+    const requestId = ++this.loadRequestId;
+    this.isAiPowered.set(true);
+    this.currentPage.set(1);
+    this.recipes.set([]);
+    this.totalCount.set(0);
+    this.multiSelect.clearSelection();
+
+    this.asyncState.execute(
+      this.chatApi.send({ message: query, history: [] }).pipe(
+        switchMap((response) => this.hydrateSuggestions(response.suggestions)),
+        catchError(() => {
+          this.isAiPowered.set(false);
+          return this.recipeApi
+            .getRecipes({
+              page: 1,
+              pageSize: this.pageSize(),
+              sortBy: this.sortBy(),
+              sortDirection: this.sortDirection(),
+              search: query,
+            })
+            .pipe(map((response) => response.items));
+        }),
+      ),
+      ERROR_MAPS.recipes.list,
+      (items) => {
+        if (requestId !== this.loadRequestId) return;
+        this.recipes.set(items);
+        this.totalCount.set(items.length);
+        this.collectAvailableTags(items);
+      },
+    );
+  }
+
+  private hydrateSuggestions(suggestions: ChatRecipeSuggestion[]) {
+    const validIds = suggestions
+      .map((suggestion) => suggestion.recipeIdentifier)
+      .filter((id): id is string => id !== null);
+
+    if (validIds.length === 0) return of([] as RecipeListItem[]);
+
+    return forkJoin(
+      validIds.map((id) =>
+        this.recipeApi.getRecipeById(id).pipe(
+          map(
+            (detail): RecipeListItem => ({
+              identifier: detail.identifier,
+              title: detail.title,
+              description: detail.description,
+              servings: detail.servings,
+              prepTimeMinutes: detail.prepTimeMinutes,
+              cookTimeMinutes: detail.cookTimeMinutes,
+              difficulty: detail.difficulty,
+              imageUrl: detail.imageUrl,
+              createdAt: detail.createdAt,
+              tags: detail.tags,
+              isFavorite: detail.isFavorite,
+              rating: detail.rating,
+              hasNotes: detail.notes !== null,
+            }),
+          ),
+          // Per-suggestion failure shouldn't tank the AI search — skip the
+          // missing one and surface the rest.
+          catchError(() => of(null)),
+        ),
+      ),
+    ).pipe(map((items) => items.filter((item): item is RecipeListItem => item !== null)));
   }
 
   private loadRecipes(append: boolean): void {
@@ -229,4 +323,17 @@ export class RecipeListComponent implements OnInit {
     }
     this.availableTags.set([...existing].sort((a, b) => a.localeCompare(b)));
   }
+}
+
+// Conversational-query detector. Triggers the chat path when the user
+// types something that looks like an intent rather than a keyword: more
+// than 3 words, more than 20 chars, or contains a question/intent phrase.
+// Single-word queries like "Bolognese" stay on the keyword path.
+function isConversationalQuery(value: string): boolean {
+  const wordCount = value.split(/\s+/).filter((word) => word.length > 0).length;
+  if (wordCount > 3) return true;
+  if (value.length > 20) return true;
+  const lower = value.toLowerCase();
+  const intentPhrases = ['what', 'how', 'show me', 'find me', 'i want', 'something', 'with'];
+  return intentPhrases.some((phrase) => lower.includes(phrase));
 }

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -24,11 +24,13 @@
       "cta": "Rezept importieren"
     },
     "search": {
-      "placeholder": "Rezepte suchen...",
+      "placeholder": "Rezepte suchen oder Frage stellen...",
       "label": "Rezepte suchen",
       "noResults": "Keine Rezepte gefunden",
       "noResultsMessage": "Keine Rezepte für \"{{query}}\" gefunden. Versuche einen anderen Suchbegriff.",
-      "clear": "Suche löschen"
+      "clear": "Suche löschen",
+      "aiBadge": "KI",
+      "aiHint": "KI-Vorschläge für deine Frage werden angezeigt"
     },
     "filter": {
       "toggle": "Filter",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -24,11 +24,13 @@
       "cta": "Import a Recipe"
     },
     "search": {
-      "placeholder": "Search recipes...",
+      "placeholder": "Search recipes or ask a question...",
       "label": "Search recipes",
       "noResults": "No recipes found",
       "noResultsMessage": "No recipes match \"{{query}}\". Try a different search term.",
-      "clear": "Clear search"
+      "clear": "Clear search",
+      "aiBadge": "AI",
+      "aiHint": "Showing AI-suggested recipes for your question"
     },
     "filter": {
       "toggle": "Filters",


### PR DESCRIPTION
## Summary
- Detects conversational queries in the recipe-list search bar (heuristic: >3 words, >20 chars, or contains an intent phrase like "what", "show me", "find me", "i want", "something", "with")
- Routes conversational queries through `ChatApiService.send`, hydrates the returned `suggestions[].recipeIdentifier` set into full `RecipeListItem`s via parallel `getRecipeById`, and renders them in the existing grid
- Single-word / short queries stay on the keyword path; load-more + pagination are disabled in AI mode (chat returns a fixed top-N)
- Adds an `AI` badge inside the search input and an info banner explaining the mode; falls back to keyword search if the chat call fails so an LLM outage cannot regress baseline search
- Adds `recipes.list.search.aiBadge` / `.aiHint` keys + updated placeholder in EN + DE, synced to shell

## Test plan
- [x] `nx test recipes` (190 tests, including 5 new for AI search: conversational routing, keyword path stays, fallback on chat error, AI flag clears on search clear, load-more disabled in AI mode)
- [x] `nx lint recipes`
- [x] `nx build recipes`
- [x] `yarn sync:i18n:check`

Closes #117