### PR TITLE
feat(recipes): voice-enhanced cook-mode integration (US-362)

### DIFF
--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
@@ -3,7 +3,7 @@ import { provideRouter, ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { signal } from '@angular/core';
 import { CookModeComponent } from './cook-mode.component';
-import { RecipeApiService, type RecipeDetail } from '../api';
+import { ChatApiService, RecipeApiService, type RecipeDetail } from '../api';
 import {
   UserPreferencesService,
   VoiceService,
@@ -65,6 +65,7 @@ describe('CookModeComponent', () => {
     speak: ReturnType<typeof vi.fn>;
     stopSpeaking: ReturnType<typeof vi.fn>;
     startListening: ReturnType<typeof vi.fn>;
+    startListeningWithFallback: ReturnType<typeof vi.fn>;
     stopListening: ReturnType<typeof vi.fn>;
     setLanguage: ReturnType<typeof vi.fn>;
     setMuted: ReturnType<typeof vi.fn>;
@@ -74,6 +75,7 @@ describe('CookModeComponent', () => {
     ttsSupported: ReturnType<typeof signal<boolean>>;
     sttSupported: ReturnType<typeof signal<boolean>>;
   };
+  let chatApiMock: { send: ReturnType<typeof vi.fn> };
   let wakeLockMock: {
     acquire: ReturnType<typeof vi.fn>;
     release: ReturnType<typeof vi.fn>;
@@ -108,6 +110,7 @@ describe('CookModeComponent', () => {
       speak: vi.fn(),
       stopSpeaking: vi.fn(),
       startListening: vi.fn(),
+      startListeningWithFallback: vi.fn(),
       stopListening: vi.fn(),
       setLanguage: vi.fn(),
       setMuted: vi.fn(),
@@ -116,6 +119,10 @@ describe('CookModeComponent', () => {
       muted: signal(false),
       ttsSupported: signal(true),
       sttSupported: signal(true),
+    };
+
+    chatApiMock = {
+      send: vi.fn().mockReturnValue(of({ reply: 'OK', suggestions: [] })),
     };
 
     wakeLockMock = {
@@ -150,6 +157,7 @@ describe('CookModeComponent', () => {
         provideYumneyIcons(),
         provideRouter([]),
         { provide: RecipeApiService, useValue: recipeApiMock },
+        { provide: ChatApiService, useValue: chatApiMock },
         { provide: VoiceService, useValue: voiceMock },
         { provide: WakeLockService, useValue: wakeLockMock },
         { provide: CookingTimerService, useValue: timersMock },
@@ -256,14 +264,48 @@ describe('CookModeComponent', () => {
     expect(wakeLockMock.release).toHaveBeenCalled();
   }));
 
-  it('should toggle listening when toggleListening is called', fakeAsync(() => {
+  it('auto-starts continuous listening with cook+global fallback on entry (US-362)', fakeAsync(() => {
     setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
     fixture.detectChanges();
     tick();
 
-    component.toggleListening();
+    expect(voiceMock.startListeningWithFallback).toHaveBeenCalled();
+    // Old single-path startListening should no longer be used in cook mode.
+    expect(voiceMock.startListening).not.toHaveBeenCalled();
+  }));
 
-    expect(voiceMock.startListening).toHaveBeenCalled();
+  it('re-starts listening with fallback when toggleListening is tapped off-then-on (US-362)', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+    voiceMock.startListeningWithFallback.mockClear();
+
+    voiceMock.isListening.set(true);
+    component.toggleListening();
+    expect(voiceMock.stopListening).toHaveBeenCalled();
+
+    voiceMock.isListening.set(false);
+    component.toggleListening();
+    expect(voiceMock.startListeningWithFallback).toHaveBeenCalled();
+  }));
+
+  it('routes unparsed transcripts through chat and speaks the reply (US-362)', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    chatApiMock.send.mockReturnValue(of({ reply: 'Adding butter…', suggestions: [] }));
+    fixture.detectChanges();
+    tick();
+
+    const onTranscript = voiceMock.startListeningWithFallback.mock.calls[0][1] as (
+      text: string,
+    ) => void;
+    onTranscript('add butter to shopping list');
+    tick();
+
+    expect(chatApiMock.send).toHaveBeenCalledWith({
+      message: 'add butter to shopping list',
+      history: [],
+    });
+    expect(voiceMock.speak).toHaveBeenCalledWith('Adding butter…');
   }));
 
   it('should close ingredients panel by default', fakeAsync(() => {

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -10,9 +10,10 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { RecipeApiService, type RecipeDetail } from '../api';
+import { ChatApiService, RecipeApiService, type RecipeDetail } from '../api';
 import {
   CookingTimerService,
   createAsyncState,
@@ -55,6 +56,7 @@ export class CookModeComponent implements OnInit, OnDestroy {
   protected readonly ROUTES = ROUTES;
 
   private recipeApi = inject(RecipeApiService);
+  private chatApi = inject(ChatApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
@@ -101,7 +103,13 @@ export class CookModeComponent implements OnInit, OnDestroy {
     this.loadState.execute(
       this.recipeApi.getRecipeById(identifier),
       ERROR_MAPS.recipes.detail,
-      (recipe) => this.recipe.set(recipe),
+      (recipe) => {
+        this.recipe.set(recipe);
+        // Auto-activate continuous listening on entry per US-362 AC. Stays
+        // silent if Web Speech isn't supported — the existing toggle button
+        // remains available either way. Cleanup happens in `ngOnDestroy`.
+        this.startListeningInCookMode();
+      },
       (error) => this.serverError.set(error),
     );
 
@@ -142,8 +150,29 @@ export class CookModeComponent implements OnInit, OnDestroy {
     if (this.voice.isListening()) {
       this.voice.stopListening();
     } else {
-      this.voice.startListening((command) => this.handleCommand(command));
+      this.startListeningInCookMode();
     }
+  }
+
+  private startListeningInCookMode(): void {
+    this.voice.startListeningWithFallback(
+      (command) => this.handleCommand(command),
+      (transcript) => this.handleTranscript(transcript),
+    );
+  }
+
+  private handleTranscript(transcript: string): void {
+    // Global voice command while cooking — route through chat so users can say
+    // "add butter to shopping list" or "what's for dinner tomorrow?" without
+    // leaving cook mode. The reply gets spoken via the TTS path used by the
+    // step-read effect.
+    this.chatApi
+      .send({ message: transcript, history: [] })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => this.voice.speak(response.reply),
+        error: () => undefined,
+      });
   }
 
   toggleMute(): void {

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -293,3 +293,91 @@ describe('VoiceService.startListeningForTranscript (US-360)', () => {
     expect(first.start).not.toHaveBeenCalled();
   });
 });
+
+describe('VoiceService.startListeningWithFallback (US-362)', () => {
+  let service: VoiceService;
+  let getRecognition: () => MockRecognition;
+
+  beforeEach(() => {
+    getRecognition = installSpeechRecognition();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [VoiceService, { provide: UserPreferencesService, useValue: makePrefsStub(true) }],
+    });
+    service = TestBed.inject(VoiceService);
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
+  });
+
+  it('starts a continuous recognition session', () => {
+    service.startListeningWithFallback(
+      () => undefined,
+      () => undefined,
+    );
+
+    const recognition = getRecognition();
+    expect(recognition.continuous).toBe(true);
+    expect(recognition.interimResults).toBe(false);
+    expect(recognition.start).toHaveBeenCalled();
+    expect(service.isListening()).toBe(true);
+  });
+
+  it('routes a cook-mode command to onCommand, not onTranscript', () => {
+    const onCommand = vi.fn();
+    const onTranscript = vi.fn();
+    service.startListeningWithFallback(onCommand, onTranscript);
+
+    getRecognition().onresult?.({ results: [[{ transcript: 'next step' }]] });
+
+    expect(onCommand).toHaveBeenCalledWith({ type: 'next' });
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it('routes an unknown phrase to onTranscript, not onCommand', () => {
+    const onCommand = vi.fn();
+    const onTranscript = vi.fn();
+    service.startListeningWithFallback(onCommand, onTranscript);
+
+    getRecognition().onresult?.({
+      results: [[{ transcript: 'add butter to shopping list' }]],
+    });
+
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledWith('add butter to shopping list');
+  });
+
+  it('gives cook-mode commands precedence ("timer 5 minutes" → timer command)', () => {
+    const onCommand = vi.fn();
+    const onTranscript = vi.fn();
+    service.startListeningWithFallback(onCommand, onTranscript);
+
+    getRecognition().onresult?.({ results: [[{ transcript: 'timer 5 minutes' }]] });
+
+    expect(onCommand).toHaveBeenCalledWith({ type: 'timer', minutes: 5 });
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it('skips empty transcripts entirely', () => {
+    const onCommand = vi.fn();
+    const onTranscript = vi.fn();
+    service.startListeningWithFallback(onCommand, onTranscript);
+
+    getRecognition().onresult?.({ results: [[{ transcript: '   ' }]] });
+
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it('clears isListening on end', () => {
+    service.startListeningWithFallback(
+      () => undefined,
+      () => undefined,
+    );
+
+    getRecognition().onend?.();
+
+    expect(service.isListening()).toBe(false);
+  });
+});

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -145,6 +145,55 @@ export class VoiceService {
   }
 
   /**
+   * Cook-mode + chat hybrid capture (US-362). Listens continuously and tries to
+   * match each utterance against the known cook-mode patterns first
+   * (next/previous/repeat/stop/ingredients/timer). If the utterance matches,
+   * <paramref name="onCommand" /> fires and the transcript is consumed. If no
+   * cook-mode pattern matches, the raw transcript is handed to
+   * <paramref name="onTranscript" /> so the caller can route it to the chat
+   * pipeline (global commands like "add butter to the shopping list",
+   * "what's for dinner tomorrow?").
+   *
+   * Cook-mode precedence is intentional: AC TC-362-03 — "timer 5 minutes" must
+   * fire the local timer, not a chat round-trip.
+   */
+  startListeningWithFallback(
+    onCommand: (command: VoiceCommand) => void,
+    onTranscript: (transcript: string) => void,
+  ): void {
+    if (!this.sttSupported() || this.isListening()) {
+      return;
+    }
+    const recognition = this.createRecognition();
+    if (!recognition) return;
+
+    recognition.lang = this.currentLang;
+    recognition.continuous = true;
+    recognition.interimResults = false;
+    recognition.onresult = (event) => {
+      const last = event.results[event.results.length - 1];
+      const transcript = last[0]?.transcript?.trim() ?? '';
+      if (transcript === '') return;
+      const command = VoiceService.parseCommand(transcript);
+      if (command) {
+        onCommand(command);
+        return;
+      }
+      onTranscript(transcript);
+    };
+    recognition.onerror = () => {
+      this.isListening.set(false);
+    };
+    recognition.onend = () => {
+      this.isListening.set(false);
+    };
+
+    this.recognition = recognition;
+    recognition.start();
+    this.isListening.set(true);
+  }
+
+  /**
    * Push-to-talk capture for the command bar (US-360). Unlike the cook-mode
    * `startListening` path — which keeps the mic open for back-to-back commands
    * and only emits when the utterance matches a known pattern — this returns


### PR DESCRIPTION
## Summary

Closes the cook-mode voice loop opened in US-240 / US-360. Cook mode now starts continuous listening on entry and routes utterances through two paths in order: known cook-mode commands (next/previous/repeat/stop/ingredients/timer) execute locally as before; anything else becomes a free-form chat round-trip so users can say "add butter to the shopping list" or "what's for dinner tomorrow?" without leaving the screen.

Cook commands always win precedence — AC TC-362-03: "timer 5 minutes" fires the local timer, not a chat call.

### VoiceService

- **\`startListeningWithFallback(onCommand, onTranscript)\`** — continuous recognition that tries \`parseCommand\` first and only forwards the raw transcript to \`onTranscript\` when no cook pattern matches. Empty transcripts are dropped entirely. Lifecycle (\`onerror\`, \`onend\`) clears \`isListening\` exactly like the existing methods.

### Cook mode

- Injects \`ChatApiService\`; the transcript callback POSTs the utterance through the same chat pipeline the chat panel uses, then speaks the reply via the existing \`voice.speak\`. History is empty per call — each cook-mode utterance is treated as a standalone command, so the user's recipe context doesn't accidentally bias unrelated requests like "what's for dinner tomorrow?".
- \`ngOnInit\`'s load callback auto-starts listening with fallback — AC TC-362-04: "entering cook mode auto-activates continuous listening". \`toggleListening\` re-uses the same path on a deliberate off/on tap.
- \`ngOnDestroy\` already stops listening; exit returns the user to the push-to-talk model from US-360 on the chat panel — AC TC-362-05.

## Tests

- **\`voice.service.spec\`** (6 new under "US-362"): continuous config, cook command routes to \`onCommand\`, unknown phrase routes to \`onTranscript\`, cook-precedence for "timer 5 minutes", empty transcript skipped, end clears \`isListening\`.
- **\`cook-mode.component.spec\`**: replaced the legacy "should toggle listening" assertion with three US-362 cases — auto-start on entry, off→on re-toggle uses the fallback path, and transcript → \`chat.send\` → \`voice.speak\`.

## Test plan

- [x] \`nx test shared-models\` clean (6 new US-362 cases pass)
- [x] \`nx test recipes\` clean (3 updated/new cook-mode cases pass)
- [x] \`nx run-many -t lint --projects=recipes,shared-models,ui\` clean
- [x] \`nx build recipes\` clean
- [x] \`yarn prettier --check\` clean
- [ ] Backend / E2E CI on this PR

Closes #189.

## Notes / out of scope

- No new i18n strings — the existing cook-mode voice labels already cover the listening indicator.
- The chat fallback uses a fresh empty \`history\` per utterance — cook context isn't conversationally threaded into shopping/planner intents. Could revisit if user reports cross-intent collisions.