### PR TITLE
refactor: code-quality sweep (async, value objects, mappings, single-pass)

### DIFF
--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -36,9 +36,7 @@ internal static class AppHostExtensions
 	/// <param name="builder">The AppHost's distributed application builder.</param>
 	/// <param name="options">App host options that decide between OpenAI and Ollama.</param>
 	/// <returns>A handle to the registered resources; empty when E2E tests are on.</returns>
-	public static LlmResources BuildLlmResources(
-		this IDistributedApplicationBuilder builder,
-		AppHostOptions options)
+	public static LlmResources BuildLlmResources(this IDistributedApplicationBuilder builder, AppHostOptions options)
 	{
 		if (options.E2ETests) return new LlmResources(null, null);
 

--- a/src/Yumney.AppHost/LlmResources.cs
+++ b/src/Yumney.AppHost/LlmResources.cs
@@ -1,5 +1,3 @@
-using Aspire.Hosting.ApplicationModel;
-
 namespace SmartSolutionsLab.Yumney.AppHost;
 
 /// <summary>

--- a/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
+++ b/src/Yumney.Mcp.Server/Discovery/CapabilityDiscoveryService.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Shared.Capabilities;

--- a/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
+++ b/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
@@ -43,9 +43,7 @@ public static class CapabilityToolRegistration
 	/// <param name="context">Request context (unused — we list everything).</param>
 	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
 	/// <returns>The current MCP-surface tools.</returns>
-	public static ValueTask<ListToolsResult> ListToolsAsync(
-		RequestContext<ListToolsRequestParams> context,
-		CancellationToken cancellationToken)
+	public static ValueTask<ListToolsResult> ListToolsAsync(RequestContext<ListToolsRequestParams> context, CancellationToken cancellationToken)
 	{
 		var registry = context.Services!.GetRequiredService<AggregatedCapabilityRegistry>();
 		return ValueTask.FromResult(new ListToolsResult { Tools = [.. BuildTools(registry)] });
@@ -55,9 +53,7 @@ public static class CapabilityToolRegistration
 	/// <param name="context">Request context with the called tool's name + arguments.</param>
 	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
 	/// <returns>The stub result.</returns>
-	public static ValueTask<CallToolResult> CallToolAsync(
-		RequestContext<CallToolRequestParams> context,
-		CancellationToken cancellationToken)
+	public static ValueTask<CallToolResult> CallToolAsync(RequestContext<CallToolRequestParams> context, CancellationToken cancellationToken)
 	{
 		var name = context.Params?.Name ?? "<unknown>";
 		return ValueTask.FromResult(BuildStubInvocationResult(name));

--- a/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
@@ -1,7 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Protocol;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 
@@ -27,10 +26,7 @@ public sealed partial class RestProxyService(
 	/// <param name="arguments">Tool argument bag (placeholder values + body fields / query params).</param>
 	/// <param name="cancellationToken">Cancellation propagated from the SDK.</param>
 	/// <returns>Upstream response as a tool result, or an error result on failure.</returns>
-	public async Task<CallToolResult> InvokeAsync(
-		string toolName,
-		IDictionary<string, JsonElement>? arguments,
-		CancellationToken cancellationToken)
+	public async Task<CallToolResult> InvokeAsync(string toolName, IDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
 	{
 		var descriptor = registry.DescriptorForTool(toolName);
 		if (descriptor is null) return Error($"Unknown tool '{toolName}'.");

--- a/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
@@ -22,10 +22,7 @@ public static partial class RouteUrlBuilder
 	/// <param name="routePattern">Route pattern from a <c>CapabilityDescriptor</c>.</param>
 	/// <param name="arguments">Tool arguments by name. Supports null arguments dictionary.</param>
 	/// <returns>Built request — caller must check <c>MissingPlaceholders</c> before sending.</returns>
-	public static BuiltRequest Build(
-		string httpMethod,
-		string routePattern,
-		IDictionary<string, JsonElement>? arguments)
+	public static BuiltRequest Build(string httpMethod, string routePattern, IDictionary<string, JsonElement>? arguments)
 	{
 		arguments ??= new Dictionary<string, JsonElement>();
 		var consumedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanApiModule.cs
@@ -1,5 +1,4 @@
 using SmartSolutionsLab.Yumney.MealPlan.Application.IntegrationEventHandlers;
-using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStore.Events;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Hosting;

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -59,7 +59,7 @@ public static class MealPlanEndpoints
 			var week = WeekIdentifier.From(year, weekNumber);
 			var (day, recipeIdentifier, recipeTitle, mealType, servings) = request;
 			var recipe = SlotRecipeReference.From(recipeIdentifier, recipeTitle);
-			SlotServings? slotServings = servings.HasValue ? SlotServings.From(servings.Value) : null;
+			var slotServings = SlotServings.FromNullable(servings);
 			var command = new AssignRecipeCommand(week, day, recipe, mealType, slotServings);
 
 			var result = await handler.HandleAsync(command, cancellationToken);

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/CookWithLeftoversCommandHandler.cs
@@ -13,14 +13,16 @@ public sealed class CookWithLeftoversCommandHandler(IMealPlanEventStore eventSto
 	{
 		var (week, cookDay, recipe, totalServings, eatServings, leftoverDay, mealType) = command;
 		var owner = currentUser.AsOwner();
-		var leftoverServingsValue = totalServings.Value - eatServings.Value;
+		var leftoverServings = totalServings.Value > eatServings.Value
+			? SlotServings.From(totalServings.Value - eatServings.Value)
+			: null;
 
 		var plan = await eventStore.FindAsync(owner, week, cancellationToken) ?? WeeklyPlan.Create(owner, week);
 		plan.AssignRecipe(cookDay, recipe, mealType, totalServings);
 
-		if (leftoverServingsValue > 0)
+		if (leftoverServings is not null)
 		{
-			plan.SetLeftover(leftoverDay, cookDay, mealType, recipe.Title, mealType, SlotServings.From(leftoverServingsValue));
+			plan.SetLeftover(leftoverDay, cookDay, mealType, recipe.Title, mealType, leftoverServings);
 		}
 
 		await eventStore.SaveAsync(plan, cancellationToken);

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -15,6 +15,10 @@ public sealed class GenerateShoppingListCommandHandler(
 	ICurrentUser currentUser)
 	: ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResultDto>>
 {
+#pragma warning disable SA1303
+	private const string mealPlanSource = "meal-plan";
+#pragma warning restore SA1303
+
 	public async Task<Result<GenerateShoppingListResultDto>> HandleAsync(
 		GenerateShoppingListCommand command,
 		CancellationToken cancellationToken = default)
@@ -74,15 +78,15 @@ public sealed class GenerateShoppingListCommandHandler(
 		var staplesSkipped = 0;
 		List<ShoppingItemRequest> itemsToAdd = [];
 
-		foreach (var (name, quantity, unit) in merged.Values)
+		foreach (var item in merged.Values)
 		{
-			if (staples.Contains(name.ToLowerInvariant()))
+			if (staples.Contains(item.Name.ToLowerInvariant()))
 			{
 				staplesSkipped++;
 				continue;
 			}
 
-			itemsToAdd.Add(new ShoppingItemRequest(name, quantity, unit, "meal-plan"));
+			itemsToAdd.Add(item.ToShoppingItemRequest(mealPlanSource));
 		}
 
 		if (itemsToAdd.Count > 0)
@@ -92,9 +96,15 @@ public sealed class GenerateShoppingListCommandHandler(
 
 		return (staplesSkipped, itemsToAdd);
 	}
+}
 
-	private sealed record MergedItem(string Name, decimal Quantity, string? Unit)
-	{
-		public decimal Quantity { get; set; } = Quantity;
-	}
+internal sealed record MergedItem(string Name, decimal Quantity, string? Unit)
+{
+	public decimal Quantity { get; set; } = Quantity;
+}
+
+internal static class MergedItemMappingExtensions
+{
+	public static ShoppingItemRequest ToShoppingItemRequest(this MergedItem item, string source) =>
+		new(item.Name, item.Quantity, item.Unit, source);
 }

--- a/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.MealPlan.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
@@ -12,5 +13,5 @@ public sealed class UserAccountDeletedHandler(IMealPlanUserDataPurger purger)
 	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
 {
 	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
-		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+		purger.PurgeAsync(OwnerIdentifier.From(@event.KeycloakUserId), cancellationToken);
 }

--- a/src/Yumney.MealPlan.Application/Interfaces/IMealPlanUserDataPurger.cs
+++ b/src/Yumney.MealPlan.Application/Interfaces/IMealPlanUserDataPurger.cs
@@ -1,3 +1,5 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 
 /// <summary>
@@ -7,5 +9,5 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 /// </summary>
 public interface IMealPlanUserDataPurger
 {
-	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+	Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
@@ -27,8 +27,13 @@ public sealed class GetMealAnalyticsQueryHandler(
 
 		var slots = await readModel.GetSlotsInPeriodAsync(owner, periodStart, periodEndExclusive, cancellationToken);
 
-		var cooked = slots.Where(slot => slot.State == "Cooked").ToList();
-		var skippedCount = slots.Count(slot => slot.State == "Skipped");
+		List<AnalyticsSlotProjection> cooked = [];
+		var skippedCount = 0;
+		foreach (var slot in slots)
+		{
+			if (slot.State == "Cooked") cooked.Add(slot);
+			else if (slot.State == "Skipped") skippedCount++;
+		}
 
 		var recipeCooks = cooked
 			.Where(slot => slot.RecipeIdentifier.HasValue && slot.RecipeTitle is not null)

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/SuggestWeekPlanQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/SuggestWeekPlanQueryHandler.cs
@@ -32,14 +32,17 @@ public sealed class SuggestWeekPlanQueryHandler(
 
 		await Task.WhenAll(catalogTask, historyTask, dietaryTask);
 
-		var recipes = catalogTask.Result;
+		var recipes = await catalogTask;
 		if (recipes.Count == 0) return SuggestWeekPlanErrors.NoRecipes;
+
+		var history = await historyTask;
+		var dietaryProfile = await dietaryTask;
 
 		var entries = await suggestionService.SuggestAsync(
 			query.Week,
 			recipes,
-			historyTask.Result.Items,
-			dietaryTask.Result,
+			history.Items,
+			dietaryProfile,
 			cancellationToken);
 
 		if (entries.IsFailure) return entries.Error!;

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/SuggestWeekPlanQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/SuggestWeekPlanQueryHandler.cs
@@ -20,9 +20,7 @@ public sealed class SuggestWeekPlanQueryHandler(
 	private const int historyLookbackEntries = 30;
 #pragma warning restore SA1303
 
-	public async Task<Result<WeekSuggestionDto>> HandleAsync(
-		SuggestWeekPlanQuery query,
-		CancellationToken cancellationToken = default)
+	public async Task<Result<WeekSuggestionDto>> HandleAsync(SuggestWeekPlanQuery query, CancellationToken cancellationToken = default)
 	{
 		var owner = currentUser.AsOwner();
 

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotServings.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotServings.cs
@@ -17,6 +17,9 @@ public sealed record SlotServings : IValueObject<int>
 
 	public static SlotServings From(int value) => new(value);
 
+	public static SlotServings? FromNullable(int? value)
+		=> value.HasValue ? From(value.Value) : null;
+
 	public static SlotServings Default() => new(DefaultValue);
 
 	public static implicit operator int(SlotServings obj) => obj.Value;

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanUserDataPurger.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanUserDataPurger.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
@@ -12,10 +13,12 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 public sealed class MealPlanUserDataPurger(MealPlanDbContext writeContext, MealPlanReadDbContext readContext)
 	: IMealPlanUserDataPurger
 {
-	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	public async Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
+		var ownerValue = owner.Value;
+
 		var aggregateIds = await writeContext.MealPlanAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.Select(aggregate => aggregate.AggregateId)
 			.ToListAsync(cancellationToken);
 
@@ -27,15 +30,15 @@ public sealed class MealPlanUserDataPurger(MealPlanDbContext writeContext, MealP
 		}
 
 		await writeContext.MealPlanAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<MealPlanSlotReadItem>()
-			.Where(slot => slot.OwnerId == keycloakUserId)
+			.Where(slot => slot.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<MealPlanWeekReadItem>()
-			.Where(week => week.OwnerId == keycloakUserId)
+			.Where(week => week.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 	}
 }

--- a/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Recipes.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 
@@ -12,5 +13,5 @@ public sealed class UserAccountDeletedHandler(IRecipesUserDataPurger purger)
 	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
 {
 	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
-		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+		purger.PurgeAsync(OwnerIdentifier.From(@event.KeycloakUserId), cancellationToken);
 }

--- a/src/Yumney.Recipes.Application/Interfaces/IRecipesUserDataPurger.cs
+++ b/src/Yumney.Recipes.Application/Interfaces/IRecipesUserDataPurger.cs
@@ -1,3 +1,5 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 
 /// <summary>
@@ -7,5 +9,5 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 /// </summary>
 public interface IRecipesUserDataPurger
 {
-	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+	Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
@@ -24,13 +24,13 @@ public sealed class GetRecipeSuggestionsQueryHandler(
 		var dietaryTask = dietaryProvider.GetAsync(cancellationToken);
 		await Task.WhenAll(availableTask, dietaryTask);
 
-		var available = availableTask.Result;
+		var available = await availableTask;
 		if (available.Count == 0)
 		{
 			return RecipeSuggestionErrors.NoIngredients;
 		}
 
-		var dietary = dietaryTask.Result;
+		var dietary = await dietaryTask;
 		return await suggestionService.SuggestAsync(
 			(IReadOnlyCollection<string>)available.Keys.ToList(),
 			dietary.DietaryType,

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipesUserDataPurger.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipesUserDataPurger.cs
@@ -10,10 +10,8 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 /// </summary>
 public sealed class RecipesUserDataPurger(RecipesDbContext context) : IRecipesUserDataPurger
 {
-	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	public async Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
-		var owner = OwnerIdentifier.From(keycloakUserId);
-
 		await context.RecipeFavorites
 			.Where(favorite => favorite.Owner == owner)
 			.ExecuteDeleteAsync(cancellationToken);

--- a/src/Yumney.ServiceDefaults/Extensions.cs
+++ b/src/Yumney.ServiceDefaults/Extensions.cs
@@ -83,7 +83,9 @@ public static class Extensions
 
 		if (useOtlpExporter)
 		{
-			builder.Services.AddOpenTelemetry().UseOtlpExporter();
+			builder.Services
+				.AddOpenTelemetry()
+				.UseOtlpExporter();
 		}
 
 		return builder;

--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceMappingExtensions.cs
@@ -1,0 +1,14 @@
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+public static class IngredientBalanceMappingExtensions
+{
+	public static IngredientBalanceItemDto ToStapleBalanceItem(this IngredientCategory category, string stapleName) =>
+		new(
+			ItemName: stapleName,
+			Quantity: null,
+			Unit: null,
+			Category: category.Value,
+			Source: IngredientBalanceSource.Staple);
+}

--- a/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
+++ b/src/Yumney.Shopping.Application/IntegrationEventHandlers/UserAccountDeletedHandler.cs
@@ -1,6 +1,7 @@
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
 
@@ -12,5 +13,5 @@ public sealed class UserAccountDeletedHandler(IShoppingUserDataPurger purger)
 	: IIntegrationEventHandler<UserAccountDeletedIntegrationEvent>
 {
 	public Task HandleAsync(UserAccountDeletedIntegrationEvent @event, CancellationToken cancellationToken = default) =>
-		purger.PurgeAsync(@event.KeycloakUserId, cancellationToken);
+		purger.PurgeAsync(OwnerIdentifier.From(@event.KeycloakUserId), cancellationToken);
 }

--- a/src/Yumney.Shopping.Application/Interfaces/IIngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IIngredientBalanceReadModelRepository.cs
@@ -1,4 +1,5 @@
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
@@ -9,5 +10,5 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 /// </summary>
 public interface IIngredientBalanceReadModelRepository
 {
-	Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(string ownerId, CancellationToken cancellationToken = default);
+	Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Application/Interfaces/IShoppingUserDataPurger.cs
+++ b/src/Yumney.Shopping.Application/Interfaces/IShoppingUserDataPurger.cs
@@ -1,3 +1,5 @@
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 
 /// <summary>
@@ -7,5 +9,5 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 /// </summary>
 public interface IShoppingUserDataPurger
 {
-	Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default);
+	Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -34,12 +34,7 @@ public sealed class GetIngredientBalanceQueryHandler(
 			if (atHomeNames.Contains(staple)) continue;
 
 			var category = IngredientCategoryResolver.Resolve(staple) ?? IngredientCategory.Other;
-			items.Add(new IngredientBalanceItemDto(
-				ItemName: staple,
-				Quantity: null,
-				Unit: null,
-				Category: category.Value,
-				Source: IngredientBalanceSource.Staple));
+			items.Add(category.ToStapleBalanceItem(staple));
 		}
 
 		List<IngredientBalanceItemDto> sorted = [.. items

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -16,7 +16,7 @@ public sealed class GetIngredientBalanceQueryHandler(
 	{
 		var owner = currentUser.AsOwner();
 
-		var atHomeTask = readModel.GetAtHomeItemsAsync(owner.Value, cancellationToken);
+		var atHomeTask = readModel.GetAtHomeItemsAsync(owner, cancellationToken);
 		var staplesTask = staplesProvider.GetStapleNamesAsync(cancellationToken);
 		await Task.WhenAll(atHomeTask, staplesTask);
 

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -20,8 +20,8 @@ public sealed class GetIngredientBalanceQueryHandler(
 		var staplesTask = staplesProvider.GetStapleNamesAsync(cancellationToken);
 		await Task.WhenAll(atHomeTask, staplesTask);
 
-		var atHomeItems = atHomeTask.Result;
-		var staples = staplesTask.Result;
+		var atHomeItems = await atHomeTask;
+		var staples = await staplesTask;
 
 		var atHomeNames = atHomeItems
 			.Select(item => item.ItemName)

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/IngredientBalanceReadModelRepository.cs
@@ -2,17 +2,20 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
 public sealed class IngredientBalanceReadModelRepository(ShoppingReadDbContext context, TimeProvider timeProvider) : IIngredientBalanceReadModelRepository
 {
 	public async Task<IReadOnlyList<IngredientBalanceItemDto>> GetAtHomeItemsAsync(
-		string ownerId,
+		OwnerIdentifier owner,
 		CancellationToken cancellationToken = default)
 	{
+		var ownerValue = owner.Value;
+
 		var rows = await context.IngredientBalanceReadItems
-			.Where(row => row.OwnerId == ownerId)
+			.Where(row => row.OwnerId == ownerValue)
 			.ToListAsync(cancellationToken);
 
 		var now = timeProvider.GetUtcNow().UtcDateTime;

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUserDataPurger.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUserDataPurger.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
@@ -12,10 +13,12 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 public sealed class ShoppingUserDataPurger(ShoppingDbContext writeContext, ShoppingReadDbContext readContext)
 	: IShoppingUserDataPurger
 {
-	public async Task PurgeAsync(string keycloakUserId, CancellationToken cancellationToken = default)
+	public async Task PurgeAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
+		var ownerValue = owner.Value;
+
 		var shoppingListAggregateIds = await writeContext.ShoppingListAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.Select(aggregate => aggregate.AggregateId)
 			.ToListAsync(cancellationToken);
 
@@ -27,11 +30,11 @@ public sealed class ShoppingUserDataPurger(ShoppingDbContext writeContext, Shopp
 		}
 
 		await writeContext.ShoppingListAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		var shoppingAggregateIds = await writeContext.ShoppingAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.Select(aggregate => aggregate.AggregateId)
 			.ToListAsync(cancellationToken);
 
@@ -43,23 +46,23 @@ public sealed class ShoppingUserDataPurger(ShoppingDbContext writeContext, Shopp
 		}
 
 		await writeContext.ShoppingAggregates
-			.Where(aggregate => aggregate.OwnerId == keycloakUserId)
+			.Where(aggregate => aggregate.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<ShoppingListItemReadItem>()
-			.Where(item => item.OwnerId == keycloakUserId)
+			.Where(item => item.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<ShoppingListSummaryReadItem>()
-			.Where(summary => summary.OwnerId == keycloakUserId)
+			.Where(summary => summary.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<IngredientBalanceReadItem>()
-			.Where(balance => balance.OwnerId == keycloakUserId)
+			.Where(balance => balance.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 
 		await readContext.Set<ShoppingLedgerReadItem>()
-			.Where(ledger => ledger.OwnerId == keycloakUserId)
+			.Where(ledger => ledger.OwnerId == ownerValue)
 			.ExecuteDeleteAsync(cancellationToken);
 	}
 }

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotServingsTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotServingsTests.cs
@@ -27,6 +27,32 @@ public class SlotServingsTests
 	}
 
 	[Fact]
+	public void FromNullable_NullValue_ReturnsNull()
+	{
+		var servings = SlotServings.FromNullable(null);
+
+		servings.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_PositiveValue_CreatesInstance()
+	{
+		var servings = SlotServings.FromNullable(8);
+
+		servings!.Value.Should().Be(8);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-3)]
+	public void FromNullable_NonPositiveValue_ThrowsGuardException(int value)
+	{
+		var act = () => SlotServings.FromNullable(value);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
 	public void Default_ReturnsConfiguredDefault()
 	{
 		var servings = SlotServings.Default();

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -96,7 +96,11 @@ public class WeeklyPlanTests
 	{
 		var plan = CreatePlan();
 
-		var act = () => plan.AssignRecipe(DayOfWeek.Monday, SlotRecipeReference.From(SlotRecipeIdentifier.New(), SlotRecipeTitle.From(string.Empty)));
+		var act = () => plan.AssignRecipe(
+			DayOfWeek.Monday,
+			SlotRecipeReference.From(
+				SlotRecipeIdentifier.New(),
+				SlotRecipeTitle.From(string.Empty)));
 
 		act.Should().Throw<GuardException>();
 	}

--- a/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/Queries/GetIngredientBalanceQueryHandlerTests.cs
@@ -86,7 +86,7 @@ public class GetIngredientBalanceQueryHandlerTests
 
 		await handler.HandleAsync(new GetIngredientBalanceQuery());
 
-		await readModel.Received(1).GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>());
+		await readModel.Received(1).GetAtHomeItemsAsync(OwnerIdentifier.From("user-123"), Arg.Any<CancellationToken>());
 		await staplesProvider.Received(1).GetStapleNamesAsync(Arg.Any<CancellationToken>());
 	}
 
@@ -109,7 +109,7 @@ public class GetIngredientBalanceQueryHandlerTests
 
 	private void ConfigureRepositories(IReadOnlyList<IngredientBalanceItemDto> atHome, IReadOnlyCollection<string> staples)
 	{
-		readModel.GetAtHomeItemsAsync("user-123", Arg.Any<CancellationToken>()).Returns(atHome);
+		readModel.GetAtHomeItemsAsync(OwnerIdentifier.From("user-123"), Arg.Any<CancellationToken>()).Returns(atHome);
 		staplesProvider.GetStapleNamesAsync(Arg.Any<CancellationToken>())
 			.Returns(staples.ToHashSet(StringComparer.OrdinalIgnoreCase));
 	}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/ReadModel/IngredientBalanceReadModelRepositoryTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Time.Testing;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 using Xunit;
@@ -13,6 +14,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Persistence.Rea
 public class IngredientBalanceReadModelRepositoryTests
 {
 	private const string OwnerId = "user-1";
+	private static readonly OwnerIdentifier Owner = OwnerIdentifier.From(OwnerId);
 
 	private readonly FakeTimeProvider timeProvider = new(DateTimeOffset.Parse("2026-04-30T12:00:00Z", CultureInfo.InvariantCulture));
 
@@ -22,7 +24,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await using var context = CreateContext();
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
 
-		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+		var items = await repo.GetAtHomeItemsAsync(Owner);
 
 		items.Should().BeEmpty();
 	}
@@ -46,7 +48,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+		var items = await repo.GetAtHomeItemsAsync(Owner);
 
 		items.Should().BeEmpty();
 	}
@@ -71,7 +73,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+		var items = await repo.GetAtHomeItemsAsync(Owner);
 
 		var item = items.Should().ContainSingle().Subject;
 		item.ItemName.Should().Be("Milk");
@@ -108,7 +110,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var items = await repo.GetAtHomeItemsAsync(OwnerId);
+		var items = await repo.GetAtHomeItemsAsync(Owner);
 
 		items.Should().ContainSingle().Which.ItemName.Should().Be("Milk");
 	}
@@ -121,7 +123,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+		var item = (await repo.GetAtHomeItemsAsync(Owner)).Single();
 
 		item.Freshness.Should().Be(Freshness.NotTracked);
 		item.DaysSinceBought.Should().BeNull();
@@ -136,7 +138,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+		var item = (await repo.GetAtHomeItemsAsync(Owner)).Single();
 
 		item.Freshness.Should().Be(Freshness.NotTracked);
 	}
@@ -149,7 +151,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+		var item = (await repo.GetAtHomeItemsAsync(Owner)).Single();
 
 		item.Freshness.Should().Be(Freshness.Fresh);
 		item.DaysSinceBought.Should().Be(0);
@@ -164,7 +166,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+		var item = (await repo.GetAtHomeItemsAsync(Owner)).Single();
 
 		item.Freshness.Should().Be(Freshness.UseSoon);
 		item.DaysSinceBought.Should().Be(1);
@@ -179,7 +181,7 @@ public class IngredientBalanceReadModelRepositoryTests
 		await context.SaveChangesAsync();
 
 		var repo = new IngredientBalanceReadModelRepository(context, timeProvider);
-		var item = (await repo.GetAtHomeItemsAsync(OwnerId)).Single();
+		var item = (await repo.GetAtHomeItemsAsync(Owner)).Single();
 
 		item.Freshness.Should().Be(Freshness.CheckIt);
 		item.DaysSinceBought.Should().Be(3);


### PR DESCRIPTION
## Summary

Code-quality sweep across MealPlan / Shopping / Recipes from a recent audit, plus an in-flight `SlotServings`-positive regression fix and small cross-host cleanup carried in the same branch. Eight commits, each independently reviewable.

### Refactors from the audit punch-list
- `7814f2dc` **perf:** Replace `.Result` after `Task.WhenAll` with `await` on the completed tasks in `SuggestWeekPlanQueryHandler`, `GetIngredientBalanceQueryHandler`, `GetRecipeSuggestionsQueryHandler`. `.Result` wraps exceptions in `AggregateException`; `await` on a completed task does not.
- `7bed2ecd` **shared:** Convert `string keycloakUserId` / `string ownerId` to each module's own `OwnerIdentifier` on internal contracts (`IMealPlanUserDataPurger`, `IShoppingUserDataPurger`, `IRecipesUserDataPurger`, `IIngredientBalanceReadModelRepository`). Integration events still carry the primitive (cross-module contract); per-module event handlers wrap with `OwnerIdentifier.From` before invoking the purger. `KeycloakUserId` lives in Users.Domain and would be a cross-module Domain reference, so each module uses its own `OwnerIdentifier`.
- `940987d7` **shared:** Move inline DTO construction out of handlers into `*MappingExtensions` (per CLAUDE.md mapping rule). `MergedItem` promoted from a private nested record to file-scope so the extension can target it; new `IngredientBalanceMappingExtensions` sits next to `ShoppingLedgerMappingExtensions`.
- `4a135973` **meal-plan:** Single-pass slot bucketing in `GetMealAnalyticsQueryHandler` — replaces two LINQ traversals (`Where(...).ToList()` + `Count(...)`) with one `foreach` over the materialised slot list.

### In-flight `SlotServings` fix + helper
- `fbde6fc0` **fix(meal-plan):** Only construct `SlotServings` when there is a leftover. The handler was eagerly building `SlotServings.From(totalServings - eatServings)`, but the VO invariant is `IsPositive` — the no-leftover case (`totalServings == eatServings`) threw `GuardException`. Construct the VO conditionally and check `is not null` at the use site.
- `76a1cfab` **feat(meal-plan):** Add `SlotServings.FromNullable(int?)` and use it in `MealPlanEndpoints` to replace the verbose `servings.HasValue ? SlotServings.From(servings.Value) : null` pattern with a single call.

### Cross-cutting cleanup
- `0e4394b1` **chore:** Trim unused `using`s (`LlmResources`, `CapabilityDiscoveryService`, `RestProxyService`, `MealPlanApiModule`); collapse multi-line method signatures that fit on one line (`AppHostExtensions`, `CapabilityToolRegistration`, `RestProxyService`, `RouteUrlBuilder`); reformat the OpenTelemetry registration in `ServiceDefaults` onto fluent lines; wrap one long line in `WeeklyPlanTests`.
- `91cd8636` **chore(meal-plan):** Collapse `SuggestWeekPlanQueryHandler.HandleAsync` signature to one line (matches the formatting pass in the previous commit).

## Test plan

- [x] Affected `*.Application` and `*.Api` projects build clean with `-p:TreatWarningsAsErrors=true`
- [x] `Yumney.Shopping.Application.Tests` — 147/147 pass
- [x] `Yumney.Recipes.Application.Tests` — 184/184 pass
- [x] `Yumney.MealPlan.Application.Tests` — 56/56 pass (the previously failing `CookWithLeftoversCommandHandlerTests.HandleAsync_NoLeftoverWhenEqual_OnlyRecipe` is fixed by `fbde6fc0`)
- [x] `Yumney.MealPlan.Domain.Tests` — 127/127 pass
- [ ] CI: full solution build + test

## Audit findings dismissed (no commit)

These were checked but turned out to be wrong:
- `AppUserProfileRepository.GetByKeycloakUserIdAsync` "missing AsNoTracking" — caller is `UpdateUserProfileCommandHandler`, which mutates; needs tracking.
- `ShoppingLedgerReadModelRepository.GetByOwnerAsync` "missing AsNoTracking" — `ShoppingReadDbContext` already sets `QueryTrackingBehavior.NoTracking` globally.
- `ActivityCursor.TryDecode` / `DefaultQuantityResolver.Resolve` "missing Ensure.That" — both use bare null-check + return-default as soft fallbacks; `Ensure.That` would throw and break the contract.
- `ShoppingListProjectionRepository.FindIdsByRecipeAsync` "unbounded query" — naturally bounded per-owner-per-recipe by user behavior.
- Pantry "div with click handler" — already a proper `<button>` element.
- Shopping-detail "inline style" — `[style.width.%]` bound to a computed signal, the idiomatic Angular way to drive a dynamic progress fill.