### PR TITLE
feat(users): send confirmation email after GDPR account deletion (#567)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,6 +58,7 @@
     <!-- DI, Configuration & Logging Abstractions -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -123,10 +123,19 @@ if (!options.DatabaseOnly)
 
 	var apiEnvironment = builder.Environment.EnvironmentName;
 
+	// SMTP for outbound app email. In dev the mailpit container exposes
+	// 1025 on the host so the users-api process (running on host) reaches
+	// it at `localhost:1025`. In publish mode a Container App secret
+	// supplies real production credentials. The Users module is the only
+	// consumer today (GDPR account-deletion confirmation, US-567).
 	var usersApi = builder
 		.AddProject<Projects.Yumney_Users_Api>("users-api")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.WithEnvironment("Keycloak__ClientSecret", yumneyApiClientSecret)
+		.WithEnvironment("Smtp__Host", "localhost")
+		.WithEnvironment("Smtp__Port", "1025")
+		.WithEnvironment("Smtp__FromAddress", "noreply@yumney.local")
+		.WithEnvironment("Smtp__FromDisplayName", "Yumney")
 		.AsYumneyApi(options, usersDb, keycloak, redis, messaging, migrationRunner);
 	var shoppingApi = builder
 		.AddProject<Projects.Yumney_Shopping_Api>("shopping-api")

--- a/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
@@ -17,6 +17,7 @@ public sealed partial class DeleteAccountCommandHandler(
 	IKeycloakAdminService keycloak,
 	IEventBus eventBus,
 	ICurrentUser currentUser,
+	IAccountDeletionEmailSender emailSender,
 	ILogger<DeleteAccountCommandHandler> logger)
 	: ICommandHandler<DeleteAccountCommand, Result>
 {
@@ -24,6 +25,13 @@ public sealed partial class DeleteAccountCommandHandler(
 	{
 		var keycloakId = KeycloakUserId.From(currentUser.UserId);
 		LogDeletionRequested(keycloakId.Value);
+
+		// Capture the confirmation-email payload BEFORE the purge — profile +
+		// Keycloak rows are gone by send-time (AC: localise via the last-known
+		// PreferredLanguage). A missing profile or Keycloak email isn't fatal:
+		// the user has the right to be forgotten regardless of whether we can
+		// notify them, so we skip the send instead of aborting the deletion.
+		var emailPayload = await TryBuildEmailPayloadAsync(keycloakId, cancellationToken);
 
 		// 1. Tell every other module to wipe owner-scoped data first. Subscribers
 		// must be idempotent — see UserAccountDeletedIntegrationEvent docstring.
@@ -48,7 +56,49 @@ public sealed partial class DeleteAccountCommandHandler(
 		}
 
 		LogDeletionCompleted(keycloakId.Value);
+
+		// 4. Fire-and-log the confirmation. The user's data is already gone — a
+		// send failure must NOT roll the deletion back (AC). Surface it in the
+		// logs for ops triage.
+		if (emailPayload is not null)
+		{
+			await TrySendConfirmationAsync(emailPayload, cancellationToken);
+		}
+
 		return Result.Success();
+	}
+
+	private async Task<AccountDeletionEmailPayload?> TryBuildEmailPayloadAsync(
+		KeycloakUserId keycloakId,
+		CancellationToken cancellationToken)
+	{
+		var profile = await unitOfWork.Profiles.FindByKeycloakUserIdAsync(keycloakId, cancellationToken);
+		if (profile is null)
+		{
+			LogConfirmationProfileMissing(keycloakId.Value);
+			return null;
+		}
+
+		var emailResult = await keycloak.GetEmailAsync(keycloakId, cancellationToken);
+		if (emailResult.IsFailure)
+		{
+			LogConfirmationEmailUnavailable(keycloakId.Value);
+			return null;
+		}
+
+		return new AccountDeletionEmailPayload(emailResult.Value!, profile.DisplayName, profile.PreferredLanguage);
+	}
+
+	private async Task TrySendConfirmationAsync(AccountDeletionEmailPayload payload, CancellationToken cancellationToken)
+	{
+		try
+		{
+			await emailSender.SendAsync(payload, cancellationToken);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			LogConfirmationSendFailed(payload.RecipientEmail.Value, ex.Message);
+		}
 	}
 
 	[LoggerMessage(Level = LogLevel.Information, Message = "GDPR: account deletion requested for {KeycloakUserId}")]
@@ -59,4 +109,13 @@ public sealed partial class DeleteAccountCommandHandler(
 
 	[LoggerMessage(Level = LogLevel.Error, Message = "GDPR: local data erased but Keycloak deletion failed for {KeycloakUserId}")]
 	private partial void LogKeycloakDeletionFailed(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "GDPR: profile missing for {KeycloakUserId}; skipping confirmation email")]
+	private partial void LogConfirmationProfileMissing(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "GDPR: could not read Keycloak email for {KeycloakUserId}; skipping confirmation email")]
+	private partial void LogConfirmationEmailUnavailable(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "GDPR: failed to send deletion-confirmation email to {EmailAddress} — {Reason}; user data is already erased")]
+	private partial void LogConfirmationSendFailed(string emailAddress, string reason);
 }

