### PR TITLE
refactor(shared): drop redundant Identifier suffix from VO-typed properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,7 +731,7 @@ public static IQueryable<Recipe> ApplyFavoritesOnly(this IQueryable<Recipe> quer
 
 // ✅ REQUIRED — repository owns the subquery, passes it in
 private IQueryable<RecipeIdentifier> GetFavoriteRecipeIdsOfUserQuery(OwnerIdentifier owner) =>
-    context.RecipeFavorites.Where(f => f.Owner == owner).Select(f => f.RecipeIdentifier);
+    context.RecipeFavorites.Where(favorite => favorite.Owner == owner).Select(favorite => favorite.Recipe);
 
 // in repository:
 query = query

--- a/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/ConfirmMealCommandHandler.cs
@@ -26,7 +26,7 @@ public sealed class ConfirmMealCommandHandler(
 			case MealState.Cooked:
 				var slot = plan.GetVisibleSlots().FirstOrDefault(slot => slot.Day == day && slot.MealType == mealType);
 				var ingredients = slot?.Recipe is not null
-					? await FetchIngredientsAsync(slot.Recipe.RecipeIdentifier, cancellationToken)
+					? await FetchIngredientsAsync(slot.Recipe.Identifier, cancellationToken)
 					: [];
 				plan.MarkAsCooked(day, mealType, ingredients);
 				break;

--- a/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Application/DTOs/WeeklyPlanMappingExtensions.cs
@@ -14,7 +14,7 @@ public static class WeeklyPlanMappingExtensions
 			slot.MealType.ToString(),
 			slot.ContentType.ToString(),
 			slot.State.ToString(),
-			slot.Recipe?.RecipeIdentifier.Value,
+			slot.Recipe?.Identifier.Value,
 			slot.Recipe?.Title.Value,
 			slot.Servings.Value,
 			slot.FreetextLabel?.Value,

--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeReference.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/SlotRecipeReference.cs
@@ -4,13 +4,13 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 
 public sealed record SlotRecipeReference : IValueObject
 {
-	public SlotRecipeIdentifier RecipeIdentifier { get; }
+	public SlotRecipeIdentifier Identifier { get; }
 
 	public SlotRecipeTitle Title { get; }
 
 	private SlotRecipeReference(SlotRecipeIdentifier recipe, SlotRecipeTitle title)
 	{
-		RecipeIdentifier = recipe;
+		Identifier = recipe;
 		Title = title;
 	}
 
@@ -19,5 +19,5 @@ public sealed record SlotRecipeReference : IValueObject
 	public static SlotRecipeReference From(Guid recipe, string title) =>
 		From(SlotRecipeIdentifier.From(recipe), SlotRecipeTitle.From(title));
 
-	public override string ToString() => $"{Title} ({RecipeIdentifier})";
+	public override string ToString() => $"{Title} ({Identifier})";
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/SlotRecipeReferenceJsonConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/SlotRecipeReferenceJsonConverter.cs
@@ -45,7 +45,7 @@ internal sealed class SlotRecipeReferenceJsonConverter : JsonConverter<SlotRecip
 	public override void Write(Utf8JsonWriter writer, SlotRecipeReference value, JsonSerializerOptions options)
 	{
 		writer.WriteStartObject();
-		writer.WriteString("recipeIdentifier", value.RecipeIdentifier.Value);
+		writer.WriteString("recipeIdentifier", value.Identifier.Value);
 		writer.WriteString("title", value.Title.Value);
 		writer.WriteEndObject();
 	}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/CrossModule/MealConfirmedMapper.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/CrossModule/MealConfirmedMapper.cs
@@ -17,7 +17,7 @@ internal sealed class MealConfirmedMapper : ICrossModuleEventMapper
 
 		return new MealConfirmedIntegrationEvent(
 			(string)context[0],
-			cooked.Recipe.RecipeIdentifier.Value,
+			cooked.Recipe.Identifier.Value,
 			cooked.Servings.Value,
 			cooked.Ingredients
 				.Select(ingredient => new MealConfirmedIngredient(ingredient.Name, ingredient.Quantity, ingredient.Unit))

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
@@ -87,7 +87,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Recipe);
-		slot.RecipeIdentifier = inner.Recipe.RecipeIdentifier.Value;
+		slot.RecipeIdentifier = inner.Recipe.Identifier.Value;
 		slot.RecipeTitle = inner.Recipe.Title.Value;
 		slot.FreetextLabel = null;
 		slot.LeftoverLabel = null;

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeDeletedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeDeletedEvent.cs
@@ -3,6 +3,6 @@ using SmartSolutionsLab.Yumney.Shared.Abstractions;
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 
 public sealed record RecipeDeletedEvent(
-	RecipeIdentifier RecipeIdentifier,
+	RecipeIdentifier Recipe,
 	RecipeTitle Title,
 	OwnerIdentifier Owner) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeNotesUpdatedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeNotesUpdatedEvent.cs
@@ -3,5 +3,5 @@ using SmartSolutionsLab.Yumney.Shared.Abstractions;
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 
 public sealed record RecipeNotesUpdatedEvent(
-	RecipeIdentifier RecipeIdentifier,
+	RecipeIdentifier Recipe,
 	bool HasNotes) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeRatedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeRatedEvent.cs
@@ -3,5 +3,5 @@ using SmartSolutionsLab.Yumney.Shared.Abstractions;
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 
 public sealed record RecipeRatedEvent(
-	RecipeIdentifier RecipeIdentifier,
+	RecipeIdentifier Recipe,
 	Rating Rating) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeSavedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeSavedEvent.cs
@@ -3,5 +3,5 @@ using SmartSolutionsLab.Yumney.Shared.Abstractions;
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 
 public sealed record RecipeSavedEvent(
-	RecipeIdentifier RecipeIdentifier,
+	RecipeIdentifier Recipe,
 	RecipeTitle Title) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/Recipe/Events/RecipeUpdatedEvent.cs
+++ b/src/Yumney.Recipes.Domain/Recipe/Events/RecipeUpdatedEvent.cs
@@ -3,5 +3,5 @@ using SmartSolutionsLab.Yumney.Shared.Abstractions;
 namespace SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
 
 public sealed record RecipeUpdatedEvent(
-	RecipeIdentifier RecipeIdentifier,
+	RecipeIdentifier Recipe,
 	RecipeTitle Title) : DomainEvent;

--- a/src/Yumney.Recipes.Domain/RecipeFavorite/RecipeFavorite.cs
+++ b/src/Yumney.Recipes.Domain/RecipeFavorite/RecipeFavorite.cs
@@ -6,13 +6,13 @@ namespace SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
 
 /// <summary>
 /// Records that a specific user has marked a recipe as favorite. The
-/// (Owner, RecipeIdentifier) pair is unique. This is its own small
-/// aggregate so favoriting/unfavoriting does not load or mutate the
-/// full Recipe aggregate.
+/// (Owner, Recipe) pair is unique. This is its own small aggregate so
+/// favoriting/unfavoriting does not load or mutate the full Recipe
+/// aggregate.
 /// </summary>
 public sealed class RecipeFavorite : AggregateRoot<RecipeFavoriteIdentifier>
 {
-	public RecipeIdentifier RecipeIdentifier { get; private set; } = default!;
+	public RecipeIdentifier Recipe { get; private set; } = default!;
 
 	public OwnerIdentifier Owner { get; private set; } = default!;
 
@@ -30,7 +30,7 @@ public sealed class RecipeFavorite : AggregateRoot<RecipeFavoriteIdentifier>
 		return new RecipeFavorite
 		{
 			Id = RecipeFavoriteIdentifier.New(),
-			RecipeIdentifier = recipe,
+			Recipe = recipe,
 			Owner = owner,
 			FavoritedAt = DateTime.UtcNow,
 		};

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
@@ -15,8 +15,9 @@ internal sealed class RecipeFavoriteConfiguration : IEntityTypeConfiguration<Rec
 		entity.Property(e => e.Id)
 			.HasConversion<RecipeFavoriteIdentifierConverter>();
 
-		entity.Property(e => e.RecipeIdentifier)
+		entity.Property(e => e.Recipe)
 			.HasConversion<RecipeIdentifierConverter>()
+			.HasColumnName("RecipeIdentifier")
 			.IsRequired();
 
 		entity.Property(e => e.Owner)
@@ -26,7 +27,7 @@ internal sealed class RecipeFavoriteConfiguration : IEntityTypeConfiguration<Rec
 
 		entity.Property(e => e.FavoritedAt).IsRequired();
 
-		entity.HasIndex(e => new { e.Owner, e.RecipeIdentifier }).IsUnique();
+		entity.HasIndex(e => new { e.Owner, e.Recipe }).IsUnique();
 		entity.Ignore(e => e.DomainEvents);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeFavoriteRepository.cs
@@ -16,7 +16,7 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 		return await favorites
 			.AsNoTracking()
 			.AnyAsync(
-				favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe,
+				favorite => favorite.Owner == owner && favorite.Recipe == recipe,
 				cancellationToken);
 	}
 
@@ -30,8 +30,8 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 		var idList = recipes.ToList();
 		var favorited = await favorites
 			.AsNoTracking()
-			.Where(favorite => favorite.Owner == owner && idList.Contains(favorite.RecipeIdentifier))
-			.Select(favorite => favorite.RecipeIdentifier)
+			.Where(favorite => favorite.Owner == owner && idList.Contains(favorite.Recipe))
+			.Select(favorite => favorite.Recipe)
 			.ToListAsync(cancellationToken);
 
 		return favorited.Select(recipeId => recipeId.Value).ToHashSet();
@@ -45,7 +45,7 @@ public sealed class RecipeFavoriteRepository(RecipesDbContext context) : IRecipe
 	public async Task RemoveAsync(OwnerIdentifier owner, RecipeIdentifier recipe, CancellationToken cancellationToken = default)
 	{
 		await favorites
-			.Where(favorite => favorite.Owner == owner && favorite.RecipeIdentifier == recipe)
+			.Where(favorite => favorite.Owner == owner && favorite.Recipe == recipe)
 			.ExecuteDeleteAsync(cancellationToken);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipeRepository.cs
@@ -80,7 +80,7 @@ public sealed class RecipeRepository(RecipesDbContext context) : IRecipeReposito
 	{
 		var favoriteRecipeIds = context.RecipeFavorites
 			.Where(favorite => favorite.Owner == owner)
-			.Select(favorite => favorite.RecipeIdentifier);
+			.Select(favorite => favorite.Recipe);
 		return favoriteRecipeIds;
 	}
 }

--- a/src/Yumney.Shopping.Application/Commands/ChangeItemCategoryCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/ChangeItemCategoryCommand.cs
@@ -6,6 +6,6 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
 public sealed record ChangeItemCategoryCommand(
-	ShoppingListIdentifier ListIdentifier,
+	ShoppingListIdentifier List,
 	ShoppingListItemIdentifier ItemId,
 	IngredientCategory Category) : ICommand<Result>;

--- a/src/Yumney.Shopping.Application/Commands/CheckOffAllItemsCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/CheckOffAllItemsCommand.cs
@@ -5,5 +5,5 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
 public sealed record CheckOffAllItemsCommand(
-	ShoppingListIdentifier ListIdentifier,
+	ShoppingListIdentifier List,
 	bool IsChecked) : ICommand<Result>;

--- a/src/Yumney.Shopping.Application/Commands/CheckOffItemCommand.cs
+++ b/src/Yumney.Shopping.Application/Commands/CheckOffItemCommand.cs
@@ -5,6 +5,6 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Commands;
 
 public sealed record CheckOffItemCommand(
-	ShoppingListIdentifier ListIdentifier,
+	ShoppingListIdentifier List,
 	ShoppingListItemIdentifier ItemId,
 	bool IsChecked) : ICommand<Result>;

--- a/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
+++ b/tests/Yumney.MealPlan.Application.Tests/FakeMealPlanReadModelRepository.cs
@@ -30,7 +30,7 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 		var recipes = plan.Slots
 			.Where(slot => slot.ContentType == SlotContentType.Recipe && slot.Recipe is not null)
 			.Select(slot => new PlannedRecipeDto(
-				slot.Recipe!.RecipeIdentifier.Value,
+				slot.Recipe!.Identifier.Value,
 				slot.Recipe.Title.Value,
 				slot.Servings.Value,
 				slot.Day.ToString(),
@@ -47,7 +47,7 @@ internal sealed class FakeMealPlanReadModelRepository : IMealPlanReadModelReposi
 			.SelectMany(kv => kv.Value.Slots
 				.Where(slot => slot.State == MealState.Cooked && slot.Recipe is not null)
 				.Select(slot => new MealHistoryEntryDto(
-					slot.Recipe!.RecipeIdentifier.Value,
+					slot.Recipe!.Identifier.Value,
 					slot.Recipe.Title.Value,
 					kv.Key.Week,
 					slot.Day.ToString(),

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
@@ -14,7 +14,7 @@ public class SlotRecipeReferenceTests
 
 		var reference = SlotRecipeReference.From(recipe, title);
 
-		reference.RecipeIdentifier.Should().Be(recipe);
+		reference.Identifier.Should().Be(recipe);
 		reference.Title.Should().Be(title);
 	}
 
@@ -25,7 +25,7 @@ public class SlotRecipeReferenceTests
 
 		var reference = SlotRecipeReference.From(recipeGuid, "Carbonara");
 
-		reference.RecipeIdentifier.Value.Should().Be(recipeGuid);
+		reference.Identifier.Value.Should().Be(recipeGuid);
 		reference.Title.Value.Should().Be("Carbonara");
 	}
 
@@ -49,7 +49,7 @@ public class SlotRecipeReferenceTests
 	}
 
 	[Fact]
-	public void Equality_DifferentRecipeIdentifier_AreNotEqual()
+	public void Equality_DifferentIdentifier_AreNotEqual()
 	{
 		var first = SlotRecipeReference.From(Guid.NewGuid(), "Same");
 		var second = SlotRecipeReference.From(Guid.NewGuid(), "Same");

--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/WeeklyPlanTests.cs
@@ -38,7 +38,7 @@ public class WeeklyPlanTests
 
 		var monday = plan.Slots.First(slot => slot.Day == DayOfWeek.Monday);
 		monday.IsEmpty.Should().BeFalse();
-		monday.Recipe!.RecipeIdentifier.Should().Be(recipe.RecipeIdentifier);
+		monday.Recipe!.Identifier.Should().Be(recipe.Identifier);
 		monday.Recipe.Title.Should().Be(recipe.Title);
 	}
 
@@ -134,7 +134,7 @@ public class WeeklyPlanTests
 		plan.AssignRecipe(DayOfWeek.Monday, steak);
 
 		var monday = plan.Slots.First(slot => slot.Day == DayOfWeek.Monday);
-		monday.Recipe!.RecipeIdentifier.Should().Be(steak.RecipeIdentifier);
+		monday.Recipe!.Identifier.Should().Be(steak.Identifier);
 		monday.Recipe.Title.Should().Be(steak.Title);
 	}
 
@@ -434,7 +434,7 @@ public class WeeklyPlanTests
 
 		var tuesday = plan.Slots.First(slot => slot.Day == DayOfWeek.Tuesday);
 		tuesday.ContentType.Should().Be(SlotContentType.Recipe);
-		tuesday.Recipe!.RecipeIdentifier.Should().Be(pasta.RecipeIdentifier);
+		tuesday.Recipe!.Identifier.Should().Be(pasta.Identifier);
 		tuesday.FreetextLabel.Should().BeNull();
 	}
 

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ToggleFavoriteCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ToggleFavoriteCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class ToggleFavoriteCommandHandlerTests
 		await handler.HandleAsync(new ToggleFavoriteCommand(recipe.Id));
 
 		await favorites.Received(1).AddAsync(
-			Arg.Is<RecipeFavorite>(f => f.RecipeIdentifier == recipe.Id),
+			Arg.Is<RecipeFavorite>(f => f.Recipe == recipe.Id),
 			Arg.Any<CancellationToken>());
 	}
 

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeRatingAndNotesTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeRatingAndNotesTests.cs
@@ -35,7 +35,7 @@ public class RecipeRatingAndNotesTests
 		recipe.RateAs(Rating.From(5));
 
 		var raised = recipe.DomainEvents.OfType<RecipeRatedEvent>().Single();
-		raised.RecipeIdentifier.Should().Be(recipe.Id);
+		raised.Recipe.Should().Be(recipe.Id);
 		raised.Rating.Value.Should().Be(5);
 	}
 
@@ -79,7 +79,7 @@ public class RecipeRatingAndNotesTests
 		recipe.UpdateNotes(Notes.From("Salty"));
 
 		var raised = recipe.DomainEvents.OfType<RecipeNotesUpdatedEvent>().Last();
-		raised.RecipeIdentifier.Should().Be(recipe.Id);
+		raised.Recipe.Should().Be(recipe.Id);
 		raised.HasNotes.Should().BeTrue();
 	}
 

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeTests.cs
@@ -183,7 +183,7 @@ public class RecipeTests
 		var domainEvent = recipe.DomainEvents.Should().ContainSingle()
 			.Which.Should().BeOfType<RecipeSavedEvent>().Subject;
 
