### PR TITLE
refactor(users): extract RecipeActivityStats → DTO mapping

### DIFF
--- a/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
+++ b/src/Yumney.Users.Application/DTOs/UserActivityMappingExtensions.cs
@@ -13,4 +13,7 @@ public static class UserActivityMappingExtensions
 
 	public static IReadOnlyList<UserActivityDto> ToDtos(this IEnumerable<UserActivity> activities) =>
 		activities.Select(activity => activity.ToDto()).ToList();
+
+	public static RecipeActivityStatsDto ToDto(this RecipeActivityStats stats) =>
+		new(stats.CookCount, stats.LastCookedAt, stats.ViewCount);
 }

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
@@ -16,6 +16,6 @@ public sealed class GetRecipeActivityStatsQueryHandler(IUserActivityRepository a
 			owner,
 			RecipeIdentifierSnapshot.From(query.RecipeIdentifier),
 			cancellationToken);
-		return Result.Success(new RecipeActivityStatsDto(stats.CookCount, stats.LastCookedAt, stats.ViewCount));
+		return Result.Success(stats.ToDto());
 	}
 }


### PR DESCRIPTION
## Summary

Users-module slice of the inline-DTO cleanup (item #2 of the refactoring sweep).

`GetRecipeActivityStatsQueryHandler` had an inline `new RecipeActivityStatsDto(stats.CookCount, stats.LastCookedAt, stats.ViewCount)` — a true field-by-field projection from the Domain \`RecipeActivityStats\` record to the Application DTO. Now routes through:

\`\`\`csharp
return Result.Success(stats.ToDto());
\`\`\`

defined as a one-liner extension in \`UserActivityMappingExtensions\`.

## Deliberately not extracted

The scan also flagged four other inline DTO constructions in this module:

| Site | DTO | Reason for keeping inline |
| --- | --- | --- |
| \`RegisterUserCommandHandler:25\` | \`RegisterUserResultDto(\"...\")\` | Single string literal — pure result envelope, no source to map from |
| \`AuthEndpoints:79\` (resend verification) | \`ResendVerificationEmailResultDto(\"...\")\` | Same — string literal envelope |
| \`GetSuggestionsQueryHandler:18\` | \`SuggestionsResponseDto(Suggestions: [], QuickActions: …)\` | Empty list + computed list, no source object |
| \`GetRecentActivityQueryHandler:24\` | \`UserActivityPageDto(entries.ToDtos(), nextCursor)\` | Two computed values wrapped — borderline; the embedded \`entries.ToDtos()\` already routes through the mapper |

These are all result envelopes constructed from primitives or literals; CLAUDE.md's mapper rule targets field-to-field projections from a source object.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.Users.Application.Tests\` (59 tests) — pass
- [ ] CI: full backend + integration + E2E