### PR TITLE
refactor(mealplan): hoist inline DTO projections into MealPlanReadModelMappingExtensions

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelMappingExtensions.cs
@@ -27,6 +27,12 @@ public static class MealPlanReadModelMappingExtensions
 			.ThenBy(slot => Enum.Parse<MealType>(slot.MealType))
 			.ToList();
 
+	public static WeeklyPlanDto ToWeeklyPlanDto(this MealPlanWeekReadItem weekItem, IEnumerable<MealPlanSlotReadItem> visibleRows) =>
+		new(weekItem.Week, weekItem.IsExtendedMode, visibleRows.ToDtos());
+
+	public static WeeklyPlanDto EmptyWeeklyPlanDto(string week, int defaultServings) =>
+		new(week, false, EmptyDinnerSlots(defaultServings));
+
 	public static PlannedRecipeDto ToPlannedRecipeDto(this MealPlanSlotReadItem row) =>
 		new(
 			row.RecipeIdentifier!.Value,
@@ -40,6 +46,9 @@ public static class MealPlanReadModelMappingExtensions
 			.Select(row => row.ToPlannedRecipeDto())
 			.ToList();
 
+	public static WeeklyPlannedRecipesDto ToWeeklyPlannedRecipesDto(this IEnumerable<MealPlanSlotReadItem> rows, string week) =>
+		new(week, rows.ToPlannedRecipeDtos());
+
 	public static MealHistoryEntryDto ToHistoryEntryDto(this MealPlanSlotReadItem row) =>
 		new(
 			row.RecipeIdentifier,
@@ -51,5 +60,22 @@ public static class MealPlanReadModelMappingExtensions
 	public static IReadOnlyList<MealHistoryEntryDto> ToHistoryEntryDtos(this IEnumerable<MealPlanSlotReadItem> rows) =>
 		rows
 			.Select(row => row.ToHistoryEntryDto())
+			.ToList();
+
+	private static List<MealSlotDto> EmptyDinnerSlots(int defaultServings) =>
+		WeekDays.MondayToSunday
+			.Select(day => new MealSlotDto(
+				day.ToString(),
+				MealType.Dinner.ToString(),
+				SlotContentType.Empty.ToString(),
+				MealState.Planned.ToString(),
+				null,
+				null,
+				defaultServings,
+				null,
+				null,
+				null,
+				null,
+				true))
 			.ToList();
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -19,7 +19,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 
 		if (weekItem is null)
 		{
-			return new WeeklyPlanDto(weekValue, false, EmptyDinnerSlots(SlotServings.DefaultValue));
+			return MealPlanReadModelMappingExtensions.EmptyWeeklyPlanDto(weekValue, SlotServings.DefaultValue);
 		}
 
 		var slotRows = await context.MealPlanSlotReadItems
@@ -31,7 +31,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 			? slotRows
 			: slotRows.Where(slot => slot.MealType == MealType.Dinner.ToString()).ToList();
 
-		return new WeeklyPlanDto(weekValue, weekItem.IsExtendedMode, visible.ToDtos());
+		return weekItem.ToWeeklyPlanDto(visible);
 	}
 
 	public async Task<WeeklyPlannedRecipesDto> GetPlannedRecipesAsync(OwnerIdentifier owner, WeekIdentifier week, CancellationToken cancellationToken = default)
@@ -48,7 +48,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 				&& slot.RecipeIdentifier != null)
 			.ToListAsync(cancellationToken);
 
-		return new WeeklyPlannedRecipesDto(weekValue, slotRows.ToPlannedRecipeDtos());
+		return slotRows.ToWeeklyPlannedRecipesDto(weekValue);
 	}
 
 	public async Task<PagedResult<MealHistoryEntryDto>> SearchCookedHistoryAsync(
@@ -162,21 +162,4 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 #pragma warning disable SA1402, SA1649
 	private sealed record RawSlot(string Week, string Day, string State, Guid? RecipeIdentifier, string? RecipeTitle);
 #pragma warning restore SA1402, SA1649
-
-	private static List<MealSlotDto> EmptyDinnerSlots(int defaultServings) =>
-		WeekDays.MondayToSunday
-			.Select(day => new MealSlotDto(
-				day.ToString(),
-				MealType.Dinner.ToString(),
-				SlotContentType.Empty.ToString(),
-				MealState.Planned.ToString(),
-				null,
-				null,
-				defaultServings,
-				null,
-				null,
-				null,
-				null,
-				true))
-			.ToList();
 }


### PR DESCRIPTION
## Summary

Part of the inline-DTO cleanup (item #2 of the refactoring sweep). Scoped to the MealPlan read-model repository.

Three inline `new ...Dto(...)` calls in `MealPlanReadModelRepository` are moved to `MealPlanReadModelMappingExtensions`:

| Repository site | New extension |
| --- | --- |
| empty-week fallback | `MealPlanReadModelMappingExtensions.EmptyWeeklyPlanDto(week, defaultServings)` |
| populated week | `weekItem.ToWeeklyPlanDto(visibleRows)` |
| planned recipes | `slotRows.ToWeeklyPlannedRecipesDto(week)` |

The repository's private `EmptyDinnerSlots(int)` helper moves with it (the constructor call is now the single allowed exception inside the mapper itself).

## Deliberately not extracted

The original scan flagged three more sites:

- `SuggestWeekPlanQueryHandler.cs:48` — `new WeekSuggestionDto(week.ToString(), entries)`
- `GetMealAnalyticsQueryHandler.cs:60` — `new MealAnalyticsDto(...)` (8 computed values)
- `GenerateShoppingListCommandHandler.cs:35` — `new GenerateShoppingListResultDto(itemCount, skippedCount)`

These are result envelopes assembled from computed primitives — they don't map field-to-field from a source object, so they fall outside what CLAUDE.md describes as a "mapping" case. Pushing them into extensions would shift the constructor call one method away without adding clarity.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] MealPlan.Application + MealPlan.Infrastructure unit tests pass
- [ ] CI: full backend + integration + E2E