### PR TITLE
feat(recipes): metric/imperial unit-system toggle on recipe detail (US-125)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -47,6 +47,11 @@
     "rating": {
       "label": "Bewertung",
       "value": "Mit {{value}} von 5 bewerten"
+    },
+    "unitToggle": {
+      "label": "Einheitensystem",
+      "metric": "Metrisch",
+      "imperial": "Imperial"
     }
   },
   "dashboard": {

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -47,6 +47,11 @@
     "rating": {
       "label": "Rating",
       "value": "Rate {{value}} of 5"
+    },
+    "unitToggle": {
+      "label": "Unit system",
+      "metric": "Metric",
+      "imperial": "Imperial"
     }
   },
   "dashboard": {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -174,9 +174,12 @@
     </div>
 
     <section class="ingredients-section">
-      <h2>{{ t('recipes.detail.ingredients') }}</h2>
+      <div class="ingredients-header">
+        <h2>{{ t('recipes.detail.ingredients') }}</h2>
+        <yn-unit-toggle [system]="unitSystem()" (systemChange)="unitSystem.set($event)" />
+      </div>
       <ul class="ingredients-list">
-        @for (ingredient of scaledIngredients(); track ingredient.name) {
+        @for (ingredient of displayedIngredients(); track ingredient.name) {
           <li>
             @if (ingredient.amount) {
               <span class="ingredient-amount">{{ ingredient.amount }}</span>

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.scss
@@ -254,10 +254,19 @@
   border-left: 3px solid var(--yn-primary);
 
   h2 {
-    margin: 0 0 var(--yn-space-5);
+    margin: 0;
     font-size: var(--yn-text-2xl);
     font-weight: var(--yn-font-semibold);
   }
+}
+
+.ingredients-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--yn-space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--yn-space-5);
 }
 
 // ── Steps section ──

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -23,6 +23,8 @@ import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
 import {
   createAsyncState,
   scaleIngredients,
+  toSystem,
+  type UnitSystem,
   ERROR_MAPS,
   ROUTES,
   VALIDATION,
@@ -36,6 +38,7 @@ import {
   LoadingSpinnerComponent,
   MessageBannerComponent,
   StarRatingComponent,
+  UnitToggleComponent,
 } from '@yumney/ui';
 import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog/create-shopping-list-dialog.component';
 
@@ -53,6 +56,7 @@ import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog
     MessageBannerComponent,
     FavoriteButtonComponent,
     StarRatingComponent,
+    UnitToggleComponent,
   ],
   templateUrl: './recipe-detail.component.html',
   styleUrl: './recipe-detail.component.scss',
@@ -80,6 +84,7 @@ export class RecipeDetailComponent implements OnInit {
   isCreatingShoppingList = this.createShoppingListState.isLoading;
   serverError = signal<string | null>(null);
   desiredServings = signal<number | null>(null);
+  unitSystem = signal<UnitSystem>('metric');
   showDeleteConfirm = signal(false);
   showCreateShoppingListConfirm = signal(false);
 
@@ -97,6 +102,22 @@ export class RecipeDetailComponent implements OnInit {
       return ingredients;
     }
     return scaleIngredients(ingredients, servings, desired);
+  });
+
+  // Final ingredient list rendered in the template — applies the unit-system
+  // toggle on top of the servings-scaled list. When the system is metric the
+  // recipe ships as-stored; flipping to imperial routes each amount/unit pair
+  // through unit-conversion (no-op for count/unknown units like "pinch" or
+  // "clove", smart-rounded for grams/litres/etc.).
+  displayedIngredients = computed(() => {
+    const ingredients = this.scaledIngredients();
+    const system = this.unitSystem();
+    if (system === 'metric') return ingredients;
+    return ingredients.map((ingredient) => {
+      if (ingredient.amount == null) return ingredient;
+      const converted = toSystem(ingredient.amount, ingredient.unit, system);
+      return { ...ingredient, amount: converted.amount, unit: converted.unit || null };
+    });
   });
 
   isScaled = computed(() => {

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -90,6 +90,11 @@
     "rating": {
       "label": "Bewertung",
       "value": "Mit {{value}} von 5 bewerten"
+    },
+    "unitToggle": {
+      "label": "Einheitensystem",
+      "metric": "Metrisch",
+      "imperial": "Imperial"
     }
   },
   "layout": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -90,6 +90,11 @@
     "rating": {
       "label": "Rating",
       "value": "Rate {{value}} of 5"
+    },
+    "unitToggle": {
+      "label": "Unit system",
+      "metric": "Metric",
+      "imperial": "Imperial"
     }
   },
   "layout": {

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -8,6 +8,16 @@ export { urlValidator, passwordsMatchValidator } from './lib/validators';
 export { VALIDATION } from './lib/validation-constants';
 export { scaleIngredients, type ScalableIngredient } from './lib/scale-ingredients';
 export {
+  toImperial,
+  toMetric,
+  toSystem,
+  celsiusToFahrenheit,
+  fahrenheitToCelsius,
+  smartRound,
+  type ConvertedAmount,
+  type UnitSystem,
+} from './lib/unit-conversion';
+export {
   mergeRecipeIngredients,
   type RecipeForMerge,
   type MergedIngredient,

--- a/client/libs/shared/models/src/lib/unit-conversion.spec.ts
+++ b/client/libs/shared/models/src/lib/unit-conversion.spec.ts
@@ -1,0 +1,112 @@
+import {
+  celsiusToFahrenheit,
+  fahrenheitToCelsius,
+  smartRound,
+  toImperial,
+  toMetric,
+  toSystem,
+} from './unit-conversion';
+
+describe('unit-conversion', () => {
+  describe('toImperial', () => {
+    it('converts grams to ounces', () => {
+      const result = toImperial(500, 'g');
+      expect(result.unit).toBe('oz');
+      // 500g ≈ 17.64 oz → SmartRound for <100 rounds to nearest whole
+      expect(result.amount).toBe(18);
+    });
+
+    it('converts kilograms to pounds', () => {
+      const result = toImperial(2, 'kg');
+      expect(result.unit).toBe('lb');
+      // 2kg = 4.41 lb → <10 rounds to 0.5 step
+      expect(result.amount).toBe(4.5);
+    });
+
+    it('converts millilitres to fluid ounces', () => {
+      const result = toImperial(200, 'ml');
+      expect(result.unit).toBe('fl oz');
+      // 200ml ≈ 6.76 fl oz → <10 rounds to 0.5 step
+      expect(result.amount).toBe(7);
+    });
+
+    it('converts litres to cups', () => {
+      const result = toImperial(1, 'l');
+      expect(result.unit).toBe('cup');
+      // 1L ≈ 4.23 cup → <10 rounds to 0.5 step
+      expect(result.amount).toBe(4);
+    });
+
+    it('passes through unknown units unchanged', () => {
+      const result = toImperial(3, 'pinch');
+      expect(result.unit).toBe('pinch');
+      expect(result.amount).toBe(3);
+    });
+
+    it('treats empty unit as countable and only smart-rounds', () => {
+      // 1.7 falls in the absolute<10 bucket → rounds to nearest 0.5.
+      const result = toImperial(1.7, null);
+      expect(result.unit).toBe('');
+      expect(result.amount).toBe(1.5);
+    });
+  });
+
+  describe('toMetric', () => {
+    it('converts ounces to grams', () => {
+      const result = toMetric(8, 'oz');
+      expect(result.unit).toBe('g');
+      // 8oz = 226.79 g → 100..1000 rounds to 5 step
+      expect(result.amount).toBe(225);
+    });
+
+    it('converts cups to millilitres', () => {
+      const result = toMetric(1, 'cup');
+      expect(result.unit).toBe('ml');
+      // 1 cup = 236.59 ml → 100..1000 rounds to 5 step
+      expect(result.amount).toBe(235);
+    });
+  });
+
+  describe('toSystem', () => {
+    it('routes to imperial when target is imperial', () => {
+      expect(toSystem(500, 'g', 'imperial').unit).toBe('oz');
+    });
+
+    it('routes to metric when target is metric', () => {
+      expect(toSystem(8, 'oz', 'metric').unit).toBe('g');
+    });
+  });
+
+  describe('temperature', () => {
+    it('converts 180°C → 356°F', () => {
+      expect(celsiusToFahrenheit(180)).toBe(356);
+    });
+
+    it('converts 350°F → 177°C', () => {
+      expect(fahrenheitToCelsius(350)).toBe(177);
+    });
+  });
+
+  describe('smartRound', () => {
+    it('rounds tiny values to nearest 0.25', () => {
+      expect(smartRound(0.34)).toBe(0.25);
+      expect(smartRound(0.4)).toBe(0.5);
+    });
+
+    it('rounds small values to nearest 0.5', () => {
+      expect(smartRound(4.3)).toBe(4.5);
+    });
+
+    it('rounds mid values to nearest whole', () => {
+      expect(smartRound(17.64)).toBe(18);
+    });
+
+    it('rounds large values to nearest 5', () => {
+      expect(smartRound(127.4)).toBe(125);
+    });
+
+    it('rounds huge values to nearest 10', () => {
+      expect(smartRound(1234)).toBe(1230);
+    });
+  });
+});

--- a/client/libs/shared/models/src/lib/unit-conversion.ts
+++ b/client/libs/shared/models/src/lib/unit-conversion.ts
@@ -1,0 +1,90 @@
+// Cooking-grade unit conversion. Mirrors src/Yumney.Shared.Quantities/
+// UnitConversion.cs — the backend uses the same factors when ingesting
+// imperial recipes and normalising shopping-list ingredients. Keep the two in
+// lockstep when adding new rules.
+
+export type UnitSystem = 'metric' | 'imperial';
+
+export interface ConvertedAmount {
+  amount: number;
+  unit: string;
+}
+
+interface ConversionRule {
+  targetUnit: string;
+  factor: number;
+}
+
+const metricToImperial = new Map<string, ConversionRule>([
+  ['g', { targetUnit: 'oz', factor: 1 / 28.3495 }],
+  ['kg', { targetUnit: 'lb', factor: 2.20462 }],
+  ['ml', { targetUnit: 'fl oz', factor: 1 / 29.5735 }],
+  ['cl', { targetUnit: 'fl oz', factor: 10 / 29.5735 }],
+  ['dl', { targetUnit: 'cup', factor: 100 / 236.588 }],
+  ['l', { targetUnit: 'cup', factor: 1000 / 236.588 }],
+]);
+
+const imperialToMetric = new Map<string, ConversionRule>([
+  ['oz', { targetUnit: 'g', factor: 28.3495 }],
+  ['lb', { targetUnit: 'g', factor: 453.592 }],
+  ['fl oz', { targetUnit: 'ml', factor: 29.5735 }],
+  ['cup', { targetUnit: 'ml', factor: 236.588 }],
+  ['tsp', { targetUnit: 'ml', factor: 4.92892 }],
+  ['tbsp', { targetUnit: 'ml', factor: 14.7868 }],
+]);
+
+export function toImperial(amount: number, unit: string | null): ConvertedAmount {
+  return apply(amount, unit, metricToImperial);
+}
+
+export function toMetric(amount: number, unit: string | null): ConvertedAmount {
+  return apply(amount, unit, imperialToMetric);
+}
+
+export function toSystem(amount: number, unit: string | null, target: UnitSystem): ConvertedAmount {
+  return target === 'imperial' ? toImperial(amount, unit) : toMetric(amount, unit);
+}
+
+export function celsiusToFahrenheit(celsius: number): number {
+  return Math.round((celsius * 9) / 5 + 32);
+}
+
+export function fahrenheitToCelsius(fahrenheit: number): number {
+  return Math.round(((fahrenheit - 32) * 5) / 9);
+}
+
+// Coerce a converted amount to a number a cook can actually measure. Mirrors
+// backend SmartRound — the thresholds are the same so a server-rendered
+// ingredient list and a client-converted one agree to the rounded unit.
+export function smartRound(value: number): number {
+  const absolute = Math.abs(value);
+  if (absolute < 1) return roundToStep(value, 0.25);
+  if (absolute < 10) return roundToStep(value, 0.5);
+  if (absolute < 100) return Math.round(value);
+  if (absolute < 1000) return roundToStep(value, 5);
+  return roundToStep(value, 10);
+}
+
+function apply(
+  amount: number,
+  unit: string | null,
+  table: Map<string, ConversionRule>,
+): ConvertedAmount {
+  const normalized = (unit ?? '').trim();
+  if (normalized.length === 0) {
+    return { amount: smartRound(amount), unit: '' };
+  }
+
+  const rule = table.get(normalized.toLowerCase());
+  if (!rule) return { amount, unit: normalized };
+
+  return { amount: smartRound(amount * rule.factor), unit: rule.targetUnit };
+}
+
+function roundToStep(value: number, step: number): number {
+  // Half-away-from-zero rounding matches the backend's
+  // MidpointRounding.AwayFromZero so the two sides agree on edge cases like
+  // 0.125 → 0.25, 0.375 → 0.5, 2.5 → 3.
+  const sign = value < 0 ? -1 : 1;
+  return sign * Math.round(Math.abs(value) / step + Number.EPSILON) * step;
+}

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -38,6 +38,7 @@ export { ConfirmDialogComponent } from './lib/confirm-dialog/confirm-dialog.comp
 export { HeaderComponent } from './lib/header/header.component';
 export { AppLayoutComponent } from './lib/app-layout/app-layout.component';
 export { UnitSelectComponent } from './lib/unit-select/unit-select.component';
+export { UnitToggleComponent } from './lib/unit-toggle/unit-toggle.component';
 export { LoadingSpinnerComponent } from './lib/loading-spinner/loading-spinner.component';
 export { AsyncStateComponent } from './lib/async-state/async-state.component';
 

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.html
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.html
@@ -1,0 +1,29 @@
+<div
+  class="unit-toggle"
+  role="radiogroup"
+  *transloco="let t"
+  [attr.aria-label]="t('shared.unitToggle.label')"
+>
+  <button
+    type="button"
+    class="unit-toggle-option"
+    role="radio"
+    data-testid="unit-toggle-metric"
+    [class.selected]="system() === 'metric'"
+    [attr.aria-checked]="system() === 'metric'"
+    (click)="onSelect('metric')"
+  >
+    {{ t('shared.unitToggle.metric') }}
+  </button>
+  <button
+    type="button"
+    class="unit-toggle-option"
+    role="radio"
+    data-testid="unit-toggle-imperial"
+    [class.selected]="system() === 'imperial'"
+    [attr.aria-checked]="system() === 'imperial'"
+    (click)="onSelect('imperial')"
+  >
+    {{ t('shared.unitToggle.imperial') }}
+  </button>
+</div>

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.scss
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.scss
@@ -1,0 +1,31 @@
+.unit-toggle {
+  display: inline-flex;
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+  overflow: hidden;
+}
+
+.unit-toggle-option {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border: 0;
+  background: transparent;
+  color: var(--yn-text);
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  cursor: pointer;
+  transition:
+    background var(--yn-duration-fast) var(--yn-ease-glass),
+    color var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover:not(.selected) {
+    color: var(--yn-primary);
+  }
+
+  &.selected {
+    background: var(--yn-primary);
+    color: var(--yn-on-primary, white);
+  }
+}

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.spec.ts
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { UnitToggleComponent } from './unit-toggle.component';
+
+const en = {
+  shared: {
+    unitToggle: {
+      label: 'Unit system',
+      metric: 'Metric',
+      imperial: 'Imperial',
+    },
+  },
+};
+
+describe('UnitToggleComponent', () => {
+  let fixture: ComponentFixture<UnitToggleComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UnitToggleComponent, setupTranslocoTesting(en)],
+    });
+    fixture = TestBed.createComponent(UnitToggleComponent);
+    fixture.componentRef.setInput('system', 'metric');
+    fixture.detectChanges();
+  });
+
+  it('marks the selected system aria-checked', () => {
+    const metric = fixture.nativeElement.querySelector(
+      '[data-testid="unit-toggle-metric"]',
+    ) as HTMLButtonElement;
+    const imperial = fixture.nativeElement.querySelector(
+      '[data-testid="unit-toggle-imperial"]',
+    ) as HTMLButtonElement;
+    expect(metric.getAttribute('aria-checked')).toBe('true');
+    expect(imperial.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('emits systemChange when the other option is clicked', () => {
+    const handler = vi.fn();
+    fixture.componentInstance.systemChange.subscribe(handler);
+
+    const imperial = fixture.nativeElement.querySelector(
+      '[data-testid="unit-toggle-imperial"]',
+    ) as HTMLButtonElement;
+    imperial.click();
+
+    expect(handler).toHaveBeenCalledWith('imperial');
+  });
+
+  it('does not emit when the already-selected option is clicked', () => {
+    const handler = vi.fn();
+    fixture.componentInstance.systemChange.subscribe(handler);
+
+    const metric = fixture.nativeElement.querySelector(
+      '[data-testid="unit-toggle-metric"]',
+    ) as HTMLButtonElement;
+    metric.click();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('reflects an updated input', () => {
+    fixture.componentRef.setInput('system', 'imperial');
+    fixture.detectChanges();
+
+    const imperial = fixture.nativeElement.querySelector(
+      '[data-testid="unit-toggle-imperial"]',
+    ) as HTMLButtonElement;
+    expect(imperial.getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.ts
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import type { UnitSystem } from '@yumney/shared/models';
+
+@Component({
+  selector: 'yn-unit-toggle',
+  imports: [TranslocoModule],
+  templateUrl: './unit-toggle.component.html',
+  styleUrl: './unit-toggle.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UnitToggleComponent {
+  system = input.required<UnitSystem>();
+  systemChange = output<UnitSystem>();
+
+  protected onSelect(system: UnitSystem): void {
+    if (system === this.system()) return;
+    this.systemChange.emit(system);
+  }
+}


### PR DESCRIPTION
## Summary

Slice 2 of US-125 — the user-facing toggle on the recipe detail page.

Backend slice 1 (\`src/Yumney.Shared.Quantities/UnitConversion.cs\`) gave us a canonical conversion table for cooking units. This slice ports the same factors to TypeScript, adds a small two-state toggle component in \`@yumney/ui\`, and renders it next to the recipe-detail's \"Ingredients\" header.

### Behaviour

When the user flips the toggle:

- \`scaledIngredients\` (output of the servings adjuster) is routed through \`toSystem(amount, unit, target)\` per row
- Known mappings: g/kg → oz/lb, ml/cl → fl oz, dl/l → cup
- \`smartRound\` coerces to a cookable number (0.25 / 0.5 / whole / 5 / 10 buckets — same thresholds as the backend)
- Unknown / count units (\"pinch\", \"clove\", null) pass through unchanged

### Files

- \`client/libs/shared/models/src/lib/unit-conversion.ts\` (+ \`.spec.ts\`, 17 tests)
- \`client/libs/ui/src/lib/unit-toggle/{component.ts,.html,.scss,.spec.ts}\` (4 tests)
- \`recipe-detail.component\` integration (new \`displayedIngredients\` computed; toggle rendered in the ingredients-header)
- EN + DE \`shared.unitToggle\` i18n keys, synced

### Out of scope

- Profile-default lookup (US-100 wiring) — natural next slice
- Cook-mode voice command \"show in cups\" / \"zeige in Tassen\" — US-240 dependency
- Shopping list unit-system rendering — same conversion utility reusable when needed

Default unit system is \`metric\`.

## Test plan

- [x] \`nx test shared-models -- --run unit-conversion\` (17 tests)
- [x] \`nx test ui -- --run unit-toggle\` (4 tests)
- [x] \`nx test recipes -- --run recipe-detail\` (196 tests, no regressions)
- [x] \`nx run-many -t lint\`
- [x] \`nx build recipes\`
- [x] \`yarn sync:i18n:check\`

Closes the recipe-detail toggle slice of #36.