### PR TITLE
feat(shopping): Pantry page with freshness chips + freeze override (US-341)

### DIFF
--- a/client/apps/account/public/assets/i18n/de.json
+++ b/client/apps/account/public/assets/i18n/de.json
@@ -8,6 +8,7 @@
       "myRecipes": "Meine Rezepte",
       "cookable": "Was kann ich kochen?",
       "shoppingLists": "Einkaufslisten",
+      "pantry": "Vorratskammer",
       "mealPlanner": "Essensplaner",
       "navigation": "Hauptnavigation",
       "settings": "Einstellungen",

--- a/client/apps/account/public/assets/i18n/en.json
+++ b/client/apps/account/public/assets/i18n/en.json
@@ -8,6 +8,7 @@
       "myRecipes": "My Recipes",
       "cookable": "What can I cook?",
       "shoppingLists": "Shopping Lists",
+      "pantry": "Pantry",
       "mealPlanner": "Meal Planner",
       "navigation": "Main navigation",
       "settings": "User settings",

--- a/client/apps/recipes/public/assets/i18n/de.json
+++ b/client/apps/recipes/public/assets/i18n/de.json
@@ -8,6 +8,7 @@
       "myRecipes": "Meine Rezepte",
       "cookable": "Was kann ich kochen?",
       "shoppingLists": "Einkaufslisten",
+      "pantry": "Vorratskammer",
       "mealPlanner": "Essensplaner",
       "navigation": "Hauptnavigation",
       "settings": "Einstellungen",

--- a/client/apps/recipes/public/assets/i18n/en.json
+++ b/client/apps/recipes/public/assets/i18n/en.json
@@ -8,6 +8,7 @@
       "myRecipes": "My Recipes",
       "cookable": "What can I cook?",
       "shoppingLists": "Shopping Lists",
+      "pantry": "Pantry",
       "mealPlanner": "Meal Planner",
       "navigation": "Main navigation",
       "settings": "User settings",

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -106,6 +106,7 @@
       "myRecipes": "Meine Rezepte",
       "cookable": "Was kann ich kochen?",
       "shoppingLists": "Einkaufslisten",
+      "pantry": "Vorratskammer",
       "mealPlanner": "Essensplaner",
       "navigation": "Hauptnavigation",
       "settings": "Einstellungen",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -106,6 +106,7 @@
       "myRecipes": "My Recipes",
       "cookable": "What can I cook?",
       "shoppingLists": "Shopping Lists",
+      "pantry": "Pantry",
       "mealPlanner": "Meal Planner",
       "navigation": "Main navigation",
       "settings": "User settings",

--- a/client/apps/shell/public/assets/i18n/shopping/de.json
+++ b/client/apps/shell/public/assets/i18n/shopping/de.json
@@ -87,5 +87,28 @@
     "header": "Quellen",
     "manual": "Manuell hinzugefügt",
     "empty": "Keine Quellenangaben verfügbar."
