### PR TITLE
refactor(frontend): accessibility + trackBy + handler-extraction quick wins

### DIFF
--- a/client/apps/shell/src/app/auth/login/login.component.html
+++ b/client/apps/shell/src/app/auth/login/login.component.html
@@ -11,14 +11,9 @@
       </button>
 
       <p class="forgot-password">
-        <a
-          (click)="onForgotPassword()"
-          (keydown.enter)="onForgotPassword()"
-          tabindex="0"
-          role="button"
-        >
+        <button type="button" class="forgot-link" (click)="onForgotPassword()">
           {{ t('auth.login.forgotPassword') }}
-        </a>
+        </button>
       </p>
 
       <p class="register-link">

--- a/client/apps/shell/src/app/auth/login/login.component.scss
+++ b/client/apps/shell/src/app/auth/login/login.component.scss
@@ -32,7 +32,10 @@ button {
   text-align: center;
   font-size: var(--yn-text-base);
 
-  a {
+  .forgot-link {
+    background: none;
+    border: none;
+    font: inherit;
     color: var(--yn-text-muted);
     text-decoration: none;
     cursor: pointer;

--- a/client/apps/shell/src/app/auth/login/login.component.spec.ts
+++ b/client/apps/shell/src/app/auth/login/login.component.spec.ts
@@ -87,7 +87,7 @@ describe('LoginComponent', () => {
   });
 
   it('should render forgot password link', () => {
-    const link = fixture.nativeElement.querySelector('.forgot-password a');
+    const link = fixture.nativeElement.querySelector('.forgot-password .forgot-link');
     expect(link).toBeTruthy();
     expect(link.textContent).toContain('Forgot your password?');
   });
@@ -102,14 +102,15 @@ describe('LoginComponent', () => {
     expect(component.rememberMe()).toBe(true);
   });
 
-  it('should have accessible keyboard navigation on forgot password link', () => {
-    const link = fixture.nativeElement.querySelector('.forgot-password a');
-    expect(link.getAttribute('tabindex')).toBe('0');
+  it('renders the forgot-password control as a real button', () => {
+    const button = fixture.nativeElement.querySelector('.forgot-password .forgot-link');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.getAttribute('type')).toBe('button');
   });
 
   it('should call authService.forgotPassword on forgot password click', () => {
-    const link = fixture.nativeElement.querySelector('.forgot-password a');
-    link.click();
+    const button = fixture.nativeElement.querySelector('.forgot-password .forgot-link');
+    button.click();
 
     expect(authServiceMock.forgotPassword).toHaveBeenCalled();
   });

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -146,11 +146,7 @@
         [params]="{ title: savedTitle }"
         testId="success-banner"
       />
-      <yn-button
-        variant="ghost"
-        extraClass="import-another"
-        (click)="onImportAnother()"
-      >
+      <yn-button variant="ghost" extraClass="import-another" (click)="onImportAnother()">
         {{ t('dashboard.save.importAnother') }}
       </yn-button>
     </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -149,7 +149,7 @@
       <yn-button
         variant="ghost"
         extraClass="import-another"
-        (click)="onDiscardRecipe(); importSectionExpanded.set(true)"
+        (click)="onImportAnother()"
       >
         {{ t('dashboard.save.importAnother') }}
       </yn-button>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -279,6 +279,11 @@ export class DashboardComponent implements OnInit {
     this.saveSuccess.set(null);
   }
 
+  onImportAnother(): void {
+    this.onDiscardRecipe();
+    this.importSectionExpanded.set(true);
+  }
+
   private cancelNavigateAfterSave(): void {
     if (this.navigateAfterSaveTimer !== null) {
       clearTimeout(this.navigateAfterSaveTimer);

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
@@ -48,7 +48,7 @@ export class MealHistoryComponent {
   constructor() {
     this.runSearch('');
     this.term.valueChanges
-      .pipe(debounceTime(SEARCH_DEBOUNCE_MS), distinctUntilChanged(), takeUntilDestroyed())
+      .pipe(debounceTime(SEARCH_DEBOUNCE_MS), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.runSearch(value));
   }
 

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
@@ -48,7 +48,11 @@ export class MealHistoryComponent {
   constructor() {
     this.runSearch('');
     this.term.valueChanges
-      .pipe(debounceTime(SEARCH_DEBOUNCE_MS), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        debounceTime(SEARCH_DEBOUNCE_MS),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef),
+      )
       .subscribe((value) => this.runSearch(value));
   }
 

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -141,16 +141,14 @@
             <lucide-icon name="minus" [size]="20" />
           </div>
         } @else {
-          <div
+          <button
+            type="button"
             class="empty-slot"
-            tabindex="0"
-            role="button"
             [attr.aria-label]="t('mealPlanner.addMeal', { day: entry.day })"
             (click)="onSelectSlot(entry.day)"
-            (keydown.enter)="onSelectSlot(entry.day)"
           >
             <lucide-icon name="plus" [size]="24" />
-          </div>
+          </button>
         }
       </div>
     }

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.scss
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.scss
@@ -242,6 +242,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  background: none;
+  border: none;
+  font: inherit;
   color: var(--yn-text-placeholder);
   cursor: pointer;
   border-radius: var(--yn-radius-card);
@@ -249,6 +253,11 @@
 
   &:hover {
     background: var(--yn-glass-bg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--yn-primary);
+    outline-offset: 2px;
   }
 }
 

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -64,44 +64,46 @@
     >
       @for (item of group.items; track item.itemName + '|' + item.unit) {
         <div class="item-card" data-testid="shopping-item-card">
-          <button
-            type="button"
-            class="item-row"
+          <div
+            class="item-row-container"
             [class.bought]="item.isBought"
             [class.expanded]="isExpanded(item)"
-            (click)="onToggleExpanded(item)"
-            [attr.aria-expanded]="isExpanded(item)"
-            [attr.aria-label]="t('shopping.sources.toggle')"
-            data-testid="shopping-item-row"
           >
-            <span class="item-info">
-              <span class="item-quantity"
-                >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
-              >
-              <span class="item-name">{{ item.itemName }}</span>
-            </span>
-            <span class="item-actions">
-              <span class="source-count" [attr.aria-hidden]="true">{{
-                item.sources.length || 1
-              }}</span>
-              <lucide-icon
-                name="chevron-down"
-                [size]="16"
-                class="chevron"
-                [attr.aria-hidden]="true"
-              />
-              <span
-                class="remove-btn"
-                role="button"
-                tabindex="0"
-                (click)="$event.stopPropagation(); onRemoveItem(item.itemName)"
-                (keydown.enter)="$event.stopPropagation(); onRemoveItem(item.itemName)"
-                [attr.aria-label]="t('shopping.remove')"
-              >
-                <lucide-icon name="x" [size]="14" />
+            <button
+              type="button"
+              class="item-row"
+              (click)="onToggleExpanded(item)"
+              [attr.aria-expanded]="isExpanded(item)"
+              [attr.aria-label]="t('shopping.sources.toggle')"
+              data-testid="shopping-item-row"
+            >
+              <span class="item-info">
+                <span class="item-quantity"
+                  >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
+                >
+                <span class="item-name">{{ item.itemName }}</span>
               </span>
-            </span>
-          </button>
+              <span class="item-meta">
+                <span class="source-count" [attr.aria-hidden]="true">{{
+                  item.sources.length || 1
+                }}</span>
+                <lucide-icon
+                  name="chevron-down"
+                  [size]="16"
+                  class="chevron"
+                  [attr.aria-hidden]="true"
+                />
+              </span>
+            </button>
+            <button
+              type="button"
+              class="remove-btn"
+              (click)="onRemoveItem(item.itemName)"
+              [attr.aria-label]="t('shopping.remove')"
+            >
+              <lucide-icon name="x" [size]="14" />
+            </button>
+          </div>
           @if (isExpanded(item)) {
             <div class="sources-panel" data-testid="shopping-sources-panel">
               <div class="sources-header">{{ t('shopping.sources.header') }}</div>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.scss
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.scss
@@ -97,24 +97,13 @@
   margin-bottom: var(--yn-space-2);
 }
 
-.item-row {
+.item-row-container {
   @include glass.glass-surface(0);
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: stretch;
   width: 100%;
-  padding: var(--yn-space-3) var(--yn-space-4);
-  border: none;
   border-radius: var(--yn-radius-card);
-  text-align: left;
-  cursor: pointer;
-  color: var(--yn-text);
-  font: inherit;
-
-  &:focus-visible {
-    outline: 2px solid var(--yn-primary);
-    outline-offset: 2px;
-  }
+  overflow: hidden;
 
   &.bought {
     opacity: 0.5;
@@ -128,6 +117,25 @@
     .chevron {
       transform: rotate(180deg);
     }
+  }
+}
+
+.item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1 1 auto;
+  padding: var(--yn-space-3) var(--yn-space-4);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--yn-text);
+  font: inherit;
+
+  &:focus-visible {
+    outline: 2px solid var(--yn-primary);
+    outline-offset: -2px;
   }
 }
 
@@ -146,7 +154,7 @@
   color: var(--yn-text);
 }
 
-.item-actions {
+.item-meta {
   display: flex;
   align-items: center;
   gap: var(--yn-space-3);
@@ -168,6 +176,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
+  padding: 0 var(--yn-space-3);
   background: none;
   border: none;
   color: var(--yn-text-muted);
@@ -175,9 +185,14 @@
   opacity: 0;
   transition: opacity var(--yn-duration-fast);
 
-  .item-row:hover &,
-  .item-row:focus-within & {
+  .item-row-container:hover &,
+  .item-row-container:focus-within & {
     opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--yn-primary);
+    outline-offset: -2px;
   }
 }
 

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -410,13 +410,14 @@ describe('MergedListComponent', () => {
     });
 
     it('clicking the remove button does not toggle expansion', () => {
-      const rows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-item-row"]');
-      const removeButton = rows[0].querySelector('.remove-btn');
+      const containers = fixture.nativeElement.querySelectorAll('.item-row-container');
+      const row = containers[0].querySelector('[data-testid="shopping-item-row"]');
+      const removeButton = containers[0].querySelector('.remove-btn');
       removeButton.click();
       fixture.detectChanges();
 
       // Row stays collapsed; only the remove API call should fire.
-      expect(rows[0].getAttribute('aria-expanded')).toBe('false');
+      expect(row.getAttribute('aria-expanded')).toBe('false');
       expect(apiMock.removeItem).toHaveBeenCalledWith({ name: 'Milk' });
     });
   });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -81,7 +81,10 @@
 
       @if (lastActions().length > 0) {
         <div class="chat-actions" data-testid="chat-actions">
-          @for (action of lastActions(); track action.type + ':' + (action.route ?? action.recipeIdentifier ?? '')) {
+          @for (
+            action of lastActions();
+            track action.type + ':' + (action.route ?? action.recipeIdentifier ?? '')
+          ) {
             <button
               type="button"
               class="chat-action"

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -44,7 +44,7 @@
         </div>
       }
 
-      @for (msg of state.messages(); track $index) {
+      @for (msg of state.messages(); track msg.role + ':' + msg.content) {
         <div class="chat-message" [class]="'role-' + msg.role">
           <div class="chat-bubble">{{ msg.content }}</div>
         </div>
@@ -81,7 +81,7 @@
 
       @if (lastActions().length > 0) {
         <div class="chat-actions" data-testid="chat-actions">
-          @for (action of lastActions(); track $index) {
+          @for (action of lastActions(); track action.type + ':' + (action.route ?? action.recipeIdentifier ?? '')) {
             <button
               type="button"
               class="chat-action"


### PR DESCRIPTION
## Summary

Five small frontend cleanups from the refactoring sweep. 12 files changed, +106/-77.

| # | Concern | Files |
| --- | --- | --- |
| 1 | \`@for ... track \$index\` → composite stable keys | \`chat-panel.component.html\` (2 loops) |
| 2 | \`role=\"button\"\` on non-button elements → real \`<button>\` | \`login\`, \`meal-planner\`, \`merged-list\` |
| 3 | Multi-statement inline event handlers → extracted methods | \`dashboard\`, \`merged-list\` |
| 4 | Explicit \`takeUntilDestroyed(this.destroyRef)\` | \`meal-history.component.ts:51\` |

### Notable: \`merged-list\` row restructure

The shopping list row had a remove \`<span role=\"button\">\` **nested inside the row's \`<button>\`** — invalid HTML. Restructured into:

\`\`\`
<div class=\"item-row-container\">       <!-- hover/focus parent -->
  <button class=\"item-row\">...</button>  <!-- toggle -->
  <button class=\"remove-btn\">...</button> <!-- remove -->
</div>
\`\`\`

The hover-to-reveal interaction moves from \`.item-row:hover\` to \`.item-row-container:hover\`, and the previously needed \`\$event.stopPropagation()\` on the remove handler is gone — bubbling is naturally separate now.

### Deliberately not fixed

The frontend scan also flagged \`user-preferences.service.refresh()\` as an \"unmanaged subscription\" (potential leak). It's a false positive — HttpClient observables auto-complete after one emission, and the service is \`providedIn: 'root'\` with no \`DestroyRef\` available anyway. Documented in the commit message.

## Test plan

- [x] \`yarn nx run-many --target=lint\` — clean (3 pre-existing test-file warnings unrelated)
- [x] \`yarn nx run-many --target=test --projects=shell,shopping,ui,shared-models\` — 264 + 63 tests pass
- [x] \`yarn nx run-many --target=build --projects=shell,shopping\` — green
- [ ] CI: full E2E (the merged-list restructure changes the row's DOM shape — E2E specs that select \`.remove-btn\` will exercise it)