### PR TITLE
feat(chat): push-to-talk mic button on chat panel (US-360)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -328,6 +328,11 @@
       "openSettings": "Einstellungen öffnen",
       "openRecipe": "Rezept öffnen",
       "startCooking": "Kochen starten"
+    },
+    "mic": {
+      "start": "Sprachsteuerung starten",
+      "stop": "Sprachsteuerung stoppen",
+      "listening": "Höre zu..."
     }
   },
   "commandBar": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -328,6 +328,11 @@
       "openSettings": "Open settings",
       "openRecipe": "Open recipe",
       "startCooking": "Start cooking"
+    },
+    "mic": {
+      "start": "Start voice input",
+      "stop": "Stop voice input",
+      "listening": "Listening..."
     }
   },
   "commandBar": {

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -178,3 +178,118 @@ describe('VoiceService.speak', () => {
     expect(prefs.ensureLoaded).toHaveBeenCalledTimes(1);
   });
 });
+
+interface MockRecognition {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+  onerror: ((event: { error: string }) => void) | null;
+  onend: (() => void) | null;
+}
+
+function installSpeechRecognition(): () => MockRecognition {
+  let last: MockRecognition | null = null;
+  const remember = (instance: MockRecognition): void => {
+    last = instance;
+  };
+
+  function MockCtor(this: MockRecognition): void {
+    this.lang = '';
+    this.continuous = false;
+    this.interimResults = false;
+    this.start = vi.fn();
+    this.stop = vi.fn();
+    this.onresult = null;
+    this.onerror = null;
+    this.onend = null;
+    remember(this);
+  }
+
+  (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition = MockCtor;
+  return () => {
+    if (!last) throw new Error('SpeechRecognition was not constructed');
+    return last;
+  };
+}
+
+describe('VoiceService.startListeningForTranscript (US-360)', () => {
+  let service: VoiceService;
+  let getRecognition: () => MockRecognition;
+
+  beforeEach(() => {
+    getRecognition = installSpeechRecognition();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [VoiceService, { provide: UserPreferencesService, useValue: makePrefsStub(true) }],
+    });
+    service = TestBed.inject(VoiceService);
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
+  });
+
+  it('starts a single-utterance session', () => {
+    service.startListeningForTranscript(() => undefined);
+
+    const recognition = getRecognition();
+    expect(recognition.continuous).toBe(false);
+    expect(recognition.interimResults).toBe(false);
+    expect(recognition.start).toHaveBeenCalled();
+    expect(service.isListening()).toBe(true);
+  });
+
+  it('emits the raw transcript, trimmed', () => {
+    const callback = vi.fn();
+    service.startListeningForTranscript(callback);
+
+    getRecognition().onresult?.({ results: [[{ transcript: ' add milk ' }]] });
+
+    expect(callback).toHaveBeenCalledWith('add milk');
+  });
+
+  it('does not emit for empty transcripts', () => {
+    const callback = vi.fn();
+    service.startListeningForTranscript(callback);
+
+    getRecognition().onresult?.({ results: [[{ transcript: '   ' }]] });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('uses the configured language', () => {
+    service.setLanguage('de');
+    service.startListeningForTranscript(() => undefined);
+
+    expect(getRecognition().lang).toBe('de-DE');
+  });
+
+  it('clears isListening on end', () => {
+    service.startListeningForTranscript(() => undefined);
+
+    getRecognition().onend?.();
+
+    expect(service.isListening()).toBe(false);
+  });
+
+  it('clears isListening on error', () => {
+    service.startListeningForTranscript(() => undefined);
+
+    getRecognition().onerror?.({ error: 'no-speech' });
+
+    expect(service.isListening()).toBe(false);
+  });
+
+  it('does nothing when already listening', () => {
+    service.startListeningForTranscript(() => undefined);
+    const first = getRecognition();
+    first.start.mockClear();
+
+    service.startListeningForTranscript(() => undefined);
+
+    expect(first.start).not.toHaveBeenCalled();
+  });
+});

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -144,6 +144,45 @@ export class VoiceService {
     }
   }
 