--- a/src/Yumney.Users.Application/Interfaces/IAccountDeletionEmailSender.cs
+++ b/src/Yumney.Users.Application/Interfaces/IAccountDeletionEmailSender.cs
@@ -1,0 +1,23 @@
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+
+/// <summary>
+/// Sends the GDPR account-deletion confirmation email. The message is
+/// localised by the user's <see cref="PreferredLanguage" /> captured before
+/// purge — by send-time the profile row is already gone.
+/// </summary>
+public interface IAccountDeletionEmailSender
+{
+	Task SendAsync(AccountDeletionEmailPayload payload, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Snapshot of the data needed to render the deletion-confirmation email,
+/// captured from the user's profile + Keycloak account before the GDPR purge
+/// runs.
+/// </summary>
+public sealed record AccountDeletionEmailPayload(
+	Email RecipientEmail,
+	DisplayName DisplayName,
+	PreferredLanguage Language);

--- a/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
+++ b/src/Yumney.Users.Application/Interfaces/IKeycloakAdminService.cs
@@ -20,4 +20,15 @@ public interface IKeycloakAdminService
 	/// <param name="cancellationToken">Token to cancel the in-flight request.</param>
 	/// <returns>Success on deletion (or 404); failure when Keycloak is unreachable.</returns>
 	Task<Result> DeleteUserAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Looks up the user's email in Keycloak. Used by the GDPR account-deletion
+	/// flow to capture the destination address before the local profile row is
+	/// purged. Returns a not-found error when the user is missing on Keycloak —
+	/// the caller decides whether to proceed without sending a confirmation.
+	/// </summary>
+	/// <param name="keycloakUserId">The Keycloak user identifier to look up.</param>
+	/// <param name="cancellationToken">Token to cancel the in-flight request.</param>
+	/// <returns>The user's email when known; failure otherwise.</returns>
+	Task<Result<Email>> GetEmailAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Users.Infrastructure/Services/AccountDeletionEmailTemplate.cs
+++ b/src/Yumney.Users.Infrastructure/Services/AccountDeletionEmailTemplate.cs
@@ -1,0 +1,68 @@
+using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+/// <summary>
+/// Renders the GDPR account-deletion confirmation. Two locales (EN / DE)
+/// inlined as constants rather than embedded resources — the message is
+/// fixed and short enough that a templating engine would be overkill.
+/// Add cases when new <see cref="Yumney.Users.Domain.AppUserProfile.PreferredLanguage"/>
+/// values appear.
+/// </summary>
+internal static class AccountDeletionEmailTemplate
+{
+	public static AccountDeletionEmail Render(AccountDeletionEmailPayload payload)
+	{
+		var name = payload.DisplayName.Value;
+		return payload.Language.Value == "de"
+			? new AccountDeletionEmail(GermanSubject, RenderGermanBody(name))
+			: new AccountDeletionEmail(EnglishSubject, RenderEnglishBody(name));
+	}
+
+#pragma warning disable SA1303
+	private const string englishSubject = "Your Yumney account has been deleted";
+	private const string germanSubject = "Dein Yumney-Konto wurde gelöscht";
+#pragma warning restore SA1303
+
+	public static string EnglishSubject => englishSubject;
+
+	public static string GermanSubject => germanSubject;
+
+	private static string RenderEnglishBody(string name) => $"""
+        Hi {name},
+
+        your account-deletion request has been processed. We've permanently erased the following data:
+
+        • Profile (display name, language, preferences)
+        • Activity history
+        • Staples and shopping lists
+        • Meal plans and cooked-meal records
+        • Imported recipes
+        • Your Keycloak sign-in
+
+        If you didn't request this deletion, please contact support@yumney.local right away.
+
+        We hope to see you again sometime.
+        The Yumney team
+        """;
+
+	private static string RenderGermanBody(string name) => $"""
+        Hallo {name},
+
+        deine Anfrage zur Kontolöschung wurde bearbeitet. Wir haben die folgenden Daten unwiderruflich entfernt:
+
+        • Profil (Anzeigename, Sprache, Einstellungen)
+        • Aktivitäts-Verlauf
+        • Vorratslisten und Einkaufslisten
+        • Wochenplanung und gekochte Mahlzeiten
+        • Importierte Rezepte
+        • Dein Login bei Keycloak
+
+        Falls du diese Löschung nicht angefordert hast, kontaktiere bitte umgehend support@yumney.local.
+
+        Wir hoffen, dich irgendwann wiederzusehen.
+        Dein Yumney-Team
+        """;
+}
+
+internal sealed record AccountDeletionEmail(string Subject, string Body);

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.GetEmail.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.GetEmail.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Users.Application.Commands;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+#pragma warning disable SA1601
+public sealed partial class KeycloakAdminService
+{
+	public async Task<Result<Email>> GetEmailAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
+	{
+		using var activity = UsersDiagnostics.ActivitySource.StartActivity("keycloak.get_email");
+		activity?.SetTag("keycloak.user_id", keycloakUserId.Value);
+
+		var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}";
+
+		var response = await SendAuthenticatedAsync(HttpMethod.Get, url, null, "get_email", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
+		if (response.IsFailure)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);
+			return Result<Email>.Failure(response.Error!);
+		}
+
+		if (response.Value.StatusCode == HttpStatusCode.NotFound)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, "user not found");
+			LogGetEmailUserMissing(keycloakUserId.Value);
+			return Result<Email>.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+
+		if (!response.Value.IsSuccessStatusCode)
+		{
+			var body = await response.Value.Content.ReadAsStringAsync(cancellationToken);
+			activity?.SetStatus(ActivityStatusCode.Error, $"HTTP {response.Value.StatusCode}");
+			LogGetEmailFailed(response.Value.StatusCode, body);
+			return Result<Email>.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+
+		var representation = await response.Value.Content.ReadFromJsonAsync<KeycloakUserEmailRepresentation>(jsonOptions, cancellationToken);
+		if (representation?.Email is null)
+		{
+			activity?.SetStatus(ActivityStatusCode.Error, "email missing on Keycloak user");
+			LogGetEmailMissing(keycloakUserId.Value);
+			return Result<Email>.Failure(VerificationErrors.IdentityProviderUnavailable);
+		}
+
+		activity?.SetStatus(ActivityStatusCode.Ok);
+		return Result<Email>.Success(Email.From(representation.Email));
+	}
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Keycloak user {KeycloakUserId} not found while reading email")]
+	private partial void LogGetEmailUserMissing(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Keycloak user {KeycloakUserId} has no email field set")]
+	private partial void LogGetEmailMissing(string keycloakUserId);
+
+	[LoggerMessage(Level = LogLevel.Error, Message = "Failed to read Keycloak user email. Status: {StatusCode}, Body: {Body}")]
+	private partial void LogGetEmailFailed(HttpStatusCode statusCode, string body);
+
+#pragma warning disable SA1402, SA1649
+	private sealed record KeycloakUserEmailRepresentation(
+		[property: JsonPropertyName("email")] string? Email);
+#pragma warning restore SA1402, SA1649
+}

--- a/src/Yumney.Users.Infrastructure/Services/SmtpAccountDeletionEmailSender.cs
+++ b/src/Yumney.Users.Infrastructure/Services/SmtpAccountDeletionEmailSender.cs
@@ -1,0 +1,45 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+#pragma warning disable SA1601
+public sealed partial class SmtpAccountDeletionEmailSender(
+	IOptions<SmtpOptions> options,
+	ILogger<SmtpAccountDeletionEmailSender> logger)
+	: IAccountDeletionEmailSender
+{
+	public async Task SendAsync(AccountDeletionEmailPayload payload, CancellationToken cancellationToken = default)
+	{
+		var settings = options.Value;
+		var template = AccountDeletionEmailTemplate.Render(payload);
+
+		var message = new MimeMessage();
+		message.From.Add(new MailboxAddress(settings.FromDisplayName, settings.FromAddress));
+		message.To.Add(new MailboxAddress(payload.DisplayName.Value, payload.RecipientEmail.Value));
+		message.Subject = template.Subject;
+		message.Body = new TextPart("plain") { Text = template.Body };
+
+		using var client = new SmtpClient();
+		var socketOptions = settings.UseStartTls
+			? SecureSocketOptions.StartTls
+			: SecureSocketOptions.None;
+		await client.ConnectAsync(settings.Host, settings.Port, socketOptions, cancellationToken);
+		if (!string.IsNullOrEmpty(settings.Username))
+		{
+			await client.AuthenticateAsync(settings.Username, settings.Password ?? string.Empty, cancellationToken);
+		}
+
+		await client.SendAsync(message, cancellationToken);
+		await client.DisconnectAsync(quit: true, cancellationToken);
+
+		LogConfirmationSent(payload.RecipientEmail.Value);
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "GDPR: account-deletion confirmation email sent to {EmailAddress}")]
+	private partial void LogConfirmationSent(string emailAddress);
+}

