### PR TITLE
refactor(test): fluent VO builders for Recipes.Domain (PoC)

### DIFF
--- a/tests/Yumney.Recipes.Domain.Tests/Builders/CookingTimeBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/CookingTimeBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class CookingTimeBuilder
+{
+	private int value = 30;
+
+	public static CookingTimeBuilder A() => new();
+
+	public CookingTimeBuilder With(int value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public CookingTime Build() => CookingTime.From(value);
+
+	public static implicit operator CookingTime(CookingTimeBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/DifficultyBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/DifficultyBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class DifficultyBuilder
+{
+	private string value = "Easy";
+
+	public static DifficultyBuilder A() => new();
+
+	public DifficultyBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public Difficulty Build() => Difficulty.From(value);
+
+	public static implicit operator Difficulty(DifficultyBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/ImageUrlBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/ImageUrlBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class ImageUrlBuilder
+{
+	private string value = "https://example.com/image.jpg";
+
+	public static ImageUrlBuilder A() => new();
+
+	public ImageUrlBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public ImageUrl Build() => ImageUrl.From(value);
+
+	public static implicit operator ImageUrl(ImageUrlBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/IngredientNameBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/IngredientNameBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class IngredientNameBuilder
+{
+	private string value = "Flour";
+
+	public static IngredientNameBuilder A() => new();
+
+	public IngredientNameBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public IngredientName Build() => IngredientName.From(value);
+
+	public static implicit operator IngredientName(IngredientNameBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/OwnerIdentifierBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/OwnerIdentifierBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class OwnerIdentifierBuilder
+{
+	private string value = "user-123";
+
+	public static OwnerIdentifierBuilder A() => new();
+
+	public OwnerIdentifierBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public OwnerIdentifier Build() => OwnerIdentifier.From(value);
+
+	public static implicit operator OwnerIdentifier(OwnerIdentifierBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/PreparationTimeBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/PreparationTimeBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class PreparationTimeBuilder
+{
+	private int value = 15;
+
+	public static PreparationTimeBuilder A() => new();
+
+	public PreparationTimeBuilder With(int value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public PreparationTime Build() => PreparationTime.From(value);
+
+	public static implicit operator PreparationTime(PreparationTimeBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/QuantityBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/QuantityBuilder.cs
@@ -1,0 +1,44 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+/// <summary>
+/// Composite VO builder. <see cref="Quantity.Of"/> takes an <see cref="Amount"/>
+/// and a nullable <see cref="Unit"/>; this builder exposes one <c>With*</c> per
+/// component so tests can vary either independently.
+/// </summary>
+public sealed class QuantityBuilder
+{
+	private Amount amount = Amount.From(1m);
+	private Unit? unit = Unit.Gram;
+
+	public static QuantityBuilder A() => new();
+
+	public QuantityBuilder WithAmount(decimal value)
+	{
+		amount = Amount.From(value);
+		return this;
+	}
+
+	public QuantityBuilder WithAmount(Amount value)
+	{
+		amount = value;
+		return this;
+	}
+
+	public QuantityBuilder WithUnit(Unit? value)
+	{
+		unit = value;
+		return this;
+	}
+
+	public QuantityBuilder WithoutUnit()
+	{
+		unit = null;
+		return this;
+	}
+
+	public Quantity Build() => Quantity.Of(amount, unit);
+
+	public static implicit operator Quantity(QuantityBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeBuilder.cs
@@ -8,8 +8,8 @@ public sealed class RecipeBuilder
 	private readonly List<Ingredient> ingredients = [];
 	private readonly List<Step> steps = [];
 	private readonly List<RecipeTag> tags = [];
-	private RecipeTitle title = RecipeTitle.From("Test Recipe");
-	private OwnerIdentifier owner = OwnerIdentifier.From("user-123");
+	private RecipeTitle title = RecipeTitleBuilder.A();
+	private OwnerIdentifier owner = OwnerIdentifierBuilder.A();
 	private RecipeDescription? description;
 	private Servings? servings;
 	private TimingInfo? timing;
@@ -17,6 +17,8 @@ public sealed class RecipeBuilder
 	private ImageUrl? imageUrl;
 	private RecipeLanguage? language;
 	private RecipeUrl? sourceUrl;
+
+	public static RecipeBuilder A() => new();
 
 	public RecipeBuilder WithTitle(string value) => WithTitle(RecipeTitle.From(value));
 
@@ -61,49 +63,49 @@ public sealed class RecipeBuilder
 
 	public RecipeBuilder WithDescription(string value)
 	{
-		description = RecipeDescription.From(value);
+		description = RecipeDescriptionBuilder.A().With(value);
 		return this;
 	}
 
 	public RecipeBuilder WithServings(int value)
 	{
-		servings = Servings.From(value);
+		servings = ServingsBuilder.A().With(value);
 		return this;
 	}
 
 	public RecipeBuilder WithTiming(int prepMinutes, int cookMinutes)
 	{
-		timing = TimingInfo.Of(PreparationTime.From(prepMinutes), CookingTime.From(cookMinutes));
+		timing = TimingInfoBuilder.A().WithPreparationMinutes(prepMinutes).WithCookingMinutes(cookMinutes);
 		return this;
 	}
 
 	public RecipeBuilder WithDifficulty(string value)
 	{
-		difficulty = Difficulty.From(value);
+		difficulty = DifficultyBuilder.A().With(value);
 		return this;
 	}
 
 	public RecipeBuilder WithImageUrl(string url)
 	{
-		imageUrl = ImageUrl.From(url);
+		imageUrl = ImageUrlBuilder.A().With(url);
 		return this;
 	}
 
 	public RecipeBuilder WithLanguage(string code)
 	{
-		language = RecipeLanguage.From(code);
+		language = RecipeLanguageBuilder.A().With(code);
 		return this;
 	}
 
 	public RecipeBuilder WithSourceUrl(string url)
 	{
-		sourceUrl = RecipeUrl.From(url);
+		sourceUrl = RecipeUrlBuilder.A().With(url);
 		return this;
 	}
 
 	public RecipeBuilder WithTag(string value)
 	{
-		tags.Add(RecipeTag.From(value));
+		tags.Add(RecipeTagBuilder.A().With(value));
 		return this;
 	}
 
@@ -111,12 +113,12 @@ public sealed class RecipeBuilder
 	{
 		if (ingredients.Count == 0)
 		{
-			ingredients.Add(Ingredient.Create(IngredientName.From("Flour"), null));
+			ingredients.Add(Ingredient.Create(IngredientNameBuilder.A(), null));
 		}
 
 		if (steps.Count == 0)
 		{
-			steps.Add(Step.Create(StepNumber.From(1), StepDescription.From("Mix")));
+			steps.Add(Step.Create(StepNumber.From(1), StepDescriptionBuilder.A()));
 		}
 
 		return RecipeAggregate.Create(

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeDescriptionBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeDescriptionBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class RecipeDescriptionBuilder
+{
+	private string value = "Test description";
+
+	public static RecipeDescriptionBuilder A() => new();
+
+	public RecipeDescriptionBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public RecipeDescription Build() => RecipeDescription.From(value);
+
+	public static implicit operator RecipeDescription(RecipeDescriptionBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeLanguageBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeLanguageBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class RecipeLanguageBuilder
+{
+	private string value = "en";
+
+	public static RecipeLanguageBuilder A() => new();
+
+	public RecipeLanguageBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public RecipeLanguage Build() => RecipeLanguage.From(value);
+
+	public static implicit operator RecipeLanguage(RecipeLanguageBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeTagBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeTagBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class RecipeTagBuilder
+{
+	private string value = "vegetarian";
+
+	public static RecipeTagBuilder A() => new();
+
+	public RecipeTagBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public RecipeTag Build() => RecipeTag.From(value);
+
+	public static implicit operator RecipeTag(RecipeTagBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeTitleBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeTitleBuilder.cs
@@ -1,0 +1,29 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+/// <summary>
+/// Test builder for <see cref="RecipeTitle"/>. Use when a test needs a valid
+/// <c>RecipeTitle</c> as a setup detail and doesn't care about the specific
+/// value — <c>RecipeTitleBuilder.A().Build()</c> yields a sensible default.
+///
+/// VO builders intentionally have a much smaller surface than aggregate
+/// builders: a single optional override and an implicit conversion so they
+/// can be passed directly where a <c>RecipeTitle</c> is expected.
+/// </summary>
+public sealed class RecipeTitleBuilder
+{
+	private string value = "Test Recipe";
+
+	public static RecipeTitleBuilder A() => new();
+
+	public RecipeTitleBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public RecipeTitle Build() => RecipeTitle.From(value);
+
+	public static implicit operator RecipeTitle(RecipeTitleBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeUrlBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/RecipeUrlBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class RecipeUrlBuilder
+{
+	private string value = "https://example.com/recipe";
+
+	public static RecipeUrlBuilder A() => new();
+
+	public RecipeUrlBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public RecipeUrl Build() => RecipeUrl.From(value);
+
+	public static implicit operator RecipeUrl(RecipeUrlBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/ServingsBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/ServingsBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class ServingsBuilder
+{
+	private int value = 4;
+
+	public static ServingsBuilder A() => new();
+
+	public ServingsBuilder With(int value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public Servings Build() => Servings.From(value);
+
+	public static implicit operator Servings(ServingsBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/StepDescriptionBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/StepDescriptionBuilder.cs
@@ -1,0 +1,20 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+public sealed class StepDescriptionBuilder
+{
+	private string value = "Mix ingredients";
+
+	public static StepDescriptionBuilder A() => new();
+
+	public StepDescriptionBuilder With(string value)
+	{
+		this.value = value;
+		return this;
+	}
+
+	public StepDescription Build() => StepDescription.From(value);
+
+	public static implicit operator StepDescription(StepDescriptionBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Builders/TimingInfoBuilder.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Builders/TimingInfoBuilder.cs
@@ -1,0 +1,44 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+
+/// <summary>
+/// Composite VO builder. <see cref="TimingInfo"/> wraps optional preparation
+/// and cooking times; defaults to both components present so the resulting
+/// instance is non-null. Use <c>Without*</c> to clear an individual component.
+/// </summary>
+public sealed class TimingInfoBuilder
+{
+	private PreparationTime? preparation = PreparationTime.From(15);
+	private CookingTime? cooking = CookingTime.From(30);
+
+	public static TimingInfoBuilder A() => new();
+
+	public TimingInfoBuilder WithPreparationMinutes(int minutes)
+	{
+		preparation = PreparationTime.From(minutes);
+		return this;
+	}
+
+	public TimingInfoBuilder WithCookingMinutes(int minutes)
+	{
+		cooking = CookingTime.From(minutes);
+		return this;
+	}
+
+	public TimingInfoBuilder WithoutPreparation()
+	{
+		preparation = null;
+		return this;
+	}
+
+	public TimingInfoBuilder WithoutCooking()
+	{
+		cooking = null;
+		return this;
+	}
+
+	public TimingInfo Build() => TimingInfo.Of(preparation, cooking);
+
+	public static implicit operator TimingInfo(TimingInfoBuilder builder) => builder.Build();
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using Xunit;
 
@@ -12,7 +13,7 @@ public class RecipeTests
 	[Fact]
 	public void Create_ValidInput_CreatesRecipeWithId()
 	{
-		var recipe = CreateValidRecipe();
+		var recipe = RecipeBuilder.A().Build();
 
 		recipe.Id.Should().NotBeNull();
 	}
@@ -20,31 +21,25 @@ public class RecipeTests
 	[Fact]
 	public void Create_ValidInput_SetsTitle()
 	{
-		var title = RecipeTitle.From("Pasta Carbonara");
+		var recipe = RecipeBuilder.A().WithTitle("Pasta Carbonara").Build();
 
-		var recipe = CreateValidRecipe(title: title);
-
-		recipe.Title.Should().Be(title);
+		recipe.Title.Should().Be(RecipeTitle.From("Pasta Carbonara"));
 	}
 
 	[Fact]
 	public void Create_WithSourceUrl_SetsSourceUrl()
 	{
-		var sourceUrl = RecipeUrl.From("https://example.com/recipe");
+		var recipe = RecipeBuilder.A().WithSourceUrl("https://example.com/recipe").Build();
 
-		var recipe = CreateValidRecipe(sourceUrl: sourceUrl);
-
-		recipe.SourceUrl.Should().Be(sourceUrl);
+		recipe.SourceUrl.Should().Be(RecipeUrl.From("https://example.com/recipe"));
 	}
 
 	[Fact]
 	public void Create_ValidInput_SetsOwner()
 	{
-		var owner = OwnerIdentifier.From("user-123");
+		var recipe = RecipeBuilder.A().OwnedBy("user-123").Build();
 
-		var recipe = CreateValidRecipe(owner: owner);
-
-		recipe.Owner.Should().Be(owner);
+		recipe.Owner.Should().Be(OwnerIdentifier.From("user-123"));
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Proof-of-concept rollout of the **fluent VO builder** pattern for `Yumney.Recipes.Domain` test fixtures, signed off in chat. Establishes the convention and a working subset; the remaining tests in `RecipeTests.cs` (50 inline usages of `CreateValidRecipe` / `RecipeTitle.From`) and other modules (Shopping, MealPlan, Users) are intentionally left for follow-up PRs so this one stays reviewable.

## The pattern

```csharp
var t = RecipeTitleBuilder.A().Build();                 // sensible default ("Test Recipe")
var t = RecipeTitleBuilder.A().With("Pasta").Build();   // override
RecipeTitle implicit = RecipeTitleBuilder.A();          // implicit conversion at any VO use-site
```

Each builder:
- Static `A()` factory.
- Single `With(value)` mutator (or per-component `WithX()` on composite VOs).
- `Build()` returning the VO.
- Implicit conversion so the builder can pass directly where the VO is expected — no `.Build()` needed.

## Files

**14 new VO builders** under `tests/Yumney.Recipes.Domain.Tests/Builders/`:
- 12 single-value: `RecipeTitle`, `OwnerIdentifier`, `RecipeUrl`, `RecipeDescription`, `Servings`, `PreparationTime`, `CookingTime`, `Difficulty`, `ImageUrl`, `RecipeLanguage`, `RecipeTag`, `IngredientName`, `StepDescription`
- 2 composite: `QuantityBuilder`, `TimingInfoBuilder` (per-component `WithX()` plus `Without*()` clearers)

**Existing `RecipeBuilder.cs`** — added `static A()` factory; defaults now compose the new VO builders (implicit conversion makes this seamless).

**`RecipeTests.cs`** — 4 sample tests in the `Create_*` section refactored from `CreateValidRecipe(title: ...)` to `RecipeBuilder.A().WithTitle("...").Build()` as the canonical usage example.

## Open follow-ups (not in this PR)

- **`RecipeTests.cs` end-to-end refactor** — 50 remaining inline-VO usages. Mechanical once the pattern's locked in.
- **Entity-level builders** — `IngredientBuilder`, `StepBuilder` (currently inlined via `Ingredient.Create(...)`).
- **Other domain modules** — same 24-builder shape for `Yumney.Shopping.Domain`, `Yumney.MealPlan.Domain`, `Yumney.Users.Domain`.
- **Less-common Recipes VOs** — `Rating`, `Notes`, `SearchTerm`, `RecipeIdentifier`, `Amount`, etc. (~10 more files) once we see them used in tests.

## Test plan

- [x] All 274 `Yumney.Recipes.Domain.Tests` pass locally with `-p:TreatWarningsAsErrors=true`
- [ ] CI: same on the runner