### PR TITLE
test(shared): rewire 4 test-data factories on top of Yumney.TestBuilders

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/RecipeFactory.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 
@@ -17,28 +16,32 @@ public static class RecipeFactory
 		IReadOnlyList<string>? steps = null,
 		IReadOnlyList<string>? tags = null)
 	{
-		var recipeIngredients = (ingredients ?? [("Default Ingredient", null, null)])
-			.Select(spec => Ingredient.Create(
-				IngredientName.From(spec.Name),
-				Quantity.FromNullable(
-					Amount.FromNullable(spec.Amount),
-					Unit.FromNullable(spec.Unit))))
-			.ToList();
+		var builder = RecipeBuilder.A().WithTitle(title).OwnedBy(owner ?? DefaultOwner);
+		if (description is not null) builder.WithDescription(description);
+		if (servings is not null) builder.WithServings(servings.Value);
 
-		var recipeSteps = (steps ?? ["Default step"])
-			.Select((s, i) => Step.Create(StepNumber.From(i + 1), StepDescription.From(s)))
-			.ToList();
+		if (ingredients is not null)
+		{
+			builder.WithIngredients([.. ingredients.Select(spec =>
+			{
+				var ingredient = IngredientBuilder.A().Named(spec.Name);
+				if (spec.Amount.HasValue) ingredient.WithQuantity(spec.Amount.Value, Unit.FromNullable(spec.Unit));
+				return ingredient.Build();
+			})]);
+		}
 
-		var recipeTags = tags?.Select(RecipeTag.From).ToList();
+		if (steps is not null)
+		{
+			builder.WithSteps([.. steps.Select((s, i) =>
+				StepBuilder.A().Numbered(i + 1).WithDescription(s).Build())]);
+		}
 
-		return Recipe.Create(
-			RecipeTitle.From(title),
-			OwnerIdentifier.From(owner ?? DefaultOwner),
-			recipeIngredients,
-			recipeSteps,
-			RecipeDescription.FromNullable(description),
-			Servings.FromNullable(servings),
-			tags: recipeTags);
+		if (tags is not null)
+		{
+			foreach (var tag in tags) builder.WithTag(tag);
+		}
+
+		return builder.Build();
 	}
 
 	public static Recipe Lasagne(string? owner = null) => Create(

--- a/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipeFilterTests.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Paging;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes;
@@ -193,22 +190,16 @@ public class RecipeFilterTests(AspireFixture fixture) : IAsyncLifetime
 		int? prepMinutes,
 		int? cookMinutes)
 	{
-		var ingredients = new[]
-		{
-			Ingredient.Create(IngredientName.From("Test Ingredient"), Quantity.FromNullable(null, null)),
-		};
-		var steps = new[]
-		{
-			Step.Create(StepNumber.From(1), StepDescription.From("Test step")),
-		};
+		var builder = RecipeBuilder.A().WithTitle(title).OwnedBy(owner);
 
-		return Recipe.Create(
-			RecipeTitle.From(title),
-			owner,
-			ingredients,
-			steps,
-			timing: TimingInfo.FromNullable(PreparationTime.FromNullable(prepMinutes), CookingTime.FromNullable(cookMinutes)),
-			difficulty: Difficulty.FromNullable(difficulty),
-			tags: tags?.Select(RecipeTag.From).ToList());
+		if (prepMinutes.HasValue || cookMinutes.HasValue)
+		{
+			builder.WithTiming(prepMinutes ?? 0, cookMinutes ?? 0);
+		}
+
+		if (difficulty is not null) builder.WithDifficulty(difficulty);
+		if (tags is not null) builder.WithTags([.. tags.Select(RecipeTag.From)]);
+
+		return builder.Build();
 	}
 }

--- a/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/RecipePersistenceTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Paging;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Integration.Tests.Recipes;
@@ -196,8 +197,8 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 			var loaded = await recipes.GetByIdForUpdateAsync(recipe.Id);
 			loaded.Update(
 				updatedTitle,
-				[Ingredient.Create(ingredientName, Quantity.Of(Amount.From(800), Unit.Gram))],
-				[Step.Create(StepNumber.From(1), StepDescription.From("Roast cherry tomatoes"))],
+				[IngredientBuilder.A().Named(ingredientName).WithQuantity(800, Unit.Gram)],
+				[StepBuilder.A().Numbered(1).WithDescription("Roast cherry tomatoes")],
 				updatedDescription,
 				updatedServings);
 			await updateContext.SaveChangesAsync();
