### PR TITLE
refactor(recipes): extract FavoriteStateDto construction into mapper extension

### DIFF
--- a/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
@@ -30,7 +30,7 @@ public sealed class ToggleFavoriteCommandHandler(IRecipesUnitOfWork unitOfWork, 
 		{
 			await unitOfWork.Favorites.RemoveAsync(owner, identifier, cancellationToken);
 			await unitOfWork.SaveChangesAsync(cancellationToken);
-			return new FavoriteStateDto(identifier.Value, false);
+			return identifier.ToFavoriteStateDto(isFavorite: false);
 		}
 
 		var favorite = RecipeFavorite.Create(identifier, owner);
@@ -49,6 +49,6 @@ public sealed class ToggleFavoriteCommandHandler(IRecipesUnitOfWork unitOfWork, 
 			// favorited" instead of bubbling a 500 to the caller.
 		}
 
-		return new FavoriteStateDto(identifier.Value, true);
+		return identifier.ToFavoriteStateDto(isFavorite: true);
 	}
 }

--- a/src/Yumney.Recipes.Application/DTOs/FavoriteStateMappingExtensions.cs
+++ b/src/Yumney.Recipes.Application/DTOs/FavoriteStateMappingExtensions.cs
@@ -1,0 +1,9 @@
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+
+public static class FavoriteStateMappingExtensions
+{
+	public static FavoriteStateDto ToFavoriteStateDto(this RecipeIdentifier recipe, bool isFavorite) =>
+		new(recipe.Value, isFavorite);
+}


### PR DESCRIPTION
## Summary

Recipes-module slice of the inline-DTO cleanup (item #2 of the refactoring sweep).

`ToggleFavoriteCommandHandler` had two inline \`new FavoriteStateDto(identifier.Value, …)\` returns — one for the unfavorite path, one for the favorite path. Both now route through a small mapper extension:

\`\`\`csharp
identifier.ToFavoriteStateDto(isFavorite: false);
identifier.ToFavoriteStateDto(isFavorite: true);
\`\`\`

defined in \`src/Yumney.Recipes.Application/DTOs/FavoriteStateMappingExtensions.cs\`.

## Deliberately not extracted

The original scan also flagged \`JsonLdRecipeParser.ReadSteps\` constructing \`ExtractedStepDto\` inline. That parser IS itself a mapper — its whole job is JSON-LD → DTO projection. CLAUDE.md's rule targets handlers, repositories, and endpoints, not parser/mapper classes.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.Recipes.Application.Tests\` (184 tests) — pass
- [ ] CI: full backend + integration + E2E