-		domainEvent.RecipeIdentifier.Should().Be(recipe.Id);
+		domainEvent.Recipe.Should().Be(recipe.Id);
 	}
 
 	[Fact]
@@ -310,7 +310,7 @@ public class RecipeTests
 		var domainEvent = recipe.DomainEvents.Should().ContainSingle()
 			.Which.Should().BeOfType<RecipeUpdatedEvent>().Subject;
 
-		domainEvent.RecipeIdentifier.Should().Be(recipe.Id);
+		domainEvent.Recipe.Should().Be(recipe.Id);
 	}
 
 	[Fact]
@@ -428,7 +428,7 @@ public class RecipeTests
 		var domainEvent = recipe.DomainEvents.Should().ContainSingle()
 			.Which.Should().BeOfType<RecipeDeletedEvent>().Subject;
 
-		domainEvent.RecipeIdentifier.Should().Be(recipe.Id);
+		domainEvent.Recipe.Should().Be(recipe.Id);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Applies the CLAUDE.md naming rule (variable name drops `Identifier` suffix when the type itself ends in `Identifier`) to record / aggregate properties — closes the #1 item from the latest refactoring sweep.

**Renames (10 declarations + cascading callers):**

| File | Old | New |
| --- | --- | --- |
| `RecipeFavorite.cs` | `RecipeIdentifier RecipeIdentifier` | `RecipeIdentifier Recipe` |
| `Recipe{Rated,Saved,Updated,Deleted,NotesUpdated}Event.cs` | `RecipeIdentifier RecipeIdentifier` | `RecipeIdentifier Recipe` |
| `CheckOffItemCommand.cs`, `CheckOffAllItemsCommand.cs`, `ChangeItemCategoryCommand.cs` | `ShoppingListIdentifier ListIdentifier` | `ShoppingListIdentifier List` |
| `SlotRecipeReference.cs` | `SlotRecipeIdentifier RecipeIdentifier` | `SlotRecipeIdentifier Identifier` |

`SlotRecipeReference` uses `Identifier` instead of `Recipe` to avoid the `slot.Recipe.Recipe` collision (the wrapper VO IS a recipe reference, so within it the inner ID is just `Identifier`).

## Backwards-compat preserved

- **DB schema** — `RecipeFavoriteConfiguration` adds `.HasColumnName(\"RecipeIdentifier\")` on the renamed property. No migration needed; existing index `IX_RecipeFavorites_Owner_RecipeIdentifier` stays as-is.
- **Event-sourcing wire format** — `SlotRecipeReferenceJsonConverter` still writes/reads the `\"recipeIdentifier\"` JSON key. Existing serialized events in `mealplandb` keep deserializing.
- **Integration-event contracts** — untouched. Their primitive `Guid RecipeIdentifier` fields are not affected by this rule (rule only applies when the **type** ends in `Identifier`).
- **Read-model `Guid?` properties** — untouched for the same reason.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — green
- [x] `dotnet format --verify-no-changes` — clean
- [x] All non-Aspire test suites pass locally (unit + Domain + Application + Infrastructure)
- [ ] CI: integration tests + architecture tests