@@ -241,12 +242,11 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task ExistsBySourceUrlAsync_ExistingUrl_ReturnsTrue()
 	{
 		var sourceUrl = RecipeUrl.From("https://example.com/lasagne-test");
-		var recipe = Recipe.Create(
-			RecipeTitle.From("URL Test Recipe"),
-			owner,
-			[Ingredient.Create(IngredientName.From("Test"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Test"))],
-			sourceUrl: sourceUrl);
+		var recipe = RecipeBuilder.A()
+			.WithTitle("URL Test Recipe")
+			.OwnedBy(owner)
+			.WithSourceUrl(sourceUrl)
+			.Build();
 		await fixture.SeedRecipesAsync(recipe);
 
 		await using var readContext = await fixture.CreateRecipesDbContextAsync();
@@ -260,12 +260,11 @@ public class RecipePersistenceTests(AspireFixture fixture) : IAsyncLifetime
 	public async Task ExistsBySourceUrlAsync_DifferentOwner_ReturnsFalse()
 	{
 		var sourceUrl = RecipeUrl.From("https://example.com/owner-test");
-		var recipe = Recipe.Create(
-			RecipeTitle.From("Owner Test Recipe"),
-			owner,
-			[Ingredient.Create(IngredientName.From("Test"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Test"))],
-			sourceUrl: sourceUrl);
+		var recipe = RecipeBuilder.A()
+			.WithTitle("Owner Test Recipe")
+			.OwnedBy(owner)
+			.WithSourceUrl(sourceUrl)
+			.Build();
 		await fixture.SeedRecipesAsync(recipe);
 
 		await using var readContext = await fixture.CreateRecipesDbContextAsync();

--- a/tests/Yumney.Integration.Tests/Shopping/EventStore/ShoppingListEventStoreTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/EventStore/ShoppingListEventStoreTests.cs
@@ -9,6 +9,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 using Wolverine.EntityFrameworkCore;
 using Xunit;
 
@@ -153,12 +154,10 @@ public class ShoppingListEventStoreTests(AspireFixture fixture) : IAsyncLifetime
 			Substitute.For<IDbContextOutbox<ShoppingDbContext>>(),
 			NullLogger<ShoppingListEventStore>.Instance);
 
-	private ShoppingList CreateList()
-	{
-		var item = ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram));
-		return ShoppingList.Create(
-			ShoppingListTitle.From("Weekly Groceries"),
-			owner,
-			[item]);
-	}
+	private ShoppingList CreateList() =>
+		ShoppingListBuilder.A()
+			.WithTitle("Weekly Groceries")
+			.OwnedBy(owner)
+			.WithItems([ShoppingListItemBuilder.A().Named("Flour").WithQuantity(500, Unit.Gram)])
+			.Build();
 }

--- a/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/ReadModel/ShoppingListProjectionRebuilderTests.cs
@@ -8,6 +8,7 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 using Wolverine.EntityFrameworkCore;
 using Xunit;
 
@@ -99,9 +100,9 @@ public class ShoppingListProjectionRebuilderTests(AspireFixture fixture) : IAsyn
 		var store = new ShoppingListEventStore(ctx, bus, Substitute.For<IDbContextOutbox<ShoppingDbContext>>(), NullLogger<ShoppingListEventStore>.Instance);
 
 		var items = itemNames
-			.Select(name => ShoppingListItem.Create(ItemName.From(name), Quantity.Of(Amount.From(1), Unit.Gram)))
+			.Select(name => ShoppingListItemBuilder.A().Named(name).WithQuantity(1, Unit.Gram).Build())
 			.ToList();
-		var list = ShoppingList.Create(ShoppingListTitle.From(title), owner, items);
+		var list = ShoppingListBuilder.A().WithTitle(title).OwnedBy(owner).WithItems(items).Build();
 		await store.SaveAsync(list);
 		return list.Identifier;
 	}

--- a/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
+++ b/tests/Yumney.Integration.Tests/Yumney.Integration.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Infrastructure\Yumney.MealPlan.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shopping.Client\Yumney.Shopping.Client.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Capabilities\Yumney.Shared.Capabilities.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/MealPlanTestFixture.cs
@@ -1,6 +1,7 @@
 using NSubstitute;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.TestBuilders.MealPlan;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Tests;
 
@@ -9,7 +10,7 @@ internal static class MealPlanTestFixture
 	public static readonly OwnerIdentifier TestOwner = OwnerIdentifier.From("user-123");
 	public static readonly WeekIdentifier TestWeek = WeekIdentifier.From(2026, 15);
 
-	public static WeeklyPlan CreatePlan() => WeeklyPlan.Create(TestOwner, TestWeek);
+	public static WeeklyPlan CreatePlan() => WeeklyPlanBuilder.A().OwnedBy(TestOwner).ForWeek(TestWeek).Build();
 
 	public static SlotRecipeReference Recipe(string title = "Pasta") =>
 		SlotRecipeReference.From(SlotRecipeIdentifier.New(), SlotRecipeTitle.From(title));

--- a/tests/Yumney.MealPlan.Application.Tests/Yumney.MealPlan.Application.Tests.csproj
+++ b/tests/Yumney.MealPlan.Application.Tests/Yumney.MealPlan.Application.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Application\Yumney.MealPlan.Application.csproj" />
     <ProjectReference Include="..\..\src\Yumney.MealPlan.Domain\Yumney.MealPlan.Domain.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/UpdateRecipeCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Abstractions;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
@@ -272,16 +273,14 @@ public class UpdateRecipeCommandHandlerTests
 	[Fact]
 	public async Task HandleAsync_NullOptionalFields_ClearsExistingValues()
 	{
-		var recipe = Recipe.Create(
-			RecipeTitle.From("Original"),
-			OwnerIdentifier.From("user-123"),
-			[Ingredient.Create(IngredientName.From("Flour"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))],
-			RecipeDescription.From("Old description"),
-			Servings.From(4),
-			TimingInfo.Of(PreparationTime.From(10), CookingTime.From(20)),
-			Difficulty.From("easy"),
-			ImageUrl.From("https://example.com/old.jpg"));
+		var recipe = RecipeBuilder.A()
+			.WithTitle("Original")
+			.WithDescription("Old description")
+			.WithServings(4)
+			.WithTiming(prepMinutes: 10, cookMinutes: 20)
+			.WithDifficulty("easy")
+			.WithImageUrl("https://example.com/old.jpg")
+			.Build();
 
 		var recipeId = recipe.Id;
 		recipes.GetByIdForUpdateAsync(recipeId, Arg.Any<CancellationToken>()).Returns(recipe);

--- a/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Queries/GetCookableRecipesQueryHandlerTests.cs
@@ -7,9 +7,9 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Queries;
 using SmartSolutionsLab.Yumney.Recipes.Application.Queries.Handlers;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.Common;
-using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using SmartSolutionsLab.Yumney.Shared.Paging;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Queries;
@@ -227,14 +227,12 @@ public class GetCookableRecipesQueryHandlerTests
 	private static GetCookableRecipesQuery Query(bool fullMatchOnly = false)
 		=> new(PagingOptions.From(PagingOptions.DefaultPage, PagingOptions.DefaultPageSize), fullMatchOnly);
 
-	private static Recipe MakeRecipe(string title, params string[] ingredientNames)
-	{
-		return Recipe.Create(
-			RecipeTitle.From(title),
-			OwnerIdentifier.From(OwnerId),
-			ingredientNames.Select(name => Ingredient.Create(IngredientName.From(name), null)).ToList(),
-			[Step.Create(StepNumber.From(1), StepDescription.From("Cook"))]);
-	}
+	private static Recipe MakeRecipe(string title, params string[] ingredientNames) =>
+		RecipeBuilder.A()
+			.WithTitle(title)
+			.OwnedBy(OwnerId)
+			.WithIngredients([.. ingredientNames.Select(name => IngredientBuilder.A().Named(name).Build())])
+			.Build();
 
 	private void ConfigureRecipes(params Recipe[] recipeList)
 	{

--- a/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
+++ b/tests/Yumney.Recipes.Application.Tests/RecipeTestData.cs
@@ -1,64 +1,45 @@
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests;
 
 internal static class RecipeTestData
 {
-	public static Recipe CreateRecipe(string ownerId = "user-123", string title = "Test Recipe")
-	{
-		return Recipe.Create(
-			RecipeTitle.From(title),
-			OwnerIdentifier.From(ownerId),
-			[Ingredient.Create(IngredientName.From("Flour"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);
-	}
+	public static Recipe CreateRecipe(string ownerId = "user-123", string title = "Test Recipe") =>
+		RecipeBuilder.A().OwnedBy(ownerId).WithTitle(title).Build();
 
-	public static Recipe CreateRecipeWithSourceUrl(string ownerId = "user-123")
-	{
-		return Recipe.Create(
-			RecipeTitle.From("Test Recipe"),
-			OwnerIdentifier.From(ownerId),
-			[Ingredient.Create(IngredientName.From("Flour"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))],
-			sourceUrl: RecipeUrl.From("https://example.com/recipe"));
-	}
+	public static Recipe CreateRecipeWithSourceUrl(string ownerId = "user-123") =>
+		RecipeBuilder.A().OwnedBy(ownerId).WithSourceUrl("https://example.com/recipe").Build();
 
-	public static Recipe CreateRecipeWithOptionals(string ownerId = "user-123")
-	{
-		return Recipe.Create(
-			RecipeTitle.From("Full Recipe"),
-			OwnerIdentifier.From(ownerId),
-			[Ingredient.Create(IngredientName.From("Flour"), null)],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))],
-			RecipeDescription.From("A test recipe"),
-			Servings.From(4),
-			TimingInfo.Of(PreparationTime.From(10), CookingTime.From(20)),
-			Difficulty.From("easy"),
-			ImageUrl.From("https://example.com/image.jpg"),
-			sourceUrl: RecipeUrl.From("https://example.com/recipe"));
-	}
+	public static Recipe CreateRecipeWithOptionals(string ownerId = "user-123") =>
+		RecipeBuilder.A()
+			.OwnedBy(ownerId)
+			.WithTitle("Full Recipe")
+			.WithDescription("A test recipe")
+			.WithServings(4)
+			.WithTiming(prepMinutes: 10, cookMinutes: 20)
+			.WithDifficulty("easy")
+			.WithImageUrl("https://example.com/image.jpg")
+			.WithSourceUrl("https://example.com/recipe")
+			.Build();
 
-	public static Recipe CreateRecipeWithIngredients(string ownerId = "user-123")
-	{
-		return Recipe.Create(
-			RecipeTitle.From("Recipe With Ingredients"),
-			OwnerIdentifier.From(ownerId),
-			[
-				Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500m), Unit.Gram)),
-				Ingredient.Create(IngredientName.From("Eggs"), null)
-			],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix"))]);
-	}
+	public static Recipe CreateRecipeWithIngredients(string ownerId = "user-123") =>
+		RecipeBuilder.A()
+			.OwnedBy(ownerId)
+			.WithTitle("Recipe With Ingredients")
+			.WithIngredients([
+				IngredientBuilder.A().Named("Flour").WithQuantity(500m, Unit.Gram),
+				IngredientBuilder.A().Named("Eggs"),
+			])
+			.Build();
 
-	public static Recipe CreateRecipeWithSteps(string ownerId = "user-123")
-	{
-		return Recipe.Create(
-			RecipeTitle.From("Recipe With Steps"),
-			OwnerIdentifier.From(ownerId),
-			[Ingredient.Create(IngredientName.From("Flour"), null)],
-			[
-				Step.Create(StepNumber.From(1), StepDescription.From("Mix flour")),
-				Step.Create(StepNumber.From(2), StepDescription.From("Add eggs"))
-			]);
-	}
+	public static Recipe CreateRecipeWithSteps(string ownerId = "user-123") =>
+		RecipeBuilder.A()
+			.OwnedBy(ownerId)
+			.WithTitle("Recipe With Steps")
+			.WithSteps([
+				StepBuilder.A().Numbered(1).WithDescription("Mix flour"),
+				StepBuilder.A().Numbered(2).WithDescription("Add eggs"),
+			])
+			.Build();
 }

--- a/tests/Yumney.Recipes.Application.Tests/Yumney.Recipes.Application.Tests.csproj
+++ b/tests/Yumney.Recipes.Application.Tests/Yumney.Recipes.Application.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Recipes.Application\Yumney.Recipes.Application.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeRatingAndNotesTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeRatingAndNotesTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe;
@@ -94,9 +95,7 @@ public class RecipeRatingAndNotesTests
 	}
 
 	private static Domain.Recipe.Recipe CreateRecipe() =>
-		Domain.Recipe.Recipe.Create(
-			RecipeTitle.From("Test Recipe"),
-			OwnerIdentifier.From("user-123"),
-			[Ingredient.Create(IngredientName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))],
-			[Step.Create(StepNumber.From(1), StepDescription.From("Mix ingredients"))]);
+		RecipeBuilder.A()
+			.WithIngredients([IngredientBuilder.A().Named("Flour").WithQuantity(500, Unit.Gram)])
+			.Build();
 }