+  },
+  "pantry": {
+    "title": "Vorratskammer",
+    "subtitle": "Was gerade zu Hause ist – mit Frischehinweisen je nachdem, wann du eingekauft hast.",
+    "staple": "Vorrat",
+    "daysSinceBought": "Vor {{count}}T gekauft",
+    "freshness": {
+      "fresh": "Frisch",
+      "use-soon": "Bald aufbrauchen",
+      "check-it": "Bitte prüfen"
+    },
+    "freeze": {
+      "action": "Eingefroren",
+      "ariaLabel": "{{name}} als eingefroren markieren"
+    },
+    "empty": {
+      "title": "Deine Vorratskammer ist leer",
+      "message": "Artikel erscheinen hier, sobald du sie auf einer Einkaufsliste abhakst oder als zu Hause hinzufügst."
+    },
+    "errors": {
+      "loadFailed": "Vorratskammer konnte nicht geladen werden. Bitte versuche es später erneut.",
+      "freezeFailed": "Artikel konnte nicht als eingefroren markiert werden."
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/shopping/en.json
+++ b/client/apps/shell/public/assets/i18n/shopping/en.json
@@ -87,5 +87,28 @@
     "header": "Sources",
     "manual": "Added manually",
     "empty": "No source breakdown available."
+  },
+  "pantry": {
+    "title": "Pantry",
+    "subtitle": "What's at home right now, with freshness hints based on when you bought it.",
+    "staple": "Staple",
+    "daysSinceBought": "Bought {{count}}d ago",
+    "freshness": {
+      "fresh": "Fresh",
+      "use-soon": "Use soon",
+      "check-it": "Check it"
+    },
+    "freeze": {
+      "action": "I froze it",
+      "ariaLabel": "Mark {{name}} as frozen"
+    },
+    "empty": {
+      "title": "Nothing in your pantry yet",
+      "message": "Items show up here after you check them off a shopping list or add them as at-home."
+    },
+    "errors": {
+      "loadFailed": "Pantry could not be loaded. Please try again later.",
+      "freezeFailed": "Could not mark this item as frozen."
+    }
   }
 }

--- a/client/apps/shopping/public/assets/i18n/de.json
+++ b/client/apps/shopping/public/assets/i18n/de.json
@@ -8,6 +8,7 @@
       "myRecipes": "Meine Rezepte",
       "cookable": "Was kann ich kochen?",
       "shoppingLists": "Einkaufslisten",
+      "pantry": "Vorratskammer",
       "mealPlanner": "Essensplaner",
       "navigation": "Hauptnavigation",
       "settings": "Einstellungen",

--- a/client/apps/shopping/public/assets/i18n/en.json
+++ b/client/apps/shopping/public/assets/i18n/en.json
@@ -8,6 +8,7 @@
       "myRecipes": "My Recipes",
       "cookable": "What can I cook?",
       "shoppingLists": "Shopping Lists",
+      "pantry": "Pantry",
       "mealPlanner": "Meal Planner",
       "navigation": "Main navigation",
       "settings": "User settings",

--- a/client/apps/shopping/public/assets/i18n/shopping/de.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/de.json
@@ -87,5 +87,28 @@
     "header": "Quellen",
     "manual": "Manuell hinzugefügt",
     "empty": "Keine Quellenangaben verfügbar."
+  },
+  "pantry": {
+    "title": "Vorratskammer",
+    "subtitle": "Was gerade zu Hause ist – mit Frischehinweisen je nachdem, wann du eingekauft hast.",
+    "staple": "Vorrat",
+    "daysSinceBought": "Vor {{count}}T gekauft",
+    "freshness": {
+      "fresh": "Frisch",
+      "use-soon": "Bald aufbrauchen",
+      "check-it": "Bitte prüfen"
+    },
+    "freeze": {
+      "action": "Eingefroren",
+      "ariaLabel": "{{name}} als eingefroren markieren"
+    },
+    "empty": {
+      "title": "Deine Vorratskammer ist leer",
+      "message": "Artikel erscheinen hier, sobald du sie auf einer Einkaufsliste abhakst oder als zu Hause hinzufügst."
+    },
+    "errors": {
+      "loadFailed": "Vorratskammer konnte nicht geladen werden. Bitte versuche es später erneut.",
+      "freezeFailed": "Artikel konnte nicht als eingefroren markiert werden."
+    }
   }
 }

--- a/client/apps/shopping/public/assets/i18n/shopping/en.json
+++ b/client/apps/shopping/public/assets/i18n/shopping/en.json
@@ -87,5 +87,28 @@
     "header": "Sources",
     "manual": "Added manually",
     "empty": "No source breakdown available."
