### PR TITLE
fix(infra): give shopping-api an Aspire reference to recipes-api

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -153,6 +153,14 @@ if (!options.DatabaseOnly)
 	// declared after recipesApi.
 	recipesApi.WithReference(mealplanApi);
 
+	// Reverse reference: shopping-api's CreateShoppingListFromRecipes handler
+	// calls recipes-api over HTTP via HttpRecipeIngredientLookup. Without this
+	// reference Aspire doesn't register service discovery for "recipes-api" in
+	// the shopping host, so cross-module HTTP calls fall through to DNS for
+	// the literal hostname "recipes-api" and hit the 30s Polly timeout. Same
+	// recipesApi-declared-after-shoppingApi inline-impossibility as above.
+	shoppingApi.WithReference(recipesApi);
+
 	// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
 	// ACA pulls them via the environment's managed identity, so no registry credentials
 	// are baked into the container app revisions.

--- a/tests/Yumney.Integration.Tests/Mcp/McpWriteToolBehaviorTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpWriteToolBehaviorTests.cs
@@ -110,10 +110,19 @@ public class McpWriteToolBehaviorTests(AspireFixture fixture)
 
 		await using var client = await CreateClientAsync();
 
+		// Body shape matches Shopping.Api.Requests.CreateFromRecipes:
+		// { title, recipes: [{ recipeIdentifier, servings }] }. The MCP tool
+		// proxy serializes whatever argument bag we hand it straight to the
+		// upstream body, so the field names + structure have to line up. The
+		// original `recipeIdentifiers: "guid"` shape never matched and the
+		// upstream returned 422 "At least one recipe is required.".
 		var createResult = await client.CallToolAsync("create_shopping_list_from_recipes", new Dictionary<string, object?>
 		{
 			["title"] = $"MCP integration list {Guid.NewGuid():N}",
-			["recipeIdentifiers"] = recipe.Id.Value.ToString(),
+			["recipes"] = new[]
+			{
+				new { recipeIdentifier = recipe.Id.Value, servings = (int?)null },
+			},
 		});
 
 		createResult.IsError.Should().BeFalse(because: GetText(createResult));


### PR DESCRIPTION
## Summary

Without this reverse reference, Aspire didn't register service discovery for \`recipes-api\` in the shopping host. The cross-module HTTP client built by \`AddYumneyServiceClient\` targeted \`http://recipes-api\`, which then fell through to DNS for that literal hostname — no host of that name → the client hung until the standard-resilience handler's 30s total-request timeout fired.

Two integration tests caught this:

- \`CrossModuleClientContractTests.ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody\`
- \`McpWriteToolBehaviorTests.CreateShoppingListFromRecipes_PersistsList_VisibleViaMergedRead\`

Both call \`POST /api/v1/shopping-lists/from-recipes\`, whose handler resolves recipe ingredients via \`HttpRecipeIngredientLookup\` → \`RecipesClient\` → \`http://recipes-api/api/v1/recipes/{id}\`.

### Fix

Symmetric to the existing \`recipesApi.WithReference(mealplanApi)\` reverse reference: declare \`shoppingApi\` above, add the reference after \`recipesApi\` exists.

### Bonus

Fix a wrong body shape in \`McpWriteToolBehaviorTests.CreateShoppingListFromRecipes\` that the timeout was hiding. The test sent

\`\`\`json
{ \"title\": \"…\", \"recipeIdentifiers\": \"guid-string\" }
\`\`\`

but the shopping-api request DTO expects

\`\`\`json
{ \"title\": \"…\", \"recipes\": [{ \"recipeIdentifier\": \"…\", \"servings\": null }] }
\`\`\`

After this PR surfaces the upstream's real behavior, the body-shape mismatch produced a 422 (\"At least one recipe is required.\"). Sending the right shape lets the create succeed.

## Test plan

- [x] \`dotnet build src/Yumney.AppHost\` — clean
- [x] Local Aspire+Docker integration: \`ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody\` runs in 9s (was 30s timeout) and passes.
- [x] \`CreateShoppingListFromRecipes_PersistsList_VisibleViaMergedRead\` — \`createResult.IsError\` now \`false\` (was true at 422); the *tailing* \`Eventually\` assertion against the merged-list reader still fails — \`merged-list\` returns \`{\"items\":[]}\` and the test expects \"Tomatoes\". That's a separate eventual-consistency / projection issue worth its own ticket.
- [ ] Backend CI on this PR — should drop \`ShoppingFromRecipesEndpoint_AcceptsCreateListFromRecipesBody\` from the failing list.