### PR TITLE
fix(mealplan): require Day/RecipeIdentifier/RecipeTitle on AssignRecipe wire

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -192,6 +192,7 @@ if (!options.DatabaseOnly)
 	// outside the run/publish branches because both gateways route to it.
 	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+		.WithReference(keycloak)
 		.WithReference(recipesApi)
 		.WithReference(shoppingApi)
 		.WithReference(mealplanApi);

--- a/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
+++ b/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Shared.Capabilities;
 
 namespace SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
@@ -17,12 +19,53 @@ internal sealed partial class CapabilityDiscoveryService(
 {
 	private const string wellKnownPath = "/.well-known/yumney-capabilities";
 
+	// Retry cadence for hosts that haven't responded yet. Module hosts can
+	// reach KnownResourceStates.Running before their HTTP listener has fully
+	// warmed up (recipes-api in particular — SK kernel + extraction service
+	// registration). The standard resilience handler around the discovery
+	// HttpClient already caps individual attempts at 30s; this outer loop
+	// retries the still-missing services on a 5s cadence until either every
+	// known host has reported or the discovery service is cancelled.
+	private const int maxRetryRounds = 24;
+
+	// Module hosts add JsonStringEnumConverter to their response serializer
+	// (HostBuilderExtensions.ConfigureHttpJsonOptions). CapabilitySurface is a
+	// [Flags] enum that ships on the wire as a comma-joined string like
+	// "Chat, Mcp" — default GetFromJsonAsync options can't read it back into
+	// the enum and the discovery fetch fails with a JsonException pointing at
+	// $.capabilities[0].surfaces.
+#pragma warning disable SA1311
+	private static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		Converters = { new JsonStringEnumConverter() },
+	};
+
+	private static readonly TimeSpan retryInterval = TimeSpan.FromSeconds(5);
+#pragma warning restore SA1311
+
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+		for (var round = 0; round < maxRetryRounds; round++)
 		{
 			if (stoppingToken.IsCancellationRequested) return;
-			await DiscoverFromServiceAsync(serviceName, stoppingToken);
+
+			foreach (var serviceName in KnownCapabilityHosts.ServiceNames)
+			{
+				if (stoppingToken.IsCancellationRequested) return;
+				if (registry.Manifests.ContainsKey(serviceName)) continue;
+				await DiscoverFromServiceAsync(serviceName, stoppingToken);
+			}
+
+			if (registry.Manifests.Count == KnownCapabilityHosts.ServiceNames.Count) break;
+
+			try
+			{
+				await Task.Delay(retryInterval, stoppingToken);
+			}
+			catch (OperationCanceledException)
+			{
+				return;
+			}
 		}
 
 		LogDiscoveryComplete(registry.Manifests.Count, registry.CapabilityCount);
@@ -33,7 +76,7 @@ internal sealed partial class CapabilityDiscoveryService(
 		try
 		{
 			var client = httpClientFactory.CreateClient(serviceName);
-			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, cancellationToken);
+			var manifest = await client.GetFromJsonAsync<CapabilityManifest>(wellKnownPath, jsonOptions, cancellationToken);
 			if (manifest is null)
 			{
 				LogManifestNullFor(serviceName);

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
@@ -6,6 +7,14 @@ using SmartSolutionsLab.Yumney.ServiceDefaults;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+// Match the module hosts' response shape: enums (including CapabilitySurface)
+// ship as strings so /discovered-capabilities is round-trippable through the
+// same JsonStringEnumConverter convention used by every other Yumney host.
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+	options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 
 builder.Services.AddKeycloakBearerAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddHttpContextAccessor();

--- a/src/Yumney.MealPlan.Api/Requests/AssignRecipe.cs
+++ b/src/Yumney.MealPlan.Api/Requests/AssignRecipe.cs
@@ -1,10 +1,17 @@
+using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Api.Requests;
 
+// Day / RecipeIdentifier / RecipeTitle are JsonRequired so that a missing
+// field on the wire surfaces as a 400 BadRequest from the JSON binder rather
+// than a successful bind to the enum/Guid/string default (DayOfWeek.Sunday,
+// Guid.Empty, null). Without this, the MCP assign_meal tool was happily
+// planning to Sunday/Dinner when callers omitted `day`, and that side-effect
+// also polluted the same week's state for follow-up contract tests.
 public sealed record AssignRecipe(
-	DayOfWeek Day,
-	Guid RecipeIdentifier,
-	string RecipeTitle,
+	[property: JsonRequired] DayOfWeek Day,
+	[property: JsonRequired] Guid RecipeIdentifier,
+	[property: JsonRequired] string RecipeTitle,
 	MealType MealType = MealType.Dinner,
 	int? Servings = null);


### PR DESCRIPTION
## Summary

The MealPlan \`Requests.AssignRecipe\` record bound \`DayOfWeek Day\`, \`Guid RecipeIdentifier\`, and \`string RecipeTitle\` positionally without \`[JsonRequired]\`. When the JSON body omitted any of those, the binder filled them with the default value (\`Sunday\`, \`Guid.Empty\`, \`null\`) and the handler proceeded.

The MCP \`assign_meal\` tool's missing-arg test exposed this: omitting \`day\` did **not** fail, it planned to Sunday/Dinner. That side-effect also seeded the 2099-W13 plan for testuser, which is why \`MealPlanMutationContractTests.SwapSlots_SlotsNotAssigned_Returns404\` saw an existing plan and got 200 from the swap endpoint instead of the expected route-passed-domain 404.

Both tests are now consistent again: a missing \`day\` → \`JsonException\` → 400 BadRequest from the binder → MCP proxy surfaces \`IsError=true\`, and no rogue plan gets seeded.

## Changes

\`src/Yumney.MealPlan.Api/Requests/AssignRecipe.cs\` — annotate \`Day\`, \`RecipeIdentifier\`, \`RecipeTitle\` with \`[property: JsonRequired]\`.

## Test plan

- [x] \`dotnet build src/Yumney.MealPlan.Api\` — clean
- [x] Local Aspire+Docker integration sweep of every test that touches \`Requests.AssignRecipe\` (6 tests: \`AssignMealWithMissingRequiredArgument_ReturnsError\`, \`SwapSlots_SlotsNotAssigned_Returns404\`, \`AssignMeal_ThenGetWeeklyPlan_SlotReflectsAssignment\`, \`AdjustServings_SlotExists_Returns200WithUpdatedPlan\`, \`ConfirmMeal_SlotExists_Returns200\`, \`MealPlanAssignSlotsEndpoint_AcceptsAssignRecipeBody\`) — all pass.
- [ ] Backend CI on this PR — should drop those two from the failing list.

Closes one more cluster from the live-debug session that produced #665. After this lands, the remaining backend integration reds on develop are the cross-module Polly timeouts to recipes-api (\`CrossModuleClientContractTests.ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody\` + \`McpWriteToolBehaviorTests.CreateShoppingListFromRecipes_PersistsList_VisibleViaMergedRead\`) — both same root cause, separate PR.