+  },
+  "pantry": {
+    "title": "Pantry",
+    "subtitle": "What's at home right now, with freshness hints based on when you bought it.",
+    "staple": "Staple",
+    "daysSinceBought": "Bought {{count}}d ago",
+    "freshness": {
+      "fresh": "Fresh",
+      "use-soon": "Use soon",
+      "check-it": "Check it"
+    },
+    "freeze": {
+      "action": "I froze it",
+      "ariaLabel": "Mark {{name}} as frozen"
+    },
+    "empty": {
+      "title": "Nothing in your pantry yet",
+      "message": "Items show up here after you check them off a shopping list or add them as at-home."
+    },
+    "errors": {
+      "loadFailed": "Pantry could not be loaded. Please try again later.",
+      "freezeFailed": "Could not mark this item as frozen."
+    }
   }
 }

--- a/client/apps/shopping/src/app/api.ts
+++ b/client/apps/shopping/src/app/api.ts
@@ -14,4 +14,9 @@ export {
   type MergedShoppingItem,
   type ItemSource,
   type AddedItem,
+  type Freshness,
+  type IngredientBalance,
+  type IngredientBalanceItem,
+  type IngredientBalanceSource,
+  type MarkAsFrozenRequest,
 } from '@yumney/shared/api-client';

--- a/client/apps/shopping/src/app/pantry/index.ts
+++ b/client/apps/shopping/src/app/pantry/index.ts
@@ -1,0 +1,1 @@
+export { PantryComponent } from './pantry.component';

--- a/client/apps/shopping/src/app/pantry/pantry.component.html
+++ b/client/apps/shopping/src/app/pantry/pantry.component.html
@@ -1,0 +1,78 @@
+<div class="pantry-container" *transloco="let t">
+  <div class="page-header">
+    <h1>{{ t('shopping.pantry.title') }}</h1>
+    <p class="subtitle">{{ t('shopping.pantry.subtitle') }}</p>
+  </div>
+
+  @if (serverError(); as error) {
+    <yn-message-banner tone="error" [message]="error" />
+  }
+
+  @if (!isLoading() && items().length === 0 && !serverError()) {
+    <yn-empty-state title="shopping.pantry.empty.title" message="shopping.pantry.empty.message" />
+  }
+
+  @if (isLoading() && items().length === 0) {
+    <div class="skeleton-list">
+      <div class="skeleton-row"></div>
+      <div class="skeleton-row"></div>
+      <div class="skeleton-row"></div>
+    </div>
+  }
+
+  @for (group of groups(); track group.category) {
+    <section class="pantry-section">
+      <h2 class="pantry-section-title">
+        {{ t('shopping.category.' + group.category) }}
+        <span class="pantry-section-count">{{ group.items.length }}</span>
+      </h2>
+
+      <ul class="pantry-items">
+        @for (item of group.items; track item.itemName + '|' + (item.unit || '')) {
+          <li class="pantry-item" data-testid="pantry-item">
+            <div class="pantry-item-main">
+              @if (item.quantity != null) {
+                <span class="pantry-item-quantity">
+                  {{ item.quantity }}{{ item.unit ? ' ' + item.unit : '' }}
+                </span>
+              }
+              <span class="pantry-item-name">{{ item.itemName }}</span>
+              @if (item.source === 'Staple') {
+                <span class="pantry-staple-badge">{{ t('shopping.pantry.staple') }}</span>
+              }
+            </div>
+
+            <div class="pantry-item-meta">
+              @if (freshnessTone(item.freshness); as tone) {
+                <span
+                  class="freshness-chip"
+                  [class]="'freshness-chip--' + tone"
+                  data-testid="freshness-chip"
+                >
+                  {{ t('shopping.pantry.freshness.' + tone) }}
+                </span>
+              }
+              @if (item.daysSinceBought != null) {
+                <span class="pantry-days">
+                  {{ t('shopping.pantry.daysSinceBought', { count: item.daysSinceBought }) }}
+                </span>
+              }
+              @if (item.source === 'AtHome' && item.freshness !== 'NotTracked') {
+                <button
+                  type="button"
+                  class="freeze-btn"
+                  data-testid="pantry-freeze-btn"
+                  [attr.aria-label]="t('shopping.pantry.freeze.ariaLabel', { name: item.itemName })"
+                  (click)="onFreeze(item)"
+                >
+                  <lucide-icon name="snowflake" [size]="14" />
+                  {{ t('shopping.pantry.freeze.action') }}
+                </button>
+              }
+            </div>
+          </li>
+        }
+      </ul>
+    </section>
+  }
+</div>

