### PR TITLE
fix(ci): unblock develop CI — prettier + integration-test JSON options

### DIFF
--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -360,9 +360,7 @@ describe('MergedListComponent', () => {
       rows[0].click();
       fixture.detectChanges();
 
-      const panel = fixture.nativeElement.querySelector(
-        '[data-testid="shopping-sources-panel"]',
-      );
+      const panel = fixture.nativeElement.querySelector('[data-testid="shopping-sources-panel"]');
       expect(panel).toBeTruthy();
       expect(rows[0].getAttribute('aria-expanded')).toBe('true');
     });
@@ -398,9 +396,7 @@ describe('MergedListComponent', () => {
       rows[1].click();
       fixture.detectChanges();
 
-      const panel = fixture.nativeElement.querySelector(
-        '[data-testid="shopping-sources-panel"]',
-      );
+      const panel = fixture.nativeElement.querySelector('[data-testid="shopping-sources-panel"]');
       expect(panel.textContent).toContain('No source breakdown available');
     });
 

--- a/tests/Yumney.Integration.Tests/Capabilities/CapabilityManifestEndpointIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Capabilities/CapabilityManifestEndpointIntegrationTests.cs
@@ -20,7 +20,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task RecipesManifest_ContainsExpectedTaggedEndpoints()
 	{
-		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		manifest.Should().NotBeNull();
 		manifest!.ServiceName.Should().Be("recipes-api");
@@ -35,7 +35,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task MealPlanManifest_ContainsExpectedTaggedEndpoints()
 	{
-		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		manifest.Should().NotBeNull();
 		manifest!.ServiceName.Should().Be("mealplan-api");
@@ -49,7 +49,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task ShoppingManifest_ContainsExpectedTaggedEndpoints()
 	{
-		var manifest = await fixture.ShoppingApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.ShoppingApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		manifest.Should().NotBeNull();
 		manifest!.ServiceName.Should().Be("shopping-api");
@@ -72,7 +72,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task EveryDescriptor_HasMcpOrChatSurface_AndPathStartsWithApiV1()
 	{
-		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		manifest!.Capabilities.Should().NotBeEmpty();
 		manifest.Capabilities.Should().AllSatisfy(capability =>
@@ -85,7 +85,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task SearchRecipesDescriptor_HasGetMethodAndCorrectRoute()
 	{
-		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.RecipesApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		var search = manifest!.Capabilities.Single(capability => capability.Name == "search_recipes");
 		search.HttpMethod.Should().Be("GET");
@@ -95,7 +95,7 @@ public class CapabilityManifestEndpointIntegrationTests(AspireFixture fixture)
 	[Fact]
 	public async Task AssignMealDescriptor_HasPostMethodAndIncludesPlaceholders()
 	{
-		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath);
+		var manifest = await fixture.MealPlanApi.GetFromJsonAsync<CapabilityManifest>(WellKnownPath, AspireFixture.JsonOptions);
 
 		var assign = manifest!.Capabilities.Single(capability => capability.Name == "assign_meal");
 		assign.HttpMethod.Should().Be("POST");

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Aspire.Hosting;
@@ -36,6 +37,16 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 public sealed class AspireFixture : IAsyncLifetime
 {
 	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(8);
+
+	// Hosts add JsonStringEnumConverter via ConfigureHttpJsonOptions, so enums
+	// (CapabilitySurface, ChatActionType, …) are serialised as strings on the
+	// wire. Default GetFromJsonAsync<T> options cannot read those strings back
+	// into the enum types. Tests must deserialise responses with this options
+	// instance so the round-trip stays consistent.
+	public static JsonSerializerOptions JsonOptions { get; } = new(JsonSerializerDefaults.Web)
+	{
+		Converters = { new JsonStringEnumConverter() },
+	};
 
 	public static async Task CleanupAsync<TContext>(Func<Task<TContext>> contextFactory, Func<TContext, IQueryable<object>> query)
 		where TContext : DbContext

--- a/tests/Yumney.Integration.Tests/Recipes/RecipesChatActionsContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipesChatActionsContractTests.cs
@@ -27,7 +27,7 @@ public class RecipesChatActionsContractTests(AspireFixture fixture)
 		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
 
 		response.IsSuccessStatusCode.Should().BeTrue();
-		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>(AspireFixture.JsonOptions);
 		dto.Should().NotBeNull();
 		dto!.Actions.Should().ContainSingle();
 		dto.Actions[0].Type.Should().Be(ChatActionType.Navigate);
@@ -43,7 +43,7 @@ public class RecipesChatActionsContractTests(AspireFixture fixture)
 		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
 
 		response.IsSuccessStatusCode.Should().BeTrue();
-		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>(AspireFixture.JsonOptions);
 		dto!.Actions.Should().ContainSingle();
 		dto.Actions[0].Route.Should().Be("/meal-planner");
 	}
@@ -57,7 +57,7 @@ public class RecipesChatActionsContractTests(AspireFixture fixture)
 		var response = await client.PostAsJsonAsync("/api/v1/recipes/chat", request);
 
 		response.IsSuccessStatusCode.Should().BeTrue();
-		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>();
+		var dto = await response.Content.ReadFromJsonAsync<ChatResponseDto>(AspireFixture.JsonOptions);
 		dto!.Actions.Should().BeEmpty();
 	}
 


### PR DESCRIPTION
## Summary

Two unrelated regressions are keeping develop's Deploy red. Each was being admin-merged through and the next PR caught it (per the \"admin-merge masks regressions\" pattern). This PR fixes only the ones I can fix without running the live Aspire fixture.

### Fixed here

- **Prettier**: `apps/shopping/src/app/merged-list/merged-list.component.spec.ts` reformatted. The frontend CI's `yarn prettier --check` step was failing on this single file.

- **CapabilityManifest + ChatActions deserialization**: hosts add `JsonStringEnumConverter` via `ConfigureHttpJsonOptions`, so `CapabilitySurface` / `ChatActionType` go over the wire as strings (e.g. `\"Chat, Mcp\"`). The integration tests deserialized with default `JsonSerializerOptions` that can't read those strings back, producing `JsonException : ... Path: \$.capabilities[0].surfaces` and `\$.actions[0].type`. Added `AspireFixture.JsonOptions` and switched the affected calls.

  Affected and now fixed (8 tests):
  - `CapabilityManifestEndpointIntegrationTests.*` (6)
  - `RecipesChatActionsContractTests.*` (2)

### Still broken on develop — not in this PR

The remaining backend integration failures need runtime investigation against a live Aspire/Keycloak fixture. They cluster as:

- `CrossModuleClientContractTests.MealPlanConfirmEndpoint_AcceptsConfirmMealBody` → 404 NotFound on `PUT /api/v1/meal-plans/2026/w/19/slots/confirm` even though the endpoint is registered.
- `CrossModuleClientContractTests.ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody` → Polly 30s timeout, endpoint hangs.
- `McpAuthIntegrationTests.PostToMcp_WithValidKeycloakBearer_IsNotUnauthorized` → 401 returned even with a valid Keycloak bearer.
- `McpToolInvocationIntegrationTests.*` and `McpWriteToolBehaviorTests.*` → all return 401 (likely the MCP server's REST proxy forwards an invalid bearer or fails token forwarding).
- `McpDiscoveryIntegrationTests` — discovered MCP tools collection is empty (missing \`search_recipes\`).

These all share a smell of Keycloak/MCP auth wiring in the Aspire fixture, but pinning that down needs Docker + a debug iteration cycle. Flagging here so they don't fall further behind.

## Test plan

- [x] `dotnet build tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj --configuration Release` — clean.
- [x] `dotnet format ... --verify-no-changes` — clean.
- [x] `yarn prettier --check apps/shopping/src/app/merged-list/merged-list.component.spec.ts` — clean.
- [ ] Backend integration tests (CI will exercise these).