### PR TITLE
fix(test): tighten Wolverine for E2E + CI-aware Eventually timeout (#606)

### DIFF
--- a/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
@@ -61,6 +61,7 @@ public static class WolverineEventBusExtensions
 		// module's handler runs per message). Prefixing with the application
 		// name gives each module an isolated queue that receives every message.
 		var moduleQueuePrefix = builder.Environment.ApplicationName ?? "yumney-app";
+		var isE2ETests = builder.Configuration.GetValue<bool>("E2ETests");
 
 		builder.Host.UseWolverine(opts =>
 		{
@@ -84,6 +85,18 @@ public static class WolverineEventBusExtensions
 				{
 					routing.QueueNameForListener(eventType => $"{moduleQueuePrefix}.{eventType.FullName}");
 				});
+
+			if (isE2ETests)
+			{
+				// Single-node integration-test process: Solo durability mode skips
+				// the multi-node health-check / agent-election overhead, and a
+				// tighter scheduled-job poll lets the outbox flush in tens of
+				// milliseconds instead of seconds. The combination removes the
+				// dominant cold-start delay that caused `Eventually.AssertAsync`
+				// to time out on first writes — see issue #606.
+				opts.Durability.Mode = DurabilityMode.Solo;
+				opts.Durability.ScheduledJobPollingTime = TimeSpan.FromMilliseconds(100);
+			}
 
 			foreach (var assembly in eventHandlerAssemblies)
 			{

--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -15,29 +15,38 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 /// </summary>
 public static class Eventually
 {
-	// 30s is a deliberate trade between fast feedback and tolerance for
-	// suite-wide load. Wolverine handlers race the polling assert; with the
-	// full integration suite running on a cold GitHub Actions runner,
-	// RabbitMQ + projection workers can stack up enough that a single
-	// check-off event needs >15s to surface in the read model — see
-	// issue #606 for the recurrence trail. 30s leaves headroom without
-	// making a real failure (a handler bug that never converges) feel
-	// sluggish; a converging handler typically wins on the first or second
-	// poll, so the timeout is only paid on genuine breakage.
-	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+	// Local default sits at 30s — fast enough for inner-loop iteration on a
+	// warm machine, generous enough that a converging handler always wins.
+	//
+	// On CI the same suite shares a runner with the full backend test matrix
+	// plus a cold AppHost boot, so the first writes can serialise behind
+	// Wolverine + RabbitMQ start-up. We double to 60s there to keep the
+	// recurrence trail under issue #606 from flaking PRs that are otherwise
+	// green. A genuinely broken handler still surfaces inside the window
+	// because polling probes every 100 ms.
+	private static readonly TimeSpan LocalTimeout = TimeSpan.FromSeconds(30);
+	private static readonly TimeSpan CiTimeout = TimeSpan.FromSeconds(60);
 	private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
+
+	private static readonly bool IsCi = IsRunningOnCi();
+
+	private static TimeSpan DefaultTimeout => IsCi ? CiTimeout : LocalTimeout;
 
 	public static async Task AssertAsync(
 		Func<Task> assertion,
 		TimeSpan? timeout = null,
 		TimeSpan? pollInterval = null)
 	{
-		var deadline = DateTime.UtcNow + (timeout ?? DefaultTimeout);
+		var effectiveTimeout = timeout ?? DefaultTimeout;
+		var start = DateTime.UtcNow;
+		var deadline = start + effectiveTimeout;
 		var interval = pollInterval ?? DefaultPollInterval;
 		Exception? lastError = null;
+		var attempts = 0;
 
 		while (true)
 		{
+			attempts++;
 			try
 			{
 				await assertion();
@@ -55,6 +64,20 @@ public static class Eventually
 			}
 		}
 
-		throw lastError!;
+		var elapsed = DateTime.UtcNow - start;
+		throw new TimeoutException(
+			$"Eventually.AssertAsync timed out after {elapsed.TotalSeconds:F1}s "
+			+ $"and {attempts} attempts (configured timeout {effectiveTimeout.TotalSeconds:F0}s, "
+			+ $"CI={IsCi}). Last assertion error: {lastError?.Message}",
+			lastError);
+	}
+
+	private static bool IsRunningOnCi()
+	{
+		// Both GitHub Actions and most other runners set CI=true. Treat any
+		// truthy CI env var as the trigger so the longer timeout applies
+		// uniformly across runner flavours.
+		var ciFlag = Environment.GetEnvironmentVariable("CI");
+		return !string.IsNullOrEmpty(ciFlag) && ciFlag.Equals("true", StringComparison.OrdinalIgnoreCase);
 	}
 }


### PR DESCRIPTION
## Summary

Issue #606 catalogued a recurring ~30-50% flake on the Shopping eventual-consistency integration tests (`ShoppingListCreateFlowTests.CreateAndCheckOff_PersistsCheckedState`, `CheckOffItemContractTests.CheckOff_IsCheckedTrue_*`). The issue listed three candidate fixes; this PR takes the lowest-risk variant of fix #1 + the smarter version of fix #2.

### Root cause

Two compounding factors:

1. **Wolverine's default durability is built for clusters.** It runs node-election + health-check + agent-bootstrap machinery whose first-run cost stacks on top of RabbitMQ provisioning. The scheduled-job poll (which advances the outbox) defaults to several seconds — production-appropriate, far too coarse for a test that wants the projection visible on the very next GET.
2. **`Eventually.AssertAsync` used one default timeout (30s) regardless of environment.** Locally 30s is generous; on a saturated GitHub Actions runner the cold-start Wolverine cycle + RabbitMQ delivery walked past it.

### Changes

- `Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs` — when the host runs with `E2ETests=true`, switch to `DurabilityMode.Solo` (single-node test process, no cluster bookkeeping) and set `ScheduledJobPollingTime` to 100 ms. Production wiring untouched.
- `Yumney.Integration.Tests/Fixtures/Eventually.cs` — CI-aware default timeout: 60 s when `CI=true`, 30 s locally. Polling cadence stays at 100 ms. On timeout the thrown `TimeoutException` carries elapsed time + attempt count + CI flag so a future regression is diagnosable from the stack trace alone.

### Why not the other suggested fixes

- **Sync drain test hook (#1 in the issue).** Wolverine's `TrackedSession` requires the test to own the IHost in-process; our Aspire fixture starts each API as a separate process, so the tracking surface isn't accessible. A custom `/_test/drain` endpoint would work but adds a production-flagged route and a chunk of new infrastructure. Held in reserve if Solo-mode + adaptive timeout isn't enough.
- **Test-runner retries (#3).** Masks the issue; correctly flagged as least-preferred in the issue text.

## Verification

Local: three consecutive green runs of the targeted suite, no retries.

\`\`\`
dotnet test tests/Yumney.Integration.Tests \
  --filter \"FullyQualifiedName~ShoppingListCreateFlowTests|FullyQualifiedName~CheckOffItemContractTests\"
# Run 1: 12 / 12 passed (1m 46s cold start)
# Run 2: 12 / 12 passed (10s, warm containers)
# Run 3: 12 / 12 passed (10s, warm containers)
\`\`\`

## Test plan

- [x] `dotnet build` clean with TreatWarningsAsErrors
- [x] `dotnet format --verify-no-changes` clean
- [x] Three consecutive green runs of the originally flaky tests locally
- [ ] Backend CI green on this PR
- [ ] Two-week soak (per issue AC) — track flake recurrence after merge

Closes #606.