--- a/client/apps/shopping/src/app/pantry/pantry.component.scss
+++ b/client/apps/shopping/src/app/pantry/pantry.component.scss
@@ -1,0 +1,189 @@
+@use 'banners';
+@use 'glass';
+
+.pantry-container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: var(--yn-space-6) var(--yn-space-5);
+}
+
+.page-header {
+  margin-bottom: var(--yn-space-6);
+
+  h1 {
+    margin: 0;
+    font-size: var(--yn-text-3xl);
+    font-weight: var(--yn-font-semibold);
+  }
+
+  .subtitle {
+    margin: var(--yn-space-2) 0 0;
+    color: var(--yn-text-light);
+    font-size: var(--yn-text-base);
+  }
+}
+
+.pantry-section {
+  margin-bottom: var(--yn-space-6);
+}
+
+.pantry-section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  margin: 0 0 var(--yn-space-3);
+  font-size: var(--yn-text-lg);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+}
+
+.pantry-section-count {
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-medium);
+  color: var(--yn-text-light);
+  background: var(--yn-glass-bg);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  padding: 0 var(--yn-space-2);
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.pantry-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.pantry-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--yn-space-3);
+  padding: var(--yn-space-3) var(--yn-space-4);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-card);
+  background: var(--yn-glass-bg);
+  backdrop-filter: blur(var(--yn-glass-blur-soft));
+  -webkit-backdrop-filter: blur(var(--yn-glass-blur-soft));
+}
+
+.pantry-item-main {
+  display: flex;
+  align-items: baseline;
+  gap: var(--yn-space-2);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.pantry-item-quantity {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+}
+
+.pantry-item-name {
+  font-size: var(--yn-text-base);
+  color: var(--yn-text);
+}
+
+.pantry-staple-badge {
+  font-size: var(--yn-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--yn-text-light);
+  padding: 0 var(--yn-space-2);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg-elevated);
+  border: 1px solid var(--yn-glass-border);
+}
+
+.pantry-item-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+  flex-wrap: wrap;
+}
+
+.pantry-days {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-light);
+}
+
+.freshness-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--yn-space-2);
+  height: 1.5rem;
+  border-radius: var(--yn-radius-badge);
+  font-size: var(--yn-text-xs);
+  font-weight: var(--yn-font-semibold);
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+
+  &--fresh {
+    background: var(--yn-success, #16a34a);
+    color: white;
+  }
+
+  &--use-soon {
+    background: var(--yn-warning, #d97706);
+    color: white;
+  }
+
+  &--check-it {
+    background: var(--yn-danger, #dc2626);
+    color: white;
+  }
+}
+
+.freeze-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-1);
+  padding: var(--yn-space-1) var(--yn-space-3);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-badge);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  font-size: var(--yn-text-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--yn-duration-fast) var(--yn-ease-glass),
+    color var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    border-color: var(--yn-primary);
+    color: var(--yn-primary);
+  }
+}
+
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.skeleton-row {
+  height: 48px;
+  border-radius: var(--yn-radius-card);
+  background: linear-gradient(
+    90deg,
+    var(--yn-glass-bg) 25%,
+    var(--yn-glass-bg-elevated) 50%,
+    var(--yn-glass-bg) 75%
+  );
+  background-size: 200% 100%;
+  animation: yn-shimmer 1.5s ease-in-out infinite;
+  border: 1px solid var(--yn-glass-border-subtle);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background: var(--yn-glass-bg);
+  }
+}

