### PR TITLE
fix(infra): register LLM parameter once across all consumer APIs

### DIFF
--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -27,21 +27,44 @@ internal static class AppHostExtensions
 		return configured;
 	}
 
-	public static IResourceBuilder<ProjectResource> WithLlmProvider(
-		this IResourceBuilder<ProjectResource> builder,
-		IDistributedApplicationBuilder aspireBuilder,
+	/// <summary>
+	/// Registers the LLM provider's shared resources on the AppHost. Call once
+	/// from <c>Program.cs</c> before any <see cref="WithLlmProvider"/> usage —
+	/// <c>AddParameter</c> / <c>AddOllama</c> throw on duplicate names, so the
+	/// resource has to be created in exactly one place.
+	/// </summary>
+	/// <param name="builder">The AppHost's distributed application builder.</param>
+	/// <param name="options">App host options that decide between OpenAI and Ollama.</param>
+	/// <returns>A handle to the registered resources; empty when E2E tests are on.</returns>
+	public static LlmResources BuildLlmResources(
+		this IDistributedApplicationBuilder builder,
 		AppHostOptions options)
 	{
-		if (options.E2ETests) return builder;
+		if (options.E2ETests) return new LlmResources(null, null);
 
 		if (options.UseOllama)
 		{
-			var ollama = aspireBuilder.AddOllama("ollama").WithDataVolume();
+			var ollama = builder.AddOllama("ollama").WithDataVolume();
+			return new LlmResources(null, ollama);
+		}
+
+		var apiKey = builder.AddParameter("OpenAiApiKey", secret: true);
+		return new LlmResources(apiKey, null);
+	}
+
+	public static IResourceBuilder<ProjectResource> WithLlmProvider(
+		this IResourceBuilder<ProjectResource> builder,
+		AppHostOptions options,
+		LlmResources llm)
+	{
+		if (options.E2ETests) return builder;
+
+		if (llm.Ollama is { } ollama)
+		{
 			builder.WithReference(ollama).WaitFor(ollama);
 		}
-		else
+		else if (llm.OpenAiApiKey is { } apiKey)
 		{
-			var apiKey = aspireBuilder.AddParameter("OpenAiApiKey", secret: true);
 			builder
 				.WithEnvironment("SemanticKernel__Provider", "OpenAI")
 				.WithEnvironment("SemanticKernel__ModelId", options.OpenAiModelId)

--- a/src/Yumney.AppHost/LlmResources.cs
+++ b/src/Yumney.AppHost/LlmResources.cs
@@ -1,0 +1,12 @@
+using Aspire.Hosting.ApplicationModel;
+
+namespace SmartSolutionsLab.Yumney.AppHost;
+
+/// <summary>
+/// Shared LLM resources for the AppHost graph. Built once in <c>Program.cs</c>
+/// (parameter / ollama registration must not happen twice) and passed into
+/// each <see cref="AppHostExtensions.WithLlmProvider"/> call.
+/// </summary>
+internal sealed record LlmResources(
+	IResourceBuilder<ParameterResource>? OpenAiApiKey,
+	IResourceBuilder<IOllamaResource>? Ollama);

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -133,18 +133,24 @@ if (!options.DatabaseOnly)
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.AsYumneyApi(options, shoppingDb, keycloak, redis, messaging, migrationRunner)
 		.WithReference(usersApi);
+
+	// Shared LLM resources registered once — Aspire's parameter / ollama
+	// collections refuse duplicate names, so each `WithLlmProvider` consumer
+	// gets the same handle here rather than creating its own.
+	var llm = builder.BuildLlmResources(options);
+
 	var recipesApi = builder
 		.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.AsYumneyApi(options, recipesDb, keycloak, redis, messaging, migrationRunner)
-		.WithLlmProvider(builder, options)
+		.WithLlmProvider(options, llm)
 		.WithReference(shoppingApi)
 		.WithReference(usersApi);
 	var mealplanApi = builder
 		.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.AsYumneyApi(options, mealplanDb, keycloak, redis, messaging, migrationRunner)
-		.WithLlmProvider(builder, options)
+		.WithLlmProvider(options, llm)
 		.WithReference(recipesApi)
 		.WithReference(shoppingApi)
 		.WithReference(usersApi);


### PR DESCRIPTION
## Summary

`Deploy to staging` has been failing since the US-330 merge (run 25694459582):

\`\`\`
Aspire.Hosting.DistributedApplicationException: Cannot add resource of type
'ParameterResource' with name 'OpenAiApiKey' because resource of type
'ParameterResource' with that name already exists.
\`\`\`

\`AppHostExtensions.WithLlmProvider\` registers \`OpenAiApiKey\` (or \`ollama\`) inside the per-project call. US-330 added \`mealplan-api\` as a second consumer on top of the existing \`recipes-api\` wiring — the parameter is now registered twice and Aspire refuses the duplicate at AppHost boot.

**Why local + CI didn't catch it:** \`WithLlmProvider\` short-circuits when \`E2ETests=true\`, and the integration suite's Aspire fixture runs in that mode. The deploy pipeline runs the AppHost without that flag, so the duplicate registration triggers there for the first time.

## Fix

Split the resource registration from the per-project wiring:

- **`BuildLlmResources(this IDistributedApplicationBuilder, options)`** registers \`OpenAiApiKey\` (or \`ollama\`, with \`UseOllama=true\`) exactly **once** and returns an \`LlmResources\` handle.
- **`WithLlmProvider(options, LlmResources)`** now consumes the handle — no more \`AddParameter\`/\`AddOllama\` inside the per-project call.
- **`Program.cs`** calls \`BuildLlmResources\` once before the API project blocks and passes the handle into both \`recipes-api\` and \`mealplan-api\`.

The env-var wiring (\`SemanticKernel__Provider\`, \`__ModelId\`, \`__ApiKey\`) and references on each project are unchanged — pure dedup.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\`
- [x] \`dotnet format --verify-no-changes\`
- [ ] Backend CI on this PR
- [ ] \`Deploy\` workflow once this lands on develop — should unstick

Refs the failing run: https://github.com/smartsolutionslab/yumney/actions/runs/25694459582