### PR TITLE
fix(mcp): wire Keycloak ref + serialize enums + retry discovery

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -192,6 +192,7 @@ if (!options.DatabaseOnly)
 	// outside the run/publish branches because both gateways route to it.
 	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.WithReference(keycloak)
 		.WithReference(recipesApi)
 		.WithReference(shoppingApi)
 		.WithReference(mealplanApi);

--- a/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
+++ b/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Shared.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
@@ -17,12 +19,53 @@ internal sealed partial class CapabilityDiscoveryService(
 {
 	private const string wellKnownPath = "/.well-known/yumney-capabilities";
 
+	// Retry cadence for hosts that haven't responded yet. Module hosts can
+	// reach KnownResourceStates.Running before their HTTP listener has fully
+	// warmed up (recipes-api in particular — SK kernel + extraction service
+	// registration). The standard resilience handler around the discovery
+	// HttpClient already caps individual attempts at 30s; this outer loop
+	// retries the still-missing services on a 5s cadence until either every
+	// known host has reported or the discovery service is cancelled.
+	private const int maxRetryRounds = 24;
+
+	// Module hosts add JsonStringEnumConverter to their response serializer
+	// (HostBuilderExtensions.ConfigureHttpJsonOptions). CapabilitySurface is a
+	// [Flags] enum that ships on the wire as a comma-joined string like
+	// "Chat, Mcp" — default GetFromJsonAsync options can't read it back into
+	// the enum and the discovery fetch fails with a JsonException pointing at
+	// $.capabilities[0].surfaces.
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		Converters = { new JsonStringEnumConverter() },
+	};
+
+	private static readonly TimeSpan retryInterval = TimeSpan.FromSeconds(5);
+#pragma warning restore SA1311
+
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		for (var round = 0; round < maxRetryRounds; round++)
 		{
 			if (stoppingToken.IsCancellationRequested) return;
-			await DiscoverFromServiceAsync(serviceName, stoppingToken);
+
+			foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+			{
+				if (stoppingToken.IsCancellationRequested) return;
+				if (registry.Manifests.ContainsKey(serviceName)) continue;
+				await DiscoverFromServiceAsync(serviceName, stoppingToken);
+			}
+
+			if (registry.Manifests.Count == KnownCapabilityHosts.ServiceNames.Count) break;
+
+			try
+			{
+				await Task.Delay(retryInterval, stoppingToken);
+			}
+			catch (OperationCanceledException)
+			{
+				return;
+			}
 		}
 
 		LogDiscoveryComplete(registry.Manifests.Count, registry.CapabilityCount);
@@ -33,7 +76,7 @@ internal sealed partial class CapabilityDiscoveryService(
 		try
 		{
 			var client = httpClientFactory.CreateClient(serviceName);
-			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, cancellationToken);
+			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, jsonOptions, cancellationToken);
 			if (manifest is null)
 			{
 				LogManifestNullFor(serviceName);

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
@@ -6,6 +7,14 @@ using SmartSolutionsLab.Yumney.ServiceDefaults;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+// Match the module hosts' response shape: enums (including CapabilitySurface)
+// ship as strings so /discovered-capabilities is round-trippable through the
+// same JsonStringEnumConverter convention used by every other Yumney host.
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+	options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 
 builder.Services.AddKeycloakBearerAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddHttpContextAccessor();


### PR DESCRIPTION
## Summary

Three independent root causes inside \`Yumney.Mcp.Server\` were keeping the MCP integration cluster red on develop. All three came out of a live debugging session against Aspire+Docker.

### 1. AppHost missed \`WithReference(keycloak)\` for mcp-server

Module APIs get the Keycloak connection string via \`AsYumneyApi(...)\` which adds the reference. MCP didn't. So \`AddKeycloakBearerAuthentication\` fell back to \`http://localhost:8080\` (= the MCP container itself), JwtBearer fetched JWKS from there, found nothing, and replied \`WWW-Authenticate: Bearer error=invalid_token, error_description=The signature key was not found\` to every valid Keycloak bearer.

Fix: \`.WithReference(keycloak)\` on the \`mcp-server\` resource in \`AppHost/Program.cs\`.

### 2. \`CapabilityDiscoveryService\` deserialized with default JSON options

Module hosts serialize \`CapabilitySurface\` (a \`[Flags]\` enum) as the string \`\"Chat, Mcp\"\` via \`JsonStringEnumConverter\`. The discovery service ran \`GetFromJsonAsync<CapabilityManifest>\` without any converter and threw on \`\$.capabilities[0].surfaces\` for every module manifest. Registry stayed empty.

Fix: static \`jsonOptions\` with \`JsonStringEnumConverter\` passed to every \`GetFromJsonAsync\` call.

### 3. MCP server's response had no \`JsonStringEnumConverter\`

\`AddServiceDefaults\` doesn't register \`ConfigureHttpJsonOptions\` (only \`AddYumneyDefaults\` does). So \`/discovered-capabilities\` returned \`surfaces\` as the numeric flag value, breaking the integration test deserializer that expected the same string shape every other Yumney host emits.

Fix: matching \`ConfigureHttpJsonOptions\` in \`Yumney.Mcp.Server/Program.cs\`.

### Bonus: retry loop in the discovery service

\`BackgroundService.ExecuteAsync\` only ran the discovery sweep once at startup. If any host wasn't fully warm yet — recipes-api in particular hit the 30s standard-resilience timeout on its first call after \`KnownResourceStates.Running\` — it stayed missing forever. Added a 5s-cadence retry loop that re-fetches only still-missing services, up to 24 rounds (~2 min budget).

## Net effect

Local Aspire+Docker run: failing integration tests dropped **14 → 5** (passes 279 → 283). The remaining failures are independent and not in scope here:

- \`McpWriteToolBehaviorTests.AssignMealWithMissingRequiredArgument_ReturnsError\` — MealPlan \`AssignRecipe\` endpoint defaults \`Day\` to \`DayOfWeek.Sunday\` when the field is missing; the test correctly catches that validation gap.
- \`McpWriteToolBehaviorTests.CreateShoppingListFromRecipes_PersistsList_VisibleViaMergedRead\` — MCP→API mapping drops \`recipeIdentifiers\` so the body arrives empty; shopping-api responds 422.
- \`McpWriteToolBehaviorTests.AssignMeal_ThenGetWeeklyPlan_SlotReflectsAssignment\` — observed flaky locally.
- \`CrossModuleClientContractTests.ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody\` — Polly 30s timeout calling Recipes API for a non-existent recipe; possibly slow-first-request.
- \`MealPlanMutationContractTests.SwapSlots_SlotsNotAssigned_Returns404\` — observed flaky.

## Test plan

- [x] \`dotnet build src/Yumney.Mcp.Server\` — clean
- [x] \`dotnet build tests/Yumney.Integration.Tests\` — clean
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] Local Aspire+Docker integration run: McpAuth 4/4, McpDiscovery 4/4, McpToolInvocation 5/5, McpWriteToolBehavior 2/4 pass