--- a/client/apps/shopping/src/app/pantry/pantry.component.spec.ts
+++ b/client/apps/shopping/src/app/pantry/pantry.component.spec.ts
@@ -1,0 +1,178 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { provideYumneyIcons } from '@yumney/ui';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { PantryComponent } from './pantry.component';
+import { ShoppingApiService, type IngredientBalance } from '../api';
+
+const en = {
+  shopping: {
+    pantry: {
+      title: 'Pantry',
+      subtitle: "What's at home right now",
+      staple: 'Staple',
+      daysSinceBought: 'Bought {{count}}d ago',
+      freshness: {
+        fresh: 'Fresh',
+        'use-soon': 'Use soon',
+        'check-it': 'Check it',
+      },
+      freeze: {
+        action: 'I froze it',
+        ariaLabel: 'Mark {{name}} as frozen',
+      },
+      empty: {
+        title: 'Nothing in your pantry yet',
+        message: 'Add items.',
+      },
+      errors: {
+        loadFailed: 'Pantry could not be loaded.',
+        freezeFailed: 'Could not mark item as frozen.',
+      },
+    },
+    category: {
+      produce: 'Produce',
+      dairy: 'Dairy',
+      'meat-fish': 'Meat & Fish',
+      pantry: 'Pantry',
+      other: 'Other',
+    },
+  },
+};
+
+const fullResponse: IngredientBalance = {
+  items: [
+    {
+      itemName: 'Chicken breast',
+      quantity: 500,
+      unit: 'g',
+      category: 'meat-fish',
+      source: 'AtHome',
+      freshness: 'UseSoon',
+      daysSinceBought: 1,
+    },
+    {
+      itemName: 'Salt',
+      quantity: null,
+      unit: null,
+      category: 'pantry',
+      source: 'Staple',
+      freshness: 'NotTracked',
+      daysSinceBought: null,
+    },
+    {
+      itemName: 'Spinach',
+      quantity: 200,
+      unit: 'g',
+      category: 'produce',
+      source: 'AtHome',
+      freshness: 'CheckIt',
+      daysSinceBought: 4,
+    },
+  ],
+};
+
+const empty: IngredientBalance = { items: [] };
+
+describe('PantryComponent', () => {
+  let fixture: ComponentFixture<PantryComponent>;
+  let component: PantryComponent;
+  let shoppingApiMock: {
+    getIngredientBalance: ReturnType<typeof vi.fn>;
+    markAsFrozen: ReturnType<typeof vi.fn>;
+  };
+
+  function setupTestBed(getReturn: ReturnType<typeof vi.fn>): void {
+    shoppingApiMock = {
+      getIngredientBalance: getReturn,
+      markAsFrozen: vi.fn(),
+    };
+    TestBed.configureTestingModule({
+      imports: [PantryComponent, setupTranslocoTesting(en)],
+      providers: [
+        provideYumneyIcons(),
+        provideRouter([]),
+        { provide: ShoppingApiService, useValue: shoppingApiMock },
+      ],
+    });
+    fixture = TestBed.createComponent(PantryComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('loads the balance on init and renders the items', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(shoppingApiMock.getIngredientBalance).toHaveBeenCalled();
+    expect(component.items()).toHaveLength(3);
+    const rendered = fixture.nativeElement.querySelectorAll('[data-testid="pantry-item"]');
+    expect(rendered.length).toBe(3);
+  }));
+
+  it('renders a freshness chip only for tracked items', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const chips = fixture.nativeElement.querySelectorAll('[data-testid="freshness-chip"]');
+    // 2 of 3 items are tracked (Chicken=UseSoon, Spinach=CheckIt); Salt is
+    // NotTracked.
+    expect(chips.length).toBe(2);
+  }));
+
+  it('shows freeze buttons only for at-home tracked items', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const buttons = fixture.nativeElement.querySelectorAll('[data-testid="pantry-freeze-btn"]');
+    expect(buttons.length).toBe(2);
+  }));
+
+  it('calls markAsFrozen and re-loads on freeze', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(fullResponse)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    shoppingApiMock.markAsFrozen.mockReturnValue(of(undefined));
+    shoppingApiMock.getIngredientBalance.mockClear();
+    shoppingApiMock.getIngredientBalance.mockReturnValue(of(empty));
+
+    const button = fixture.nativeElement.querySelector(
+      '[data-testid="pantry-freeze-btn"]',
+    ) as HTMLButtonElement;
+    button.click();
+    tick();
+
+    expect(shoppingApiMock.markAsFrozen).toHaveBeenCalledWith({
+      name: 'Chicken breast',
+      unit: 'g',
+    });
+    expect(shoppingApiMock.getIngredientBalance).toHaveBeenCalled();
+  }));
+
+  it('shows the empty state when nothing is at home', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(empty)));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const empty_ = fixture.nativeElement.querySelector('.empty-state');
+    expect(empty_).toBeTruthy();
+    expect(empty_.textContent).toContain('Nothing in your pantry yet');
+  }));
+
+  it('surfaces error on load failure', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+    fixture.detectChanges();
+    tick();
+
+    expect(component.serverError()).toBe('shopping.pantry.errors.loadFailed');
+  }));
+});