--- a/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
+++ b/tests/Yumney.Shopping.Application.Tests/ShoppingListTestData.cs
@@ -1,36 +1,30 @@
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests;
 
 internal static class ShoppingListTestData
 {
-	public static ShoppingList CreateList(string ownerId = "user-123")
-	{
-		return ShoppingList.Create(
-			ShoppingListTitle.From("Test List"),
-			OwnerIdentifier.From(ownerId),
-			[ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram))]);
-	}
+	public static ShoppingList CreateList(string ownerId = "user-123") =>
+		ShoppingListBuilder.A()
+			.OwnedBy(ownerId)
+			.WithItems([ShoppingListItemBuilder.A().Named("Flour").WithQuantity(500, Unit.Gram)])
+			.Build();
 
-	public static ShoppingList CreateListWithItems(string ownerId = "user-123")
-	{
-		return ShoppingList.Create(
-			ShoppingListTitle.From("Test List"),
-			OwnerIdentifier.From(ownerId),
-			[
-				ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter)),
-				ShoppingListItem.Create(ItemName.From("Flour"), Quantity.Of(Amount.From(500), Unit.Gram)),
-				ShoppingListItem.Create(ItemName.From("Eggs"), Quantity.Of(Amount.From(6), null))
-			]);
-	}
+	public static ShoppingList CreateListWithItems(string ownerId = "user-123") =>
+		ShoppingListBuilder.A()
+			.OwnedBy(ownerId)
+			.WithItems([
+				ShoppingListItemBuilder.A().Named("Milk").WithQuantity(1, Unit.Liter),
+				ShoppingListItemBuilder.A().Named("Flour").WithQuantity(500, Unit.Gram),
+				ShoppingListItemBuilder.A().Named("Eggs").WithQuantity(6, null),
+			])
+			.Build();
 
 	public static ShoppingList CreateListWithItem(string ownerId, out ShoppingListItemIdentifier itemId)
 	{
-		var item = ShoppingListItem.Create(ItemName.From("Milk"), Quantity.Of(Amount.From(1), Unit.Liter));
-		var list = ShoppingList.Create(
-			ShoppingListTitle.From("Test List"),
-			OwnerIdentifier.From(ownerId),
-			[item]);
+		var item = ShoppingListItemBuilder.A().Named("Milk").WithQuantity(1, Unit.Liter).Build();
+		var list = ShoppingListBuilder.A().OwnedBy(ownerId).WithItems([item]).Build();
 		itemId = item.Id;
 		return list;
 	}

