### PR TITLE
fix(test): seed slot before MealPlan confirm contract test

### DIFF
--- a/tests/Yumney.Integration.Tests/CrossModule/CrossModuleClientContractTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/CrossModuleClientContractTests.cs
@@ -59,9 +59,21 @@ public class CrossModuleClientContractTests(AspireFixture fixture)
 	[Fact]
 	public async Task MealPlanConfirmEndpoint_AcceptsConfirmMealBody()
 	{
+		// Confirm requires an existing slot — its handler uses LoadAsync (throws
+		// EntityNotFoundException → 404) instead of AssignRecipe's lazy
+		// FindAsync ?? Create. Without a slot, the route's domain 404 would be
+		// indistinguishable from a route 404 and the contract assertion below
+		// would mis-fire. Assign first so the Monday/Dinner slot exists.
 		var client = await fixture.CreateAuthenticatedClientAsync("mealplan-api");
-		var body = new ConfirmMealBody(Day: "Monday", MealType: "Dinner", State: "Cooked");
+		var assignBody = new AssignRecipeBody(
+			Day: "Monday",
+			RecipeIdentifier: Guid.NewGuid(),
+			RecipeTitle: "Carbonara",
+			MealType: "Dinner",
+			Servings: 4);
+		await client.PostAsJsonAsync("/api/v1/meal-plans/2026/w/19/slots", assignBody);
 
+		var body = new ConfirmMealBody(Day: "Monday", MealType: "Dinner", State: "Cooked");
 		var response = await client.PutAsJsonAsync("/api/v1/meal-plans/2026/w/19/slots/confirm", body);
 
 		response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);


### PR DESCRIPTION
## Summary

\`CrossModuleClientContractTests.MealPlanConfirmEndpoint_AcceptsConfirmMealBody\` has been red on develop since the contract suite was added. The assertion is \`NotBe(NotFound)\`, intended to distinguish a route miss from a working endpoint — but it can't tell apart route-404 from domain-404, and \`ConfirmMealCommandHandler\` returns a domain 404 when no plan exists for the week.

### Why the sibling assign test passes

- \`AssignRecipeCommandHandler\` → \`FindAsync(...) ?? WeeklyPlan.Create(...)\` (lazy create), and \`OnCreated\` auto-populates 7 Dinner slots. So \`PUT slots\` against a brand-new week succeeds.
- \`ConfirmMealCommandHandler\` → \`eventStore.LoadAsync(...)\` which throws \`EntityNotFoundException\` → middleware maps to 404. So \`PUT slots/confirm\` against a brand-new week 404s — even though the route and binding work.

The asymmetry is intentional (you can't confirm a meal that was never assigned), so the right fix is in the test: seed the slot first.

### Change

POST an \`AssignRecipeBody\` to \`/slots\` for Monday/Dinner before the \`Confirm\` PUT. The route + body shape are still what the test validates; the 404-vs-404 ambiguity is now gone.

## Test plan
- [x] \`dotnet build tests/Yumney.Integration.Tests --configuration Release\` — clean
- [x] \`dotnet format --verify-no-changes\` — clean
- [ ] Backend Integration CI on this PR — should drop this test from the failing list