### PR TITLE
refactor(test): extract domain test builders into shared Yumney.TestBuilders project

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -89,5 +89,6 @@
     <Project Path="tests/Yumney.Architecture.Tests/Yumney.Architecture.Tests.csproj" />
     <Project Path="tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj" />
     <Project Path="tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj" />
+    <Project Path="tests/Yumney.TestBuilders/Yumney.TestBuilders.csproj" />
   </Folder>
 </Solution>

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.Builders;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.TestBuilders.MealPlan;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.WeeklyPlan;

--- a/tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj
+++ b/tests/Yumney.MealPlan.Domain.Tests/Yumney.MealPlan.Domain.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -2,8 +2,8 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
-using SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
 using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe;

--- a/tests/Yumney.Recipes.Domain.Tests/Yumney.Recipes.Domain.Tests.csproj
+++ b/tests/Yumney.Recipes.Domain.Tests/Yumney.Recipes.Domain.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListTests.cs
@@ -1,9 +1,8 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Guards;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
-using SmartSolutionsLab.Yumney.Shopping.Domain.Tests.Builders;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;

--- a/tests/Yumney.Shopping.Domain.Tests/Yumney.Shopping.Domain.Tests.csproj
+++ b/tests/Yumney.Shopping.Domain.Tests/Yumney.Shopping.Domain.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.TestBuilders/MealPlan/WeeklyPlanBuilder.cs
+++ b/tests/Yumney.TestBuilders/MealPlan/WeeklyPlanBuilder.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using WeeklyPlanAggregate = SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan.WeeklyPlan;
 
-namespace SmartSolutionsLab.Yumney.MealPlan.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.MealPlan;
 
 public sealed class WeeklyPlanBuilder
 {

--- a/tests/Yumney.TestBuilders/Recipes/IngredientBuilder.cs
+++ b/tests/Yumney.TestBuilders/Recipes/IngredientBuilder.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 /// <summary>
 /// Test builder for the <see cref="Ingredient"/> entity. Defaults to the

--- a/tests/Yumney.TestBuilders/Recipes/QuantityBuilder.cs
+++ b/tests/Yumney.TestBuilders/Recipes/QuantityBuilder.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 /// <summary>
 /// Composite VO builder. <see cref="Quantity.Of"/> takes an <see cref="Amount"/>

--- a/tests/Yumney.TestBuilders/Recipes/RecipeBuilder.cs
+++ b/tests/Yumney.TestBuilders/Recipes/RecipeBuilder.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using RecipeAggregate = SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 public sealed class RecipeBuilder
 {

--- a/tests/Yumney.TestBuilders/Recipes/StepBuilder.cs
+++ b/tests/Yumney.TestBuilders/Recipes/StepBuilder.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 /// <summary>
 /// Test builder for the <see cref="Step"/> entity. Defaults to step number 1

--- a/tests/Yumney.TestBuilders/Recipes/TimingInfoBuilder.cs
+++ b/tests/Yumney.TestBuilders/Recipes/TimingInfoBuilder.cs
@@ -1,6 +1,6 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 
-namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 /// <summary>
 /// Composite VO builder. <see cref="TimingInfo"/> wraps optional preparation

--- a/tests/Yumney.TestBuilders/Shopping/ShoppingListBuilder.cs
+++ b/tests/Yumney.TestBuilders/Shopping/ShoppingListBuilder.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using ShoppingListAggregate = SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList;
 
-namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 
 public sealed class ShoppingListBuilder
 {

--- a/tests/Yumney.TestBuilders/Shopping/ShoppingListItemBuilder.cs
+++ b/tests/Yumney.TestBuilders/Shopping/ShoppingListItemBuilder.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 
 /// <summary>
 /// Test builder for the <see cref="ShoppingListItem"/> entity. Defaults to

--- a/tests/Yumney.TestBuilders/Users/AppUserProfileBuilder.cs
+++ b/tests/Yumney.TestBuilders/Users/AppUserProfileBuilder.cs
@@ -1,7 +1,7 @@
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
 using AppUserProfileAggregate = SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile.AppUserProfile;
 
-namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.Builders;
+namespace SmartSolutionsLab.Yumney.TestBuilders.Users;
 
 public sealed class AppUserProfileBuilder
 {

--- a/tests/Yumney.TestBuilders/Yumney.TestBuilders.csproj
+++ b/tests/Yumney.TestBuilders/Yumney.TestBuilders.csproj
@@ -1,0 +1,16 @@
+
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yumney.Recipes.Domain\Yumney.Recipes.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Users.Domain\Yumney.Users.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
+using SmartSolutionsLab.Yumney.TestBuilders.Users;
 using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
-using SmartSolutionsLab.Yumney.Users.Domain.Tests.Builders;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;

--- a/tests/Yumney.Users.Domain.Tests/Yumney.Users.Domain.Tests.csproj
+++ b/tests/Yumney.Users.Domain.Tests/Yumney.Users.Domain.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Users.Domain\Yumney.Users.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Sets up the foundation for using the test builders (#685-#690) from `Yumney.{Application,Infrastructure,Integration,Api}.Tests`. Until now they lived inside each `*.Domain.Tests` project, which made cross-test-project reuse impossible without an awkward test-on-test ProjectReference.

## What's changed

**New project: `tests/Yumney.TestBuilders/`** — thin class library, NOT a test project (no xUnit / Test.Sdk). References all four `*.Domain` projects (it has to — each builder's API exposes that module's domain types).

**Layout:**

```
tests/Yumney.TestBuilders/
├── Recipes/   (RecipeBuilder, IngredientBuilder, StepBuilder, QuantityBuilder, TimingInfoBuilder)
├── Shopping/  (ShoppingListBuilder, ShoppingListItemBuilder)
├── MealPlan/  (WeeklyPlanBuilder)
└── Users/     (AppUserProfileBuilder)
```

Namespaces become `SmartSolutionsLab.Yumney.TestBuilders.{Recipes,Shopping,MealPlan,Users}`.

The four `*.Domain.Tests` projects:
- Add a `ProjectReference` to `Yumney.TestBuilders`.
- Drop their now-empty `Builders/` subfolders.
- The four test files that imported builders update their `using` to the new namespace.

**Solution:** added under `tests/Cross-Cutting/`.

## What this unblocks

Application/Infrastructure/Integration test projects can now `<ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />` and use the same builders the Domain tests use. That's the prerequisite for the next round of work — replacing inline aggregate construction in `RecipeFactory`, `MealPlanTestFixture`, `RecipePersistenceTests`, etc.

## Test plan

- [x] `dotnet build` clean on TestBuilders + all 4 Domain.Tests
- [x] All 830 Domain tests still pass (274 + 182 + 131 + 243)
- [ ] CI: same on the runner