### PR TITLE
test(e2e): cover three error paths flagged by the deep audit

### DIFF
--- a/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/import-recipe.spec.ts
@@ -51,6 +51,49 @@ test.describe('Dashboard — Recipe Import (US-010, US-011, US-012, US-013)', ()
     await expect(dashboard.errorBanner).toBeVisible({ timeout: 75_000 });
   });
 
+  // Mid-import server failure: the gateway returns 422 with ProblemDetails
+  // before the SSE stream starts (LLM extraction rejected the URL because the
+  // page didn't contain a recipe). Verifies the error banner surfaces instead
+  // of leaving the form spinning indefinitely.
+  test('should show error banner when import stream returns 422', async ({ authenticatedPage }) => {
+    await authenticatedPage.context().route('**/api/v1/recipes/import/stream*', (route) =>
+      route.fulfill({
+        status: 422,
+        contentType: 'application/problem+json',
+        body: JSON.stringify({
+          type: 'about:blank',
+          title: 'Validation error(s) occurred.',
+          status: 422,
+          detail: 'No recipe could be extracted from the supplied URL.',
+        }),
+      }),
+    );
+
+    await dashboard.urlInput.fill('https://example.com/not-a-recipe');
+    await dashboard.importButton.click();
+
+    await expect(dashboard.errorBanner).toBeVisible();
+  });
+
+  // In-stream failure: the server starts the SSE response then emits a
+  // `fail` event (LLM returned malformed JSON, or scraping hit a dead end
+  // partway through). The UI must surface the banner and re-enable the form.
+  test('should show error banner when SSE emits a fail event', async ({ authenticatedPage }) => {
+    await authenticatedPage.context().route('**/api/v1/recipes/import/stream*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'event: status\ndata: Starting extraction…\n\nevent: fail\ndata: extraction failed\n\n',
+      }),
+    );
+
+    await dashboard.urlInput.fill('https://example.com/partial-recipe');
+    await dashboard.importButton.click();
+
+    await expect(dashboard.errorBanner).toBeVisible();
+    await expect(dashboard.importButton).toBeEnabled();
+  });
+
   test('should display create recipe button', async () => {
     await expect(dashboard.createButton).toBeVisible();
   });

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -118,6 +118,49 @@ export async function createTestRecipe(
 }
 
 /**
+ * Assign a recipe to a meal-plan slot via the API (POST
+ * /api/v1/meal-plans/{year}/w/{week}/slots). Returns the year/week the slot
+ * was assigned to so tests can navigate the planner to that exact week.
+ */
+export async function assignMealSlot(
+  page: Page,
+  options: {
+    year: number;
+    weekNumber: number;
+    day: string;
+    recipeIdentifier: string;
+    recipeTitle: string;
+    mealType?: string;
+  },
+): Promise<void> {
+  await page.evaluate(
+    async ({ assignOptions, gatewayUrl }) => {
+      const token = localStorage.getItem('access_token');
+      const res = await fetch(
+        `${gatewayUrl}/api/v1/meal-plans/${assignOptions.year}/w/${assignOptions.weekNumber}/slots`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            day: assignOptions.day,
+            recipeIdentifier: assignOptions.recipeIdentifier,
+            recipeTitle: assignOptions.recipeTitle,
+            mealType: assignOptions.mealType ?? 'Dinner',
+          }),
+        },
+      );
+      if (!res.ok) {
+        throw new Error(`assignMealSlot failed: ${res.status} ${await res.text()}`);
+      }
+    },
+    { assignOptions: options, gatewayUrl: GATEWAY_URL },
+  );
+}
+
+/**
  * Delete a recipe via the API. Mirror of createTestRecipe for cleanup in
  * afterAll blocks.
  */

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { MealPlannerPage } from '../pages/meal-planner.page';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
+import { assignMealSlot, openAuthenticatedPage } from '../helpers/test-data.helper';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+/**
+ * Error-path coverage for the meal-planner "Generate Shopping List" flow.
+ *
+ * Happy-path is covered by meal-planner-shopping.spec.ts; this spec
+ * exercises the failure branch (server returns 5xx). Without the test, a
+ * regression that leaves the planner in an infinite spinner — or one that
+ * silently swallows the error — would slip through.
+ *
+ * Seeds a recipe + a meal-plan slot via API in beforeAll so the generate
+ * button is reliably visible, instead of relying on whatever happens to
+ * be in the shared testuser plan today.
+ */
+test.describe('Meal Planner — generate shopping list error path', () => {
+  const recipe = setupSharedRecipe(test, 'E2E GenerateError', { ingredient: 'Olive Oil' });
+
+  // ISO week the test seeds + asserts against. Far-future so it doesn't
+  // collide with happy-path specs that exercise the current week.
+  const seededYear = 2030;
+  const seededWeek = 15;
+
+  test.beforeAll(async ({ browser }) => {
+    const setupPage = await openAuthenticatedPage(browser);
+    try {
+      await assignMealSlot(setupPage, {
+        year: seededYear,
+        weekNumber: seededWeek,
+        day: 'Monday',
+        recipeIdentifier: recipe().identifier,
+        recipeTitle: recipe().title,
+      });
+    } finally {
+      await setupPage.context().close();
+    }
+  });
+
+  test('surfaces server error when generate-shopping-list returns 500', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.context().route(
+      '**/api/v1/meal-plans/*/w/*/generate-shopping-list',
+      (route) =>
+        route.fulfill({
+          status: 500,
+          contentType: 'application/problem+json',
+          body: JSON.stringify({
+            type: 'about:blank',
+            title: 'Internal Server Error',
+            status: 500,
+            detail: 'Synthetic failure injected by E2E to exercise the error path.',
+          }),
+        }),
+    );
+
+    await authenticatedPage.goto(`/meal-planner?year=${seededYear}&week=${seededWeek}`);
+
+    const planner = new MealPlannerPage(authenticatedPage);
+    await expect(planner.weekLabel).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(planner.generateButton).toBeVisible({ timeout: TIMEOUTS.default });
+
+    await planner.generateButton.click();
+
+    // The async-state contract: error becomes visible, loading clears, and
+    // the planner stays interactive (no permanent spinner). Generate button
+    // re-enables so the user can retry.
+    await expect(planner.error).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(planner.generateButton).toBeEnabled();
+  });
+});

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
@@ -42,9 +42,9 @@ test.describe('Meal Planner — generate shopping list error path', () => {
   test('surfaces server error when generate-shopping-list returns 500', async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.context().route(
-      '**/api/v1/meal-plans/*/w/*/generate-shopping-list',
-      (route) =>
+    await authenticatedPage
+      .context()
+      .route('**/api/v1/meal-plans/*/w/*/generate-shopping-list', (route) =>
         route.fulfill({
           status: 500,
           contentType: 'application/problem+json',
@@ -55,7 +55,7 @@ test.describe('Meal Planner — generate shopping list error path', () => {
             detail: 'Synthetic failure injected by E2E to exercise the error path.',
           }),
         }),
-    );
+      );
 
     await authenticatedPage.goto(`/meal-planner?year=${seededYear}&week=${seededWeek}`);
 

--- a/client/apps/shell-e2e/src/shopping/shopping-detail-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-detail-error-paths.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { ShoppingCreatePage } from '../pages/shopping-create.page';
+import { ShoppingDetailPage } from '../pages/shopping-detail.page';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+/**
+ * Error-path coverage for the shopping-list detail page. Happy paths are
+ * covered by shopping-list.spec.ts / shopping-mode.spec.ts; this spec
+ * exercises optimistic-update rollback when the server rejects a mutation.
+ *
+ * The check-off mutation is wrapped in `optimisticSignalUpdate` so the UI
+ * flips immediately and reverts on API failure. Without an E2E for the
+ * revert branch, a future regression that drops the rollback step would
+ * silently leak through (the optimistic flip alone would still look right
+ * in passing happy-path tests).
+ */
+test.describe('Shopping List Detail — optimistic rollback', () => {
+  const recipe = setupSharedRecipe(test, 'E2E Rollback', { ingredient: 'Flour' });
+
+  test('reverts checkbox state when check-off API returns 500', async ({ authenticatedPage }) => {
+    // Set up the route mock BEFORE creating the list so the very first
+    // user click (post-navigation) hits the failure path. Cross-origin
+    // gateway request — context.route, not page.route.
+    await authenticatedPage.context().route('**/api/v1/shopping-lists/*/items/*/check*', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/problem+json',
+        body: JSON.stringify({
+          type: 'about:blank',
+          title: 'Internal Server Error',
+          status: 500,
+          detail: 'Synthetic failure injected by E2E to exercise the rollback path.',
+        }),
+      }),
+    );
+
+    const createPage = new ShoppingCreatePage(authenticatedPage);
+    await createPage.goto(recipe().identifier);
+    await createPage.createButton.click();
+
+    await expect(authenticatedPage).toHaveURL(/\/shopping\/.+/, { timeout: TIMEOUTS.default });
+    const detailPage = new ShoppingDetailPage(authenticatedPage);
+    await expect(detailPage.heading).toBeVisible({ timeout: TIMEOUTS.default });
+
+    const firstCheckbox = detailPage.itemCheckboxes.first();
+    await expect(firstCheckbox).not.toBeChecked();
+
+    await firstCheckbox.click();
+
+    // After the optimistic flip + failed POST + rollback, the checkbox is
+    // back to its original unchecked state. Allow a generous timeout — the
+    // optimistic helper waits for the POST to settle before reverting.
+    await expect(firstCheckbox).not.toBeChecked({ timeout: TIMEOUTS.default });
+  });
+});


### PR DESCRIPTION
## Summary

Closes 3 of the high-priority gaps from the deeper E2E coverage audit. Each spec exercises a code path that today only fires when a real backend fails — easy regression magnets if the rollback / banner wiring breaks.

- **Recipe import — 422 + in-stream fail event** (\`dashboard/import-recipe.spec.ts\`):
  - Mocks the import-stream endpoint to return 422 with ProblemDetails BEFORE the SSE starts → error banner surfaces.
  - Mocks the stream body to emit an \`event: fail\` chunk mid-stream → banner surfaces AND the import button re-enables.
- **Shopping check-off rollback** (\`shopping/shopping-detail-error-paths.spec.ts\`):
  - Mocks PUT /shopping-lists/{id}/items/{itemId}/check to return 500.
  - Creates a list from a shared recipe, clicks the first item's checkbox, asserts the optimistic flip reverts.
- **Meal-planner generate 5xx** (\`meal-planner/meal-planner-generate-error.spec.ts\`):
  - Mocks POST /meal-plans/{year}/w/{week}/generate-shopping-list to return 500.
  - Seeds a recipe + a Monday slot in week 2030-W15 via API in beforeAll so the generate button is reliably visible.
  - Asserts \`.error\` appears AND the generate button re-enables (no infinite spinner).

Adds an \`assignMealSlot\` helper to \`test-data.helper.ts\` for pre-seeding meal-plan slots — same shape as \`createTestRecipe\`. Likely to be reused by future meal-planner E2E tests.

## Test plan

- [x] \`yarn nx run shell-e2e:lint\` clean on the new files
- [ ] CI: \`Frontend (Build + Test)\` + \`E2E Tests\` exercise the new specs