--- a/tests/Yumney.Shopping.Application.Tests/Yumney.Shopping.Application.Tests.csproj
+++ b/tests/Yumney.Shopping.Application.Tests/Yumney.Shopping.Application.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/CategoryAssignmentTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/CategoryAssignmentTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
 using Xunit;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
@@ -33,15 +33,8 @@ public class CategoryAssignmentTests
 	[Fact]
 	public void Create_PropagatesCategoryIntoListItemAddedEvent()
 	{
-		var item = ShoppingListItem.Create(
-			ItemName.From("Cheese"),
-			Quantity.Of(Amount.From(200), Unit.Gram),
-			IngredientCategory.Dairy);
-
-		var list = Domain.ShoppingList.ShoppingList.Create(
-			ShoppingListTitle.From("Cheese list"),
-			OwnerIdentifier.From("user-123"),
-			[item]);
+		var item = ShoppingListItemBuilder.A().Named("Cheese").WithQuantity(200, Unit.Gram).InCategory(IngredientCategory.Dairy).Build();
+		var list = ShoppingListBuilder.A().WithItems([item]).Build();
 
 		var added = list.UncommittedEvents.OfType<ListItemAdded>().Single();
 		added.Category.Should().Be(IngredientCategory.Dairy);
@@ -50,11 +43,8 @@ public class CategoryAssignmentTests
 	[Fact]
 	public void ChangeItemCategory_RaisesListItemCategoryChanged()
 	{
-		var item = ShoppingListItem.Create(ItemName.From("Salmon"), null, IngredientCategory.Other);
-		var list = Domain.ShoppingList.ShoppingList.Create(
-			ShoppingListTitle.From("Dinner"),
-			OwnerIdentifier.From("user-123"),
-			[item]);
+		var item = ShoppingListItemBuilder.A().Named("Salmon").Build();
+		var list = ShoppingListBuilder.A().WithItems([item]).Build();
 		list.MarkCommitted();
 
 		list.ChangeItemCategory(item.Id, IngredientCategory.MeatFish);
@@ -67,11 +57,8 @@ public class CategoryAssignmentTests
 	[Fact]
 	public void ChangeItemCategory_UpdatesItemState()
 	{
-		var item = ShoppingListItem.Create(ItemName.From("Bread"), null, IngredientCategory.Other);
-		var list = Domain.ShoppingList.ShoppingList.Create(
-			ShoppingListTitle.From("Lunch"),
-			OwnerIdentifier.From("user-123"),
-			[item]);
+		var item = ShoppingListItemBuilder.A().Named("Bread").Build();
+		var list = ShoppingListBuilder.A().WithItems([item]).Build();
 
 		list.ChangeItemCategory(item.Id, IngredientCategory.Bakery);
 
@@ -81,11 +68,8 @@ public class CategoryAssignmentTests
 	[Fact]
 	public void Replay_CategoryEventsRehydrateLatestState()
 	{
-		var item = ShoppingListItem.Create(ItemName.From("Apple"), null, IngredientCategory.Other);
-		var original = Domain.ShoppingList.ShoppingList.Create(
-			ShoppingListTitle.From("Snacks"),
-			OwnerIdentifier.From("user-123"),
-			[item]);
+		var item = ShoppingListItemBuilder.A().Named("Apple").Build();
+		var original = ShoppingListBuilder.A().WithItems([item]).Build();
 		original.ChangeItemCategory(item.Id, IngredientCategory.Produce);
 
 		var replayed = Domain.ShoppingList.ShoppingList.FromEvents(original.Identifier, original.UncommittedEvents);


### PR DESCRIPTION
## Summary

Builds on #691 (which extracted the builders into the shared `Yumney.TestBuilders` project). Now the Application/Integration test projects' hand-rolled domain-construction helpers compose through the same builders the Domain tests use.

> Note: depends on #691 being merged first. Once #691 lands, this PR rebases cleanly onto develop.

## What's changed

- **`RecipeTestData`** (`Recipes.Application.Tests`) — every `CreateRecipe*` method collapses to a single `RecipeBuilder.A()....Build()` chain. ~50 lines deleted.
- **`ShoppingListTestData`** (`Shopping.Application.Tests`) — same pattern via `ShoppingListBuilder` + `ShoppingListItemBuilder`.
- **`MealPlanTestFixture.CreatePlan`** (`MealPlan.Application.Tests`) — now uses `WeeklyPlanBuilder.A().OwnedBy(TestOwner).ForWeek(TestWeek).Build()`. The `Recipe(...)` / `SeedPlanWithRecipe` / `CreateCurrentUser` helpers stay (they're not pure construction factories).
- **`RecipeFactory`** (`Integration.Tests`) — the generic `Create(...)` Object Mother routes through `RecipeBuilder` + `IngredientBuilder` + `StepBuilder`. The three named-recipe helpers (`Lasagne`, `TomatoSoup`, `ChocolateCake`) stay on top.

Plus 4 ProjectReferences added.

## Test plan

- [x] All 4 affected Application.Tests projects pass locally (184 + 147 + 56 = 387)
- [x] `Yumney.Integration.Tests` compiles clean with `-p:TreatWarningsAsErrors=true`
- [ ] CI: full Integration.Tests run on the Aspire-equipped runner

## What's not in scope

22 individual test files still construct domain aggregates inline (e.g., `RecipePersistenceTests`, `ShoppingListEventStoreTests`, `UpdateRecipeCommandHandlerTests`). They're easier to refactor incrementally per-test-area than in a single mega-PR; this PR establishes the wiring + the 4 factories most other tests rely on.