### PR TITLE
refactor(shopping): hoist single-field DTO wrappers into mapper extensions

### DIFF
--- a/src/Yumney.Shopping.Application/DTOs/IngredientBalanceMappingExtensions.cs
+++ b/src/Yumney.Shopping.Application/DTOs/IngredientBalanceMappingExtensions.cs
@@ -11,4 +11,7 @@ public static class IngredientBalanceMappingExtensions
 			Unit: null,
 			Category: category.Value,
 			Source: IngredientBalanceSource.Staple);
+
+	public static IngredientBalanceDto ToBalanceDto(this IReadOnlyList<IngredientBalanceItemDto> items) =>
+		new(items);
 }

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -41,6 +41,6 @@ public sealed class GetIngredientBalanceQueryHandler(
 			.OrderBy(item => IngredientCategory.From(item.Category).DisplayOrder)
 			.ThenBy(item => item.ItemName, StringComparer.OrdinalIgnoreCase)];
 
-		return new IngredientBalanceDto(sorted);
+		return sorted.ToBalanceDto();
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelMappingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelMappingExtensions.cs
@@ -17,4 +17,7 @@ public static class ShoppingLedgerReadModelMappingExtensions
 			row.IsBought,
 			sources);
 	}
+
+	public static MergedShoppingListDto ToMergedListDto(this IReadOnlyList<MergedShoppingItemDto> items) =>
+		new(items);
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingLedgerReadModelRepository.cs
@@ -32,7 +32,7 @@ public sealed class ShoppingLedgerReadModelRepository(ShoppingReadDbContext cont
 			.OrderBy(item => IngredientCategory.From(item.Category).DisplayOrder)
 			.ToList();
 
-		return new MergedShoppingListDto(dtoItems);
+		return dtoItems.ToMergedListDto();
 	}
 
 	private static List<ItemSourceDto> DeserializeSources(string sourcesJson)


### PR DESCRIPTION
## Summary

Shopping-module slice of the inline-DTO cleanup (item #2 of the refactoring sweep). This is the last of the four module PRs.

| Site | Before | After |
| --- | --- | --- |
| \`GetIngredientBalanceQueryHandler:44\` | \`new IngredientBalanceDto(sorted)\` | \`sorted.ToBalanceDto()\` |
| \`ShoppingLedgerReadModelRepository:35\` | \`new MergedShoppingListDto(dtoItems)\` | \`dtoItems.ToMergedListDto()\` |

The new extensions are added to the existing mapper files (\`IngredientBalanceMappingExtensions.cs\` in Application, \`ShoppingLedgerReadModelMappingExtensions.cs\` in Infrastructure).

## Deliberately not extracted

The scan also flagged \`ShoppingLedgerReadModelRepository.DeserializeSources\` for its \`Select(source => new ItemSourceDto(...))\` projection. That helper IS itself a JSON parser/mapper for the \`SourcesJson\` column — its whole purpose is the projection. CLAUDE.md's rule targets handlers, repositories, and endpoints; parser/mapper helpers are exactly the destination for projection logic, not a violation site.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.Shopping.Application.Tests\` (147) + \`Yumney.Shopping.Infrastructure.Tests\` (28) — pass
- [ ] CI: full backend + integration + E2E