### PR TITLE
feat(recipes): seed recipe-detail unit toggle from profile preference (US-125)

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -176,7 +176,7 @@
     <section class="ingredients-section">
       <div class="ingredients-header">
         <h2>{{ t('recipes.detail.ingredients') }}</h2>
-        <yn-unit-toggle [system]="unitSystem()" (systemChange)="unitSystem.set($event)" />
+        <yn-unit-toggle [system]="unitSystem()" (systemChange)="onUnitSystemChange($event)" />
       </div>
       <ul class="ingredients-list">
         @for (ingredient of displayedIngredients(); track ingredient.name) {

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -11,7 +11,8 @@ import {
   ShoppingListDetail,
 } from '../api';
 import { HttpErrorResponse } from '@angular/common/http';
-import { setupTranslocoTesting } from '@yumney/shared/models';
+import { signal } from '@angular/core';
+import { setupTranslocoTesting, UserPreferencesService } from '@yumney/shared/models';
 
 const mockRecipe: RecipeDetail = {
   identifier: 'abc-123',
@@ -103,10 +104,17 @@ describe('RecipeDetailComponent', () => {
   let activityApiMock: {
     getRecipeStats: ReturnType<typeof vi.fn>;
   };
+  let preferencesMock: {
+    preferredUnitSystem: ReturnType<typeof signal<'metric' | 'imperial'>>;
+    ensureLoaded: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
+    applyProfile: ReturnType<typeof vi.fn>;
+  };
 
   function setupTestBed(
     getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
     identifier = 'abc-123',
+    preferredUnitSystem: 'metric' | 'imperial' = 'metric',
   ) {
     recipeApiMock = {
       getRecipeById: getRecipeByIdReturn,
@@ -119,6 +127,13 @@ describe('RecipeDetailComponent', () => {
       getRecipeStats: vi.fn().mockReturnValue(EMPTY),
     };
 
+    preferencesMock = {
+      preferredUnitSystem: signal<'metric' | 'imperial'>(preferredUnitSystem),
+      ensureLoaded: vi.fn(),
+      refresh: vi.fn(),
+      applyProfile: vi.fn(),
+    };
+
     TestBed.configureTestingModule({
       imports: [RecipeDetailComponent, setupTranslocoTesting(en)],
       providers: [
@@ -127,6 +142,7 @@ describe('RecipeDetailComponent', () => {
         { provide: RecipeApiService, useValue: recipeApiMock },
         { provide: ShoppingApiService, useValue: shoppingApiMock },
         { provide: ActivityApiService, useValue: activityApiMock },
+        { provide: UserPreferencesService, useValue: preferencesMock },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -817,4 +833,57 @@ describe('RecipeDetailComponent', () => {
     expect(error.textContent).toContain('Failed to create shopping list.');
     expect(component.showCreateShoppingListConfirm()).toBe(false);
   }));
+
+  describe('unit-system profile default (US-125)', () => {
+    it('seeds unitSystem from the profile preference', fakeAsync(() => {
+      setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), 'abc-123', 'imperial');
+      fixture.detectChanges();
+      tick();
+
+      expect(component.unitSystem()).toBe('imperial');
+    }));
+
+    it('triggers ensureLoaded so the profile is fetched on entry', fakeAsync(() => {
+      setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+      fixture.detectChanges();
+      tick();
+
+      expect(preferencesMock.ensureLoaded).toHaveBeenCalled();
+    }));
+
+    it('reacts when the profile preference lands after init', fakeAsync(() => {
+      setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), 'abc-123', 'metric');
+      fixture.detectChanges();
+      tick();
+      expect(component.unitSystem()).toBe('metric');
+
+      // Simulate the async profile fetch resolving with imperial.
+      preferencesMock.preferredUnitSystem.set('imperial');
+      fixture.detectChanges();
+
+      expect(component.unitSystem()).toBe('imperial');
+    }));
+
+    it('per-view override beats the profile preference', fakeAsync(() => {
+      setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), 'abc-123', 'imperial');
+      fixture.detectChanges();
+      tick();
+
+      component.onUnitSystemChange('metric');
+      fixture.detectChanges();
+
+      expect(component.unitSystem()).toBe('metric');
+    }));
+
+    it('override does not write back to the preference signal', fakeAsync(() => {
+      setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)), 'abc-123', 'imperial');
+      fixture.detectChanges();
+      tick();
+
+      component.onUnitSystemChange('metric');
+
+      // The override is local — the saved preference stays untouched.
+      expect(preferencesMock.preferredUnitSystem()).toBe('imperial');
+    }));
+  });
 });

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -27,6 +27,7 @@ import {
   type UnitSystem,
   ERROR_MAPS,
   ROUTES,
+  UserPreferencesService,
   VALIDATION,
   toggleFavoriteOnItem,
 } from '@yumney/shared/models';
