### PR TITLE
refactor(shared): drop single-letter lambdas + var-with-collection-init

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -118,7 +118,7 @@ if (!options.DatabaseOnly)
 			.WithEnvironment("KC_HTTP_ENABLED", "true")
 			.WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
 			.WithEnvironment("KC_HOSTNAME_STRICT", "false")
-			.WithEndpoint("http", e => e.IsExternal = true);
+			.WithEndpoint("http", endpoint => endpoint.IsExternal = true);
 	}
 
 	var apiEnvironment = builder.Environment.EnvironmentName;

--- a/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RouteUrlBuilder.cs
@@ -25,8 +25,8 @@ public static partial class RouteUrlBuilder
 	public static BuiltRequest Build(string httpMethod, string routePattern, IDictionary<string, JsonElement>? arguments)
 	{
 		arguments ??= new Dictionary<string, JsonElement>();
-		var consumedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var missing = new List<string>();
+		HashSet<string> consumedKeys = new(StringComparer.OrdinalIgnoreCase);
+		List<string> missing = [];
 
 		var path = PlaceholderPattern().Replace(routePattern, match =>
 		{

--- a/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
+++ b/src/Yumney.MealPlan.Application/Queries/Handlers/GetMealAnalyticsQueryHandler.cs
@@ -107,7 +107,7 @@ public sealed class GetMealAnalyticsQueryHandler(
 	{
 		if (cooked.Count == 0) return [];
 
-		var totals = new Dictionary<string, int>(StringComparer.Ordinal);
+		Dictionary<string, int> totals = new(StringComparer.Ordinal);
 		foreach (var slot in cooked)
 		{
 			var category = slot.RecipeIdentifier is { } id && tagsByRecipe.TryGetValue(id, out var recipeTags)

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/AggregateMetadataConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/AggregateMetadataConfiguration.cs
@@ -6,12 +6,12 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Configura
 
 internal sealed class AggregateMetadataConfiguration : IEntityTypeConfiguration<AggregateMetadata>
 {
-	public void Configure(EntityTypeBuilder<AggregateMetadata> entity)
+	public void Configure(EntityTypeBuilder<AggregateMetadata> builder)
 	{
-		entity.ToTable("MealPlanAggregates");
-		entity.HasKey(e => e.AggregateId);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.Week).HasMaxLength(10).IsRequired();
-		entity.HasIndex(e => new { e.OwnerId, e.Week }).IsUnique();
+		builder.ToTable("MealPlanAggregates");
+		builder.HasKey(metadata => metadata.AggregateId);
+		builder.Property(metadata => metadata.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(metadata => metadata.Week).HasMaxLength(10).IsRequired();
+		builder.HasIndex(metadata => new { metadata.OwnerId, metadata.Week }).IsUnique();
 	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/MealPlanSlotReadItemConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/MealPlanSlotReadItemConfiguration.cs
@@ -6,24 +6,24 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Configura
 
 internal sealed class MealPlanSlotReadItemConfiguration : IEntityTypeConfiguration<MealPlanSlotReadItem>
 {
-	public void Configure(EntityTypeBuilder<MealPlanSlotReadItem> entity)
+	public void Configure(EntityTypeBuilder<MealPlanSlotReadItem> builder)
 	{
-		entity.ToTable("MealPlanSlotReadItems");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.Week).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.Day).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.MealType).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.ContentType).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.State).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.RecipeTitle).HasMaxLength(200);
-		entity.Property(e => e.FreetextLabel).HasMaxLength(200);
-		entity.Property(e => e.LeftoverLabel).HasMaxLength(200);
-		entity.Property(e => e.LeftoverSourceDay).HasMaxLength(10);
-		entity.Property(e => e.LeftoverSourceMealType).HasMaxLength(10);
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("MealPlanSlotReadItems");
+		builder.HasKey(slot => slot.Id);
+		builder.Property(slot => slot.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(slot => slot.Week).HasMaxLength(10).IsRequired();
+		builder.Property(slot => slot.Day).HasMaxLength(10).IsRequired();
+		builder.Property(slot => slot.MealType).HasMaxLength(10).IsRequired();
+		builder.Property(slot => slot.ContentType).HasMaxLength(10).IsRequired();
+		builder.Property(slot => slot.State).HasMaxLength(10).IsRequired();
+		builder.Property(slot => slot.RecipeTitle).HasMaxLength(200);
+		builder.Property(slot => slot.FreetextLabel).HasMaxLength(200);
+		builder.Property(slot => slot.LeftoverLabel).HasMaxLength(200);
+		builder.Property(slot => slot.LeftoverSourceDay).HasMaxLength(10);
+		builder.Property(slot => slot.LeftoverSourceMealType).HasMaxLength(10);
+		builder.Property(slot => slot.LastUpdated).IsRequired();
 
-		entity.HasIndex(e => new { e.OwnerId, e.Week, e.Day, e.MealType }).IsUnique();
-		entity.HasIndex(e => new { e.OwnerId, e.Week });
+		builder.HasIndex(slot => new { slot.OwnerId, slot.Week, slot.Day, slot.MealType }).IsUnique();
+		builder.HasIndex(slot => new { slot.OwnerId, slot.Week });
 	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/MealPlanWeekReadItemConfiguration.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Configurations/MealPlanWeekReadItemConfiguration.cs
@@ -6,13 +6,13 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Configura
 
 internal sealed class MealPlanWeekReadItemConfiguration : IEntityTypeConfiguration<MealPlanWeekReadItem>
 {
-	public void Configure(EntityTypeBuilder<MealPlanWeekReadItem> entity)
+	public void Configure(EntityTypeBuilder<MealPlanWeekReadItem> builder)
 	{
-		entity.ToTable("MealPlanWeekReadItems");
-		entity.HasKey(e => new { e.OwnerId, e.Week });
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.Week).HasMaxLength(10).IsRequired();
-		entity.Property(e => e.IsExtendedMode).IsRequired();
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("MealPlanWeekReadItems");
+		builder.HasKey(week => new { week.OwnerId, week.Week });
+		builder.Property(week => week.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(week => week.Week).HasMaxLength(10).IsRequired();
+		builder.Property(week => week.IsExtendedMode).IsRequired();
+		builder.Property(week => week.LastUpdated).IsRequired();
 	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDesignTimeDbContextFactory.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class MealPlanDesignTimeDbContextFactory : IDesignTimeDbContextFac
 		var optionsBuilder = new DbContextOptionsBuilder<MealPlanDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
 
 		return new MealPlanDbContext(optionsBuilder.Options);
 	}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanReadDesignTimeDbContextFactory.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanReadDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class MealPlanReadDesignTimeDbContextFactory : IDesignTimeDbContex
 		var optionsBuilder = new DbContextOptionsBuilder<MealPlanReadDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__MealPlanMigrationsHistory"));
 
 		return new MealPlanReadDbContext(optionsBuilder.Options);
 	}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
@@ -248,7 +248,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		return context.MealPlanSlotReadItems
 			.AsTracking()
 			.FirstOrDefaultAsync(
-				s => s.OwnerId == ownerId && s.Week == week && s.Day == dayName && s.MealType == mealTypeName,
+				slot => slot.OwnerId == ownerId && slot.Week == week && slot.Day == dayName && slot.MealType == mealTypeName,
 				cancellationToken);
 	}
 

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanReadModelRepository.cs
@@ -114,7 +114,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 			.Select(slot => new RawSlot(slot.Week, slot.Day, slot.State, slot.RecipeIdentifier, slot.RecipeTitle))
 			.ToListAsync(cancellationToken);
 
-		var projections = new List<AnalyticsSlotProjection>(rows.Count);
+		List<AnalyticsSlotProjection> projections = new(rows.Count);
 		foreach (var row in rows)
 		{
 			var date = MealPlanPeriodMath.SlotDate(row.Week, row.Day);
@@ -145,7 +145,7 @@ public sealed class MealPlanReadModelRepository(MealPlanReadDbContext context) :
 			.Select(slot => new { slot.RecipeIdentifier, slot.Week, slot.Day })
 			.ToListAsync(cancellationToken);
 
-		var earliest = new Dictionary<Guid, DateOnly>();
+		Dictionary<Guid, DateOnly> earliest = [];
 		foreach (var row in rows)
 		{
 			if (row.RecipeIdentifier is not { } id) continue;

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -186,7 +186,7 @@ public static partial class RecipesEndpoints
 				});
 			}
 
-			var photoDataList = new List<PhotoData>(photos.Count);
+			List<PhotoData> photoDataList = new(photos.Count);
 			foreach (var file in photos)
 			{
 				var photoData = await LoadPhotoDataAsync(file, cancellationToken);

--- a/src/Yumney.Recipes.Api/Requests/Validator/ImportRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/ImportRecipeValidator.cs
@@ -8,7 +8,7 @@ public sealed class ImportRecipeValidator : AbstractValidator<ImportRecipe>
 {
 	public ImportRecipeValidator()
 	{
-		RuleFor(x => x.Url)
+		RuleFor(request => request.Url)
 			.NotEmpty()
 			.MustBeValidHttpUrl(RecipeUrl.MaxLength);
 	}

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeIngredientValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeIngredientValidator.cs
@@ -7,16 +7,16 @@ public sealed class SaveRecipeIngredientValidator : AbstractValidator<SaveRecipe
 {
 	public SaveRecipeIngredientValidator()
 	{
-		RuleFor(i => i.Name)
+		RuleFor(ingredient => ingredient.Name)
 			.NotEmpty()
 			.MaximumLength(IngredientName.MaxLength);
 
-		RuleFor(i => i.Amount)
+		RuleFor(ingredient => ingredient.Amount)
 			.GreaterThanOrEqualTo(0)
-			.When(i => i.Amount.HasValue);
+			.When(ingredient => ingredient.Amount.HasValue);
 
-		RuleFor(i => i.Unit)
+		RuleFor(ingredient => ingredient.Unit)
 			.MaximumLength(Unit.MaxLength)
-			.When(i => i.Unit is not null);
+			.When(ingredient => ingredient.Unit is not null);
 	}
 }

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeStepValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeStepValidator.cs
@@ -7,10 +7,10 @@ public sealed class SaveRecipeStepValidator : AbstractValidator<SaveRecipeStep>
 {
 	public SaveRecipeStepValidator()
 	{
-		RuleFor(s => s.Number)
+		RuleFor(step => step.Number)
 			.GreaterThan(0);
 
-		RuleFor(s => s.Description)
+		RuleFor(step => step.Description)
 			.NotEmpty()
 			.MaximumLength(StepDescription.MaxLength);
 	}

--- a/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/SaveRecipeValidator.cs
@@ -9,52 +9,52 @@ public sealed class SaveRecipeValidator : AbstractValidator<SaveRecipe>
 {
 	public SaveRecipeValidator()
 	{
-		RuleFor(x => x.Title)
+		RuleFor(request => request.Title)
 			.NotEmpty()
 			.MaximumLength(RecipeTitle.MaxLength);
 
-		RuleFor(x => x.SourceUrl!)
+		RuleFor(request => request.SourceUrl!)
 			.MustBeValidHttpUrl(RecipeUrl.MaxLength)
-			.When(x => x.SourceUrl.HasValue());
+			.When(request => request.SourceUrl.HasValue());
 
 		ConfigureOptionalFieldRules();
 
-		RuleFor(x => x.Ingredients)
+		RuleFor(request => request.Ingredients)
 			.NotEmpty()
 			.WithMessage("At least one ingredient is required.");
-		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
+		RuleForEach(request => request.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
 
-		RuleFor(x => x.Steps)
+		RuleFor(request => request.Steps)
 			.NotEmpty()
 			.WithMessage("At least one step is required.");
-		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepValidator());
+		RuleForEach(request => request.Steps).SetValidator(new SaveRecipeStepValidator());
 	}
 
 	private void ConfigureOptionalFieldRules()
 	{
-		RuleFor(x => x.Description)
+		RuleFor(request => request.Description)
 			.MaximumLength(RecipeDescription.MaxLength)
-			.When(x => x.Description is not null);
+			.When(request => request.Description is not null);
 
-		RuleFor(x => x.ImageUrl!)
+		RuleFor(request => request.ImageUrl!)
 			.MustBeValidHttpUrl(ImageUrl.MaxLength)
-			.When(x => x.ImageUrl.HasValue());
+			.When(request => request.ImageUrl.HasValue());
 
-		RuleFor(x => x.Difficulty)
+		RuleFor(request => request.Difficulty)
 			.NotEmpty()
 			.MaximumLength(Difficulty.MaxLength)
-			.When(x => x.Difficulty is not null);
+			.When(request => request.Difficulty is not null);
 
-		RuleFor(x => x.Servings)
+		RuleFor(request => request.Servings)
 			.GreaterThan(0)
-			.When(x => x.Servings.HasValue);
+			.When(request => request.Servings.HasValue);
 
-		RuleFor(x => x.PrepTimeMinutes)
+		RuleFor(request => request.PrepTimeMinutes)
 			.GreaterThanOrEqualTo(0)
-			.When(x => x.PrepTimeMinutes.HasValue);
+			.When(request => request.PrepTimeMinutes.HasValue);
 
-		RuleFor(x => x.CookTimeMinutes)
+		RuleFor(request => request.CookTimeMinutes)
 			.GreaterThanOrEqualTo(0)
-			.When(x => x.CookTimeMinutes.HasValue);
+			.When(request => request.CookTimeMinutes.HasValue);
 	}
 }

--- a/src/Yumney.Recipes.Api/Requests/Validator/UpdateRecipeValidator.cs
+++ b/src/Yumney.Recipes.Api/Requests/Validator/UpdateRecipeValidator.cs
@@ -9,43 +9,43 @@ public sealed class UpdateRecipeValidator : AbstractValidator<UpdateRecipe>
 {
 	public UpdateRecipeValidator()
 	{
-		RuleFor(x => x.Title)
+		RuleFor(request => request.Title)
 			.NotEmpty()
 			.MaximumLength(RecipeTitle.MaxLength);
 
-		RuleFor(x => x.Description)
+		RuleFor(request => request.Description)
 			.MaximumLength(RecipeDescription.MaxLength)
-			.When(x => x.Description is not null);
+			.When(request => request.Description is not null);
 
-		RuleFor(x => x.ImageUrl!)
+		RuleFor(request => request.ImageUrl!)
 			.MustBeValidHttpUrl(ImageUrl.MaxLength)
-			.When(x => x.ImageUrl.HasValue());
+			.When(request => request.ImageUrl.HasValue());
 
-		RuleFor(x => x.Difficulty)
+		RuleFor(request => request.Difficulty)
 			.NotEmpty()
 			.MaximumLength(Difficulty.MaxLength)
-			.When(x => x.Difficulty is not null);
+			.When(request => request.Difficulty is not null);
 
-		RuleFor(x => x.Servings)
+		RuleFor(request => request.Servings)
 			.GreaterThan(0)
-			.When(x => x.Servings.HasValue);
+			.When(request => request.Servings.HasValue);
 
-		RuleFor(x => x.PrepTimeMinutes)
+		RuleFor(request => request.PrepTimeMinutes)
 			.GreaterThanOrEqualTo(0)
-			.When(x => x.PrepTimeMinutes.HasValue);
+			.When(request => request.PrepTimeMinutes.HasValue);
 
-		RuleFor(x => x.CookTimeMinutes)
+		RuleFor(request => request.CookTimeMinutes)
 			.GreaterThanOrEqualTo(0)
-			.When(x => x.CookTimeMinutes.HasValue);
+			.When(request => request.CookTimeMinutes.HasValue);
 
-		RuleFor(x => x.Ingredients)
+		RuleFor(request => request.Ingredients)
 			.NotEmpty()
 			.WithMessage("At least one ingredient is required.");
-		RuleForEach(x => x.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
+		RuleForEach(request => request.Ingredients).SetValidator(new SaveRecipeIngredientValidator());
 
-		RuleFor(x => x.Steps)
+		RuleFor(request => request.Steps)
 			.NotEmpty()
 			.WithMessage("At least one step is required.");
-		RuleForEach(x => x.Steps).SetValidator(new SaveRecipeStepValidator());
+		RuleForEach(request => request.Steps).SetValidator(new SaveRecipeStepValidator());
 	}
 }

--- a/src/Yumney.Recipes.Application/DTOs/PhotoDataValidator.cs
+++ b/src/Yumney.Recipes.Application/DTOs/PhotoDataValidator.cs
@@ -10,18 +10,18 @@ public sealed class PhotoDataValidator : AbstractValidator<PhotoData>
 
 	public PhotoDataValidator()
 	{
-		RuleFor(x => x.Content)
+		RuleFor(photo => photo.Content)
 			.NotEmpty()
 			.WithMessage("Photo content must not be empty.")
 			.Must(content => content.Length <= MaxPhotoSizeBytes)
 			.WithMessage($"Photo exceeds the maximum size of {MaxPhotoSizeBytes / (1024 * 1024)} MB.");
 
-		RuleFor(x => x.ContentType)
+		RuleFor(photo => photo.ContentType)
 			.NotEmpty()
-			.Must(ct => AllowedContentTypes.Contains(ct.ToLowerInvariant()))
+			.Must(contentType => AllowedContentTypes.Contains(contentType.ToLowerInvariant()))
 			.WithMessage("Unsupported file format. Use JPG, PNG, or WebP.");
 
-		RuleFor(x => x.FileName)
+		RuleFor(photo => photo.FileName)
 			.NotEmpty();
 	}
 

--- a/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
+++ b/src/Yumney.Recipes.Infrastructure/ExternalServices/HttpIngredientBalanceProvider.cs
@@ -8,7 +8,7 @@ public sealed class HttpIngredientBalanceProvider(IShoppingClient shopping) : II
 {
 	public async Task<IReadOnlyDictionary<string, Freshness>> GetAvailableIngredientsAsync(CancellationToken cancellationToken = default)
 	{
-		var result = new Dictionary<string, Freshness>(StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, Freshness> result = new(StringComparer.OrdinalIgnoreCase);
 
 		var balance = await shopping.GetBalanceAsync(cancellationToken);
 		if (balance?.Items is null) return result;

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeConfiguration.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeConfiguration.cs
@@ -7,128 +7,128 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence.Configurat
 
 internal sealed class RecipeConfiguration : IEntityTypeConfiguration<Recipe>
 {
-	public void Configure(EntityTypeBuilder<Recipe> entity)
+	public void Configure(EntityTypeBuilder<Recipe> builder)
 	{
-		entity.ToTable("Recipes");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		builder.ToTable("Recipes");
+		builder.HasKey(recipe => recipe.Id);
+		builder.Property(recipe => recipe.Id)
 			.HasConversion<RecipeIdentifierConverter>();
 
-		entity.Property(e => e.Title)
+		builder.Property(recipe => recipe.Title)
 			.HasConversion<RecipeTitleConverter>()
 			.HasMaxLength(RecipeTitle.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.Description)
+		builder.Property(recipe => recipe.Description)
 			.HasConversion<RecipeDescriptionConverter>()
 			.HasMaxLength(RecipeDescription.MaxLength);
 
-		entity.Property(e => e.Servings)
+		builder.Property(recipe => recipe.Servings)
 			.HasConversion<ServingsConverter>();
 
-		entity.OwnsOne(e => e.Timing, timing =>
+		builder.OwnsOne(recipe => recipe.Timing, timing =>
 		{
-			timing.Property(t => t.Preparation)
+			timing.Property(slot => slot.Preparation)
 				.HasConversion<PreparationTimeConverter>()
 				.HasColumnName("PreparationTimeMinutes");
 
-			timing.Property(t => t.Cooking)
+			timing.Property(slot => slot.Cooking)
 				.HasConversion<CookingTimeConverter>()
 				.HasColumnName("CookingTimeMinutes");
 		});
 
-		entity.Property(e => e.Difficulty)
+		builder.Property(recipe => recipe.Difficulty)
 			.HasConversion<DifficultyConverter>()
 			.HasMaxLength(Difficulty.MaxLength);
 
-		entity.Property(e => e.ImageUrl)
+		builder.Property(recipe => recipe.ImageUrl)
 			.HasConversion<ImageUrlConverter>()
 			.HasMaxLength(ImageUrl.MaxLength);
 
-		entity.Property(e => e.Language)
+		builder.Property(recipe => recipe.Language)
 			.HasConversion<RecipeLanguageConverter>()
 			.HasMaxLength(RecipeLanguage.MaxLength);
 
-		entity.Property(e => e.SourceUrl)
+		builder.Property(recipe => recipe.SourceUrl)
 			.HasConversion<RecipeUrlConverter>()
 			.HasMaxLength(RecipeUrl.MaxLength);
 
-		entity.Property(e => e.Owner)
+		builder.Property(recipe => recipe.Owner)
 			.HasConversion<RecipeOwnerIdentifierConverter>()
 			.HasMaxLength(OwnerIdentifier.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.CreatedAt).IsRequired();
+		builder.Property(recipe => recipe.CreatedAt).IsRequired();
 
-		entity.Property(e => e.Rating)
+		builder.Property(recipe => recipe.Rating)
 			.HasConversion<RatingConverter>();
 
-		entity.Property(e => e.Notes)
+		builder.Property(recipe => recipe.Notes)
 			.HasConversion<NotesConverter>()
 			.HasMaxLength(Notes.MaxLength);
 
-		entity.OwnsMany(e => e.Ingredients, ingredient =>
+		builder.OwnsMany(recipe => recipe.Ingredients, ingredient =>
 		{
 			ingredient.ToTable("RecipeIngredients");
 			ingredient.WithOwner().HasForeignKey("RecipeId");
 			ingredient.HasKey(nameof(Ingredient.Id));
-			ingredient.Property(i => i.Id)
+			ingredient.Property(row => row.Id)
 				.HasConversion<IngredientIdentifierConverter>();
 
-			ingredient.Property(i => i.Name)
+			ingredient.Property(row => row.Name)
 				.HasConversion<IngredientNameConverter>()
 				.HasMaxLength(IngredientName.MaxLength)
 				.IsRequired();
 
-			ingredient.OwnsOne(i => i.Quantity, q =>
+			ingredient.OwnsOne(row => row.Quantity, quantity =>
 			{
-				q.Property(x => x.Amount)
+				quantity.Property(value => value.Amount)
 					.HasConversion<RecipeAmountConverter>()
 					.HasColumnName("Amount");
 
-				q.Property(x => x.Unit)
+				quantity.Property(value => value.Unit)
 					.HasConversion<RecipeUnitConverter>()
 					.HasMaxLength(Unit.MaxLength)
 					.HasColumnName("Unit");
 			});
 		});
 
-		entity.OwnsMany(e => e.Steps, step =>
+		builder.OwnsMany(recipe => recipe.Steps, step =>
 		{
 			step.ToTable("RecipeSteps");
 			step.WithOwner().HasForeignKey("RecipeId");
 			step.HasKey(nameof(Step.Id));
-			step.Property(s => s.Id)
+			step.Property(row => row.Id)
 				.HasConversion<StepIdentifierConverter>();
 
-			step.Property(s => s.Number)
+			step.Property(row => row.Number)
 				.HasConversion<StepNumberConverter>()
 				.IsRequired();
 
-			step.Property(s => s.Description)
+			step.Property(row => row.Description)
 				.HasConversion<StepDescriptionConverter>()
 				.HasMaxLength(StepDescription.MaxLength)
 				.IsRequired();
 		});
 
-		entity.OwnsMany(e => e.Tags, tag =>
+		builder.OwnsMany(recipe => recipe.Tags, tag =>
 		{
 			tag.ToTable("RecipeTags");
 			tag.WithOwner().HasForeignKey("RecipeId");
-			tag.Property(t => t.Value)
+			tag.Property(row => row.Value)
 				.HasColumnName("Tag")
 				.HasMaxLength(RecipeTag.MaxLength);
 		});
 
-		entity.HasIndex(e => e.Owner);
-		entity.HasIndex(e => new { e.Owner, e.CreatedAt });
-		entity.HasIndex(e => new { e.Owner, e.Title });
-		entity.HasIndex(e => new { e.SourceUrl, e.Owner })
+		builder.HasIndex(recipe => recipe.Owner);
+		builder.HasIndex(recipe => new { recipe.Owner, recipe.CreatedAt });
+		builder.HasIndex(recipe => new { recipe.Owner, recipe.Title });
+		builder.HasIndex(recipe => new { recipe.SourceUrl, recipe.Owner })
 			.IsUnique()
 			.HasFilter("\"SourceUrl\" IS NOT NULL");
-		entity.Property<uint>("xmin")
+		builder.Property<uint>("xmin")
 			.HasColumnType("xid")
 			.IsRowVersion();
-		entity.Ignore(e => e.DomainEvents);
+		builder.Ignore(recipe => recipe.DomainEvents);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
@@ -8,26 +8,26 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence.Configurat
 
 internal sealed class RecipeFavoriteConfiguration : IEntityTypeConfiguration<RecipeFavorite>
 {
-	public void Configure(EntityTypeBuilder<RecipeFavorite> entity)
+	public void Configure(EntityTypeBuilder<RecipeFavorite> builder)
 	{
-		entity.ToTable("RecipeFavorites");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		builder.ToTable("RecipeFavorites");
+		builder.HasKey(favorite => favorite.Id);
+		builder.Property(favorite => favorite.Id)
 			.HasConversion<RecipeFavoriteIdentifierConverter>();
 
-		entity.Property(e => e.Recipe)
+		builder.Property(favorite => favorite.Recipe)
 			.HasConversion<RecipeIdentifierConverter>()
 			.HasColumnName("RecipeIdentifier")
 			.IsRequired();
 
-		entity.Property(e => e.Owner)
+		builder.Property(favorite => favorite.Owner)
 			.HasConversion<RecipeOwnerIdentifierConverter>()
 			.HasMaxLength(OwnerIdentifier.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.FavoritedAt).IsRequired();
+		builder.Property(favorite => favorite.FavoritedAt).IsRequired();
 
-		entity.HasIndex(e => new { e.Owner, e.Recipe }).IsUnique();
-		entity.Ignore(e => e.DomainEvents);
+		builder.HasIndex(favorite => new { favorite.Owner, favorite.Recipe }).IsUnique();
+		builder.Ignore(favorite => favorite.DomainEvents);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDesignTimeDbContextFactory.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/RecipesDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class RecipesDesignTimeDbContextFactory : IDesignTimeDbContextFact
 		var optionsBuilder = new DbContextOptionsBuilder<RecipesDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__RecipesMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__RecipesMigrationsHistory"));
 
 		return new RecipesDbContext(optionsBuilder.Options);
 	}

--- a/src/Yumney.Shared.Persistence/EventStore/CrossModuleEventConvention.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/CrossModuleEventConvention.cs
@@ -10,7 +10,7 @@ public static class CrossModuleEventConvention
 
 	public static IReadOnlyDictionary<Type, CrossModuleEventFactory> BuildMap(Assembly assembly)
 	{
-		var map = new Dictionary<Type, CrossModuleEventFactory>();
+		Dictionary<Type, CrossModuleEventFactory> map = [];
 
 		var mapperTypes = assembly.GetTypes()
 			.Where(type => typeof(ICrossModuleEventMapper).IsAssignableFrom(type)

--- a/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
@@ -124,7 +124,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 			.OrderBy(row => row.Version)
 			.ToListAsync(cancellationToken);
 
-		var events = new List<IDomainEvent>(stored.Count);
+		List<IDomainEvent> events = new(stored.Count);
 		HashSet<string>? unknownTypes = null;
 		foreach (var row in stored)
 		{
@@ -156,7 +156,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 		var eventContext = BuildEventContext(aggregate);
 		var moduleFactories = ModuleEventFactories;
 		var crossFactories = CrossModuleEventFactories;
-		var busEvents = new List<IBusEvent>();
+		List<IBusEvent> busEvents = [];
 
 		foreach (var domainEvent in events)
 		{

--- a/src/Yumney.Shared.Persistence/EventStore/ModuleEventConvention.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/ModuleEventConvention.cs
@@ -18,7 +18,7 @@ public static class ModuleEventConvention
 		Assembly moduleEventsAssembly,
 		params Type[] contextParameterTypes)
 	{
-		var map = new Dictionary<Type, ModuleEventFactory>();
+		Dictionary<Type, ModuleEventFactory> map = [];
 
 		var moduleEventTypes = moduleEventsAssembly.GetTypes()
 			.Where(type => typeof(IModuleEvent).IsAssignableFrom(type) && !type.IsAbstract && !type.IsInterface);

--- a/src/Yumney.Shared.Persistence/InboxMessageConfiguration.cs
+++ b/src/Yumney.Shared.Persistence/InboxMessageConfiguration.cs
@@ -15,13 +15,13 @@ public sealed class InboxMessageConfiguration : IEntityTypeConfiguration<InboxMe
 	{
 		builder.ToTable("InboxMessages");
 
-		builder.HasKey(x => new { x.MessageId, x.ConsumerName });
+		builder.HasKey(message => new { message.MessageId, message.ConsumerName });
 
-		builder.Property(x => x.ConsumerName)
+		builder.Property(message => message.ConsumerName)
 			.IsRequired()
 			.HasMaxLength(256);
 
-		builder.Property(x => x.ProcessedAt)
+		builder.Property(message => message.ProcessedAt)
 			.IsRequired();
 	}
 }

--- a/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
@@ -14,7 +14,7 @@ public sealed class RequestContextMiddleware(RequestDelegate next, ILogger<Reque
 
 		var correlationId = context.Items[CorrelationIdMiddleware.HeaderName] as string ?? "unknown";
 
-		var state = new Dictionary<string, object?>
+		Dictionary<string, object?> state = new()
 		{
 			["UserId"] = userId,
 			["CorrelationId"] = correlationId,

--- a/src/Yumney.Shared.Web/ResultExtensions.cs
+++ b/src/Yumney.Shared.Web/ResultExtensions.cs
@@ -42,7 +42,7 @@ public static class ResultExtensions
 	// alongside for log correlation.
 	private static Dictionary<string, object?> BuildProblemExtensions(ApiError error)
 	{
-		var extensions = new Dictionary<string, object?>
+		Dictionary<string, object?> extensions = new()
 		{
 			["code"] = error.Code,
 		};

--- a/src/Yumney.Shared.Web/ValidationExtensions.cs
+++ b/src/Yumney.Shared.Web/ValidationExtensions.cs
@@ -31,7 +31,7 @@ public static class ValidationExtensions
 
 	private static Dictionary<string, object?> BuildTraceExtensions()
 	{
-		var extensions = new Dictionary<string, object?>();
+		Dictionary<string, object?> extensions = [];
 
 		var traceId = Activity.Current?.TraceId.ToString();
 		if (traceId is not null)

--- a/src/Yumney.Shopping.Api/Requests/Validator/AddManualItemValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/AddManualItemValidator.cs
@@ -6,6 +6,6 @@ public sealed class AddManualItemValidator : AbstractValidator<AddManualItem>
 {
 	public AddManualItemValidator()
 	{
-		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
+		RuleFor(request => request.Name).NotEmpty().WithMessage("Item name is required.");
 	}
 }

--- a/src/Yumney.Shopping.Api/Requests/Validator/ChangeItemCategoryValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/ChangeItemCategoryValidator.cs
@@ -7,7 +7,7 @@ public sealed class ChangeItemCategoryValidator : AbstractValidator<ChangeItemCa
 {
 	public ChangeItemCategoryValidator()
 	{
-		RuleFor(x => x.Category)
+		RuleFor(request => request.Category)
 			.NotEmpty().WithMessage("Category is required.")
 			.Must(BeKnownCategory).WithMessage("Unknown category.");
 	}

--- a/src/Yumney.Shopping.Api/Requests/Validator/CreateShoppingListValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/CreateShoppingListValidator.cs
@@ -7,27 +7,27 @@ public sealed class CreateShoppingListValidator : AbstractValidator<CreateShoppi
 {
 	public CreateShoppingListValidator()
 	{
-		RuleFor(x => x.Title)
+		RuleFor(request => request.Title)
 			.NotEmpty()
 			.MaximumLength(ShoppingListTitle.MaxLength);
 
-		RuleFor(x => x.Items)
+		RuleFor(request => request.Items)
 			.NotEmpty()
 			.WithMessage("At least one item is required.");
 
-		RuleForEach(x => x.Items).ChildRules(item =>
+		RuleForEach(request => request.Items).ChildRules(itemRule =>
 		{
-			item.RuleFor(i => i.Name)
+			itemRule.RuleFor(item => item.Name)
 				.NotEmpty()
 				.MaximumLength(ItemName.MaxLength);
 
-			item.RuleFor(i => i.Amount)
+			itemRule.RuleFor(item => item.Amount)
 				.GreaterThanOrEqualTo(0)
-				.When(i => i.Amount.HasValue);
+				.When(item => item.Amount.HasValue);
 
-			item.RuleFor(i => i.Unit)
+			itemRule.RuleFor(item => item.Unit)
 				.MaximumLength(Unit.MaxLength)
-				.When(i => i.Unit is not null);
+				.When(item => item.Unit is not null);
 		});
 	}
 }

--- a/src/Yumney.Shopping.Api/Requests/Validator/MarkAsFrozenValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/MarkAsFrozenValidator.cs
@@ -6,6 +6,6 @@ public sealed class MarkAsFrozenValidator : AbstractValidator<MarkAsFrozen>
 {
 	public MarkAsFrozenValidator()
 	{
-		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
+		RuleFor(request => request.Name).NotEmpty().WithMessage("Item name is required.");
 	}
 }

--- a/src/Yumney.Shopping.Api/Requests/Validator/RemoveItemValidator.cs
+++ b/src/Yumney.Shopping.Api/Requests/Validator/RemoveItemValidator.cs
@@ -6,6 +6,6 @@ public sealed class RemoveItemValidator : AbstractValidator<RemoveItem>
 {
 	public RemoveItemValidator()
 	{
-		RuleFor(x => x.Name).NotEmpty().WithMessage("Item name is required.");
+		RuleFor(request => request.Name).NotEmpty().WithMessage("Item name is required.");
 	}
 }

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
@@ -22,7 +22,7 @@ public sealed class CreateShoppingListFromRecipesCommandHandler(
 			return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoRecipesProvided);
 		}
 
-		var inputs = new List<IngredientMergeInput>(recipes.Count);
+		List<IngredientMergeInput> inputs = new(recipes.Count);
 		foreach (var selection in recipes)
 		{
 			var ingredients = await recipeLookup.LookupAsync(selection.Recipe, cancellationToken);

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/AggregateMetadataConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/AggregateMetadataConfiguration.cs
@@ -6,11 +6,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class AggregateMetadataConfiguration : IEntityTypeConfiguration<AggregateMetadata>
 {
-	public void Configure(EntityTypeBuilder<AggregateMetadata> entity)
+	public void Configure(EntityTypeBuilder<AggregateMetadata> builder)
 	{
-		entity.ToTable("ShoppingAggregates");
-		entity.HasKey(e => e.AggregateId);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.HasIndex(e => e.OwnerId).IsUnique();
+		builder.ToTable("ShoppingAggregates");
+		builder.HasKey(metadata => metadata.AggregateId);
+		builder.Property(metadata => metadata.OwnerId).HasMaxLength(255).IsRequired();
+		builder.HasIndex(metadata => metadata.OwnerId).IsUnique();
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/IngredientBalanceReadItemConfiguration.cs
@@ -6,24 +6,24 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class IngredientBalanceReadItemConfiguration : IEntityTypeConfiguration<IngredientBalanceReadItem>
 {
-	public void Configure(EntityTypeBuilder<IngredientBalanceReadItem> entity)
+	public void Configure(EntityTypeBuilder<IngredientBalanceReadItem> builder)
 	{
-		entity.ToTable("IngredientBalanceReadItems");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.ItemName).HasMaxLength(200).IsRequired();
-		entity.Property(e => e.NameKey).HasMaxLength(200).IsRequired();
-		entity.Property(e => e.Unit).HasMaxLength(20);
-		entity.Property(e => e.Category).HasMaxLength(30).IsRequired();
-		entity.Property(e => e.BoughtTotal).HasColumnType("numeric");
-		entity.Property(e => e.ConsumedTotal).HasColumnType("numeric");
-		entity.Property(e => e.RemovedTotal).HasColumnType("numeric");
-		entity.Property(e => e.LastBoughtAt);
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("IngredientBalanceReadItems");
+		builder.HasKey(item => item.Id);
+		builder.Property(item => item.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(item => item.ItemName).HasMaxLength(200).IsRequired();
+		builder.Property(item => item.NameKey).HasMaxLength(200).IsRequired();
+		builder.Property(item => item.Unit).HasMaxLength(20);
+		builder.Property(item => item.Category).HasMaxLength(30).IsRequired();
+		builder.Property(item => item.BoughtTotal).HasColumnType("numeric");
+		builder.Property(item => item.ConsumedTotal).HasColumnType("numeric");
+		builder.Property(item => item.RemovedTotal).HasColumnType("numeric");
+		builder.Property(item => item.LastBoughtAt);
+		builder.Property(item => item.LastUpdated).IsRequired();
 
-		entity.Ignore(e => e.AtHome);
+		builder.Ignore(item => item.AtHome);
 
-		entity.HasIndex(e => e.OwnerId);
-		entity.HasIndex(e => new { e.OwnerId, e.NameKey, e.Unit });
+		builder.HasIndex(item => item.OwnerId);
+		builder.HasIndex(item => new { item.OwnerId, item.NameKey, item.Unit });
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingLedgerReadItemConfiguration.cs
@@ -6,21 +6,21 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class ShoppingLedgerReadItemConfiguration : IEntityTypeConfiguration<ShoppingLedgerReadItem>
 {
-	public void Configure(EntityTypeBuilder<ShoppingLedgerReadItem> entity)
+	public void Configure(EntityTypeBuilder<ShoppingLedgerReadItem> builder)
 	{
 		// Physical table name kept as-is to avoid a rename migration.
 		// The C# type was renamed in the cleanup pass; the schema is stable.
-		entity.ToTable("ShoppingListReadItems");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.ItemName).HasMaxLength(200).IsRequired();
-		entity.Property(e => e.Unit).HasMaxLength(20);
-		entity.Property(e => e.Category).HasMaxLength(30).IsRequired();
-		entity.Property(e => e.SourcesJson).HasColumnType("jsonb");
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("ShoppingListReadItems");
+		builder.HasKey(item => item.Id);
+		builder.Property(item => item.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(item => item.ItemName).HasMaxLength(200).IsRequired();
+		builder.Property(item => item.Unit).HasMaxLength(20);
+		builder.Property(item => item.Category).HasMaxLength(30).IsRequired();
+		builder.Property(item => item.SourcesJson).HasColumnType("jsonb");
+		builder.Property(item => item.LastUpdated).IsRequired();
 
-		entity.HasIndex(e => e.OwnerId);
-		entity.HasIndex(e => new { e.OwnerId, e.ItemName, e.Unit });
+		builder.HasIndex(item => item.OwnerId);
+		builder.HasIndex(item => new { item.OwnerId, item.ItemName, item.Unit });
 
 		// Natural-key uniqueness on (OwnerId, lower(ItemName), COALESCE(Unit, ''))
 		// is enforced by the expression-based unique index added in migration

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListAggregateMetadataConfiguration.cs
@@ -6,11 +6,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class ShoppingListAggregateMetadataConfiguration : IEntityTypeConfiguration<ShoppingListAggregateMetadata>
 {
-	public void Configure(EntityTypeBuilder<ShoppingListAggregateMetadata> entity)
+	public void Configure(EntityTypeBuilder<ShoppingListAggregateMetadata> builder)
 	{
-		entity.ToTable("ShoppingListAggregates");
-		entity.HasKey(e => e.AggregateId);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.HasIndex(e => e.OwnerId);
+		builder.ToTable("ShoppingListAggregates");
+		builder.HasKey(metadata => metadata.AggregateId);
+		builder.Property(metadata => metadata.OwnerId).HasMaxLength(255).IsRequired();
+		builder.HasIndex(metadata => metadata.OwnerId);
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListItemReadItemConfiguration.cs
@@ -6,18 +6,18 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class ShoppingListItemReadItemConfiguration : IEntityTypeConfiguration<ShoppingListItemReadItem>
 {
-	public void Configure(EntityTypeBuilder<ShoppingListItemReadItem> entity)
+	public void Configure(EntityTypeBuilder<ShoppingListItemReadItem> builder)
 	{
-		entity.ToTable("ShoppingListItemReadItems");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
-		entity.Property(e => e.QuantityUnit).HasMaxLength(50);
-		entity.Property(e => e.Category).HasMaxLength(50).IsRequired().HasDefaultValue("other");
-		entity.Property(e => e.CreatedAt).IsRequired();
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("ShoppingListItemReadItems");
+		builder.HasKey(item => item.Id);
+		builder.Property(item => item.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(item => item.Name).HasMaxLength(200).IsRequired();
+		builder.Property(item => item.QuantityUnit).HasMaxLength(50);
+		builder.Property(item => item.Category).HasMaxLength(50).IsRequired().HasDefaultValue("other");
+		builder.Property(item => item.CreatedAt).IsRequired();
+		builder.Property(item => item.LastUpdated).IsRequired();
 
-		entity.HasIndex(e => e.ListId);
-		entity.HasIndex(e => new { e.OwnerId, e.ListId });
+		builder.HasIndex(item => item.ListId);
+		builder.HasIndex(item => new { item.OwnerId, item.ListId });
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/Configurations/ShoppingListSummaryReadItemConfiguration.cs
@@ -6,17 +6,17 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.Configura
 
 internal sealed class ShoppingListSummaryReadItemConfiguration : IEntityTypeConfiguration<ShoppingListSummaryReadItem>
 {
-	public void Configure(EntityTypeBuilder<ShoppingListSummaryReadItem> entity)
+	public void Configure(EntityTypeBuilder<ShoppingListSummaryReadItem> builder)
 	{
-		entity.ToTable("ShoppingListSummaryReadItems");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.OwnerId).HasMaxLength(255).IsRequired();
-		entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
-		entity.Property(e => e.CreatedAt).IsRequired();
-		entity.Property(e => e.LastUpdated).IsRequired();
+		builder.ToTable("ShoppingListSummaryReadItems");
+		builder.HasKey(summary => summary.Id);
+		builder.Property(summary => summary.OwnerId).HasMaxLength(255).IsRequired();
+		builder.Property(summary => summary.Title).HasMaxLength(200).IsRequired();
+		builder.Property(summary => summary.CreatedAt).IsRequired();
+		builder.Property(summary => summary.LastUpdated).IsRequired();
 
-		entity.HasIndex(e => e.OwnerId);
-		entity.HasIndex(e => new { e.OwnerId, e.CreatedAt });
-		entity.HasIndex(e => new { e.OwnerId, e.Title });
+		builder.HasIndex(summary => summary.OwnerId);
+		builder.HasIndex(summary => new { summary.OwnerId, summary.CreatedAt });
+		builder.HasIndex(summary => new { summary.OwnerId, summary.Title });
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ReadModel/ShoppingListProjection.cs
@@ -197,7 +197,7 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 	public async Task HandleAsync(RecipeReferenceClearedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var summary = await context.Set<ShoppingListSummaryReadItem>()
-			.FirstOrDefaultAsync(s => s.Id == @event.AggregateId, cancellationToken);
+			.FirstOrDefaultAsync(row => row.Id == @event.AggregateId, cancellationToken);
 		if (summary is null) return;
 
 		summary.RecipeIdentifier = null;
@@ -259,7 +259,7 @@ public sealed class ShoppingListProjection(ShoppingDbContext context)
 	private async Task TouchSummaryAsync(Guid listId, CancellationToken cancellationToken)
 	{
 		var summary = await context.Set<ShoppingListSummaryReadItem>()
-			.FirstOrDefaultAsync(s => s.Id == listId, cancellationToken);
+			.FirstOrDefaultAsync(row => row.Id == listId, cancellationToken);
 		if (summary is null) return;
 		summary.LastUpdated = DateTime.UtcNow;
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDesignTimeDbContextFactory.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class ShoppingDesignTimeDbContextFactory : IDesignTimeDbContextFac
 		var optionsBuilder = new DbContextOptionsBuilder<ShoppingDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__ShoppingMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__ShoppingMigrationsHistory"));
 
 		return new ShoppingDbContext(optionsBuilder.Options);
 	}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDesignTimeDbContextFactory.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingReadDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class ShoppingReadDesignTimeDbContextFactory : IDesignTimeDbContex
 		var optionsBuilder = new DbContextOptionsBuilder<ShoppingReadDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__ShoppingMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__ShoppingMigrationsHistory"));
 
 		return new ShoppingReadDbContext(optionsBuilder.Options);
 	}

--- a/src/Yumney.Shopping.Infrastructure/Services/SemanticKernelShoppingItemCategorizer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Services/SemanticKernelShoppingItemCategorizer.cs
@@ -63,7 +63,7 @@ public sealed partial class SemanticKernelShoppingItemCategorizer(
 		IReadOnlyCollection<ItemName> names,
 		CancellationToken cancellationToken = default)
 	{
-		var distinct = names.DistinctBy(n => n.Value).ToList();
+		var distinct = names.DistinctBy(name => name.Value).ToList();
 		var tasks = distinct.Select(async name => (name, category: await CategorizeAsync(name, cancellationToken)));
 		var results = await Task.WhenAll(tasks);
 		return results.ToDictionary(pair => pair.name, pair => pair.category);

--- a/src/Yumney.Shopping.Infrastructure/Services/StubShoppingItemCategorizer.cs
+++ b/src/Yumney.Shopping.Infrastructure/Services/StubShoppingItemCategorizer.cs
@@ -22,7 +22,7 @@ public sealed class StubShoppingItemCategorizer : IShoppingItemCategorizer
 		CancellationToken cancellationToken = default)
 	{
 		IReadOnlyDictionary<ItemName, IngredientCategory> map = names
-			.DistinctBy(n => n.Value)
+			.DistinctBy(name => name.Value)
 			.ToDictionary(name => name, name => IngredientCategoryResolver.Resolve(name.Value) ?? IngredientCategory.Other);
 		return Task.FromResult(map);
 	}

--- a/src/Yumney.Users.Api/Requests/RegisterUserValidator.cs
+++ b/src/Yumney.Users.Api/Requests/RegisterUserValidator.cs
@@ -7,19 +7,19 @@ public sealed class RegisterUserValidator : AbstractValidator<RegisterUser>
 {
 	public RegisterUserValidator()
 	{
-		RuleFor(x => x.Email)
+		RuleFor(request => request.Email)
 			.NotEmpty()
 			.MaximumLength(Email.MaxLength)
 			.EmailAddress();
 
-		RuleFor(x => x.Password)
+		RuleFor(request => request.Password)
 			.NotEmpty()
 			.MinimumLength(Password.MinLength)
 			.Matches(Password.UppercasePattern).WithMessage(Password.UppercaseMessage)
 			.Matches(Password.LowercasePattern).WithMessage(Password.LowercaseMessage)
 			.Matches(Password.DigitPattern).WithMessage(Password.DigitMessage);
 
-		RuleFor(x => x.DisplayName)
+		RuleFor(request => request.DisplayName)
 			.NotEmpty()
 			.MaximumLength(DisplayName.MaxLength);
 	}

--- a/src/Yumney.Users.Api/Requests/ResendVerificationEmailValidator.cs
+++ b/src/Yumney.Users.Api/Requests/ResendVerificationEmailValidator.cs
@@ -7,7 +7,7 @@ public sealed class ResendVerificationEmailValidator : AbstractValidator<ResendV
 {
 	public ResendVerificationEmailValidator()
 	{
-		RuleFor(x => x.Email)
+		RuleFor(request => request.Email)
 			.NotEmpty()
 			.MaximumLength(Email.MaxLength)
 			.EmailAddress();

--- a/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/AppUserProfileRepository.cs
@@ -10,12 +10,12 @@ public sealed class AppUserProfileRepository(UsersDbContext context) : IAppUserP
 
 	public async Task<AppUserProfile?> FindByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
 	{
-		return await profiles.AsNoTracking().FirstOrDefaultAsync(p => p.KeycloakUserId == keycloakUserId, cancellationToken);
+		return await profiles.AsNoTracking().FirstOrDefaultAsync(profile => profile.KeycloakUserId == keycloakUserId, cancellationToken);
 	}
 
 	public async Task<AppUserProfile> GetByKeycloakUserIdAsync(KeycloakUserId keycloakUserId, CancellationToken cancellationToken = default)
 	{
-		return await profiles.FirstOrDefaultAsync(p => p.KeycloakUserId == keycloakUserId, cancellationToken)
+		return await profiles.FirstOrDefaultAsync(profile => profile.KeycloakUserId == keycloakUserId, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(AppUserProfile), keycloakUserId.Value);
 	}
 

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/AppUserProfileConfiguration.cs
@@ -7,95 +7,95 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Configuratio
 
 internal sealed class AppUserProfileConfiguration : IEntityTypeConfiguration<AppUserProfile>
 {
-	public void Configure(EntityTypeBuilder<AppUserProfile> entity)
+	public void Configure(EntityTypeBuilder<AppUserProfile> builder)
 	{
-		entity.ToTable("AppUserProfiles");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		builder.ToTable("AppUserProfiles");
+		builder.HasKey(profile => profile.Id);
+		builder.Property(profile => profile.Id)
 			.HasConversion<AppUserProfileIdentifierConverter>();
 
-		entity.Property(e => e.KeycloakUserId)
+		builder.Property(profile => profile.KeycloakUserId)
 			.HasConversion<KeycloakUserIdConverter>()
 			.HasMaxLength(KeycloakUserId.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.DisplayName)
+		builder.Property(profile => profile.DisplayName)
 			.HasConversion<DisplayNameConverter>()
 			.HasMaxLength(DisplayName.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.PreferredLanguage)
+		builder.Property(profile => profile.PreferredLanguage)
 			.HasConversion<PreferredLanguageConverter>()
 			.HasMaxLength(PreferredLanguage.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.PreferredUnitSystem)
+		builder.Property(profile => profile.PreferredUnitSystem)
 			.HasConversion<PreferredUnitSystemConverter>()
 			.HasMaxLength(PreferredUnitSystem.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.DefaultServings)
+		builder.Property(profile => profile.DefaultServings)
 			.HasConversion<DefaultServingsConverter>()
 			.HasDefaultValue(DefaultServings.Default)
 			.IsRequired();
 
-		entity.Property(e => e.Theme)
+		builder.Property(profile => profile.Theme)
 			.HasConversion<ThemeConverter>()
 			.HasMaxLength(Theme.MaxLength)
 			.HasDefaultValue(Theme.System)
 			.IsRequired();
 
-		entity.OwnsOne(e => e.VoiceSettings, voice =>
+		builder.OwnsOne(profile => profile.VoiceSettings, voice =>
 		{
-			voice.Property(v => v.Enabled).HasColumnName("VoiceEnabled").HasDefaultValue(true);
-			voice.Property(v => v.Speed)
+			voice.Property(settings => settings.Enabled).HasColumnName("VoiceEnabled").HasDefaultValue(true);
+			voice.Property(settings => settings.Speed)
 				.HasConversion<VoiceSpeedConverter>()
 				.HasMaxLength(VoiceSpeed.MaxLength)
 				.HasColumnName("VoiceSpeed")
 				.HasDefaultValue(VoiceSpeed.Normal);
-			voice.Property(v => v.AutoReadInCookMode)
+			voice.Property(settings => settings.AutoReadInCookMode)
 				.HasColumnName("VoiceAutoReadInCookMode")
 				.HasDefaultValue(false);
 		});
 
-		entity.OwnsOne(e => e.NotificationPreferences, notifications =>
+		builder.OwnsOne(profile => profile.NotificationPreferences, notifications =>
 		{
-			notifications.Property(n => n.TimerHapticFeedback)
+			notifications.Property(prefs => prefs.TimerHapticFeedback)
 				.HasColumnName("TimerHapticFeedback")
 				.HasDefaultValue(true);
-			notifications.Property(n => n.TimerSoundAlerts)
+			notifications.Property(prefs => prefs.TimerSoundAlerts)
 				.HasColumnName("TimerSoundAlerts")
 				.HasDefaultValue(true);
 		});
 
-		entity.OwnsOne(e => e.DietaryProfile, dietary =>
+		builder.OwnsOne(profile => profile.DietaryProfile, dietary =>
 		{
-			dietary.Property(d => d.DietaryType)
+			dietary.Property(profile => profile.DietaryType)
 				.HasConversion<DietaryTypeConverter>()
 				.HasMaxLength(DietaryType.MaxLength)
 				.HasColumnName("DietaryType");
 
-			dietary.Property(d => d.Restrictions)
+			dietary.Property(profile => profile.Restrictions)
 				.HasConversion<DietaryRestrictionsConverter>()
 				.HasMaxLength(500)
 				.HasColumnName("DietaryRestrictions");
 
-			dietary.Property(d => d.CookingEffort)
+			dietary.Property(profile => profile.CookingEffort)
 				.HasConversion<CookingEffortPreferenceConverter>()
 				.HasMaxLength(CookingEffortPreference.MaxLength)
 				.HasColumnName("CookingEffort");
 
-			dietary.OwnsOne(d => d.BalanceGoals, goals =>
+			dietary.OwnsOne(profile => profile.BalanceGoals, goals =>
 			{
-				goals.Property(g => g.MinVeggieMeals)
+				goals.Property(balance => balance.MinVeggieMeals)
 					.HasColumnName("MinVeggieMeals");
 
-				goals.Property(g => g.MaxRedMeatMeals)
+				goals.Property(balance => balance.MaxRedMeatMeals)
 					.HasColumnName("MaxRedMeatMeals");
 			});
 		});
 
-		entity.HasIndex(e => e.KeycloakUserId).IsUnique();
-		entity.Ignore(e => e.DomainEvents);
+		builder.HasIndex(profile => profile.KeycloakUserId).IsUnique();
+		builder.Ignore(profile => profile.DomainEvents);
 	}
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/StaplesListConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/StaplesListConfiguration.cs
@@ -7,28 +7,28 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Configuratio
 
 internal sealed class StaplesListConfiguration : IEntityTypeConfiguration<StaplesList>
 {
-	public void Configure(EntityTypeBuilder<StaplesList> entity)
+	public void Configure(EntityTypeBuilder<StaplesList> builder)
 	{
-		entity.ToTable("StaplesLists");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		builder.ToTable("StaplesLists");
+		builder.HasKey(list => list.Id);
+		builder.Property(list => list.Id)
 			.HasConversion<StaplesListIdentifierConverter>();
 
-		entity.Property(e => e.Owner)
+		builder.Property(list => list.Owner)
 			.HasConversion<StaplesOwnerIdentifierConverter>()
 			.HasMaxLength(OwnerIdentifier.MaxLength)
 			.IsRequired();
 
-		entity.OwnsMany(e => e.Items, item =>
+		builder.OwnsMany(list => list.Items, item =>
 		{
 			item.ToTable("StapleItems");
 			item.WithOwner().HasForeignKey("StaplesListId");
-			item.Property(i => i.Value)
+			item.Property(staple => staple.Value)
 				.HasColumnName("Name")
 				.HasMaxLength(StapleItem.MaxLength);
 		});
 
-		entity.HasIndex(e => e.Owner).IsUnique();
-		entity.Ignore(e => e.DomainEvents);
+		builder.HasIndex(list => list.Owner).IsUnique();
+		builder.Ignore(list => list.DomainEvents);
 	}
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/Configurations/UserActivityConfiguration.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/Configurations/UserActivityConfiguration.cs
@@ -7,38 +7,38 @@ namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Persistence.Configuratio
 
 internal sealed class UserActivityConfiguration : IEntityTypeConfiguration<UserActivity>
 {
-	public void Configure(EntityTypeBuilder<UserActivity> entity)
+	public void Configure(EntityTypeBuilder<UserActivity> builder)
 	{
-		entity.ToTable("UserActivities");
-		entity.HasKey(e => e.Id);
-		entity.Property(e => e.Id)
+		builder.ToTable("UserActivities");
+		builder.HasKey(activity => activity.Id);
+		builder.Property(activity => activity.Id)
 			.HasConversion<UserActivityIdentifierConverter>();
 
-		entity.Property(e => e.Owner)
+		builder.Property(activity => activity.Owner)
 			.HasConversion<UserActivityOwnerIdentifierConverter>()
 			.HasMaxLength(OwnerIdentifier.MaxLength)
 			.IsRequired();
 
-		entity.Property(e => e.Type)
+		builder.Property(activity => activity.Type)
 			.HasConversion<ActivityTypeConverter>()
 			.HasMaxLength(50)
 			.IsRequired();
 
-		entity.Property(e => e.RecipeIdentifier)
+		builder.Property(activity => activity.RecipeIdentifier)
 			.HasConversion(
-				v => v == null ? (Guid?)null : v.Value,
-				v => v.HasValue ? RecipeIdentifierSnapshot.From(v.Value) : null);
+				snapshot => snapshot == null ? (Guid?)null : snapshot.Value,
+				value => value.HasValue ? RecipeIdentifierSnapshot.From(value.Value) : null);
 
-		entity.Property(e => e.RecipeTitle)
+		builder.Property(activity => activity.RecipeTitle)
 			.HasMaxLength(RecipeTitleSnapshot.MaxLength)
 			.HasConversion(
-				v => v == null ? null : v.Value,
-				v => v == null ? null : RecipeTitleSnapshot.From(v));
+				snapshot => snapshot == null ? null : snapshot.Value,
+				value => value == null ? null : RecipeTitleSnapshot.From(value));
 
-		entity.Property(e => e.OccurredAt)
+		builder.Property(activity => activity.OccurredAt)
 			.IsRequired();
 
-		entity.HasIndex(e => new { e.Owner, e.OccurredAt })
+		builder.HasIndex(activity => new { activity.Owner, activity.OccurredAt })
 			.IsDescending(false, true);
 	}
 }

--- a/src/Yumney.Users.Infrastructure/Persistence/StaplesListRepository.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/StaplesListRepository.cs
@@ -12,15 +12,15 @@ public sealed class StaplesListRepository(UsersDbContext context) : IStaplesList
 	{
 		return await staplesLists
 			.AsNoTracking()
-			.Include(s => s.Items)
-			.FirstOrDefaultAsync(s => s.Owner == owner, cancellationToken);
+			.Include(list => list.Items)
+			.FirstOrDefaultAsync(list => list.Owner == owner, cancellationToken);
 	}
 
 	public async Task<StaplesList> GetByOwnerAsync(OwnerIdentifier owner, CancellationToken cancellationToken = default)
 	{
 		return await staplesLists
-			.Include(s => s.Items)
-			.FirstOrDefaultAsync(s => s.Owner == owner, cancellationToken)
+			.Include(list => list.Items)
+			.FirstOrDefaultAsync(list => list.Owner == owner, cancellationToken)
 			?? throw new EntityNotFoundException(nameof(StaplesList), owner.Value);
 	}
 

--- a/src/Yumney.Users.Infrastructure/Persistence/UsersDesignTimeDbContextFactory.cs
+++ b/src/Yumney.Users.Infrastructure/Persistence/UsersDesignTimeDbContextFactory.cs
@@ -10,7 +10,7 @@ public sealed class UsersDesignTimeDbContextFactory : IDesignTimeDbContextFactor
 		var optionsBuilder = new DbContextOptionsBuilder<UsersDbContext>();
 		optionsBuilder.UseNpgsql(
 			"Host=localhost;Database=yumneydb;Username=postgres;Password=postgres",
-			x => x.MigrationsHistoryTable("__UsersMigrationsHistory"));
+			npgsql => npgsql.MigrationsHistoryTable("__UsersMigrationsHistory"));
 
 		return new UsersDbContext(optionsBuilder.Options);
 	}


### PR DESCRIPTION
## Summary

Items #6 and #9 of the refactoring sweep, bundled together since both are mechanical CLAUDE.md style fixes. 53 files changed, 282 / 282 insertions/deletions.

### #6 — \`var\` with collection initializers (15 sites, 12 files)

CLAUDE.md mandates explicit type for collection initializers (\`List<T> x = []\` instead of \`var x = new List<T>()\`).

| Pattern | Before | After |
| --- | --- | --- |
| Empty | \`var x = new Dictionary<...>()\` | \`Dictionary<...> x = []\` |
| With capacity | \`var x = new List<T>(count)\` | \`List<T> x = new(count)\` |
| Initialised | \`var x = new Dictionary<...> { ... }\` | \`Dictionary<...> x = new() { ... }\` |

Touches: \`RouteUrlBuilder\`, \`RequestContextMiddleware\`, \`ResultExtensions\`, \`ValidationExtensions\`, \`CrossModuleEventConvention\`, \`ModuleEventConvention\`, \`EventStoreBase\` (×2), \`GetMealAnalyticsQueryHandler\`, \`RecipesEndpoints.Streaming\`, \`MealPlanReadModelRepository\` (×2), \`HttpIngredientBalanceProvider\`, \`CreateShoppingListFromRecipesCommandHandler\`.

### #9 — Single-letter lambdas (~40 files)

CLAUDE.md forbids single-letter lambda parameters (\`x\`, \`e\`, \`s\`, \`i\`, \`r\`, \`n\`, \`p\`, \`t\`, \`f\`); only \`_\` for explicit discards is allowed. Renamed to entity-typed nouns.

**EF Configurations (10 files)** — outer parameter renamed from \`entity\` to \`builder\` (EF standard); inner lambda renamed from \`e\` to entity-typed noun (\`slot\`, \`week\`, \`recipe\`, \`favorite\`, \`profile\`, \`list\`, \`activity\`, \`item\`, \`summary\`, \`metadata\`, \`message\`).

**FluentValidation (13 files)** — \`RuleFor(x => x.Field)\` → \`RuleFor(request => request.Field)\`. Sub-validators use the validated type's name (\`step\`, \`ingredient\`, \`photo\`).

**Misc lambdas** — repositories, projection handlers, AppHost endpoint config, categorizer \`DistinctBy\`, 5 DesignTimeDbContextFactory files (npgsql callback param renamed to \`npgsql\`).

### Deliberately untouched

- **Migration files** (\`**/Migrations/*.cs\`) — auto-generated by EF Core; renaming would be undone on next \`dotnet ef migrations add\`.
- **Test code** — only production code in this PR. The same lambda rename across tests is a separate effort.

## Risk

Pure rename, no behaviour change. DB column naming on \`RecipeFavoriteConfiguration\` is preserved by existing \`.HasColumnName(\"RecipeIdentifier\")\` calls. EF interprets these expression trees by member access, not by parameter name, so all queries / configurations / indexes are equivalent.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] All 21 unit-test projects pass (Architecture: 142, MealPlan/Recipes/Shopping/Users Domain+Application+Infrastructure+Api: 2,000+ tests total)
- [ ] CI: full backend + integration + E2E (the EF config rename is the highest-risk piece — integration tests against real Postgres will catch any equivalence break)