### PR TITLE
test(e2e): cover reverse-direction favorite cross-route consistency

### DIFF
--- a/client/apps/shell-e2e/src/recipes/recipe-favorite-cross-route.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite-cross-route.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { RecipeDetailPage } from '../pages/recipe-detail.page';
+import { RecipeListPage } from '../pages/recipe-list.page';
+import { setupSharedRecipe } from '../helpers/shared-recipe';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+/**
+ * Cross-route favorite consistency in the *reverse* direction of
+ * recipe-favorite.spec.ts. That spec toggles from the list card and verifies
+ * the detail page reflects it; this one does the inverse — toggle from the
+ * detail page, then verify the list card shows the same state on a fresh
+ * navigation. Without it, a regression that drops the list query's favorite
+ * join (or that fails to refetch on route entry) would slip through, because
+ * the existing spec only exercises the list→detail axis.
+ */
+test.describe('Favorite cross-route consistency (US-071)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const recipe = setupSharedRecipe(test, 'E2E Favorite Cross-Route', {
+    ingredient: 'Salt',
+    step: 'Add salt to taste',
+  });
+
+  test('toggling favorite on detail propagates to the list card', async ({ authenticatedPage }) => {
+    const detail = new RecipeDetailPage(authenticatedPage);
+    await detail.goto(recipe().identifier);
+    await expect(detail.favoriteButton).toBeVisible({ timeout: TIMEOUTS.default });
+    await expect(detail.favoriteButton).toHaveAttribute('aria-pressed', 'false');
+
+    // Wait on the POST commit before navigating away — without it the list
+    // fetch can race the unfinished write and miss the new state (see #419
+    // on the existing favorite spec).
+    const favoriteCommitted = authenticatedPage.waitForResponse(
+      (res) =>
+        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
+        res.request().method() === 'POST' &&
+        res.ok(),
+      { timeout: TIMEOUTS.default },
+    );
+    await detail.favoriteButton.click();
+    await favoriteCommitted;
+
+    const list = new RecipeListPage(authenticatedPage);
+    await list.goto();
+    await expect(list.recipeCard(recipe().title).first()).toBeVisible({
+      timeout: TIMEOUTS.default,
+    });
+
+    const heart = list.favoriteButtonOnCard(recipe().title).first();
+    await expect(heart).toHaveAttribute('aria-pressed', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

Smaller-than-planned cross-route bundle — one solid spec instead of three. The other two proposed specs turned out to be testing features that don't exist yet (see "Pivots" below).

## What's added

**`recipe-favorite-cross-route.spec.ts`** — single test: toggle favorite from the detail page, navigate to the recipe list, verify the card's heart shows `aria-pressed="true"`.

The existing `recipe-favorite.spec.ts` already exercises the **list-toggle → detail-show** axis. This spec covers the **inverse axis** (detail-toggle → list-show) — a real gap in cross-route consistency coverage. Without it, a regression that drops the list query's favorite join (or that fails to refetch on route entry) would slip through silently.

Waits on the POST `/favorite` commit before navigating to avoid the race documented under #419 in the original favorite spec.

## Pivots from the originally-planned 3-spec bundle

| Proposed spec | Why dropped |
|---|---|
| "Favorite toggle in MealSuggestionPanel → list sync" | The suggestion panel has no favorite affordance today (verified by grep of the component template). |
| "Plan → generate shopping list → back-button state" | `onGenerateShoppingList` is an in-place action — sets `shoppingResult` signal and clears after `RESULT_DISPLAY_MS`. There's no navigation, so the back-button axis doesn't apply. |
| "Deep-link → login → land on deep link" | `auth.guard.ts` redirects unauthenticated users to `/auth/login` with no `returnUrl` preservation. That's a real feature gap, not a test gap; reintroduce the spec when the feature lands. |

## Test plan

- [x] `yarn nx run shell-e2e:lint` clean
- [ ] CI: E2E run on the runner