@@ -76,6 +77,7 @@ export class RecipeDetailComponent implements OnInit {
   private deleteState = createAsyncState(this.destroyRef);
   private createShoppingListState = createAsyncState(this.destroyRef);
   private notesAutosave = inject(RecipeNotesAutosaveService);
+  private preferences = inject(UserPreferencesService);
 
   recipe = signal<RecipeDetail | null>(null);
   recipeStats = signal<RecipeActivityStats | null>(null);
@@ -84,7 +86,14 @@ export class RecipeDetailComponent implements OnInit {
   isCreatingShoppingList = this.createShoppingListState.isLoading;
   serverError = signal<string | null>(null);
   desiredServings = signal<number | null>(null);
-  unitSystem = signal<UnitSystem>('metric');
+  // User's preferred unit system from their profile (US-125). The toggle
+  // exposes a per-view override that wins over the profile default but is
+  // NOT persisted — leaves the saved preference unchanged when a user
+  // flips imperial → metric just for this one recipe.
+  private userUnitOverride = signal<UnitSystem | null>(null);
+  unitSystem = computed<UnitSystem>(
+    () => this.userUnitOverride() ?? this.preferences.preferredUnitSystem(),
+  );
   showDeleteConfirm = signal(false);
   showCreateShoppingListConfirm = signal(false);
 
@@ -144,6 +153,10 @@ export class RecipeDetailComponent implements OnInit {
       this.serverError.set('recipes.detail.notFound');
       return;
     }
+
+    // Trigger the profile fetch so `preferredUnitSystem` populates. The
+    // `unitSystem` computed re-evaluates when the signal lands.
+    this.preferences.ensureLoaded();
 
     // Stats can fail silently — the page is still useful without the badge.
     this.activityApi
@@ -245,6 +258,10 @@ export class RecipeDetailComponent implements OnInit {
 
   onToggleFavorite(): void {
     toggleFavoriteOnItem(this.recipe, this.destroyRef, (id) => this.recipeApi.toggleFavorite(id));
+  }
+
+  onUnitSystemChange(system: UnitSystem): void {
+    this.userUnitOverride.set(system);
   }
 
   onCreateShoppingList(): void {

--- a/client/libs/shared/models/src/lib/user-preferences.service.spec.ts
+++ b/client/libs/shared/models/src/lib/user-preferences.service.spec.ts
@@ -45,6 +45,7 @@ describe('UserPreferencesService', () => {
     expect(service.voiceEnabled()).toBe(true);
     expect(service.voiceSpeed()).toBe('normal');
     expect(service.voiceAutoReadInCookMode()).toBe(false);
+    expect(service.preferredUnitSystem()).toBe('metric');
   });
 
   it('ensureLoaded fetches the profile and applies notification + voice settings', () => {
@@ -122,5 +123,35 @@ describe('UserPreferencesService', () => {
     service.ensureLoaded();
 
     expect(api.getProfile).not.toHaveBeenCalled();
+  });
+
+  it('exposes preferredUnitSystem from the loaded profile (US-125)', () => {
+    const { service } = configure(of(makeProfile({ preferredUnitSystem: 'imperial' })));
+
+    service.ensureLoaded();
+
+    expect(service.preferredUnitSystem()).toBe('imperial');
+  });
+
+  it('normalises unknown preferredUnitSystem values to metric (US-125)', () => {
+    // The API field is a free-form string at the wire; defensively coerce
+    // anything we don't recognise to 'metric' so the toggle never lands in
+    // an undefined state.
+    const { service } = configure(
+      of(makeProfile({ preferredUnitSystem: 'gallons-per-fortnight' })),
+    );
+
+    service.ensureLoaded();
+
+    expect(service.preferredUnitSystem()).toBe('metric');
+  });
+
+  it('applyProfile updates preferredUnitSystem without a GET (US-125)', () => {
+    const { service, api } = configure(of(makeProfile()));
+
+    service.applyProfile(makeProfile({ preferredUnitSystem: 'imperial' }));
+
+    expect(api.getProfile).not.toHaveBeenCalled();
+    expect(service.preferredUnitSystem()).toBe('imperial');
   });
 });

--- a/client/libs/shared/models/src/lib/user-preferences.service.ts
+++ b/client/libs/shared/models/src/lib/user-preferences.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { UserProfileApiService, type UserProfile } from '@yumney/shared/api-client';
+import type { UnitSystem } from './unit-conversion';
 
 /**
  * Lightweight in-memory cache of the parts of the user profile that
@@ -21,6 +22,13 @@ export class UserPreferencesService {
   readonly voiceEnabled = signal<boolean>(true);
   readonly voiceSpeed = signal<'slow' | 'normal' | 'fast'>('normal');
   readonly voiceAutoReadInCookMode = signal<boolean>(false);
+
+  // The user's `preferredUnitSystem` from their profile (US-100). Seeded by
+  // applyProfile / refresh. Consumers (recipe detail's unit-system toggle)
+  // use this as the initial value so a returning imperial-by-default user
+  // sees imperial right away — the metric-only fallback was the open AC in
+  // US-125. Defaults to metric until the first profile load resolves.
+  readonly preferredUnitSystem = signal<UnitSystem>('metric');
 
   private loaded = false;
 
@@ -51,5 +59,8 @@ export class UserPreferencesService {
     this.voiceEnabled.set(profile.voiceSettings.enabled);
     this.voiceSpeed.set(profile.voiceSettings.speed);
     this.voiceAutoReadInCookMode.set(profile.voiceSettings.autoReadInCookMode);
+    this.preferredUnitSystem.set(
+      profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric',
+    );
   }
 }


### PR DESCRIPTION
## Summary

Closes the profile-default slice that was deferred when US-125 first shipped the recipe-detail toggle (PR #669). A returning imperial-by-default user now lands on imperial without flipping the toggle every visit; flipping it for a single recipe still works, but the override is per-view and never writes back to the saved preference.

### shared-models

- **\`UserPreferencesService.preferredUnitSystem\`** joins the existing pref signals. \`applyProfile\` coerces the API string to \`metric\` | \`imperial\` (anything we don't recognise → \`metric\`) so the toggle never lands in an undefined state.

### recipes (recipe-detail)

- Injects \`UserPreferencesService\`; the previous writable \`unitSystem\` signal becomes a \`computed\`: \`userUnitOverride() ?? preferences.preferredUnitSystem()\`.
- New \`onUnitSystemChange\` sets the local override only; the saved preference stays untouched, so opening another recipe goes back to the saved default (the toggle is "for this recipe", not "until I change my profile").
- \`ngOnInit\` calls \`preferences.ensureLoaded()\` so a first-time visit in the session triggers the profile fetch. The computed re-evaluates when the signal lands, so even a slow profile load eventually flips imperial users to imperial.

## Tests

- **\`user-preferences.service.spec\`** (3 new): default is metric, profile imperial propagates, unknown values normalise to metric, \`applyProfile\` updates without a GET.
- **\`recipe-detail.component.spec\`** (5 new under "US-125"): profile preference seeds the toggle, \`ensureLoaded\` is triggered, late profile arrival flips the toggle, per-view override wins over the preference, override doesn't write back to the saved preference.

## Test plan

- [x] \`nx test recipes\` clean
- [x] \`nx test shared-models\` clean
- [x] \`nx run-many -t lint --projects=recipes,shared-models,ui\` clean
- [x] \`yarn prettier --check\` clean
- [x] \`nx build recipes\` clean
- [ ] Backend / E2E CI on this PR

Refs #36. Closes the **profile-default** AC item on US-125. The remaining deferred bullet — **shopping list respects unit system** — stays open for its own slice when scheduled (the third deferred AC item — "cook-mode TTS reads converted amounts" — depends on the cook-mode TTS path and is naturally bundled with that work).