### PR TITLE
feat(ui): speak chat replies after voice input + mute / replay (US-361)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -333,6 +333,11 @@
       "start": "Sprachsteuerung starten",
       "stop": "Sprachsteuerung stoppen",
       "listening": "Höre zu..."
+    },
+    "tts": {
+      "mute": "Sprachausgabe stummschalten",
+      "unmute": "Sprachausgabe einschalten",
+      "replay": "Letzte Antwort erneut vorlesen"
     }
   },
   "commandBar": {

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -333,6 +333,11 @@
       "start": "Start voice input",
       "stop": "Stop voice input",
       "listening": "Listening..."
+    },
+    "tts": {
+      "mute": "Mute spoken replies",
+      "unmute": "Unmute spoken replies",
+      "replay": "Replay last reply"
     }
   },
   "commandBar": {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -108,7 +108,7 @@
       <textarea
         data-testid="chat-input"
         [ngModel]="input()"
-        (ngModelChange)="input.set($event)"
+        (ngModelChange)="onInputChange($event)"
         (keydown)="onKeydown($event)"
         [placeholder]="t(hints.hintKey())"
         [attr.aria-label]="t('chat.inputLabel')"
@@ -130,6 +130,31 @@
         <span class="sr-only" role="status" aria-live="polite">
           {{ voice.isListening() ? t('chat.mic.listening') : '' }}
         </span>
+      }
+      @if (voice.ttsSupported()) {
+        <button
+          type="button"
+          class="chat-mute"
+          data-testid="chat-mute"
+          [class.muted]="voice.muted()"
+          [attr.aria-pressed]="voice.muted()"
+          [attr.aria-label]="voice.muted() ? t('chat.tts.unmute') : t('chat.tts.mute')"
+          (click)="onToggleMute()"
+        >
+          <lucide-icon [name]="voice.muted() ? 'volume-x' : 'volume-2'" [size]="18" />
+        </button>
+        @if (lastAssistantMessage()) {
+          <button
+            type="button"
+            class="chat-replay"
+            data-testid="chat-replay"
+            [disabled]="voice.muted() || voice.isSpeaking()"
+            [attr.aria-label]="t('chat.tts.replay')"
+            (click)="onReplayLast()"
+          >
+            <lucide-icon name="play" [size]="18" />
+          </button>
+        }
       }
       <button
         type="submit"

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
@@ -373,7 +373,9 @@
   align-self: flex-end;
 }
 
-.chat-mic {
+.chat-mic,
+.chat-mute,
+.chat-replay {
   align-self: flex-end;
   display: inline-flex;
   align-items: center;
@@ -387,15 +389,24 @@
   cursor: pointer;
   transition: background var(--yn-duration-fast) var(--yn-ease-glass);
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--yn-glass-bg-elevated);
   }
 