+  /**
+   * Push-to-talk capture for the command bar (US-360). Unlike the cook-mode
+   * `startListening` path — which keeps the mic open for back-to-back commands
+   * and only emits when the utterance matches a known pattern — this returns
+   * the raw transcript of a single utterance and auto-stops on silence.
+   *
+   * The browser auto-ends the recognition session once the user finishes
+   * speaking (continuous=false), so the caller doesn't need to call
+   * `stopListening` unless cancelling mid-utterance.
+   */
+  startListeningForTranscript(onTranscript: (transcript: string) => void): void {
+    if (!this.sttSupported() || this.isListening()) {
+      return;
+    }
+    const recognition = this.createRecognition();
+    if (!recognition) return;
+
+    recognition.lang = this.currentLang;
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.onresult = (event) => {
+      const last = event.results[event.results.length - 1];
+      const transcript = last[0]?.transcript?.trim() ?? '';
+      if (transcript !== '') {
+        onTranscript(transcript);
+      }
+    };
+    recognition.onerror = () => {
+      this.isListening.set(false);
+    };
+    recognition.onend = () => {
+      this.isListening.set(false);
+    };
+
+    this.recognition = recognition;
+    recognition.start();
+    this.isListening.set(true);
+  }
+
   static parseCommand(transcript: string): VoiceCommand | null {
     const normalized = transcript.trim().toLowerCase();
     if (normalized === '') return null;

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -115,6 +115,22 @@
         rows="2"
         name="chat-input"
       ></textarea>
+      @if (voice.sttSupported()) {
+        <button
+          type="button"
+          class="chat-mic"
+          data-testid="chat-mic"
+          [class.listening]="voice.isListening()"
+          [attr.aria-pressed]="voice.isListening()"
+          [attr.aria-label]="voice.isListening() ? t('chat.mic.stop') : t('chat.mic.start')"
+          (click)="onToggleMic()"
+        >
+          <lucide-icon name="mic" [size]="18" />
+        </button>
+        <span class="sr-only" role="status" aria-live="polite">
+          {{ voice.isListening() ? t('chat.mic.listening') : '' }}
+        </span>
+      }
       <button
         type="submit"
         class="chat-send btn-primary"

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
@@ -372,3 +372,45 @@
 .chat-send {
   align-self: flex-end;
 }
+
+.chat-mic {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--yn-radius-circle);
+  border: 1px solid var(--yn-glass-border);
+  background: var(--yn-glass-bg);
+  color: var(--yn-text);
+  cursor: pointer;
+  transition: background var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover {
+    background: var(--yn-glass-bg-elevated);
+  }
+
+  &.listening {
+    background: var(--yn-primary);
+    color: var(--yn-text-inverse);
+    animation: yn-mic-pulse 1.4s var(--yn-ease-glass) infinite;
+  }
+}
+
+@keyframes yn-mic-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(244, 63, 94, 0.6);
+  }
+
+  50% {
+    box-shadow: 0 0 0 8px rgba(244, 63, 94, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-mic.listening {
+    animation: none;
+  }
+}

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -4,7 +4,8 @@ import { provideRouter, Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { ChatPanelComponent } from './chat-panel.component';
 import { ChatApiService, RecipeApiService } from '@yumney/shared/api-client';
-import { ChatStateService, setupTranslocoTesting } from '@yumney/shared/models';
+import { ChatStateService, setupTranslocoTesting, VoiceService } from '@yumney/shared/models';
+import { signal } from '@angular/core';
 
 const en = {
   chat: {
@@ -27,6 +28,7 @@ const en = {
       openRecipe: 'Open recipe',
       startCooking: 'Start cooking',
     },
+    mic: { start: 'Start voice input', stop: 'Stop voice input', listening: 'Listening...' },
   },
   commandBar: {
     hints: {
@@ -40,6 +42,13 @@ describe('ChatPanelComponent', () => {
   let chatState: ChatStateService;
   let chatApiMock: { send: ReturnType<typeof vi.fn>; importFromText: ReturnType<typeof vi.fn> };
   let recipeApiMock: { importRecipe: ReturnType<typeof vi.fn> };
+  let voiceMock: {
+    sttSupported: ReturnType<typeof signal<boolean>>;
+    isListening: ReturnType<typeof signal<boolean>>;
+    setLanguage: ReturnType<typeof vi.fn>;
+    startListeningForTranscript: ReturnType<typeof vi.fn>;
+    stopListening: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     chatApiMock = {
@@ -49,6 +58,13 @@ describe('ChatPanelComponent', () => {
     recipeApiMock = {
       importRecipe: vi.fn().mockReturnValue(of({ title: 'Test', ingredients: [], steps: [] })),
     };
+    voiceMock = {
+      sttSupported: signal(true),
+      isListening: signal(false),
+      setLanguage: vi.fn(),
+      startListeningForTranscript: vi.fn(),
+      stopListening: vi.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [ChatPanelComponent, setupTranslocoTesting(en)],
@@ -57,6 +73,7 @@ describe('ChatPanelComponent', () => {
         provideRouter([]),
         { provide: ChatApiService, useValue: chatApiMock },
         { provide: RecipeApiService, useValue: recipeApiMock },
+        { provide: VoiceService, useValue: voiceMock },
         ChatStateService,
       ],
     }).compileComponents();
@@ -447,5 +464,83 @@ describe('ChatPanelComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance['lastActions']().length).toBe(0);
+  });
+
+  describe('mic button (US-360)', () => {
+    it('renders the mic button when speech recognition is supported', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-mic"]')).toBeTruthy();
+    });
+
+    it('hides the mic button when speech recognition is unsupported', () => {
+      voiceMock.sttSupported.set(false);
+      chatState.open();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-mic"]')).toBeNull();
+    });
+
+    it('starts transcript listening on the first click', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="chat-mic"]',
+      ) as HTMLButtonElement;
+      button.click();
+
+      expect(voiceMock.setLanguage).toHaveBeenCalled();
+      expect(voiceMock.startListeningForTranscript).toHaveBeenCalledTimes(1);
+      expect(voiceMock.stopListening).not.toHaveBeenCalled();
+    });
+
+    it('stops listening when clicked again while listening', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      voiceMock.isListening.set(true);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="chat-mic"]',
+      ) as HTMLButtonElement;
+      button.click();
+
+      expect(voiceMock.stopListening).toHaveBeenCalledTimes(1);
+      expect(voiceMock.startListeningForTranscript).not.toHaveBeenCalled();
+    });
+
+    it('appends the transcript to the existing input', () => {
+      chatState.open();
+      fixture.detectChanges();
+      fixture.componentInstance['input'].set('Plan');
+
+      fixture.componentInstance['onToggleMic']();
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
+        text: string,
+      ) => void;
+      onTranscript('the week');
+
+      expect(fixture.componentInstance['input']()).toBe('Plan the week');
+    });
+
+    it('sets recognition language to the active translation', () => {
+      chatState.open();
+      fixture.detectChanges();
+      fixture.componentInstance['onToggleMic']();
+
+      expect(voiceMock.setLanguage).toHaveBeenCalledWith(expect.stringMatching(/^(en|de)$/));
+    });
+
+    it('applies the listening class while listening', () => {
+      chatState.open();
+      voiceMock.isListening.set(true);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-mic"]');
+      expect(button.classList.contains('listening')).toBe(true);
+    });
   });
 });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -12,7 +12,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { TranslocoModule } from '@jsverse/transloco';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import {
   ChatApiService,
@@ -20,7 +20,7 @@ import {
   type ChatAction,
   type ChatRecipeSuggestion,
 } from '@yumney/shared/api-client';
-import { ChatHintService, ChatStateService, ROUTES } from '@yumney/shared/models';
+import { ChatHintService, ChatStateService, ROUTES, VoiceService } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-chat-panel',
@@ -39,6 +39,8 @@ export class ChatPanelComponent implements AfterViewInit {
   private recipeApi = inject(RecipeApiService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
+  protected voice = inject(VoiceService);
+  private transloco = inject(TranslocoService);
 
   protected input = signal('');
   protected error = signal<string | null>(null);
@@ -66,6 +68,18 @@ export class ChatPanelComponent implements AfterViewInit {
 
   protected onBackdropClick(): void {
     this.state.close();
+  }
+
+  protected onToggleMic(): void {
+    if (this.voice.isListening()) {
+      this.voice.stopListening();
+      return;
+    }
+    this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
+    this.voice.startListeningForTranscript((transcript) => {
+      const current = this.input();
+      this.input.set(current ? `${current} ${transcript}`.trim() : transcript);
+    });
   }
 
   protected onSend(): void {


### PR DESCRIPTION
## Summary

US-360 — adds a microphone button next to the chat-input textarea on the chat panel. Tap once to capture an utterance; the transcribed text is appended to the input. Tap again to cancel; the browser auto-stops on silence so most users only need one tap.

### VoiceService

- **`startListeningForTranscript(onTranscript)`** — push-to-talk capture for free-form text. Unlike the cook-mode \`startListening\` path which keeps the mic open for back-to-back commands and only emits when an utterance matches a known pattern, this returns the raw transcript of a single utterance and auto-stops on silence (\`continuous=false\`). Empty transcripts don't fire the callback so the input never gets cluttered with no-ops.

### Chat panel

- Mic button alongside textarea + send.
- **Hidden when `voice.sttSupported()` is false** (browser without Web Speech API) → no broken affordance on Firefox / unsupported environments.
- **Recognition language synced from the active Transloco language** on every tap, so the German UI honours \`de-DE\` and the English UI honours \`en-US\` per-utterance — picks up a runtime language switch without remounting the panel.
- **Pulsing-glow animation** on the button while listening (\`@keyframes yn-mic-pulse\`). Disabled under \`prefers-reduced-motion: reduce\`.
- **Visually-hidden status announcement** (\`role="status" aria-live="polite"\`) reports "Listening..." for screen readers; the button itself flips its \`aria-pressed\` + \`aria-label\` between the start / stop states.
- **Transcripts append to existing input** so users can pre-fill via voice and edit with keyboard before sending.

### i18n

EN + DE \`chat.mic.{start,stop,listening}\` keys; \`sync:i18n:check\` clean.

## Tests

- **\`voice.service.spec\`** (7 new): single-utterance config, raw + trimmed transcript emission, empty-transcript no-op, language propagation, end + error reset \`isListening\`, no-op when already listening.
- **\`chat-panel.spec\`** (7 new): mic button shown when supported / hidden when not, first click starts listening, second click stops, transcript appends to input, language set before start, listening class applied during capture.

## Test plan

- [x] \`nx test shared-models\` clean
- [x] \`nx test ui\` clean
- [x] \`nx test shell\` clean
- [x] \`nx lint shared-models,ui,shell\` (1 pre-existing error in unrelated \`global-error.interceptor.spec.ts\` — not introduced here)
- [x] \`nx build shell\`
- [x] \`yarn sync:i18n:check\`
- [ ] Backend / E2E CI on this PR

Closes #187.

## Notes / future

- The chat panel itself isn't yet wired into a "persistent command bar" — that's the larger US-303 follow-up. This PR delivers the voice-input AC against the existing chat-panel component, which is the surface users currently see.
- TTS for assistant replies (US-361) and the cook-mode voice integration (US-362) remain separate stories.