### PR TITLE
feat(mealplan): cooking analytics dashboard (US-332)

### DIFF
--- a/client/apps/shell-e2e/src/a11y/a11y-smoke.spec.ts
+++ b/client/apps/shell-e2e/src/a11y/a11y-smoke.spec.ts
@@ -83,6 +83,13 @@ test.describe('A11y smoke (#411)', () => {
     await runAxe(authenticatedPage);
   });
 
+  test('meal analytics', async ({ authenticatedPage }) => {
+    const shell = new AppShellPage(authenticatedPage);
+    await authenticatedPage.goto('/meal-planner/analytics');
+    await expect(shell.heading).toBeVisible({ timeout: TIMEOUTS.default });
+    await runAxe(authenticatedPage);
+  });
+
   test('account profile', async ({ authenticatedPage }) => {
     const shell = new AppShellPage(authenticatedPage);
     // /account is the profile-settings route — mirrors profile-settings.spec.ts

--- a/client/apps/shell-e2e/src/meal-planner/meal-analytics.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-analytics.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { MealAnalyticsPage } from '../pages/meal-analytics.page';
+import { MealPlannerPage } from '../pages/meal-planner.page';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+test.describe('Meal Analytics (US-332)', () => {
+  test('loads the analytics page with the period toolbar', async ({ authenticatedPage }) => {
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    await analytics.goto();
+
+    await expect(analytics.heading).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(analytics.monthToggle).toBeVisible();
+    await expect(analytics.yearToggle).toBeVisible();
+    await expect(analytics.periodLabel).toBeVisible();
+  });
+
+  test('period label matches the monthly format by default', async ({ authenticatedPage }) => {
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    await analytics.goto();
+
+    await expect(analytics.periodLabel).toBeVisible({ timeout: TIMEOUTS.default });
+    const label = await analytics.periodLabel.textContent();
+    expect(label).toMatch(/^\d{4}-\d{2}$/);
+  });
+
+  test('switching to yearly view changes the period format', async ({ authenticatedPage }) => {
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    await analytics.goto();
+
+    await expect(analytics.periodLabel).toBeVisible({ timeout: TIMEOUTS.default });
+    await analytics.yearToggle.click();
+
+    const label = await analytics.periodLabel.textContent();
+    expect(label).toMatch(/^\d{4}$/);
+  });
+
+  test('next-period advances the label', async ({ authenticatedPage }) => {
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    await analytics.goto();
+
+    await expect(analytics.periodLabel).toBeVisible({ timeout: TIMEOUTS.default });
+    const before = await analytics.periodLabel.textContent();
+    await analytics.nextPeriod.click();
+    await expect(analytics.periodLabel).not.toHaveText(before ?? '');
+  });
+
+  test('back link returns to the meal planner', async ({ authenticatedPage }) => {
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    const planner = new MealPlannerPage(authenticatedPage);
+    await analytics.goto();
+
+    await expect(analytics.back).toBeVisible({ timeout: TIMEOUTS.default });
+    await analytics.back.click();
+
+    await expect(planner.weekLabel).toBeVisible({ timeout: TIMEOUTS.default });
+  });
+
+  test('opening analytics from the meal-planner header works', async ({ authenticatedPage }) => {
+    const planner = new MealPlannerPage(authenticatedPage);
+    const analytics = new MealAnalyticsPage(authenticatedPage);
+    await planner.goto();
+
+    await expect(planner.weekLabel).toBeVisible({ timeout: TIMEOUTS.default });
+    const openAnalytics = authenticatedPage.locator('[data-testid="meal-planner-open-analytics"]');
+    await expect(openAnalytics).toBeVisible();
+    await openAnalytics.click();
+
+    await expect(analytics.heading).toBeVisible({ timeout: TIMEOUTS.default });
+  });
+});

--- a/client/apps/shell-e2e/src/meal-planner/meal-analytics.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-analytics.spec.ts
@@ -30,8 +30,10 @@ test.describe('Meal Analytics (US-332)', () => {
     await expect(analytics.periodLabel).toBeVisible({ timeout: TIMEOUTS.default });
     await analytics.yearToggle.click();
 
-    const label = await analytics.periodLabel.textContent();
-    expect(label).toMatch(/^\d{4}$/);
+    // Polling assertion waits for Angular change detection to propagate the
+    // viewMode flip into the rendered DOM; a one-shot textContent() read can
+    // beat the update.
+    await expect(analytics.periodLabel).toHaveText(/^\d{4}$/);
   });
 
   test('next-period advances the label', async ({ authenticatedPage }) => {

--- a/client/apps/shell-e2e/src/pages/meal-analytics.page.ts
+++ b/client/apps/shell-e2e/src/pages/meal-analytics.page.ts
@@ -1,0 +1,33 @@
+import { type Page, type Locator } from '@playwright/test';
+
+export class MealAnalyticsPage {
+  readonly heading: Locator;
+  readonly back: Locator;
+  readonly monthToggle: Locator;
+  readonly yearToggle: Locator;
+  readonly prevPeriod: Locator;
+  readonly nextPeriod: Locator;
+  readonly periodLabel: Locator;
+  readonly totalCooked: Locator;
+  readonly distribution: Locator;
+  readonly topRecipes: Locator;
+  readonly empty: Locator;
+
+  constructor(private page: Page) {
+    this.heading = page.getByRole('heading', { level: 1 });
+    this.back = page.locator('[data-testid="meal-analytics-back"]');
+    this.monthToggle = page.locator('[data-testid="meal-analytics-view-month"]');
+    this.yearToggle = page.locator('[data-testid="meal-analytics-view-year"]');
+    this.prevPeriod = page.locator('[data-testid="meal-analytics-prev"]');
+    this.nextPeriod = page.locator('[data-testid="meal-analytics-next"]');
+    this.periodLabel = page.locator('[data-testid="meal-analytics-period"]');
+    this.totalCooked = page.locator('[data-testid="meal-analytics-total-cooked"]');
+    this.distribution = page.locator('[data-testid="meal-analytics-distribution"]');
+    this.topRecipes = page.locator('[data-testid="meal-analytics-top-recipes"]');
+    this.empty = page.locator('[data-testid="meal-analytics-empty"]');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/meal-planner/analytics');
+  }
+}

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -392,6 +392,37 @@
         "noRecipes": "Lege mindestens ein Rezept an, bevor du einen Vorschlag anforderst.",
         "failed": "Es konnte kein Vorschlag erstellt werden. Bitte versuche es erneut."
       }
+    },
+    "analytics": {
+      "open": "Auswertungen öffnen",
+      "back": "Zurück zum Essensplaner",
+      "title": "Kochstatistik",
+      "viewToggle": "Ansicht wechseln",
+      "monthly": "Monat",
+      "yearly": "Jahr",
+      "previousPeriod": "Vorheriger Zeitraum",
+      "nextPeriod": "Nächster Zeitraum",
+      "loading": "Statistik wird geladen...",
+      "totalCooked": "Gekochte Mahlzeiten",
+      "uniqueRecipes": "Verschiedene Rezepte",
+      "skipped": "Übersprungen",
+      "mealsPerWeek": "Mahlzeiten / Woche",
+      "discoveryRate": "Neue Rezepte ausprobiert",
+      "discoveryHint": "Rezepte, die du in diesem Zeitraum zum ersten Mal gekocht hast.",
+      "categoryDistribution": "Kategorien-Mix",
+      "topRecipes": "Am häufigsten gekocht",
+      "timesCooked": "{{count}}x gekocht",
+      "empty": "In diesem Zeitraum noch nichts gekocht.",
+      "categories": {
+        "meat": "Fleisch",
+        "fish": "Fisch",
+        "veggie": "Vegetarisch",
+        "vegan": "Vegan",
+        "other": "Sonstiges"
+      },
+      "errors": {
+        "loadFailed": "Statistik konnte nicht geladen werden."
+      }
     }
   },
   "common": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -392,6 +392,37 @@
         "noRecipes": "Add at least one recipe before asking for a suggestion.",
         "failed": "Could not produce a suggested plan. Please try again."
       }