-  &.listening {
-    background: var(--yn-primary);
-    color: var(--yn-text-inverse);
-    animation: yn-mic-pulse 1.4s var(--yn-ease-glass) infinite;
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
+}
+
+.chat-mic.listening {
+  background: var(--yn-primary);
+  color: var(--yn-text-inverse);
+  animation: yn-mic-pulse 1.4s var(--yn-ease-glass) infinite;
+}
+
+.chat-mute.muted {
+  color: var(--yn-text-muted);
 }
 
 @keyframes yn-mic-pulse {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -29,6 +29,7 @@ const en = {
       startCooking: 'Start cooking',
     },
     mic: { start: 'Start voice input', stop: 'Stop voice input', listening: 'Listening...' },
+    tts: { mute: 'Mute', unmute: 'Unmute', replay: 'Replay' },
   },
   commandBar: {
     hints: {
@@ -44,10 +45,15 @@ describe('ChatPanelComponent', () => {
   let recipeApiMock: { importRecipe: ReturnType<typeof vi.fn> };
   let voiceMock: {
     sttSupported: ReturnType<typeof signal<boolean>>;
+    ttsSupported: ReturnType<typeof signal<boolean>>;
     isListening: ReturnType<typeof signal<boolean>>;
+    isSpeaking: ReturnType<typeof signal<boolean>>;
+    muted: ReturnType<typeof signal<boolean>>;
     setLanguage: ReturnType<typeof vi.fn>;
+    setMuted: ReturnType<typeof vi.fn>;
     startListeningForTranscript: ReturnType<typeof vi.fn>;
     stopListening: ReturnType<typeof vi.fn>;
+    speak: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -60,10 +66,15 @@ describe('ChatPanelComponent', () => {
     };
     voiceMock = {
       sttSupported: signal(true),
+      ttsSupported: signal(true),
       isListening: signal(false),
+      isSpeaking: signal(false),
+      muted: signal(false),
       setLanguage: vi.fn(),
+      setMuted: vi.fn((value: boolean) => voiceMock.muted.set(value)),
       startListeningForTranscript: vi.fn(),
       stopListening: vi.fn(),
+      speak: vi.fn(),
     };
 
     await TestBed.configureTestingModule({
@@ -541,6 +552,144 @@ describe('ChatPanelComponent', () => {
 
       const button = fixture.nativeElement.querySelector('[data-testid="chat-mic"]');
       expect(button.classList.contains('listening')).toBe(true);
+    });
+  });
+
+  describe('tts (US-361)', () => {
+    async function sendMessage(content: string): Promise<void> {
+      fixture.componentInstance['input'].set(content);
+      fixture.componentInstance['onSend']();
+      await Promise.resolve();
+      fixture.detectChanges();
+    }
+
+    it('speaks the chat reply when the message was entered via voice', async () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      // Simulate the mic callback firing — it sets lastInputWasVoice=true.
+      fixture.componentInstance['onToggleMic']();
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
+        text: string,
+      ) => void;
+      onTranscript('Add milk');
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'Added 1 liter milk', suggestions: [] }));
+      await sendMessage('Add milk');
+
+      expect(voiceMock.speak).toHaveBeenCalledWith('Added 1 liter milk');
+    });
+
+    it('does not speak the reply when the message was typed', async () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'Sure!', suggestions: [] }));
+      await sendMessage('Plan my week');
+
+      expect(voiceMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('resets the voice flag after the reply, so the next typed message stays silent', async () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      fixture.componentInstance['onToggleMic']();
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
+        text: string,
+      ) => void;
+      onTranscript('Add milk');
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'Added', suggestions: [] }));
+      await sendMessage('Add milk');
+      voiceMock.speak.mockClear();
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'OK', suggestions: [] }));
+      await sendMessage('Plan my week');
+
+      expect(voiceMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('typing replaces voice mode (no TTS even after a mic transcript)', async () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      fixture.componentInstance['onToggleMic']();
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
+        text: string,
+      ) => void;
+      onTranscript('Add milk');
+
+      // Simulate user typing — ngModelChange path through onInputChange.
+      fixture.componentInstance['onInputChange']('Add milk and bread');
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'Added', suggestions: [] }));
+      await sendMessage('Add milk and bread');
+
+      expect(voiceMock.speak).not.toHaveBeenCalled();
+    });
+
+    it('renders the mute toggle when TTS is supported', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-mute"]')).toBeTruthy();
+    });
+
+    it('hides the mute toggle when TTS is unsupported', () => {
+      voiceMock.ttsSupported.set(false);
+      chatState.open();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-mute"]')).toBeNull();
+    });
+
+    it('mute click flips voice.muted', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="chat-mute"]',
+      ) as HTMLButtonElement;
+      button.click();
+
+      expect(voiceMock.setMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('replay button is hidden until there is a last assistant message', () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-replay"]')).toBeNull();
+    });
+
+    it('replay button speaks the last assistant message', async () => {
+      chatState.open();
+      fixture.detectChanges();
+      chatApiMock.send.mockReturnValue(of({ reply: 'Hello there', suggestions: [] }));
+      await sendMessage('Hi');
+      voiceMock.speak.mockClear();
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="chat-replay"]',
+      ) as HTMLButtonElement;
+      button.click();
+
+      expect(voiceMock.speak).toHaveBeenCalledWith('Hello there');
+    });
+
+    it('replay button is disabled while muted', async () => {
+      chatState.open();
+      chatApiMock.send.mockReturnValue(of({ reply: 'Hello', suggestions: [] }));
+      await sendMessage('Hi');
+
+      voiceMock.muted.set(true);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="chat-replay"]',
+      ) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
     });
   });
 });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -48,6 +48,11 @@ export class ChatPanelComponent implements AfterViewInit {
   protected lastActions = signal<ChatAction[]>([]);
   protected lastAssistantMessage = signal('');
 
+  // Tracks whether the *currently pending* send originated from the mic so we
+  // know whether to read the assistant reply aloud (US-361). Reset on typed
+  // input / new mic capture, and re-checked in the chat response handler.
+  protected lastInputWasVoice = signal(false);
+
   messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messages');
 
   constructor() {
@@ -66,6 +71,14 @@ export class ChatPanelComponent implements AfterViewInit {
     this.state.close();
   }
 
+  protected onInputChange(value: string): void {
+    this.input.set(value);
+    // Keyboard edits switch the conversation back to a "typed" interaction,
+    // so the assistant reply won't be read aloud unless the user uses the
+    // mic again.
+    this.lastInputWasVoice.set(false);
+  }
+
   protected onBackdropClick(): void {
     this.state.close();
   }
@@ -79,7 +92,19 @@ export class ChatPanelComponent implements AfterViewInit {
     this.voice.startListeningForTranscript((transcript) => {
       const current = this.input();
       this.input.set(current ? `${current} ${transcript}`.trim() : transcript);
+      this.lastInputWasVoice.set(true);
     });
+  }
+
+  protected onToggleMute(): void {
+    this.voice.setMuted(!this.voice.muted());
+  }
+
+  protected onReplayLast(): void {
+    const reply = this.lastAssistantMessage();
+    if (!reply) return;
+    this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
+    this.voice.speak(reply);
   }
 
   protected onSend(): void {
@@ -107,6 +132,7 @@ export class ChatPanelComponent implements AfterViewInit {
 
   private handleChat(message: string): void {
     const history = this.state.messages().slice(0, -1);
+    const speakReply = this.lastInputWasVoice();
 
     this.chatApi
       .send({ message, history })
@@ -118,6 +144,11 @@ export class ChatPanelComponent implements AfterViewInit {
           this.lastActions.set(response.actions ?? []);
           this.lastAssistantMessage.set(response.reply);
           this.state.setThinking(false);
+          if (speakReply) {
+            this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
+            this.voice.speak(response.reply);
+          }
+          this.lastInputWasVoice.set(false);
         },
         error: (err) => this.handleError(err),
       });

--- a/client/libs/ui/src/lib/icons/yn-icons.ts
+++ b/client/libs/ui/src/lib/icons/yn-icons.ts
@@ -44,6 +44,8 @@ import {
   Sun,
   Trash2,
   Utensils,
+  Volume2,
+  VolumeX,
   X,
 } from 'lucide-angular';
 
@@ -99,5 +101,7 @@ export const YN_ICONS = {
   Sun,
   Trash2,
   Utensils,
+  Volume2,
+  VolumeX,
   X,
 };


### PR DESCRIPTION
## Summary

Closes the voice-conversation loop opened in US-360. When the user sends a message via the mic, the assistant's reply is read aloud via Web Speech \`speechSynthesis\`. Typed messages stay silent so the desktop experience is unchanged. A mute toggle and a replay-last button live next to the mic in the chat input row.

### What's new

- **\`lastInputWasVoice\` signal** tracks the source of the *pending* send. The mic transcript callback flips it to true; any keystroke through the new \`onInputChange\` handler flips it back. The chat-API handler captures the flag at request time (so an in-flight reply isn't retroactively muted by a later keystroke) and resets it after.
- **Reply TTS** uses the existing \`VoiceService.speak\`, which already honours the user's \`voiceEnabled\` preference, the session mute toggle, and the configured rate (\`slow\`/\`normal\`/\`fast\`).
- **Recognition + synthesis language** are re-synced from \`TranslocoService.getActiveLang()\` on every utterance, so a language switch mid-session takes effect without remounting.
- **Mute button** (volume-2 / volume-x icon, \`aria-pressed\`) toggles \`voice.setMuted\`. Visible whenever TTS is supported.
- **Replay button** speaks \`lastAssistantMessage\`. Visible only after the first assistant reply; disabled while muted or while the engine is speaking, so a rapid second click can't queue an overlap.

### i18n

EN + DE \`chat.tts.{mute,unmute,replay}\` keys; \`sync:i18n:check\` clean.

## Tests

\`chat-panel.spec\` (10 new):

- voice path speaks the reply
- typed path doesn't speak
- voice flag resets between sends
- keyboard editing after a mic capture cancels the voice path
- mute toggle visibility (shown when TTS supported, hidden otherwise)
- mute click flips \`voice.muted\`
- replay hidden until first reply
- replay speaks the last assistant message
- replay disabled while muted

## Test plan

- [x] \`nx test ui\` clean (10 new tests pass; full suite green)
- [x] \`nx test shell\` clean
- [x] \`nx run-many -t lint --projects=shell,ui,shared-models\` clean (1 pre-existing warning, not introduced here)
- [x] \`nx build shell\` clean
- [x] \`yarn sync:i18n:check\` clean
- [x] \`yarn prettier --check\` clean
- [ ] Backend / E2E CI on this PR

Closes #188.

## Notes / out of scope

- AC items "short confirmations" / "long responses summarized" are properties of the chat-API reply itself, not the speak pipeline; they're already shaped by the LLM prompt in US-639/US-640. Not changed here.
- The user-preference flow (voice enabled / speed) already exists in the profile-settings UI; no new pref surface added in this PR.