### PR TITLE
refactor(shared): split AddYumneyDefaults into per-concern helpers

### DIFF
--- a/src/Yumney.Shared.Web/HostBuilderExtensions.RateLimiting.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.RateLimiting.cs
@@ -1,0 +1,79 @@
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using RedisRateLimiting;
+using SmartSolutionsLab.Yumney.ServiceDefaults;
+using StackExchange.Redis;
+
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+/// <content>
+/// Per-policy rate-limit wiring. Three policies share the same Redis-backed
+/// partitioning shape but differ in algorithm (sliding/fixed window) and
+/// per-user vs per-IP key derivation.
+/// </content>
+public static partial class HostBuilderExtensions
+{
+	private static WebApplicationBuilder AddYumneyRateLimiting(this WebApplicationBuilder builder)
+	{
+		var isE2ETests = builder.Configuration.GetValue<bool>("E2ETests");
+		builder.Services.AddRateLimiter(options =>
+		{
+			options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+			options.AddRecipeImportPolicy(isE2ETests);
+			options.AddGeneralApiPolicy(isE2ETests);
+			options.AddAnonymousAuthPolicy(isE2ETests);
+		});
+		return builder;
+	}
+
+	private static void AddRecipeImportPolicy(this RateLimiterOptions options, bool isE2ETests) =>
+		options.AddPolicy(RateLimitPolicies.RecipeImport, context =>
+		{
+			if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
+
+			var userId = context.User?.FindFirstValue(KeycloakClaimTypes.Subject) ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+			return RedisRateLimitPartition.GetSlidingWindowRateLimiter(userId, _ => new RedisSlidingWindowRateLimiterOptions
+			{
+				PermitLimit = 10,
+				Window = TimeSpan.FromMinutes(1),
+				ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
+			});
+		});
+
+	private static void AddGeneralApiPolicy(this RateLimiterOptions options, bool isE2ETests) =>
+		options.AddPolicy(RateLimitPolicies.GeneralApi, context =>
+		{
+			if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
+
+			var userId = context.User?.FindFirstValue(KeycloakClaimTypes.Subject) ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+			return RedisRateLimitPartition.GetFixedWindowRateLimiter(userId, _ => new RedisFixedWindowRateLimiterOptions
+			{
+				PermitLimit = 60,
+				Window = TimeSpan.FromMinutes(1),
+				ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
+			});
+		});
+
+	// Anonymous-only — partitions by client IP (resolved via ForwardedHeaders).
+	// If RemoteIpAddress is somehow null, the partition key is the literal
+	// "unknown" — those requests share a single global bucket of 10/min,
+	// which still caps abuse from any path that bypasses the gateway.
+	private static void AddAnonymousAuthPolicy(this RateLimiterOptions options, bool isE2ETests) =>
+		options.AddPolicy(RateLimitPolicies.AnonymousAuth, context =>
+		{
+			if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
+
+			var clientIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+			return RedisRateLimitPartition.GetSlidingWindowRateLimiter(clientIp, _ => new RedisSlidingWindowRateLimiterOptions
+			{
+				PermitLimit = 10,
+				Window = TimeSpan.FromMinutes(1),
+				ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
+			});
+		});
+}

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -1,8 +1,6 @@
 using System.IO.Compression;
 using System.Reflection;
-using System.Security.Claims;
 using System.Text.Json.Serialization;
-using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -13,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
-using RedisRateLimiting;
 using Scalar.AspNetCore;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 using SmartSolutionsLab.Yumney.Shared.Common;
@@ -22,11 +19,17 @@ using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
 using SmartSolutionsLab.Yumney.Shared.Web.Middleware;
 using SmartSolutionsLab.Yumney.Shared.Web.Services;
-using StackExchange.Redis;
 
 namespace SmartSolutionsLab.Yumney.Shared.Web;
 