--- a/client/apps/shopping/src/app/pantry/pantry.component.ts
+++ b/client/apps/shopping/src/app/pantry/pantry.component.ts
@@ -1,0 +1,83 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  computed,
+  DestroyRef,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+import {
+  ShoppingApiService,
+  type Freshness,
+  type IngredientBalanceItem,
+  type MarkAsFrozenRequest,
+} from '../api';
+import { createAsyncState, ERROR_MAPS, groupByCategory } from '@yumney/shared/models';
+import { EmptyStateComponent, MessageBannerComponent } from '@yumney/ui';
+
+@Component({
+  selector: 'yn-pantry',
+  imports: [TranslocoModule, LucideAngularModule, EmptyStateComponent, MessageBannerComponent],
+  templateUrl: './pantry.component.html',
+  styleUrl: './pantry.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PantryComponent implements OnInit {
+  private shoppingApi = inject(ShoppingApiService);
+  private destroyRef = inject(DestroyRef);
+  private loadState = createAsyncState(this.destroyRef);
+  private freezeState = createAsyncState(this.destroyRef);
+
+  items = signal<IngredientBalanceItem[]>([]);
+  isLoading = this.loadState.isLoading;
+  serverError = computed(() => this.freezeState.serverError() ?? this.loadState.serverError());
+
+  // The balance endpoint returns items in no particular order; group them by
+  // category for the merged-list-style "sections per area of the kitchen"
+  // layout. groupByCategory takes a key function so we don't need to reshape
+  // the items.
+  groups = computed(() => groupByCategory(this.items(), (item) => item.category));
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  // Visual nudge tier — drives the color chip per row. Backend Freshness
+  // values map directly; NotTracked (staples + pantry items) hides the chip.
+  freshnessTone(freshness: Freshness): 'fresh' | 'use-soon' | 'check-it' | null {
+    switch (freshness) {
+      case 'Fresh':
+        return 'fresh';
+      case 'UseSoon':
+        return 'use-soon';
+      case 'CheckIt':
+        return 'check-it';
+      default:
+        return null;
+    }
+  }
+
+  onFreeze(item: IngredientBalanceItem): void {
+    const request: MarkAsFrozenRequest = { name: item.itemName, unit: item.unit };
+    this.freezeState.execute(
+      this.shoppingApi.markAsFrozen(request),
+      ERROR_MAPS.shopping.pantry.freeze,
+      () => this.load(),
+    );
+  }
+
+  onRetry(): void {
+    this.load();
+  }
+
+  private load(): void {
+    this.loadState.execute(
+      this.shoppingApi.getIngredientBalance(),
+      ERROR_MAPS.shopping.pantry.load,
+      (response) => this.items.set(response.items),
+    );
+  }
+}

--- a/client/apps/shopping/src/app/shopping.routes.ts
+++ b/client/apps/shopping/src/app/shopping.routes.ts
@@ -9,6 +9,12 @@ const SHOPPING_SCOPE_PROVIDERS = [provideTranslocoScope('shopping')];
 
 export const shoppingRoutes: Route[] = [
   {
+    path: 'pantry',
+    title: 'Pantry — Yumney',
+    providers: SHOPPING_SCOPE_PROVIDERS,
+    loadComponent: () => import('./pantry').then((m) => m.PantryComponent),
+  },
+  {
     path: 'create/:recipeIdentifier',
     title: 'Create Shopping List — Yumney',
     providers: SHOPPING_SCOPE_PROVIDERS,

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -49,6 +49,13 @@ export type {
   RemoveItemRequest,
 } from './lib/merged-shopping-list';
 export type { ShoppingListSummary } from './lib/shopping-list-summary';
+export type {
+  Freshness,
+  IngredientBalance,
+  IngredientBalanceItem,
+  IngredientBalanceSource,
+  MarkAsFrozenRequest,
+} from './lib/ingredient-balance';
 
 // --- Chat ---
 export { ChatApiService } from './lib/chat-api.service';

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -29,6 +29,8 @@ export const API_ENDPOINTS = {
     checkAll: (listIdentifier: string) => `${API_BASE}/shopping-lists/${listIdentifier}/check-all`,
     merged: `${API_BASE}/shopping-lists/merged`,
     items: `${API_BASE}/shopping-lists/items`,
+    itemsFreeze: `${API_BASE}/shopping-lists/items/freeze`,
+    balance: `${API_BASE}/shopping-lists/balance`,
     export: `${API_BASE}/shopping-lists/export`,
     shoppingModeStart: `${API_BASE}/shopping-lists/shopping-mode/start`,
     shoppingModeEnd: `${API_BASE}/shopping-lists/shopping-mode/end`,

--- a/client/libs/shared/api-client/src/lib/ingredient-balance.ts
+++ b/client/libs/shared/api-client/src/lib/ingredient-balance.ts
@@ -1,0 +1,22 @@
+export type Freshness = 'NotTracked' | 'Fresh' | 'UseSoon' | 'CheckIt';
+
+export type IngredientBalanceSource = 'AtHome' | 'Staple';
+
+export interface IngredientBalanceItem {
+  itemName: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  source: IngredientBalanceSource;
+  freshness: Freshness;
+  daysSinceBought: number | null;
+}
+
+export interface IngredientBalance {
+  items: IngredientBalanceItem[];
+}
+
+export interface MarkAsFrozenRequest {
+  name: string;
+  unit?: string | null;
+}

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -13,6 +13,7 @@ import type {
   AddedItem,
   RemoveItemRequest,
 } from './merged-shopping-list';
+import type { IngredientBalance, MarkAsFrozenRequest } from './ingredient-balance';
 
 @Injectable({ providedIn: 'root' })
 export class ShoppingApiService {
@@ -91,5 +92,13 @@ export class ShoppingApiService {
     return this.http.post<void>(API_ENDPOINTS.shoppingLists.shoppingModeEnd, {
       acceptPendingChanges,
     });
+  }
+
+  getIngredientBalance(): Observable<IngredientBalance> {
+    return this.http.get<IngredientBalance>(API_ENDPOINTS.shoppingLists.balance);
+  }
+
+  markAsFrozen(request: MarkAsFrozenRequest): Observable<void> {
+    return this.http.post<void>(API_ENDPOINTS.shoppingLists.itemsFreeze, request);
   }
 }

--- a/client/libs/shared/models/src/lib/error-maps.ts
+++ b/client/libs/shared/models/src/lib/error-maps.ts
@@ -62,6 +62,14 @@ export const ERROR_MAPS = {
         default: 'shopping.errors.exportFailed',
       } satisfies HttpErrorMap,
     },
+    pantry: {
+      load: {
+        default: 'shopping.pantry.errors.loadFailed',
+      } satisfies HttpErrorMap,
+      freeze: {
+        default: 'shopping.pantry.errors.freezeFailed',
+      } satisfies HttpErrorMap,
+    },
   },
   mealPlanner: {
     assign: {

--- a/client/libs/shared/models/src/lib/route-paths.ts
+++ b/client/libs/shared/models/src/lib/route-paths.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   mealPlanner: '/meal-planner',
   shopping: {
     list: '/shopping',
+    pantry: '/shopping/pantry',
     detail: (identifier: string) => `/shopping/lists/${identifier}`,
     create: (recipeId: string) => `/shopping/create/${recipeId}`,
   },

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -21,6 +21,10 @@
           <lucide-icon name="shopping-cart" [size]="18" class="nav-icon" />
           <span class="nav-label">{{ t('layout.header.shoppingLists') }}</span>
         </a>
+        <a [routerLink]="ROUTES.shopping.pantry" class="nav-link">
+          <lucide-icon name="package" [size]="18" class="nav-icon" />
+          <span class="nav-label">{{ t('layout.header.pantry') }}</span>
+        </a>
         <a [routerLink]="ROUTES.mealPlanner" class="nav-link">
           <lucide-icon name="calendar-days" [size]="18" class="nav-icon" />
           <span class="nav-label">{{ t('layout.header.mealPlanner') }}</span>

--- a/client/libs/ui/src/lib/header/header.component.spec.ts
+++ b/client/libs/ui/src/lib/header/header.component.spec.ts
@@ -18,6 +18,7 @@ const en = {
       recipes: 'My Recipes',
       cookable: 'What can I cook?',
       shoppingLists: 'Shopping Lists',
+      pantry: 'Pantry',
       mealPlanner: 'Meal Planner',
       logout: 'Logout',
       login: 'Login',


### PR DESCRIPTION
## Summary

Backend for US-341 has been shipping in pieces since #340 ingredient balance, #341 perishable freshness on the projection, and the \`/items/freeze\` endpoint. This wires the user-facing half.

### New page: \`/shopping/pantry\`

- Reads \`GET /api/v1/shopping-lists/balance\`, groups items by category using the existing \`groupByCategory\` helper
- Per-row freshness chip in three tiers — 🟢 \`Fresh\` / 🟡 \`UseSoon\` / 🔴 \`CheckIt\`. \`NotTracked\` items (staples + shelf-stable pantry) get no chip so the eye goes to what needs attention
- \"Bought 2d ago\"-style hint next to the chip when \`DaysSinceBought\` is set
- \"I froze it\" button per tracked at-home item → \`POST /items/freeze\` with \`{ name, unit }\`; on success re-loads the balance so the chip disappears
- Empty-state copy when nothing is at home yet

### Navigation

- Header nav entry between \"Shopping Lists\" and \"Meal Planner\" (package icon)
- \`layout.header.pantry\` backfilled across all 4 per-MFE i18n copies so the shared-subtree drift check stays green

### i18n

- EN + DE \`shopping.pantry.*\` scope keys
- Synced into shell

## Test plan

- [x] \`nx test shopping\` (63 tests, +6 for Pantry)
- [x] \`nx test ui -- --run header\` (header nav entry assertion updated)
- [x] \`nx run-many -t lint\`
- [x] \`nx build shopping\`
- [x] \`yarn sync:i18n:check\`

Closes the frontend slice of #182.

## Out of scope

- Recipe-detail integration of freshness (the perishable-first ranking is already live in \`/what-can-i-cook\` from US-342)
- Notification / push nudge — separate slice