--- a/src/Yumney.Users.Infrastructure/Services/SmtpOptions.cs
+++ b/src/Yumney.Users.Infrastructure/Services/SmtpOptions.cs
@@ -1,0 +1,26 @@
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+
+/// <summary>
+/// SMTP transport settings for outbound email. Bound from the
+/// <c>Smtp</c> configuration section by <c>AddUsersInfrastructure</c>.
+/// Local development uses Mailpit (port 1025, no auth, no TLS); the
+/// AppHost wires this in run mode and a Container App secret in publish.
+/// </summary>
+public sealed class SmtpOptions
+{
+	public const string SectionName = "Smtp";
+
+	public string Host { get; init; } = string.Empty;
+
+	public int Port { get; init; } = 1025;
+
+	public string? Username { get; init; }
+
+	public string? Password { get; init; }
+
+	public bool UseStartTls { get; init; }
+
+	public string FromAddress { get; init; } = "noreply@yumney.local";
+
+	public string FromDisplayName { get; init; } = "Yumney";
+}

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -21,6 +21,10 @@ public static class UsersInfrastructureServiceCollectionExtensions
 			.ValidateDataAnnotations()
 			.ValidateOnStart();
 
+		services.AddOptions<SmtpOptions>()
+			.Bind(configuration.GetSection(SmtpOptions.SectionName));
+		services.AddScoped<IAccountDeletionEmailSender, SmtpAccountDeletionEmailSender>();
+
 		services.AddYumneyNpgsqlDbContextWithOutbox<UsersDbContext>(
 			configuration,
 			"usersdb",

--- a/src/Yumney.Users.Infrastructure/Yumney.Users.Infrastructure.csproj
+++ b/src/Yumney.Users.Infrastructure/Yumney.Users.Infrastructure.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Yumney.Users.Infrastructure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MailKit" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/Commands/DeleteAccountCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
@@ -28,6 +29,7 @@ public class DeleteAccountCommandHandlerTests
 	private readonly IKeycloakAdminService keycloak = Substitute.For<IKeycloakAdminService>();
 	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
 	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly IAccountDeletionEmailSender emailSender = Substitute.For<IAccountDeletionEmailSender>();
 	private readonly DeleteAccountCommandHandler handler;
 
 	public DeleteAccountCommandHandlerTests()
@@ -38,8 +40,17 @@ public class DeleteAccountCommandHandlerTests
 		users.Profiles.Returns(profiles);
 		users.Activities.Returns(activities);
 		users.StaplesLists.Returns(staplesLists);
+
+		// Default: profile + email captured successfully so confirmation goes
+		// out. Individual tests override these returns to exercise the missing
+		// / failure paths.
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(AppUserProfile.Create(KeycloakUserId.From(KeycloakId), DisplayName.From("Test User")));
+		keycloak.GetEmailAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(Result<Email>.Success(Email.From("user@example.com")));
+
 		handler = new DeleteAccountCommandHandler(
-			users, keycloak, eventBus, currentUser, NullLogger<DeleteAccountCommandHandler>.Instance);
+			users, keycloak, eventBus, currentUser, emailSender, NullLogger<DeleteAccountCommandHandler>.Instance);
 	}
 
 	[Fact]