-public static class HostBuilderExtensions
+/// <summary>
+/// Composition-root wiring shared by every Yumney module host (Recipes, Shopping,
+/// MealPlan, Users). <see cref="AddYumneyDefaults"/> orchestrates per-concern
+/// helpers (auth, event bus, OpenAPI, compression, rate limiting, forwarded
+/// headers); <see cref="UseYumneyDefaults"/> wires the matching middleware
+/// pipeline.
+/// </summary>
+public static partial class HostBuilderExtensions
 {
 	public static WebApplicationBuilder AddYumneyDefaults(
 		this WebApplicationBuilder builder,
@@ -39,27 +42,91 @@ public static class HostBuilderExtensions
 		builder.AddRedisClient("redis");
 
 		builder.Services.ConfigureHttpJsonOptions(options =>
-		{
-			options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
-		});
+			options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 		builder.Services.Configure<HostOptions>(options =>
-		{
-			options.ShutdownTimeout = TimeSpan.FromSeconds(30);
-		});
+			options.ShutdownTimeout = TimeSpan.FromSeconds(30));
 
+		builder.Services.AddHttpContextAccessor();
+		builder.Services.AddScoped<ICurrentUser, CurrentUserProvider>();
+		builder.Services.AddQueryCounting();
+		builder.Services.TryAddSingleton(TimeProvider.System);
+		builder.Services.AddHttpClient();
+		builder.Services.AddHealthChecks()
+			.AddCheck<HealthChecks.KeycloakHealthCheck>("keycloak", tags: ["ready"])
+			.AddCheck<HealthChecks.RedisHealthCheck>("redis", tags: ["ready"]);
+
+		return builder
+			.AddYumneyAuthentication()
+			.AddYumneyEventBus(outboxConnectionName, outboxSchema, eventHandlerAssemblies)
+			.AddYumneyOpenApi()
+			.AddYumneyResponseCompression()
+			.AddYumneyRateLimiting()
+			.AddYumneyForwardedHeaders();
+	}
+
+	public static WebApplication UseYumneyDefaults(this WebApplication app)
+	{
+		app.UseForwardedHeaders();
+		app.UseMiddleware<CorrelationIdMiddleware>();
+		app.UseMiddleware<RequestLoggingMiddleware>();
+		app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
+
+		if (!app.Environment.IsDevelopment())
+		{
+			app.UseHsts();
+		}
+
+		app.UseHttpsRedirection();
+		app.UseResponseCompression();
+
+		app.UseAuthentication()
+			.UseAuthorization();
+
+		app.UseMiddleware<RequestContextMiddleware>();
+
+		app.UseRateLimiter();
+
+		app.MapOpenApi();
+
+		if (!app.Environment.IsProduction())
+		{
+			app.MapScalarApiReference(options => options
+				.WithTitle("Yumney API")
+				.WithTheme(ScalarTheme.Saturn)
+				.WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
+				.AddAuthorizationCodeFlow("keycloak", flow => flow
+					.WithClientId(KeycloakDefaults.WebClientId)
+					.WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
+					.WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
+					.WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile])));
+		}
+
+		app.MapDefaultEndpoints();
+
+		app.MapGet("/version", () => new
+		{
+			Version = typeof(HostBuilderExtensions).Assembly
+				.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
+			Environment = app.Environment.EnvironmentName,
+		}).AllowAnonymous();
+
+		return app;
+	}
+
+	private static WebApplicationBuilder AddYumneyAuthentication(this WebApplicationBuilder builder)
+	{
+		// Outside Development we require HTTPS metadata and validate the
+		// token issuer against the configured Keycloak realm URL. Development
+		// keeps both relaxed because the Aspire Keycloak runs on plain HTTP
+		// and its discovery-doc issuer can differ from the URL we call
+		// (container hostname vs localhost).
 		var isDevelopment = builder.Environment.IsDevelopment();
 		builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 			.AddJwtBearer(options =>
 			{
 				options.Authority = KeycloakDefaults.RealmUrl(builder.Configuration);
 				options.Audience = KeycloakDefaults.Audience;
-
-				// Outside Development we require HTTPS metadata and validate the
-				// token issuer against the configured Keycloak realm URL. Development
-				// keeps both relaxed because the Aspire Keycloak runs on plain HTTP
-				// and its discovery-doc issuer can differ from the URL we call
-				// (container hostname vs localhost).
 				options.RequireHttpsMetadata = !isDevelopment;
 				options.TokenValidationParameters.ValidateIssuer = !isDevelopment;
 				if (!isDevelopment)
@@ -69,9 +136,15 @@ public static class HostBuilderExtensions
 			});
 
 		builder.Services.AddAuthorization();
-		builder.Services.AddHttpContextAccessor();
-		builder.Services.AddScoped<ICurrentUser, CurrentUserProvider>();
+		return builder;
+	}
 
+	private static WebApplicationBuilder AddYumneyEventBus(
+		this WebApplicationBuilder builder,
+		string outboxConnectionName,
+		string outboxSchema,
+		Assembly[] eventHandlerAssemblies)
+	{
 		// Domain events: dispatched in-process (same transaction boundary).
 		// Integration events: published via Wolverine/RabbitMQ (cross-instance).
 		// AddInProcessEventBus() is intentionally not called here — Wolverine
@@ -87,13 +160,13 @@ public static class HostBuilderExtensions
 		// The interceptor itself opens a per-SaveChanges scope to dispatch
 		// domain events, so handlers remain scoped.
 		builder.Services.TryAddSingleton<DomainEventDispatchInterceptor>();
-		builder.Services.AddQueryCounting();
-		builder.Services.TryAddSingleton(TimeProvider.System);
+		return builder;
+	}
 