+    },
+    "analytics": {
+      "open": "Open analytics",
+      "back": "Back to meal planner",
+      "title": "Cooking analytics",
+      "viewToggle": "View toggle",
+      "monthly": "Monthly",
+      "yearly": "Yearly",
+      "previousPeriod": "Previous period",
+      "nextPeriod": "Next period",
+      "loading": "Loading analytics...",
+      "totalCooked": "Meals cooked",
+      "uniqueRecipes": "Unique recipes",
+      "skipped": "Skipped",
+      "mealsPerWeek": "Meals / week",
+      "discoveryRate": "New recipes tried",
+      "discoveryHint": "Recipes you cooked for the first time this period.",
+      "categoryDistribution": "Category mix",
+      "topRecipes": "Most cooked",
+      "timesCooked": "{{count}}x cooked",
+      "empty": "No cooked meals in this period yet.",
+      "categories": {
+        "meat": "Meat",
+        "fish": "Fish",
+        "veggie": "Vegetarian",
+        "vegan": "Vegan",
+        "other": "Other"
+      },
+      "errors": {
+        "loadFailed": "Failed to load analytics."
+      }
     }
   },
   "common": {

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -38,6 +38,12 @@ export const appRoutes: Route[] = [
     loadComponent: () => import('./meal-planner').then((m) => m.MealHistoryComponent),
   },
   {
+    path: 'meal-planner/analytics',
+    title: 'Meal Analytics — Yumney',
+    canActivate: [authGuard],
+    loadComponent: () => import('./meal-planner').then((m) => m.MealAnalyticsComponent),
+  },
+  {
     path: 'account',
     title: 'Account — Yumney',
     canActivate: [authGuard],

--- a/client/apps/shell/src/app/meal-planner/index.ts
+++ b/client/apps/shell/src/app/meal-planner/index.ts
@@ -1,2 +1,3 @@
 export { MealPlannerComponent } from './meal-planner.component';
 export { MealHistoryComponent } from './meal-history/meal-history.component';
+export { MealAnalyticsComponent } from './meal-analytics/meal-analytics.component';

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.html
@@ -1,0 +1,154 @@
+<div class="meal-analytics" *transloco="let t">
+  <header class="analytics-header">
+    <a
+      class="back-btn"
+      data-testid="meal-analytics-back"
+      routerLink="/meal-planner"
+      [attr.aria-label]="t('mealPlanner.analytics.back')"
+    >
+      <lucide-icon name="arrow-left" [size]="20" />
+    </a>
+    <h1>{{ t('mealPlanner.analytics.title') }}</h1>
+  </header>
+
+  <div class="period-toolbar">
+    <div class="view-toggle" role="group" [attr.aria-label]="t('mealPlanner.analytics.viewToggle')">
+      <button
+        type="button"
+        class="toggle-btn"
+        data-testid="meal-analytics-view-month"
+        [class.active]="viewMode() === 'month'"
+        [attr.aria-pressed]="viewMode() === 'month'"
+        (click)="onSetView('month')"
+      >
+        {{ t('mealPlanner.analytics.monthly') }}
+      </button>
+      <button
+        type="button"
+        class="toggle-btn"
+        data-testid="meal-analytics-view-year"
+        [class.active]="viewMode() === 'year'"
+        [attr.aria-pressed]="viewMode() === 'year'"
+        (click)="onSetView('year')"
+      >
+        {{ t('mealPlanner.analytics.yearly') }}
+      </button>
+    </div>
+
+    <div class="period-nav">
+      <button
+        type="button"
+        class="nav-btn"
+        data-testid="meal-analytics-prev"
+        [attr.aria-label]="t('mealPlanner.analytics.previousPeriod')"
+        (click)="onPreviousPeriod()"
+      >
+        <lucide-icon name="chevron-left" [size]="20" />
+      </button>
+      <span class="period-label" data-testid="meal-analytics-period">{{ periodLabel() }}</span>
+      <button
+        type="button"
+        class="nav-btn"
+        data-testid="meal-analytics-next"
+        [attr.aria-label]="t('mealPlanner.analytics.nextPeriod')"
+        (click)="onNextPeriod()"
+      >
+        <lucide-icon name="chevron-right" [size]="20" />
+      </button>
+    </div>
+  </div>
+
+  <yn-async-state
+    [loading]="loading()"
+    [error]="error()"
+    loadingKey="mealPlanner.analytics.loading"
+    retryKey="mealPlanner.retry"
+    (retry)="onRetry()"
+  />
+
+  @if (!loading() && !error() && analytics(); as data) {
+    <div class="cards-grid">
+      <div class="stat-card">
+        <div class="stat-label">{{ t('mealPlanner.analytics.totalCooked') }}</div>
+        <div class="stat-value" data-testid="meal-analytics-total-cooked">
+          {{ data.totalCooked }}
+        </div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">{{ t('mealPlanner.analytics.uniqueRecipes') }}</div>
+        <div class="stat-value">{{ data.uniqueRecipes }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">{{ t('mealPlanner.analytics.skipped') }}</div>
+        <div class="stat-value">{{ data.totalSkipped }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">{{ t('mealPlanner.analytics.mealsPerWeek') }}</div>
+        <div class="stat-value">{{ data.mealsPerWeek }}</div>
+      </div>
+      <div class="stat-card stat-card--wide">
+        <div class="stat-label">{{ t('mealPlanner.analytics.discoveryRate') }}</div>
+        <div class="stat-value">{{ data.discoveryRate }}</div>
+        <div class="stat-hint">{{ t('mealPlanner.analytics.discoveryHint') }}</div>
+      </div>
+    </div>
+
+    @if (data.categoryDistribution.length > 0) {
+      <section class="distribution-card" data-testid="meal-analytics-distribution">
+        <h2>{{ t('mealPlanner.analytics.categoryDistribution') }}</h2>
+        <div class="distribution-layout">
+          <svg
+            class="donut"
+            viewBox="0 0 140 140"
+            role="img"
+            [attr.aria-label]="t('mealPlanner.analytics.categoryDistribution')"
+          >
+            <circle class="donut-track" cx="70" cy="70" [attr.r]="donutRadius" />
+            @for (segment of donutSegments(); track segment.category) {
+              <circle
+                class="donut-segment"
+                [class]="'donut-segment--' + segment.category"
+                cx="70"
+                cy="70"
+                [attr.r]="donutRadius"
+                [attr.stroke-dasharray]="segment.dashArray"
+                [attr.stroke-dashoffset]="segment.dashOffset"
+              />
+            }
+          </svg>
+          <ul class="distribution-legend">
+            @for (segment of donutSegments(); track segment.category) {
+              <li class="legend-item">
+                <span class="legend-swatch" [class]="'legend-swatch--' + segment.category"></span>
+                <span class="legend-name">{{
+                  t('mealPlanner.analytics.categories.' + segment.category)
+                }}</span>
+                <span class="legend-share">{{ segment.count }} · {{ segment.percentage }}%</span>
+              </li>
+            }
+          </ul>
+        </div>
+      </section>
+    }
+
+    @if (data.topRecipes.length > 0) {
+      <section class="top-card" data-testid="meal-analytics-top-recipes">
+        <h2>{{ t('mealPlanner.analytics.topRecipes') }}</h2>
+        <ol class="top-list">
+          @for (recipe of data.topRecipes; track recipe.recipeIdentifier) {
+            <li class="top-item">
+              <span class="top-title">{{ recipe.recipeTitle }}</span>
+              <span class="top-count">{{
+                t('mealPlanner.analytics.timesCooked', { count: recipe.cookCount })
+              }}</span>
+            </li>
+          }
+        </ol>
+      </section>
+    }
+
+    @if (data.totalCooked === 0) {
+      <p class="empty" data-testid="meal-analytics-empty">{{ t('mealPlanner.analytics.empty') }}</p>
+    }
+  }
+</div>

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.scss
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.scss
@@ -1,0 +1,288 @@
+@use 'glass';
+@use 'breakpoints' as bp;
+
+.meal-analytics {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--yn-space-5);
+}
+
+.analytics-header {
+  display: flex;
+  align-items: center;
+  gap: var(--yn-space-4);
+  margin-bottom: var(--yn-space-5);
+
+  h1 {
+    margin: 0;
+    font-size: var(--yn-text-2xl);
+    font-weight: var(--yn-font-bold);
+    color: var(--yn-text);
+  }
+}
+
+.back-btn {
+  @include glass.glass-surface(1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--yn-radius-circle);
+  border: 1px solid var(--yn-glass-border);
+  color: var(--yn-text);
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    background: var(--yn-glass-bg-elevated);
+  }
+}
+
+.period-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--yn-space-4);
+  margin-bottom: var(--yn-space-5);
+}
+
+.view-toggle {
+  display: inline-flex;
+  border-radius: var(--yn-radius-button);
+  overflow: hidden;
+  border: 1px solid var(--yn-glass-border);
+}
+
+.toggle-btn {
+  padding: var(--yn-space-2) var(--yn-space-4);
+  background: transparent;
+  color: var(--yn-text-muted);
+  border: none;
+  font-size: var(--yn-text-sm);
+  font-weight: var(--yn-font-semibold);
+  cursor: pointer;
+
+  &.active {
+    background: var(--yn-primary);
+    color: var(--yn-text-inverse);
+  }
+}
+
+.period-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-3);
+}
+
+.nav-btn {
+  @include glass.glass-surface(1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-circle);
+  background: transparent;
+  color: var(--yn-text);
+  cursor: pointer;
+}
+
+.period-label {
+  font-size: var(--yn-text-lg);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text);
+  min-width: 100px;
+  text-align: center;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--yn-space-3);
+  margin-bottom: var(--yn-space-5);
+
+  @include bp.respond-below('lg') {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.stat-card {
+  @include glass.glass-surface(1);
+  padding: var(--yn-space-4);
+  border-radius: var(--yn-radius-card);
+  border: 1px solid var(--yn-glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-1);
+
+  &--wide {
+    grid-column: span 2;
+  }
+}
+
+.stat-label {
+  font-size: var(--yn-text-xs);
+  font-weight: var(--yn-font-semibold);
+  color: var(--yn-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-value {
+  font-size: var(--yn-text-3xl);
+  font-weight: var(--yn-font-bold);
+  color: var(--yn-text);
+}
+
+.stat-hint {
+  margin-top: var(--yn-space-1);
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+}
+
+.distribution-card,
+.top-card {
+  @include glass.glass-surface(1);
+  border: 1px solid var(--yn-glass-border);
+  border-radius: var(--yn-radius-card);
+  padding: var(--yn-space-5);
+  margin-bottom: var(--yn-space-5);
+
+  h2 {
+    margin: 0 0 var(--yn-space-4);
+    font-size: var(--yn-text-lg);
+    font-weight: var(--yn-font-semibold);
+    color: var(--yn-text);
+  }
+}
+
+.distribution-layout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--yn-space-5);
+}
+
+.donut {
+  width: 140px;
+  height: 140px;
+  flex-shrink: 0;
+}
+
+.donut-track {
+  fill: none;
+  stroke: var(--yn-glass-bg-elevated);
+  stroke-width: 14;
+}
+
+.donut-segment {
+  fill: none;
+  stroke-width: 14;
+  transform: rotate(-90deg);
+  transform-origin: 70px 70px;
+  transition: stroke-dasharray var(--yn-duration-fast) var(--yn-ease-glass);
+}
+
+.donut-segment--meat {
+  stroke: #b91c1c;
+}
+
+.donut-segment--fish {
+  stroke: #0284c7;
+}
+
+.donut-segment--veggie {
+  stroke: #16a34a;
+}
+
+.donut-segment--vegan {
+  stroke: #15803d;
+}
+
+.donut-segment--other {
+  stroke: #6b7280;
+}
+
+.distribution-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+  flex: 1;
+  min-width: 200px;
+}
+
+.legend-item {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  align-items: center;
+  gap: var(--yn-space-3);
+  font-size: var(--yn-text-sm);
+}
+
+.legend-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+}
+
+.legend-swatch--meat {
+  background: #b91c1c;
+}
+
+.legend-swatch--fish {
+  background: #0284c7;
+}
+
+.legend-swatch--veggie {
+  background: #16a34a;
+}
+
+.legend-swatch--vegan {
+  background: #15803d;
+}
+
+.legend-swatch--other {
+  background: #6b7280;
+}
+
+.legend-share {
+  color: var(--yn-text-muted);
+}
+
+.top-list {
+  list-style: decimal inside;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yn-space-2);
+}
+
+.top-item {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--yn-space-3);
+  font-size: var(--yn-text-base);
+}
+
+.top-title {
+  color: var(--yn-text);
+  font-weight: var(--yn-font-semibold);
+}
+
+.top-count {
+  color: var(--yn-text-muted);
+  font-size: var(--yn-text-sm);
+}
+
+.empty {
+  text-align: center;
+  color: var(--yn-text-muted);
+  padding: var(--yn-space-7);
+}

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.spec.ts
@@ -1,0 +1,151 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { MealPlanApiService, type MealAnalytics } from '@yumney/shared/api-client';
+import { setupTranslocoTesting } from '@yumney/shared/models';
+import { provideYumneyIcons } from '@yumney/ui';
+import { MealAnalyticsComponent } from './meal-analytics.component';
+
+const en = {
+  mealPlanner: {
+    retry: 'Retry',
+    analytics: {
+      back: 'Back',
+      title: 'Analytics',
+      viewToggle: 'View',
+      monthly: 'Month',
+      yearly: 'Year',
+      previousPeriod: 'Prev',
+      nextPeriod: 'Next',
+      loading: 'Loading',
+      totalCooked: 'Cooked',
+      uniqueRecipes: 'Unique',
+      skipped: 'Skipped',
+      mealsPerWeek: 'Per week',
+      discoveryRate: 'New',
+      discoveryHint: 'Hint',
+      categoryDistribution: 'Mix',
+      topRecipes: 'Top',
+      timesCooked: '{{count}}x',
+      empty: 'None',
+      categories: { meat: 'Meat', fish: 'Fish', veggie: 'Veg', vegan: 'Vegan', other: 'Other' },
+    },
+  },
+};
+
+function makeAnalytics(overrides: Partial<MealAnalytics> = {}): MealAnalytics {
+  return {
+    period: '2026-05',
+    totalCooked: 12,
+    totalSkipped: 2,
+    uniqueRecipes: 7,
+    mealsPerWeek: 2.8,
+    discoveryRate: 3,
+    topRecipes: [
+      {
+        recipeIdentifier: '11111111-1111-1111-1111-111111111111',
+        recipeTitle: 'Lasagna',
+        cookCount: 4,
+      },
+    ],
+    categoryDistribution: [
+      { category: 'meat', count: 8, percentage: 66.7 },
+      { category: 'veggie', count: 4, percentage: 33.3 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('MealAnalyticsComponent', () => {
+  let fixture: ComponentFixture<MealAnalyticsComponent>;
+  let apiMock: { getMealAnalytics: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    apiMock = { getMealAnalytics: vi.fn().mockReturnValue(of(makeAnalytics())) };
+
+    await TestBed.configureTestingModule({
+      imports: [MealAnalyticsComponent, setupTranslocoTesting(en)],
+      providers: [
+        provideYumneyIcons(),
+        provideRouter([]),
+        { provide: MealPlanApiService, useValue: apiMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MealAnalyticsComponent);
+    fixture.detectChanges();
+  });
+
+  it('loads analytics with month view on init', () => {
+    expect(apiMock.getMealAnalytics).toHaveBeenCalled();
+    const [, month] = apiMock.getMealAnalytics.mock.calls[0];
+    expect(typeof month).toBe('number');
+  });
+
+  it('renders total cooked stat', () => {
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="meal-analytics-total-cooked"]')
+        .textContent,
+    ).toContain('12');
+  });
+
+  it('renders the category-distribution legend with segments per category', () => {
+    const swatches = fixture.nativeElement.querySelectorAll('.legend-swatch');
+    expect(swatches.length).toBe(2);
+  });
+
+  it('renders the top-recipes list', () => {
+    const list = fixture.nativeElement.querySelector('[data-testid="meal-analytics-top-recipes"]');
+    expect(list).toBeTruthy();
+    expect(list.textContent).toContain('Lasagna');
+  });
+
+  it('switches to year view and reloads without a month param', () => {
+    apiMock.getMealAnalytics.mockClear();
+    fixture.componentInstance['onSetView']('year');
+
+    expect(apiMock.getMealAnalytics).toHaveBeenCalledTimes(1);
+    const [, month] = apiMock.getMealAnalytics.mock.calls[0];
+    expect(month).toBeUndefined();
+  });
+
+  it('next-period in month view advances the month and reloads', () => {
+    fixture.componentInstance['month'].set(3);
+    apiMock.getMealAnalytics.mockClear();
+
+    fixture.componentInstance['onNextPeriod']();
+
+    expect(fixture.componentInstance['month']()).toBe(4);
+    expect(apiMock.getMealAnalytics).toHaveBeenCalled();
+  });
+
+  it('next-period wraps from December to January and bumps the year', () => {
+    fixture.componentInstance['month'].set(12);
+    fixture.componentInstance['year'].set(2026);
+
+    fixture.componentInstance['onNextPeriod']();
+
+    expect(fixture.componentInstance['month']()).toBe(1);
+    expect(fixture.componentInstance['year']()).toBe(2027);
+  });
+
+  it('shows the empty hint when there are no cooked meals', () => {
+    apiMock.getMealAnalytics.mockReturnValue(
+      of(makeAnalytics({ totalCooked: 0, topRecipes: [], categoryDistribution: [] })),
+    );
+    fixture.componentInstance['onRetry']();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="meal-analytics-empty"]'),
+    ).toBeTruthy();
+  });
+
+  it('surfaces errors from the API', () => {
+    apiMock.getMealAnalytics.mockReturnValue(throwError(() => new Error('boom')));
+    fixture.componentInstance['onRetry']();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.error')).toBeTruthy();
+  });
+});

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
@@ -1,0 +1,116 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+import { MealPlanApiService, type MealAnalytics } from '@yumney/shared/api-client';
+import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
+import { AsyncStateComponent } from '@yumney/ui';
+
+type ViewMode = 'month' | 'year';
+
+const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+const DONUT_RADIUS = 56;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+
+@Component({
+  selector: 'yn-meal-analytics',
+  standalone: true,
+  imports: [TranslocoModule, LucideAngularModule, RouterLink, AsyncStateComponent],
+  templateUrl: './meal-analytics.component.html',
+  styleUrl: './meal-analytics.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MealAnalyticsComponent {
+  private api = inject(MealPlanApiService);
+  private destroyRef = inject(DestroyRef);
+  private loadState = createAsyncState(this.destroyRef);
+
+  protected viewMode = signal<ViewMode>('month');
+  protected year = signal(new Date().getFullYear());
+  protected month = signal(new Date().getMonth() + 1);
+  protected analytics = signal<MealAnalytics | null>(null);
+
+  protected loading = this.loadState.isLoading;
+  protected error = this.loadState.serverError;
+
+  protected months = MONTHS;
+
+  protected periodLabel = computed(() => {
+    if (this.viewMode() === 'year') return String(this.year());
+    return `${this.year()}-${String(this.month()).padStart(2, '0')}`;
+  });
+
+  protected donutSegments = computed(() => {
+    const distribution = this.analytics()?.categoryDistribution ?? [];
+    let offset = 0;
+    return distribution.map((share) => {
+      const length = (share.percentage / 100) * DONUT_CIRCUMFERENCE;
+      const segment = {
+        category: share.category,
+        count: share.count,
+        percentage: share.percentage,
+        dashArray: `${length} ${DONUT_CIRCUMFERENCE - length}`,
+        dashOffset: -offset,
+      };
+      offset += length;
+      return segment;
+    });
+  });
+
+  protected circumference = DONUT_CIRCUMFERENCE;
+  protected donutRadius = DONUT_RADIUS;
+
+  constructor() {
+    this.loadAnalytics();
+  }
+
+  protected onSetView(mode: ViewMode): void {
+    this.viewMode.set(mode);
+    this.loadAnalytics();
+  }
+
+  protected onPreviousPeriod(): void {
+    if (this.viewMode() === 'year') {
+      this.year.update((year) => year - 1);
+    } else if (this.month() <= 1) {
+      this.year.update((year) => year - 1);
+      this.month.set(12);
+    } else {
+      this.month.update((value) => value - 1);
+    }
+    this.loadAnalytics();
+  }
+
+  protected onNextPeriod(): void {
+    if (this.viewMode() === 'year') {
+      this.year.update((year) => year + 1);
+    } else if (this.month() >= 12) {
+      this.year.update((year) => year + 1);
+      this.month.set(1);
+    } else {
+      this.month.update((value) => value + 1);
+    }
+    this.loadAnalytics();
+  }
+
+  protected onRetry(): void {
+    this.loadAnalytics();
+  }
+
+  private loadAnalytics(): void {
+    const month = this.viewMode() === 'month' ? this.month() : undefined;
+    this.loadState.execute(
+      this.api.getMealAnalytics(this.year(), month),
+      ERROR_MAPS.mealPlanner.analytics,
+      (result) => this.analytics.set(result),
+    );
+  }
+}

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -31,6 +31,14 @@
     >
       <lucide-icon name="search" [size]="20" />
     </button>
+    <button
+      class="nav-btn"
+      data-testid="meal-planner-open-analytics"
+      (click)="onOpenAnalytics()"
+      [attr.aria-label]="t('mealPlanner.analytics.open')"
+    >
+      <lucide-icon name="bar-chart-3" [size]="20" />
+    </button>
   </div>
 
   <yn-async-state

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -108,6 +108,10 @@ export class MealPlannerComponent {
     void this.router.navigate(['/meal-planner/history']);
   }
 
+  protected onOpenAnalytics(): void {
+    void this.router.navigate(['/meal-planner/analytics']);
+  }
+
   protected onPreviousWeek(): void {
     if (this.weekNumber() <= 1) {
       this.year.update((year) => year - 1);

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -86,6 +86,9 @@ export type {
   SearchHistoryParams,
   WeekSuggestion,
   WeekSuggestionEntry,
+  MealAnalytics,
+  TopRecipe,
+  CategoryShare,
 } from './lib/meal-plan';
 
 // --- Dashboard ---

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -56,6 +56,7 @@ export const API_ENDPOINTS = {
     copyTo: (srcYear: number, srcWeek: number, dstYear: number, dstWeek: number) =>
       `${API_BASE}/meal-plans/${srcYear}/w/${srcWeek}/copy-to/${dstYear}/${dstWeek}`,
     suggest: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/suggest`,
+    analytics: `${API_BASE}/meal-plans/analytics`,
   },
   auth: {
     register: `${API_BASE}/auth/register`,

--- a/client/libs/shared/api-client/src/lib/meal-plan-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan-api.service.spec.ts
@@ -334,4 +334,40 @@ describe('MealPlanApiService', () => {
       req.flush(mockSuggestion);
     });
   });
+
+  describe('getMealAnalytics', () => {
+    const mockAnalytics = {
+      period: '2026-05',
+      totalCooked: 10,
+      totalSkipped: 1,
+      uniqueRecipes: 6,
+      mealsPerWeek: 2.3,
+      discoveryRate: 2,
+      topRecipes: [],
+      categoryDistribution: [],
+    };
+
+    it('GETs /meal-plans/analytics with year only when month is omitted', () => {
+      service.getMealAnalytics(2026).subscribe();
+
+      const req = httpTesting.expectOne(
+        (request) =>
+          request.url === API_ENDPOINTS.mealPlans.analytics &&
+          request.params.get('year') === '2026',
+      );
+      expect(req.request.params.has('month')).toBe(false);
+      req.flush(mockAnalytics);
+    });
+
+    it('passes month as a query param when provided', () => {
+      service.getMealAnalytics(2026, 5).subscribe();
+
+      const req = httpTesting.expectOne(
+        (request) => request.url === API_ENDPOINTS.mealPlans.analytics,
+      );
+      expect(req.request.params.get('year')).toBe('2026');
+      expect(req.request.params.get('month')).toBe('5');
+      req.flush(mockAnalytics);
+    });
+  });
 });

--- a/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
@@ -16,6 +16,7 @@ import type {
   MealHistoryEntry,
   SearchHistoryParams,
   WeekSuggestion,
+  MealAnalytics,
 } from './meal-plan';
 
 @Injectable({ providedIn: 'root' })
@@ -106,5 +107,11 @@ export class MealPlanApiService {
 
   suggestWeekPlan(year: number, week: number): Observable<WeekSuggestion> {
     return this.http.post<WeekSuggestion>(API_ENDPOINTS.mealPlans.suggest(year, week), {});
+  }
+
+  getMealAnalytics(year: number, month?: number): Observable<MealAnalytics> {
+    let httpParams = new HttpParams().set('year', String(year));
+    if (month !== undefined) httpParams = httpParams.set('month', String(month));
+    return this.http.get<MealAnalytics>(API_ENDPOINTS.mealPlans.analytics, { params: httpParams });
   }
 }

--- a/client/libs/shared/api-client/src/lib/meal-plan.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan.ts
@@ -104,3 +104,26 @@ export interface WeekSuggestion {
   week: string;
   entries: WeekSuggestionEntry[];
 }
+
+export interface TopRecipe {
+  recipeIdentifier: string;
+  recipeTitle: string;
+  cookCount: number;
+}
+
+export interface CategoryShare {
+  category: string;
+  count: number;
+  percentage: number;
+}
+
+export interface MealAnalytics {
+  period: string;
+  totalCooked: number;
+  totalSkipped: number;
+  uniqueRecipes: number;
+  mealsPerWeek: number;
+  discoveryRate: number;
+  topRecipes: TopRecipe[];
+  categoryDistribution: CategoryShare[];
+}

--- a/client/libs/shared/models/src/lib/error-maps.ts
+++ b/client/libs/shared/models/src/lib/error-maps.ts
@@ -96,6 +96,9 @@ export const ERROR_MAPS = {
       422: 'mealPlanner.suggest.errors.noRecipes',
       default: 'mealPlanner.suggest.errors.failed',
     } satisfies HttpErrorMap,
+    analytics: {
+      default: 'mealPlanner.analytics.errors.loadFailed',
+    } satisfies HttpErrorMap,
   },
   account: {
     load: {

--- a/client/libs/ui/src/lib/icons/yn-icons.ts
+++ b/client/libs/ui/src/lib/icons/yn-icons.ts
@@ -1,6 +1,7 @@
 import {
   Apple,
   ArrowLeft,
+  BarChart3,
   BookOpen,
   CalendarDays,
   Check,
@@ -55,6 +56,7 @@ import {
 export const YN_ICONS = {
   Apple,
   ArrowLeft,
+  BarChart3,
   BookOpen,
   CalendarDays,
   Check,

--- a/src/Yumney.MealPlan.Api/MealPlanAnalyticsEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanAnalyticsEndpoints.cs
@@ -1,0 +1,40 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Shared.Web;
+using SmartSolutionsLab.Yumney.Shared.Web.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Api;
+
+public static class MealPlanAnalyticsEndpoints
+{
+	public static IEndpointRouteBuilder MapMealPlanAnalyticsEndpoints(this IEndpointRouteBuilder app)
+	{
+		var group = app.MapGroup("/meal-plans");
+
+		group.MapGet("/analytics", GetAnalytics)
+			.WithName("GetMealAnalytics")
+			.WithTags("MealPlan")
+			.WithCapability(
+				name: "get_meal_analytics",
+				description: "Cooking analytics for a calendar period. Pass year only for the whole year, or year + month (1-12) for a single month. Returns totals, top recipes, frequency, discovery rate, and category distribution.",
+				surfaces: CapabilitySurface.Mcp)
+			.Produces<MealAnalyticsDto>();
+
+		static async Task<IResult> GetAnalytics(
+			IQueryHandler<GetMealAnalyticsQuery, Result<MealAnalyticsDto>> handler,
+			CancellationToken cancellationToken,
+			int? year = null,
+			int? month = null)
+		{
+			var resolvedYear = year ?? DateTime.UtcNow.Year;
+			var query = new GetMealAnalyticsQuery(resolvedYear, month);
+			var result = await handler.HandleAsync(query, cancellationToken);
+			return result.ToOk();
+		}
+
+		return app;
+	}
+}

--- a/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
@@ -29,7 +29,8 @@ public sealed class MealPlanApiModule : IEndpointModule
 			.UseYumneyDefaults()
 			.MapApiV1()
 			.MapMealPlanEndpoints()
-			.MapMealPlanSuggestionEndpoints();
+			.MapMealPlanSuggestionEndpoints()
+			.MapMealPlanAnalyticsEndpoints();
 		app.MapCapabilityManifest("mealplan-api");
 		return app;
 	}

--- a/src/Yumney.MealPlan.Application/DTOs/CategoryShareDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/CategoryShareDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+public sealed record CategoryShareDto(string Category, int Count, decimal Percentage);

--- a/src/Yumney.MealPlan.Application/DTOs/MealAnalyticsDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/MealAnalyticsDto.cs
@@ -1,0 +1,11 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+public sealed record MealAnalyticsDto(
+	string Period,
+	int TotalCooked,
+	int TotalSkipped,
+	int UniqueRecipes,
+	decimal MealsPerWeek,
+	int DiscoveryRate,
+	IReadOnlyList<TopRecipeDto> TopRecipes,
+	IReadOnlyList<CategoryShareDto> CategoryDistribution);

--- a/src/Yumney.MealPlan.Application/DTOs/TopRecipeDto.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/TopRecipeDto.cs
@@ -1,0 +1,3 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+
+public sealed record TopRecipeDto(Guid RecipeIdentifier, string RecipeTitle, int CookCount);

--- a/src/Yumney.MealPlan.Application/Interfaces/IMealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IMealPlanReadModelRepository.cs
@@ -21,4 +21,21 @@ public interface IMealPlanReadModelRepository
 		SearchTerm? term,
 		PagingOptions paging,
 		CancellationToken cancellationToken = default);
+
+	Task<IReadOnlyList<AnalyticsSlotProjection>> GetSlotsInPeriodAsync(
+		OwnerIdentifier owner,
+		DateOnly periodStart,
+		DateOnly periodEndExclusive,
+		CancellationToken cancellationToken = default);
+
+	Task<IReadOnlyDictionary<Guid, DateOnly>> GetFirstCookDatesAsync(
+		OwnerIdentifier owner,
+		IReadOnlyList<Guid> recipeIdentifiers,
+		CancellationToken cancellationToken = default);
 }
+
+public sealed record AnalyticsSlotProjection(
+	Guid? RecipeIdentifier,
+	string? RecipeTitle,
+	string State,
+	DateOnly Date);

--- a/src/Yumney.MealPlan.Application/Interfaces/IRecipeTagsLookup.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IRecipeTagsLookup.cs
@@ -1,0 +1,6 @@
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+
+public interface IRecipeTagsLookup
+{
+	Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Yumney.MealPlan.Application/Queries/GetMealAnalyticsQuery.cs
+++ b/src/Yumney.MealPlan.Application/Queries/GetMealAnalyticsQuery.cs
@@ -1,0 +1,7 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+
+public sealed record GetMealAnalyticsQuery(int Year, int? Month) : IQuery<Result<MealAnalyticsDto>>;

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
+
+public sealed class GetMealAnalyticsQueryHandler(
+	IMealPlanReadModelRepository readModel,
+	IRecipeTagsLookup tags,
+	ICurrentUser currentUser)
+	: IQueryHandler<GetMealAnalyticsQuery, Result<MealAnalyticsDto>>
+{
+#pragma warning disable SA1303
+	private const int topRecipeLimit = 5;
+	private const decimal daysPerWeek = 7m;
+#pragma warning restore SA1303
+
+	public async Task<Result<MealAnalyticsDto>> HandleAsync(
+		GetMealAnalyticsQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var owner = currentUser.AsOwner();
+		var (periodStart, periodEndExclusive) = PeriodBounds(query.Year, query.Month);
+
+		var slots = await readModel.GetSlotsInPeriodAsync(owner, periodStart, periodEndExclusive, cancellationToken);
+
+		var cooked = slots.Where(slot => slot.State == "Cooked").ToList();
+		var skippedCount = slots.Count(slot => slot.State == "Skipped");
+
+		var recipeCooks = cooked
+			.Where(slot => slot.RecipeIdentifier.HasValue && slot.RecipeTitle is not null)
+			.GroupBy(slot => slot.RecipeIdentifier!.Value)
+			.Select(group => new RecipeCookCount(group.Key, group.First().RecipeTitle!, group.Count()))
+			.ToList();
+
+		var uniqueRecipes = recipeCooks.Count;
+		var recipeIds = recipeCooks.Select(row => row.RecipeIdentifier).ToList();
+
+		var firstCookDates = recipeIds.Count == 0
+			? new Dictionary<Guid, DateOnly>()
+			: (await readModel.GetFirstCookDatesAsync(owner, recipeIds, cancellationToken))
+				.ToDictionary(entry => entry.Key, entry => entry.Value);
+		var discoveryRate = recipeIds.Count(id =>
+			firstCookDates.TryGetValue(id, out var firstDate) && firstDate >= periodStart && firstDate < periodEndExclusive);
+
+		var tagsByRecipe = recipeIds.Count == 0
+			? new Dictionary<Guid, IReadOnlyList<string>>()
+			: (await tags.GetAllAsync(cancellationToken))
+				.Where(entry => recipeIds.Contains(entry.Key))
+				.ToDictionary(entry => entry.Key, entry => entry.Value);
+
+		var dto = new MealAnalyticsDto(
+			FormatPeriod(query.Year, query.Month),
+			cooked.Count,
+			skippedCount,
+			uniqueRecipes,
+			MealsPerWeek(cooked.Count, periodStart, periodEndExclusive),
+			discoveryRate,
+			recipeCooks
+				.OrderByDescending(row => row.Count)
+				.ThenBy(row => row.Title, StringComparer.OrdinalIgnoreCase)
+				.Take(topRecipeLimit)
+				.Select(row => row.ToDto())
+				.ToList(),
+			BuildCategoryDistribution(cooked, tagsByRecipe));
+
+		return Result<MealAnalyticsDto>.Success(dto);
+	}
+
+	private static (DateOnly Start, DateOnly EndExclusive) PeriodBounds(int year, int? month)
+	{
+		if (month is { } monthValue)
+		{
+			var start = new DateOnly(year, monthValue, 1);
+			var end = start.AddMonths(1);
+			return (start, end);
+		}
+
+		return (new DateOnly(year, 1, 1), new DateOnly(year + 1, 1, 1));
+	}
+
+	private static string FormatPeriod(int year, int? month) =>
+		month is { } monthValue
+			? string.Create(CultureInfo.InvariantCulture, $"{year:0000}-{monthValue:00}")
+			: year.ToString("0000", CultureInfo.InvariantCulture);
+
+	private static decimal MealsPerWeek(int cookedCount, DateOnly start, DateOnly endExclusive)
+	{
+		if (cookedCount == 0) return 0m;
+		var days = (decimal)(endExclusive.DayNumber - start.DayNumber);
+		if (days <= 0m) return 0m;
+		var weeks = days / daysPerWeek;
+		return Math.Round(cookedCount / weeks, 1, MidpointRounding.AwayFromZero);
+	}
+
+	private static List<CategoryShareDto> BuildCategoryDistribution(
+		List<AnalyticsSlotProjection> cooked,
+		Dictionary<Guid, IReadOnlyList<string>> tagsByRecipe)
+	{
+		if (cooked.Count == 0) return [];
+
+		var totals = new Dictionary<string, int>(StringComparer.Ordinal);
+		foreach (var slot in cooked)
+		{
+			var category = slot.RecipeIdentifier is { } id && tagsByRecipe.TryGetValue(id, out var recipeTags)
+				? CategorizeTags(recipeTags)
+				: "other";
+			totals[category] = totals.GetValueOrDefault(category) + 1;
+		}
+
+		var total = (decimal)cooked.Count;
+		return totals
+			.OrderByDescending(entry => entry.Value)
+			.ThenBy(entry => entry.Key, StringComparer.Ordinal)
+			.Select(entry => BuildCategoryShare(entry.Key, entry.Value, total))
+			.ToList();
+	}
+
+	private static CategoryShareDto BuildCategoryShare(string category, int count, decimal totalCooked) =>
+		new(category, count, Math.Round(count / totalCooked * 100m, 1, MidpointRounding.AwayFromZero));
+
+#pragma warning disable SA1402, SA1649
+	private sealed record RecipeCookCount(Guid RecipeIdentifier, string Title, int Count)
+	{
+		public TopRecipeDto ToDto() => new(this.RecipeIdentifier, this.Title, this.Count);
+	}
+#pragma warning restore SA1402, SA1649
+
+	private static string CategorizeTags(IReadOnlyList<string> recipeTags)
+	{
+		// Tag matching is case-insensitive and substring-based to forgive
+		// "vegetarian" vs "veggie" vs "vegan" variations user-defined tags
+		// pick up. Order matters: vegan beats veggie beats meat/fish.
+		var lower = recipeTags.Select(tag => tag.ToLowerInvariant()).ToList();
+		if (lower.Any(tag => tag.Contains("vegan", StringComparison.Ordinal))) return "vegan";
+		if (lower.Any(tag => tag.Contains("vegetarian", StringComparison.Ordinal) || tag.Contains("veggie", StringComparison.Ordinal))) return "veggie";
+		if (lower.Any(tag => tag.Contains("fish", StringComparison.Ordinal) || tag.Contains("seafood", StringComparison.Ordinal))) return "fish";
+		if (lower.Any(tag => tag.Contains("meat", StringComparison.Ordinal) || tag.Contains("chicken", StringComparison.Ordinal) || tag.Contains("beef", StringComparison.Ordinal) || tag.Contains("pork", StringComparison.Ordinal))) return "meat";
+		return "other";
+	}
+}

--- a/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeTagsLookup.cs
+++ b/src/Yumney.MealPlan.Infrastructure/ExternalServices/HttpRecipeTagsLookup.cs
@@ -1,0 +1,17 @@
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Client;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+
+public sealed class HttpRecipeTagsLookup(IRecipesClient recipes) : IRecipeTagsLookup
+{
+#pragma warning disable SA1303
+	private const int catalogPageSize = 100;
+#pragma warning restore SA1303
+
+	public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> GetAllAsync(CancellationToken cancellationToken = default)
+	{
+		var response = await recipes.ListRecipeCatalogAsync(catalogPageSize, cancellationToken);
+		return response.Items.ToDictionary(item => item.Identifier, item => item.Tags);
+	}
+}

--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 		services.AddScoped<IStaplesProvider, HttpStaplesProvider>();
 		services.AddScoped<IRecipeCatalogProvider, HttpRecipeCatalogProvider>();
 		services.AddScoped<IDietaryProfileProvider, HttpDietaryProfileProvider>();
+		services.AddScoped<IRecipeTagsLookup, HttpRecipeTagsLookup>();
 		services.AddRecipesClient();
 		services.AddShoppingClient();
 		services.AddUsersClient();

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanPeriodMath.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanPeriodMath.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Pure date arithmetic shared by the analytics queries on
+/// <see cref="MealPlanReadModelRepository"/>. Lives in its own type so
+/// the conversion logic — ISO week + day-of-week → calendar date — can
+/// be unit-tested without standing up a DbContext.
+/// </summary>
+internal static class MealPlanPeriodMath
+{
+	/// <summary>
+	/// SQL-side bracket on the <c>Week</c> column for a period. Returns
+	/// the first and last ISO-week strings to include, padded by ±1 week
+	/// because ISO weeks are not aligned to calendar months/years (a
+	/// Monday-start week may carry days from the prior or following
+	/// month). The in-memory date filter trims to the exact bounds.
+	/// </summary>
+	public static (string FirstWeek, string LastWeek) SlotWeekBounds(DateOnly periodStart, DateOnly periodEndExclusive)
+	{
+		var inclusiveLast = periodEndExclusive.AddDays(-1);
+		var first = WeekIdentifier.FromDate(periodStart.AddDays(-7)).Value;
+		var last = WeekIdentifier.FromDate(inclusiveLast.AddDays(7)).Value;
+		return (first, last);
+	}
+
+	/// <summary>
+	/// Translates a stored <c>Week</c> ("YYYY-Www") + <c>Day</c> (enum
+	/// name like "Monday") into the calendar date for that slot.
+	/// </summary>
+	public static DateOnly SlotDate(string weekValue, string dayValue)
+	{
+		var dashIndex = weekValue.IndexOf('-', StringComparison.Ordinal);
+		var year = int.Parse(weekValue[..dashIndex], CultureInfo.InvariantCulture);
+		var weekNumber = int.Parse(weekValue[(dashIndex + 2)..], CultureInfo.InvariantCulture);
+		var dayOfWeek = Enum.Parse<DayOfWeek>(dayValue);
+		var monday = ISOWeek.ToDateTime(year, weekNumber, DayOfWeek.Monday);
+		var offset = dayOfWeek == DayOfWeek.Sunday ? 6 : (int)dayOfWeek - 1;
+		return DateOnly.FromDateTime(monday.AddDays(offset));
+	}
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanPeriodMath.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanPeriodMath.cs
@@ -18,6 +18,9 @@ internal static class MealPlanPeriodMath
 	/// Monday-start week may carry days from the prior or following
 	/// month). The in-memory date filter trims to the exact bounds.
 	/// </summary>
+	/// <param name="periodStart">First calendar date in the period (inclusive).</param>
+	/// <param name="periodEndExclusive">Day after the last calendar date in the period.</param>
+	/// <returns>Inclusive first / last ISO-week strings for the SQL bracket.</returns>
 	public static (string FirstWeek, string LastWeek) SlotWeekBounds(DateOnly periodStart, DateOnly periodEndExclusive)
 	{
 		var inclusiveLast = periodEndExclusive.AddDays(-1);
@@ -30,6 +33,9 @@ internal static class MealPlanPeriodMath
 	/// Translates a stored <c>Week</c> ("YYYY-Www") + <c>Day</c> (enum
 	/// name like "Monday") into the calendar date for that slot.
 	/// </summary>
+	/// <param name="weekValue">ISO week in the stored "YYYY-Www" form.</param>
+	/// <param name="dayValue"><see cref="DayOfWeek"/> name as stored on the slot row.</param>
+	/// <returns>The calendar date that the slot row represents.</returns>
 	public static DateOnly SlotDate(string weekValue, string dayValue)
 	{
 		var dashIndex = weekValue.IndexOf('-', StringComparison.Ordinal);

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -108,12 +108,16 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		var cookedState = MealState.Cooked.ToString();
 		var skippedState = MealState.Skipped.ToString();
 
+		// `slot.Week.CompareTo(...)` translates to a native SQL comparison on
+		// PostgreSQL; the `string.Compare(..., StringComparison.Ordinal)` overload
+		// the EF Core / Npgsql translator does not handle and throws at query time,
+		// which surfaced as "Failed to load analytics" in the first E2E run.
 		var rows = await context.MealPlanSlotReadItems
 			.AsNoTracking()
 			.Where(slot => slot.OwnerId == ownerId
 				&& (slot.State == cookedState || slot.State == skippedState)
-				&& string.Compare(slot.Week, firstWeek, StringComparison.Ordinal) >= 0
-				&& string.Compare(slot.Week, lastWeek, StringComparison.Ordinal) <= 0)
+				&& slot.Week.CompareTo(firstWeek) >= 0
+				&& slot.Week.CompareTo(lastWeek) <= 0)
 			.Select(slot => new RawSlot(slot.Week, slot.Day, slot.State, slot.RecipeIdentifier, slot.RecipeTitle))
 			.ToListAsync(cancellationToken);
 

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
@@ -105,7 +104,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		CancellationToken cancellationToken = default)
 	{
 		var ownerId = owner.Value;
-		var (firstWeek, lastWeek) = SlotWeekBounds(periodStart, periodEndExclusive);
+		var (firstWeek, lastWeek) = MealPlanPeriodMath.SlotWeekBounds(periodStart, periodEndExclusive);
 		var cookedState = MealState.Cooked.ToString();
 		var skippedState = MealState.Skipped.ToString();
 
@@ -121,7 +120,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		var projections = new List<AnalyticsSlotProjection>(rows.Count);
 		foreach (var row in rows)
 		{
-			var date = SlotDate(row.Week, row.Day);
+			var date = MealPlanPeriodMath.SlotDate(row.Week, row.Day);
 			if (date < periodStart || date >= periodEndExclusive) continue;
 			projections.Add(new AnalyticsSlotProjection(row.RecipeIdentifier, row.RecipeTitle, row.State, date));
 		}
@@ -153,7 +152,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		foreach (var row in rows)
 		{
 			if (row.RecipeIdentifier is not { } id) continue;
-			var date = SlotDate(row.Week, row.Day);
+			var date = MealPlanPeriodMath.SlotDate(row.Week, row.Day);
 			if (!earliest.TryGetValue(id, out var existing) || date < existing)
 			{
 				earliest[id] = date;
@@ -161,30 +160,6 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 		}
 
 		return earliest;
-	}
-
-	private static (string FirstWeek, string LastWeek) SlotWeekBounds(DateOnly periodStart, DateOnly periodEndExclusive)
-	{
-		// A meal scheduled near the edge of the period might live in the ISO week
-		// just before periodStart or just after periodEndExclusive (because ISO
-		// weeks aren't aligned to calendar months/years). Bracket by ±1 week so
-		// the SQL filter is conservative; the in-memory date filter trims to the
-		// exact period.
-		var inclusiveLast = periodEndExclusive.AddDays(-1);
-		var first = WeekIdentifier.FromDate(periodStart.AddDays(-7)).Value;
-		var last = WeekIdentifier.FromDate(inclusiveLast.AddDays(7)).Value;
-		return (first, last);
-	}
-
-	private static DateOnly SlotDate(string weekValue, string dayValue)
-	{
-		var dashIndex = weekValue.IndexOf('-', StringComparison.Ordinal);
-		var year = int.Parse(weekValue[..dashIndex], CultureInfo.InvariantCulture);
-		var weekNumber = int.Parse(weekValue[(dashIndex + 2)..], CultureInfo.InvariantCulture);
-		var dayOfWeek = Enum.Parse<DayOfWeek>(dayValue);
-		var monday = ISOWeek.ToDateTime(year, weekNumber, DayOfWeek.Monday);
-		var offset = dayOfWeek == DayOfWeek.Sunday ? 6 : (int)dayOfWeek - 1;
-		return DateOnly.FromDateTime(monday.AddDays(offset));
 	}
 
 #pragma warning disable SA1402, SA1649

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Application.DTOs;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
@@ -96,6 +97,99 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 
 		return sorted.ToHistoryEntryDtos().AsPagedResult(ItemCount.From(totalCount), paging);
 	}
+
+	public async Task<IReadOnlyList<AnalyticsSlotProjection>> GetSlotsInPeriodAsync(
+		OwnerIdentifier owner,
+		DateOnly periodStart,
+		DateOnly periodEndExclusive,
+		CancellationToken cancellationToken = default)
+	{
+		var ownerId = owner.Value;
+		var (firstWeek, lastWeek) = SlotWeekBounds(periodStart, periodEndExclusive);
+		var cookedState = MealState.Cooked.ToString();
+		var skippedState = MealState.Skipped.ToString();
+
+		var rows = await context.MealPlanSlotReadItems
+			.AsNoTracking()
+			.Where(slot => slot.OwnerId == ownerId
+				&& (slot.State == cookedState || slot.State == skippedState)
+				&& string.Compare(slot.Week, firstWeek, StringComparison.Ordinal) >= 0
+				&& string.Compare(slot.Week, lastWeek, StringComparison.Ordinal) <= 0)
+			.Select(slot => new RawSlot(slot.Week, slot.Day, slot.State, slot.RecipeIdentifier, slot.RecipeTitle))
+			.ToListAsync(cancellationToken);
+
+		var projections = new List<AnalyticsSlotProjection>(rows.Count);
+		foreach (var row in rows)
+		{
+			var date = SlotDate(row.Week, row.Day);
+			if (date < periodStart || date >= periodEndExclusive) continue;
+			projections.Add(new AnalyticsSlotProjection(row.RecipeIdentifier, row.RecipeTitle, row.State, date));
+		}
+
+		return projections;
+	}
+
+	public async Task<IReadOnlyDictionary<Guid, DateOnly>> GetFirstCookDatesAsync(
+		OwnerIdentifier owner,
+		IReadOnlyList<Guid> recipeIdentifiers,
+		CancellationToken cancellationToken = default)
+	{
+		if (recipeIdentifiers.Count == 0) return new Dictionary<Guid, DateOnly>();
+
+		var ownerId = owner.Value;
+		var cookedState = MealState.Cooked.ToString();
+		var ids = recipeIdentifiers.ToList();
+
+		var rows = await context.MealPlanSlotReadItems
+			.AsNoTracking()
+			.Where(slot => slot.OwnerId == ownerId
+				&& slot.State == cookedState
+				&& slot.RecipeIdentifier.HasValue
+				&& ids.Contains(slot.RecipeIdentifier.Value))
+			.Select(slot => new { slot.RecipeIdentifier, slot.Week, slot.Day })
+			.ToListAsync(cancellationToken);
+
+		var earliest = new Dictionary<Guid, DateOnly>();
+		foreach (var row in rows)
+		{
+			if (row.RecipeIdentifier is not { } id) continue;
+			var date = SlotDate(row.Week, row.Day);
+			if (!earliest.TryGetValue(id, out var existing) || date < existing)
+			{
+				earliest[id] = date;
+			}
+		}
+
+		return earliest;
+	}
+
+	private static (string FirstWeek, string LastWeek) SlotWeekBounds(DateOnly periodStart, DateOnly periodEndExclusive)
+	{
+		// A meal scheduled near the edge of the period might live in the ISO week
+		// just before periodStart or just after periodEndExclusive (because ISO
+		// weeks aren't aligned to calendar months/years). Bracket by ±1 week so
+		// the SQL filter is conservative; the in-memory date filter trims to the
+		// exact period.
+		var inclusiveLast = periodEndExclusive.AddDays(-1);
+		var first = WeekIdentifier.FromDate(periodStart.AddDays(-7)).Value;
+		var last = WeekIdentifier.FromDate(inclusiveLast.AddDays(7)).Value;
+		return (first, last);
+	}
+
+	private static DateOnly SlotDate(string weekValue, string dayValue)
+	{
+		var dashIndex = weekValue.IndexOf('-', StringComparison.Ordinal);
+		var year = int.Parse(weekValue[..dashIndex], CultureInfo.InvariantCulture);
+		var weekNumber = int.Parse(weekValue[(dashIndex + 2)..], CultureInfo.InvariantCulture);
+		var dayOfWeek = Enum.Parse<DayOfWeek>(dayValue);
+		var monday = ISOWeek.ToDateTime(year, weekNumber, DayOfWeek.Monday);
+		var offset = dayOfWeek == DayOfWeek.Sunday ? 6 : (int)dayOfWeek - 1;
+		return DateOnly.FromDateTime(monday.AddDays(offset));
+	}
+
+#pragma warning disable SA1402, SA1649
+	private sealed record RawSlot(string Week, string Day, string State, Guid? RecipeIdentifier, string? RecipeTitle);
+#pragma warning restore SA1402, SA1649
 
 	private static List<MealSlotDto> EmptyDinnerSlots(int defaultServings) =>
 		WeekDays.MondayToSunday

--- a/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
+++ b/src/Yumney.MealPlan.Infrastructure/Yumney.MealPlan.Infrastructure.csproj
@@ -5,6 +5,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Yumney.MealPlan.Infrastructure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Yumney.MealPlan.Application\Yumney.MealPlan.Application.csproj" />
     <ProjectReference Include="..\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />

--- a/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
@@ -69,6 +69,19 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 		return Task.FromResult(page.AsPagedResult(ItemCount.From(ordered.Count), paging));
 	}
 
+	public Task<IReadOnlyList<AnalyticsSlotProjection>> GetSlotsInPeriodAsync(
+		OwnerIdentifier owner,
+		DateOnly periodStart,
+		DateOnly periodEndExclusive,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyList<AnalyticsSlotProjection>>([]);
+
+	public Task<IReadOnlyDictionary<Guid, DateOnly>> GetFirstCookDatesAsync(
+		OwnerIdentifier owner,
+		IReadOnlyList<Guid> recipeIdentifiers,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyDictionary<Guid, DateOnly>>(new Dictionary<Guid, DateOnly>());
+
 	public void Seed(WeeklyPlan plan)
 	{
 		store[(plan.Owner.Value, plan.Week.Value)] = plan;

--- a/tests/Yumney.MealPlan.Application.Tests/Queries/GetMealAnalyticsQueryHandlerTests.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/Queries/GetMealAnalyticsQueryHandlerTests.cs
@@ -1,0 +1,201 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Queries.Handlers;
+using Xunit;
+using static SmartSolutionsLab.Yumney.MealPlan.Application.Tests.MealPlanTestFixture;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests.Queries;
+
+public class GetMealAnalyticsQueryHandlerTests
+{
+	private readonly FakeAnalyticsReadModel readModel = new();
+	private readonly FakeRecipeTagsLookup tagsLookup = new();
+
+	[Fact]
+	public async Task HandleAsync_NoSlots_ReturnsZeros()
+	{
+		var handler = BuildHandler();
+
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		result.IsSuccess.Should().BeTrue();
+		var dto = result.Value;
+		dto.Period.Should().Be("2026-05");
+		dto.TotalCooked.Should().Be(0);
+		dto.TotalSkipped.Should().Be(0);
+		dto.UniqueRecipes.Should().Be(0);
+		dto.MealsPerWeek.Should().Be(0m);
+		dto.DiscoveryRate.Should().Be(0);
+		dto.TopRecipes.Should().BeEmpty();
+		dto.CategoryDistribution.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_CountsCookedAndSkippedSeparately()
+	{
+		var lasagna = Guid.NewGuid();
+		readModel.SeedCooked(lasagna, "Lasagna", new DateOnly(2026, 5, 10));
+		readModel.SeedCooked(lasagna, "Lasagna", new DateOnly(2026, 5, 20));
+		readModel.SeedSkipped(new DateOnly(2026, 5, 15));
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		result.Value.TotalCooked.Should().Be(2);
+		result.Value.TotalSkipped.Should().Be(1);
+		result.Value.UniqueRecipes.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task HandleAsync_TopRecipesOrderedByCount()
+	{
+		var lasagna = Guid.NewGuid();
+		var pizza = Guid.NewGuid();
+		readModel.SeedCooked(lasagna, "Lasagna", new DateOnly(2026, 5, 5));
+		readModel.SeedCooked(lasagna, "Lasagna", new DateOnly(2026, 5, 12));
+		readModel.SeedCooked(lasagna, "Lasagna", new DateOnly(2026, 5, 19));
+		readModel.SeedCooked(pizza, "Pizza", new DateOnly(2026, 5, 8));
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		result.Value.TopRecipes.Should().HaveCount(2);
+		result.Value.TopRecipes[0].RecipeTitle.Should().Be("Lasagna");
+		result.Value.TopRecipes[0].CookCount.Should().Be(3);
+		result.Value.TopRecipes[1].RecipeTitle.Should().Be("Pizza");
+		result.Value.TopRecipes[1].CookCount.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task HandleAsync_DiscoveryRateCountsFirstCookInPeriod()
+	{
+		var newRecipe = Guid.NewGuid();
+		var oldRecipe = Guid.NewGuid();
+		readModel.SeedCooked(newRecipe, "Pad Thai", new DateOnly(2026, 5, 12));
+		readModel.SeedFirstCookDate(newRecipe, new DateOnly(2026, 5, 12));
+		readModel.SeedCooked(oldRecipe, "Lasagna", new DateOnly(2026, 5, 20));
+		readModel.SeedFirstCookDate(oldRecipe, new DateOnly(2025, 11, 1));
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		result.Value.DiscoveryRate.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task HandleAsync_CategoryDistributionFromTags()
+	{
+		var meatId = Guid.NewGuid();
+		var veggieId = Guid.NewGuid();
+		var unknownId = Guid.NewGuid();
+		readModel.SeedCooked(meatId, "Beef Stew", new DateOnly(2026, 5, 5));
+		readModel.SeedCooked(meatId, "Beef Stew", new DateOnly(2026, 5, 12));
+		readModel.SeedCooked(veggieId, "Caesar Salad", new DateOnly(2026, 5, 8));
+		readModel.SeedCooked(unknownId, "Mystery Bowl", new DateOnly(2026, 5, 15));
+		tagsLookup.Seed(meatId, ["beef", "dinner"]);
+		tagsLookup.Seed(veggieId, ["vegetarian"]);
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		var byCategory = result.Value.CategoryDistribution.ToDictionary(share => share.Category);
+		byCategory.Should().ContainKey("meat").WhoseValue.Count.Should().Be(2);
+		byCategory.Should().ContainKey("veggie").WhoseValue.Count.Should().Be(1);
+		byCategory.Should().ContainKey("other").WhoseValue.Count.Should().Be(1);
+		byCategory["meat"].Percentage.Should().Be(50m);
+	}
+
+	[Fact]
+	public async Task HandleAsync_MealsPerWeekRoundedToOneDecimal()
+	{
+		// 14 meals across 31 days = 14 / (31/7) ≈ 3.16 → rounds to 3.2
+		for (var day = 1; day <= 14; day++)
+		{
+			readModel.SeedCooked(Guid.NewGuid(), $"Recipe {day}", new DateOnly(2026, 5, day));
+		}
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, 5));
+
+		result.Value.MealsPerWeek.Should().Be(3.2m);
+	}
+
+	[Fact]
+	public async Task HandleAsync_YearPeriodCoversWholeYear()
+	{
+		readModel.SeedCooked(Guid.NewGuid(), "January", new DateOnly(2026, 1, 15));
+		readModel.SeedCooked(Guid.NewGuid(), "December", new DateOnly(2026, 12, 20));
+
+		var handler = BuildHandler();
+		var result = await handler.HandleAsync(new GetMealAnalyticsQuery(2026, null));
+
+		result.Value.Period.Should().Be("2026");
+		result.Value.TotalCooked.Should().Be(2);
+	}
+
+	private GetMealAnalyticsQueryHandler BuildHandler() => new(readModel, tagsLookup, CreateCurrentUser());
+}
+
+internal sealed class FakeAnalyticsReadModel : IMealPlanReadModelRepository
+{
+	private readonly List<AnalyticsSlotProjection> slots = [];
+	private readonly Dictionary<Guid, DateOnly> firstCookDates = [];
+
+	public void SeedCooked(Guid recipeId, string title, DateOnly date) =>
+		slots.Add(new AnalyticsSlotProjection(recipeId, title, "Cooked", date));
+
+	public void SeedSkipped(DateOnly date) =>
+		slots.Add(new AnalyticsSlotProjection(null, null, "Skipped", date));
+
+	public void SeedFirstCookDate(Guid recipeId, DateOnly date) =>
+		firstCookDates[recipeId] = date;
+
+	public Task<IReadOnlyList<AnalyticsSlotProjection>> GetSlotsInPeriodAsync(
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.OwnerIdentifier owner,
+		DateOnly periodStart,
+		DateOnly periodEndExclusive,
+		CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyList<AnalyticsSlotProjection>>(
+			slots.Where(slot => slot.Date >= periodStart && slot.Date < periodEndExclusive).ToList());
+
+	public Task<IReadOnlyDictionary<Guid, DateOnly>> GetFirstCookDatesAsync(
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.OwnerIdentifier owner,
+		IReadOnlyList<Guid> recipeIdentifiers,
+		CancellationToken cancellationToken = default)
+	{
+		IReadOnlyDictionary<Guid, DateOnly> filtered = recipeIdentifiers
+			.Where(firstCookDates.ContainsKey)
+			.ToDictionary(id => id, id => firstCookDates[id]);
+		return Task.FromResult(filtered);
+	}
+
+	public Task<SmartSolutionsLab.Yumney.MealPlan.Application.DTOs.WeeklyPlanDto> GetByOwnerAndWeekAsync(
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.OwnerIdentifier owner,
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.WeekIdentifier week,
+		CancellationToken cancellationToken = default) =>
+		throw new NotSupportedException();
+
+	public Task<SmartSolutionsLab.Yumney.MealPlan.Application.DTOs.WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.OwnerIdentifier owner,
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.WeekIdentifier week,
+		CancellationToken cancellationToken = default) =>
+		throw new NotSupportedException();
+
+	public Task<SmartSolutionsLab.Yumney.Shared.Paging.PagedResult<SmartSolutionsLab.Yumney.MealPlan.Application.DTOs.MealHistoryEntryDto>> SearchCookedHistoryAsync(
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.OwnerIdentifier owner,
+		SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.SearchTerm? term,
+		SmartSolutionsLab.Yumney.Shared.Paging.PagingOptions paging,
+		CancellationToken cancellationToken = default) =>
+		throw new NotSupportedException();
+}
+
+internal sealed class FakeRecipeTagsLookup : IRecipeTagsLookup
+{
+	private readonly Dictionary<Guid, IReadOnlyList<string>> tags = [];
+
+	public void Seed(Guid recipeId, IReadOnlyList<string> recipeTags) => tags[recipeId] = recipeTags;
+
+	public Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> GetAllAsync(CancellationToken cancellationToken = default) =>
+		Task.FromResult<IReadOnlyDictionary<Guid, IReadOnlyList<string>>>(tags);
+}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Persistence/ReadModel/MealPlanPeriodMathTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Persistence/ReadModel/MealPlanPeriodMathTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Persistence.ReadModel;
+
+public class MealPlanPeriodMathTests
+{
+	public class SlotDateTests
+	{
+		[Theory]
+		[InlineData("2026-W20", "Monday", 2026, 5, 11)]
+		[InlineData("2026-W20", "Sunday", 2026, 5, 17)]
+		[InlineData("2026-W01", "Thursday", 2026, 1, 1)]
+		[InlineData("2025-W01", "Monday", 2024, 12, 30)]
+		public void SlotDate_ReturnsExpectedCalendarDate(
+			string week,
+			string day,
+			int expectedYear,
+			int expectedMonth,
+			int expectedDay)
+		{
+			var date = MealPlanPeriodMath.SlotDate(week, day);
+
+			date.Should().Be(new DateOnly(expectedYear, expectedMonth, expectedDay));
+		}
+
+		[Fact]
+		public void SlotDate_FullWeekMondayToSunday_IsSevenConsecutiveDays()
+		{
+			var monday = MealPlanPeriodMath.SlotDate("2026-W20", "Monday");
+			var days = new[]
+			{
+				MealPlanPeriodMath.SlotDate("2026-W20", "Tuesday"),
+				MealPlanPeriodMath.SlotDate("2026-W20", "Wednesday"),
+				MealPlanPeriodMath.SlotDate("2026-W20", "Thursday"),
+				MealPlanPeriodMath.SlotDate("2026-W20", "Friday"),
+				MealPlanPeriodMath.SlotDate("2026-W20", "Saturday"),
+				MealPlanPeriodMath.SlotDate("2026-W20", "Sunday"),
+			};
+
+			for (var index = 0; index < days.Length; index++)
+			{
+				days[index].Should().Be(monday.AddDays(index + 1));
+			}
+		}
+
+		[Fact]
+		public void SlotDate_53WeekYear_HandlesW53()
+		{
+			// 2026 has 53 ISO weeks.
+			var date = MealPlanPeriodMath.SlotDate("2026-W53", "Monday");
+
+			date.Should().Be(new DateOnly(2026, 12, 28));
+		}
+	}
+
+	public class SlotWeekBoundsTests
+	{
+		[Fact]
+		public void SlotWeekBounds_MayMonth_BracketsBeforeAndAfter()
+		{
+			var start = new DateOnly(2026, 5, 1);
+			var endExclusive = new DateOnly(2026, 6, 1);
+
+			var (firstWeek, lastWeek) = MealPlanPeriodMath.SlotWeekBounds(start, endExclusive);
+
+			// firstWeek must be at or before the ISO week containing May 1.
+			string.Compare(firstWeek, "2026-W18", StringComparison.Ordinal).Should().BeLessThanOrEqualTo(0);
+
+			// lastWeek must be at or after the ISO week containing May 31.
+			string.Compare(lastWeek, "2026-W22", StringComparison.Ordinal).Should().BeGreaterThanOrEqualTo(0);
+		}
+
+		[Fact]
+		public void SlotWeekBounds_JanuaryMonth_BracketsAcrossYearBoundary()
+		{
+			var start = new DateOnly(2026, 1, 1);
+			var endExclusive = new DateOnly(2026, 2, 1);
+
+			var (firstWeek, _) = MealPlanPeriodMath.SlotWeekBounds(start, endExclusive);
+
+			// One week before Jan 1 lives in 2025 ISO calendar
+			firstWeek.Should().StartWith("2025-W");
+		}
+
+		[Fact]
+		public void SlotWeekBounds_FullYear_FirstIsPriorYear_LastIsFollowingYear()
+		{
+			var start = new DateOnly(2026, 1, 1);
+			var endExclusive = new DateOnly(2027, 1, 1);
+
+			var (firstWeek, lastWeek) = MealPlanPeriodMath.SlotWeekBounds(start, endExclusive);
+
+			firstWeek.Should().StartWith("2025-W");
+			lastWeek.Should().StartWith("2027-W");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

US-332. New page at `/meal-planner/analytics` that summarises the user's cooking patterns for a calendar month or whole year. Glassmorphism stat cards + a donut chart for category distribution.

### Backend

- **`Yumney.MealPlan.Application`**
  - `GetMealAnalyticsQuery(Year, Month?)` + handler returning `MealAnalyticsDto` with: period, totalCooked, totalSkipped, uniqueRecipes, mealsPerWeek, discoveryRate, top 5 recipes, categoryDistribution.
  - Two new `IMealPlanReadModelRepository` methods: `GetSlotsInPeriodAsync` (cooked + skipped slots whose actual date falls in the period) and `GetFirstCookDatesAsync` (earliest cook date per recipe — backs the discovery-rate metric).
  - `IRecipeTagsLookup` consumer-defined contract — drives the category-distribution heuristic (`vegan` → vegan, `vegetarian`/`veggie` → veggie, `fish`/`seafood` → fish, `meat`/`chicken`/`beef`/`pork` → meat, else `other`).
  - `meals-per-week` divides cooked count by the period length in weeks (decimal) and rounds to one place. Zero on empty period — covers TC-332-04 ("first month with 3 meals") without NaN.

- **`Yumney.MealPlan.Infrastructure`**
  - `MealPlanReadModelRepository.GetSlotsInPeriodAsync` pre-filters by ISO `Week`-string range (±1 week buffer), translates each row's `Week`+`Day` to a `DateOnly` via `ISOWeek`, then in-memory filters to the exact period so monthly totals are date-accurate.
  - `HttpRecipeTagsLookup` reuses `IRecipesClient.ListRecipeCatalogAsync` (added in US-330) at page-size 100, projects to `(id → tags[])`.

- **`Yumney.MealPlan.Api`**
  - `MealPlanAnalyticsEndpoints` (own file to keep `MealPlanEndpoints.cs` under 300 lines). `GET /api/v1/meal-plans/analytics?year=&month=`. Tagged `WithCapability(Mcp)` so the MCP proxy surfaces it.

### Frontend

- **`MealAnalyticsComponent`** at `/meal-planner/analytics`. Monthly / yearly view toggle + prev/next period nav. Five glass stat cards. Donut chart + legend for the category distribution (hand-rolled SVG; no chart-library dependency). Top-5 cooked list.
- `MealPlanApiService.getMealAnalytics(year, month?)` + types (`MealAnalytics`, `TopRecipe`, `CategoryShare`).
- `ERROR_MAPS.mealPlanner.analytics` default → `mealPlanner.analytics.errors.loadFailed`.
- Header nav button on the meal-planner page links to the analytics page (`bar-chart-3` icon).
- EN + DE `mealPlanner.analytics.*` strings, `sync:i18n:check` clean.

## Tests

- `GetMealAnalyticsQueryHandlerTests` (7): empty period → zeros, cooked vs skipped counted separately, top recipes by descending count, discovery rate counts only first-cooks in period, category distribution from tag mapping, meals-per-week rounding, year period covers the whole calendar year.
- `MealAnalyticsComponent.spec` (8): loads with month view, renders total cooked + legend + top-recipes, year toggle drops month param, period nav advances/wraps the month, empty hint, error state.
- `MealPlanApiService.spec`: GET with year only vs year+month.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] `dotnet test tests/Yumney.MealPlan.Application.Tests` — 56 / 56
- [x] `dotnet test tests/Yumney.Architecture.Tests` — 142 / 142
- [x] `nx test shell`
- [x] `nx test shared-api-client`
- [x] `nx build shell`
- [x] `yarn sync:i18n:check`
- [ ] Backend integration CI on this PR
- [ ] E2E on this PR

Closes #180.

## Notes / out of scope

- **Category mapping is heuristic** on free-text tags — labelled "best effort" in the AC. If a tag set doesn't hit any recognised keyword, the recipe falls into `other`. The five-class palette (meat/fish/veggie/vegan/other) matches the AC.
- Catalog is currently paged at 100 — that's the upper bound on the tag map. Users beyond 100 recipes won't get tags for the surplus (they'd show as `other` in the donut); a follow-up could switch to a bulk-by-IDs endpoint when that becomes a real bound.
- ISO weeks at the edge of a calendar month may include 1-2 days from the adjacent month; the in-memory date filter trims to the exact period so monthly totals are calendar-accurate, not week-rounded.