@@ -114,5 +125,85 @@ public class DeleteAccountCommandHandlerTests
 			Arg.Any<UserAccountDeletedIntegrationEvent>(),
 			cts.Token);
 		await keycloak.Received(1).DeleteUserAsync(Arg.Any<KeycloakUserId>(), cts.Token);
+	}
+
+	[Fact]
+	public async Task HandleAsync_SendsConfirmationEmailAfterSuccessfulDeletion()
+	{
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await emailSender.Received(1).SendAsync(
+			Arg.Is<AccountDeletionEmailPayload>(p =>
+				p.RecipientEmail.Value == "user@example.com"
+				&& p.DisplayName.Value == "Test User"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_PassesPreferredLanguageToEmailSender()
+	{
+		var profile = AppUserProfile.Create(KeycloakUserId.From(KeycloakId), DisplayName.From("Test User"));
+		profile.SwitchLanguageTo(PreferredLanguage.From("de"));
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(profile);
+
+		await handler.HandleAsync(new DeleteAccountCommand());
+
+		await emailSender.Received(1).SendAsync(
+			Arg.Is<AccountDeletionEmailPayload>(p => p.Language.Value == "de"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_EmailSendFails_DeletionStillReturnsSuccess()
+	{
+		// Send failure must NOT roll the deletion back — the user's data is
+		// already gone and the GDPR contract is satisfied.
+		emailSender.SendAsync(Arg.Any<AccountDeletionEmailPayload>(), Arg.Any<CancellationToken>())
+			.ThrowsAsync(new InvalidOperationException("SMTP unreachable"));
+
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await emailSender.Received(1).SendAsync(Arg.Any<AccountDeletionEmailPayload>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ProfileMissing_SkipsEmailButCompletesDeletion()
+	{
+		profiles.FindByKeycloakUserIdAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns((AppUserProfile?)null);
+
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await emailSender.DidNotReceive().SendAsync(Arg.Any<AccountDeletionEmailPayload>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_KeycloakEmailLookupFails_SkipsEmailButCompletesDeletion()
+	{
+		keycloak.GetEmailAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(Result<Email>.Failure(new ApiError("KC_LOOKUP", "Lookup failed", 503)));
+
+		var result = await handler.HandleAsync(new DeleteAccountCommand());
+
+		result.IsSuccess.Should().BeTrue();
+		await emailSender.DidNotReceive().SendAsync(Arg.Any<AccountDeletionEmailPayload>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_KeycloakDeleteFails_DoesNotSendConfirmationEmail()
+	{
+		// If Keycloak deletion fails, the user is in a half-deleted state
+		// (local data gone, Keycloak account intact). Don't tell them it
+		// succeeded — surface the failure to support.
+		keycloak.DeleteUserAsync(Arg.Any<KeycloakUserId>(), Arg.Any<CancellationToken>())
+			.Returns(Result.Failure(new ApiError("KC_DOWN", "Keycloak unavailable", 503)));
+
+		await handler.HandleAsync(new DeleteAccountCommand());
+
+		await emailSender.DidNotReceive().SendAsync(Arg.Any<AccountDeletionEmailPayload>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Yumney.Users.Infrastructure.Tests/Services/AccountDeletionEmailTemplateTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/Services/AccountDeletionEmailTemplateTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using SmartSolutionsLab.Yumney.Users.Infrastructure.Services;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Tests.Services;
+
+public class AccountDeletionEmailTemplateTests
+{
+	[Fact]
+	public void Render_GermanLocale_UsesGermanSubject()
+	{
+		var payload = MakePayload("de");
+
+		var email = AccountDeletionEmailTemplate.Render(payload);
+
+		email.Subject.Should().Be(AccountDeletionEmailTemplate.GermanSubject);
+		email.Body.Should().Contain("Hallo Anna").And.Contain("Vorratslisten");
+	}
+
+	[Fact]
+	public void Render_EnglishLocale_UsesEnglishSubject()
+	{
+		var payload = MakePayload("en");
+
+		var email = AccountDeletionEmailTemplate.Render(payload);
+
+		email.Subject.Should().Be(AccountDeletionEmailTemplate.EnglishSubject);
+		email.Body.Should().Contain("Hi Anna").And.Contain("Staples and shopping lists");
+	}
+
+	[Fact]
+	public void Render_BothLocales_MentionTheEraseScope()
+	{
+		// AC: the email confirms the data categories that were erased.
+		// Spot-check that the German and English bodies both reference the
+		// canonical categories — a missing line would mean we silently
+		// dropped a category from one locale during a future edit.
+		var de = AccountDeletionEmailTemplate.Render(MakePayload("de"));
+		var en = AccountDeletionEmailTemplate.Render(MakePayload("en"));
+
+		foreach (var fragment in new[] { "Profil", "Aktivitäts", "Wochenplanung", "Keycloak" })
+		{
+			de.Body.Should().Contain(fragment);
+		}
+
+		foreach (var fragment in new[] { "Profile", "Activity", "Meal plans", "Keycloak" })
+		{
+			en.Body.Should().Contain(fragment);
+		}
+	}
+
+	private static AccountDeletionEmailPayload MakePayload(string language) => new(
+		Email.From("anna@example.com"),
+		DisplayName.From("Anna"),
+		PreferredLanguage.From(language));
+}


### PR DESCRIPTION
## Summary

US-101 shipped account erasure without the confirmation email the AC called for. This adds it without changing the deletion contract: the user's data goes regardless of whether the notification can be delivered, and a send failure stays in the logs rather than rolling the deletion back.

### Application

- **\`IAccountDeletionEmailSender\` + \`AccountDeletionEmailPayload\`** capture the destination (email + display name + language) so the handler can stage them BEFORE the purge — by send-time the local profile row and Keycloak user are gone.
- **\`IKeycloakAdminService.GetEmailAsync\`** reads the user's email via the existing admin endpoint; 404 / missing-email map to a failure result so the handler can degrade gracefully.

### Handler (\`DeleteAccountCommandHandler\`)

- Captures email payload first, then runs the existing publish → erase → Keycloak-delete sequence.
- After a successful Keycloak deletion, fire-and-log the confirmation. Send exceptions are caught and logged with the recipient so ops can triage — the command still returns success because the user's data is already gone.
- If profile or Keycloak email lookup fails, skip the send and log it — never block a GDPR deletion on a notification.
- Keycloak-deletion failure suppresses the email entirely (the user is in a half-deleted state, telling them "all done" would be wrong).

### Infrastructure

- **\`SmtpAccountDeletionEmailSender\`** (MailKit) connects, optionally authenticates (StartTLS or plain), sends a localised plain-text message, logs success.
- **\`AccountDeletionEmailTemplate\`** renders EN / DE bodies inline. Subjects + canonical data-category lines are pure strings — small enough that a templating engine would be overkill and the AC explicitly wants both locales now.
- **\`SmtpOptions\`** bound from the \`Smtp\` config section.

### AppHost

- \`users-api\` gets \`Smtp__Host=localhost\`, \`Smtp__Port=1025\`, \`Smtp__From*\` env vars. In run mode that points at the mailpit container (already exposed on the host); publish mode supplies real credentials through Container App secrets.

### Packages

- Centralised **\`MailKit 4.16.0\`** in \`Directory.Packages.props\` (4.13 pulled \`MimeKit\` with a moderate-severity advisory; 4.16 is clean).

## Tests

- **\`DeleteAccountCommandHandlerTests\`** (6 new on top of 6 existing): success path sends with captured fields, language propagation, send-failure leaves deletion successful, missing profile / failed Keycloak email lookup both skip silently, failed Keycloak deletion suppresses the email.
- **\`AccountDeletionEmailTemplateTests\`** (3): EN + DE subject + body spot-checks for the data-category lines.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` clean
- [x] \`dotnet format --verify-no-changes\` clean
- [x] \`dotnet test tests/Yumney.Users.Application.Tests\` — 59 / 59
- [x] \`dotnet test tests/Yumney.Users.Infrastructure.Tests\` — 22 / 22
- [x] \`dotnet test tests/Yumney.Architecture.Tests\` — 142 / 142
- [ ] Backend / E2E CI on this PR

Closes #567.

## Notes / out of scope

- No retry queue yet — per the AC's "log + retry queue + alert ops" hint. Today the failure goes to logs only; a retry queue belongs with the broader notification-pipeline work (US-563), not coupled to this single email. If ops sees recurring SMTP failures, that's the trigger to wire one in.
- HTML alongside plain text is straightforward to add later — kept text-only for v1 to dodge the deliverability rabbithole (DKIM / image hosting / template-engine choice).