+	private static WebApplicationBuilder AddYumneyOpenApi(this WebApplicationBuilder builder)
+	{
 		var configuration = builder.Configuration;
-
 		builder.Services.AddOpenApi(options =>
-		{
 			options.AddDocumentTransformer((document, _, _) =>
 			{
 				document.Servers = [];
@@ -126,9 +199,13 @@ public static class HostBuilderExtensions
 				});
 
 				return Task.CompletedTask;
-			});
-		});
+			}));
 
+		return builder;
+	}
+
+	private static WebApplicationBuilder AddYumneyResponseCompression(this WebApplicationBuilder builder)
+	{
 		builder.Services.AddResponseCompression(options =>
 		{
 			options.EnableForHttps = true;
@@ -137,65 +214,19 @@ public static class HostBuilderExtensions
 		});
 		builder.Services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Fastest);
 		builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.SmallestSize);
+		return builder;
+	}
 
-		var isE2ETests = configuration.GetValue<bool>("E2ETests");
-
-		builder.Services.AddRateLimiter(options =>
-		{
-			options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-
-			options.AddPolicy(RateLimitPolicies.RecipeImport, context =>
-			{
-				if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
-
-				var userId = context.User?.FindFirstValue(KeycloakClaimTypes.Subject) ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
-				return RedisRateLimitPartition.GetSlidingWindowRateLimiter(userId, _ => new RedisSlidingWindowRateLimiterOptions
-				{
-					PermitLimit = 10,
-					Window = TimeSpan.FromMinutes(1),
-					ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
-				});
-			});
-
-			options.AddPolicy(RateLimitPolicies.GeneralApi, context =>
-			{
-				if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
-
-				var userId = context.User?.FindFirstValue(KeycloakClaimTypes.Subject) ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
-				return RedisRateLimitPartition.GetFixedWindowRateLimiter(userId, _ => new RedisFixedWindowRateLimiterOptions
-				{
-					PermitLimit = 60,
-					Window = TimeSpan.FromMinutes(1),
-					ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
-				});
-			});
-
-			// Anonymous-only — partitions by client IP (resolved via ForwardedHeaders).
-			// If RemoteIpAddress is somehow null, the partition key is the literal
-			// "unknown" — those requests share a single global bucket of 10/min,
-			// which still caps abuse from any path that bypasses the gateway.
-			options.AddPolicy(RateLimitPolicies.AnonymousAuth, context =>
-			{
-				if (isE2ETests) return RateLimitPartition.GetNoLimiter("e2e-tests");
-
-				var clientIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-				return RedisRateLimitPartition.GetSlidingWindowRateLimiter(clientIp, _ => new RedisSlidingWindowRateLimiterOptions
-				{
-					PermitLimit = 10,
-					Window = TimeSpan.FromMinutes(1),
-					ConnectionMultiplexerFactory = () => context.RequestServices.GetRequiredService<IConnectionMultiplexer>(),
-				});
-			});
-		});
-
-		// Trust X-Forwarded-* only from the immediate proxy (Yumney.Gateway). The gateway
-		// sits at a private/loopback address that varies per environment (loopback in
-		// Aspire dev, a Container Apps internal IP in Azure), so we trust the standard
-		// private-network ranges plus loopback. Trusting 0.0.0.0/0 would let any caller
-		// that reaches the API directly spoof X-Forwarded-For and bypass the per-IP
-		// rate limit on anonymous endpoints (e.g. Register, ResendVerification).
-		// ForwardLimit = 1 means only the gateway's claim is honoured; chained
-		// X-Forwarded-For values further upstream are discarded.
+	// Trust X-Forwarded-* only from the immediate proxy (Yumney.Gateway). The gateway
+	// sits at a private/loopback address that varies per environment (loopback in
+	// Aspire dev, a Container Apps internal IP in Azure), so we trust the standard
+	// private-network ranges plus loopback. Trusting 0.0.0.0/0 would let any caller
+	// that reaches the API directly spoof X-Forwarded-For and bypass the per-IP
+	// rate limit on anonymous endpoints (e.g. Register, ResendVerification).
+	// ForwardLimit = 1 means only the gateway's claim is honoured; chained
+	// X-Forwarded-For values further upstream are discarded.
+	private static WebApplicationBuilder AddYumneyForwardedHeaders(this WebApplicationBuilder builder)
+	{
 		builder.Services.Configure<ForwardedHeadersOptions>(options =>
 		{
 			options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
@@ -209,64 +240,6 @@ public static class HostBuilderExtensions
 			options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("::1/128"));
 			options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("fc00::/7"));
 		});
-
-		builder.Services.AddHttpClient();
-		builder.Services.AddHealthChecks()
-			.AddCheck<HealthChecks.KeycloakHealthCheck>("keycloak", tags: ["ready"])
-			.AddCheck<HealthChecks.RedisHealthCheck>("redis", tags: ["ready"]);
-
 		return builder;
-	}
-
-	public static WebApplication UseYumneyDefaults(this WebApplication app)
-	{
-		app.UseForwardedHeaders();
-		app.UseMiddleware<CorrelationIdMiddleware>();
-		app.UseMiddleware<RequestLoggingMiddleware>();
-		app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
-
-		if (!app.Environment.IsDevelopment())
-		{
-			app.UseHsts();
-		}
-
-		app.UseHttpsRedirection();
-		app.UseResponseCompression();
-
-		app.UseAuthentication()
-			.UseAuthorization();
-
-		app.UseMiddleware<RequestContextMiddleware>();
-
-		app.UseRateLimiter();
-
-		app.MapOpenApi();
-
-		if (!app.Environment.IsProduction())
-		{
-			app.MapScalarApiReference(options =>
-			{
-				options
-					.WithTitle("Yumney API")
-					.WithTheme(ScalarTheme.Saturn)
-					.WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-					.AddAuthorizationCodeFlow("keycloak", flow => flow
-						.WithClientId(KeycloakDefaults.WebClientId)
-						.WithAuthorizationUrl(KeycloakDefaults.AuthorizationUrl(app.Configuration))
-						.WithTokenUrl(KeycloakDefaults.TokenUrl(app.Configuration))
-						.WithSelectedScopes([KeycloakDefaults.ScopeOpenId, KeycloakDefaults.ScopeProfile]));
-			});
-		}
-
-		app.MapDefaultEndpoints();
-
-		app.MapGet("/version", () => new
-		{
-			Version = typeof(HostBuilderExtensions).Assembly
-				.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
-			Environment = app.Environment.EnvironmentName,
-		}).AllowAnonymous();
-
-		return app;
 	}
 }


### PR DESCRIPTION
## Summary

Item #4 of the refactoring sweep. \`HostBuilderExtensions.AddYumneyDefaults\` was 188 lines wiring 10 different concerns sequentially — way over CLAUDE.md's 30-line method cap, and the kind of method nobody wants to read end-to-end.

Split into a thin orchestrator that chains six private extension helpers:

| Helper | Concern | Approx LOC |
| --- | --- | --- |
| \`AddYumneyAuthentication\` | JWT bearer + Keycloak realm validation | 24 |
| \`AddYumneyEventBus\` | In-process domain dispatcher + Wolverine outbox | 22 |
| \`AddYumneyOpenApi\` | OpenAPI doc + Keycloak OAuth2 security scheme | 38 |
| \`AddYumneyResponseCompression\` | Brotli + Gzip providers | 11 |
| \`AddYumneyRateLimiting\` | Orchestrates 3 per-policy helpers | 12 |
| \`AddYumneyForwardedHeaders\` | Private-network proxy trust ranges | 18 |

Rate-limiting (the orchestrator + 3 policy helpers — RecipeImport / GeneralApi / AnonymousAuth) moves to \`HostBuilderExtensions.RateLimiting.cs\` (\`partial\` class) so neither file blows the 300-line cap.

\`AddYumneyDefaults\` is now ~32 lines of \`return builder.AddX().AddY()...\` with the misc small wiring (Redis, JSON config, HostOptions, HttpContext, health checks) inline at the top.

## Notes

- Pure organizational refactor — **no behaviour changes**, **no public-API changes** (the new helpers are private static extensions).
- Trimmed unused usings as a side-effect of the split.
- The OpenAPI helper at 38 lines is still over 30. Splitting further (separate \`AddKeycloakSecurityScheme\` builder helper) would help; left as-is for now since the document-transformer body is one logical unit.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean (after adding \`<summary>\` for SA1601 on the partial class)
- [x] \`Yumney.Architecture.Tests\` (142 tests) — pass
- [ ] CI: full backend (every module host calls AddYumneyDefaults at startup, so any DI breakage surfaces) + integration + E2E