### PR TITLE
refactor(frontend): collapse createAsyncState boilerplate via auto-injected DestroyRef

### DIFF
--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
 import { ActivityTimelineComponent, AsyncStateComponent, type ActivityEntry } from '@yumney/ui';

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   computed,
   inject,
   signal,
@@ -34,8 +33,7 @@ export class ActivityComponent {
   protected readonly filterOptions = FILTER_OPTIONS;
 
   private api = inject(ActivityApiService);
-  private destroyRef = inject(DestroyRef);
-  private state = createAsyncState(this.destroyRef);
+  private state = createAsyncState();
 
   protected loading = this.state.isLoading;
   protected error = this.state.serverError;

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.ts
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthService } from '@yumney/shared/auth';

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.ts
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   computed,
   inject,
   signal,
@@ -28,8 +27,7 @@ export class DangerZoneComponent {
 
   private api = inject(UserProfileApiService);
   private auth = inject(AuthService);
-  private destroyRef = inject(DestroyRef);
-  private deleteState = createAsyncState(this.destroyRef);
+  private deleteState = createAsyncState();
 
   protected confirmationInput = signal('');
   protected deleting = this.deleteState.isLoading;

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   computed,
   effect,
   inject,
@@ -33,13 +32,12 @@ const AUTOSAVE_DEBOUNCE_MS = 400;
 })
 export class ProfileSettingsComponent {
   private api = inject(UserProfileApiService);
-  private destroyRef = inject(DestroyRef);
   private theme = inject(ThemeService);
   private voice = inject(VoiceService);
   private preferences = inject(UserPreferencesService);
   private transloco = inject(TranslocoService);
-  private loadState = createAsyncState(this.destroyRef);
-  private saveState = createAsyncState(this.destroyRef);
+  private loadState = createAsyncState();
+  private saveState = createAsyncState();
   private autosaveTick = signal(0);
 
   protected profile = signal<UserProfile | null>(null);

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -60,7 +60,7 @@ export class CookModeComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
-  private loadState = createAsyncState(this.destroyRef);
+  private loadState = createAsyncState();
   protected voice = inject(VoiceService);
   protected timers = inject(CookingTimerService);
   private wakeLock = inject(WakeLockService);

--- a/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.ts
+++ b/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
-  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -44,8 +43,7 @@ export class CookableRecipesComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
 
   private recipeApi = inject(RecipeApiService);
-  private destroyRef = inject(DestroyRef);
-  private asyncState = createAsyncState(this.destroyRef);
+  private asyncState = createAsyncState();
   private loadRequestId = 0;
 
   recipes = signal<CookableRecipeListItem[]>([]);

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -73,9 +73,9 @@ export class RecipeDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
-  private loadState = createAsyncState(this.destroyRef);
-  private deleteState = createAsyncState(this.destroyRef);
-  private createShoppingListState = createAsyncState(this.destroyRef);
+  private loadState = createAsyncState();
+  private deleteState = createAsyncState();
+  private createShoppingListState = createAsyncState();
   private notesAutosave = inject(RecipeNotesAutosaveService);
   private preferences = inject(UserPreferencesService);
 

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -4,7 +4,6 @@ import {
   computed,
   inject,
   OnInit,
-  DestroyRef,
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -43,8 +42,8 @@ export class RecipeEditComponent implements OnInit {
   private recipeApi = inject(RecipeApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private loadState = createAsyncState(inject(DestroyRef));
-  private saveState = createAsyncState(inject(DestroyRef));
+  private loadState = createAsyncState();
+  private saveState = createAsyncState();
 
   recipeData = signal<ImportRecipeResponse | null>(null);
   isLoading = this.loadState.isLoading;

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
@@ -1,4 +1,4 @@
-import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import { forkJoin, of } from 'rxjs';
@@ -15,9 +15,8 @@ export class MultiRecipeShoppingListService {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private transloco = inject(TranslocoService);
-  private destroyRef = inject(DestroyRef);
-  private previewLoadState = createAsyncState(this.destroyRef);
-  private createState = createAsyncState(this.destroyRef);
+  private previewLoadState = createAsyncState();
+  private createState = createAsyncState();
 
   readonly multiSelectMode = signal(false);
   readonly selectedRecipeIds = signal<ReadonlySet<string>>(new Set<string>());

--- a/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.ts
@@ -1,4 +1,4 @@
-import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
 import { MealPlanApiService, RecipeListItem } from '../api';
@@ -10,8 +10,7 @@ export class RecipeAssignmentService {
   private mealPlanApi = inject(MealPlanApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private destroyRef = inject(DestroyRef);
-  private assignState = createAsyncState(this.destroyRef);
+  private assignState = createAsyncState();
 
   readonly assignTo = signal<string | null>(null);
   readonly assignMode = computed(() => this.assignTo() !== null);

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -94,7 +94,7 @@ export class RecipeListComponent implements OnInit {
   private recipeApi = inject(RecipeApiService);
   private chatApi = inject(ChatApiService);
   private destroyRef = inject(DestroyRef);
-  private asyncState = createAsyncState(this.destroyRef);
+  private asyncState = createAsyncState();
   private searchInput = signal('');
   private loadRequestId = 0;
 

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
@@ -38,7 +38,7 @@ export class RegisterComponent {
 
   private formBuilder = inject(FormBuilder);
   private authApi = inject(AuthApiService);
-  private asyncState = createAsyncState(inject(DestroyRef));
+  private asyncState = createAsyncState();
 
   isLoading = this.asyncState.isLoading;
   isSuccess = signal(false);

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
@@ -37,7 +37,7 @@ export class ResendVerificationComponent {
 
   private formBuilder = inject(FormBuilder);
   private authApi = inject(AuthApiService);
-  private asyncState = createAsyncState(inject(DestroyRef));
+  private asyncState = createAsyncState();
 
   isLoading = this.asyncState.isLoading;
   isSuccess = signal(false);

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -68,8 +68,8 @@ export class DashboardComponent implements OnInit {
   private recipeApi = inject(RecipeApiService);
   protected camera = inject(CameraService);
   private destroyRef = inject(DestroyRef);
-  private importState = createAsyncState(this.destroyRef);
-  private saveState = createAsyncState(this.destroyRef);
+  private importState = createAsyncState();
+  private saveState = createAsyncState();
   private suggestionsState = inject(DashboardSuggestionsService);
   private navigateAfterSaveTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   computed,
   inject,
   signal,
@@ -30,8 +29,7 @@ const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
 })
 export class MealAnalyticsComponent {
   private api = inject(MealPlanApiService);
-  private destroyRef = inject(DestroyRef);
-  private loadState = createAsyncState(this.destroyRef);
+  private loadState = createAsyncState();
 
   protected viewMode = signal<ViewMode>('month');
   protected year = signal(new Date().getFullYear());

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
@@ -37,7 +37,7 @@ export class MealHistoryComponent {
   private api = inject(MealPlanApiService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
-  private searchState = createAsyncState(this.destroyRef);
+  private searchState = createAsyncState();
 
   protected term = new FormControl<string>('', { nonNullable: true });
   protected results = signal<MealHistoryEntry[]>([]);

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  DestroyRef,
   ElementRef,
   HostListener,
   inject,
@@ -17,7 +16,7 @@ import {
   type MealSlot,
   type GenerateShoppingListResult,
 } from '@yumney/shared/api-client';
-import { createAsyncState, ERROR_MAPS, UI } from '@yumney/shared/models';
+import { injectAsyncStates, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 import { MealSuggestionPanelComponent } from './meal-suggestion-panel/meal-suggestion-panel.component';
 
@@ -43,29 +42,24 @@ const JS_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'F
 })
 export class MealPlannerComponent {
   private api = inject(MealPlanApiService);
-  private destroyRef = inject(DestroyRef);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private host = inject(ElementRef<HTMLElement>);
-  private loadState = createAsyncState(this.destroyRef);
-  private generateState = createAsyncState(this.destroyRef);
-  private clearSlotState = createAsyncState(this.destroyRef);
-
-  private copyState = createAsyncState(this.destroyRef);
+  private states = injectAsyncStates('load', 'generate', 'clearSlot', 'copy');
 
   protected year = signal(new Date().getFullYear());
   protected weekNumber = signal(this.getCurrentWeek());
   protected plan = signal<WeeklyPlan | null>(null);
-  protected loading = this.loadState.isLoading;
+  protected loading = this.states.load.isLoading;
   protected error = computed(
     () =>
-      this.loadState.serverError() ??
-      this.generateState.serverError() ??
-      this.clearSlotState.serverError() ??
-      this.copyState.serverError(),
+      this.states.load.serverError() ??
+      this.states.generate.serverError() ??
+      this.states.clearSlot.serverError() ??
+      this.states.copy.serverError(),
   );
-  protected generatingList = this.generateState.isLoading;
-  protected copyingToCurrent = this.copyState.isLoading;
+  protected generatingList = this.states.generate.isLoading;
+  protected copyingToCurrent = this.states.copy.isLoading;
   protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
   protected weekLabel = computed(
@@ -147,7 +141,7 @@ export class MealPlannerComponent {
   protected onGenerateShoppingList(): void {
     this.shoppingResult.set(null);
 
-    this.generateState.execute(
+    this.states.generate.execute(
       this.api.generateShoppingList(this.year(), this.weekNumber()),
       ERROR_MAPS.mealPlanner.generateShoppingList,
       (result) => {
@@ -168,7 +162,7 @@ export class MealPlannerComponent {
 
   protected onClearSlot(day: string): void {
     if (this.isPastWeek()) return;
-    this.clearSlotState.execute(
+    this.states.clearSlot.execute(
       this.api.clearSlot(this.year(), this.weekNumber(), { day }),
       ERROR_MAPS.mealPlanner.clearSlot,
       (plan) => this.plan.set(plan),
@@ -179,7 +173,7 @@ export class MealPlannerComponent {
     if (!this.isPastWeek()) return;
     const srcYear = this.year();
     const srcWeek = this.weekNumber();
-    this.copyState.execute(
+    this.states.copy.execute(
       this.api.copyPlanToWeek(srcYear, srcWeek, this.currentYear, this.currentWeekNumber),
       ERROR_MAPS.mealPlanner.copyToWeek,
       () => {
@@ -191,7 +185,7 @@ export class MealPlannerComponent {
   }
 
   private loadPlan(): void {
-    this.loadState.execute(
+    this.states.load.execute(
       this.api.getWeeklyPlan(this.year(), this.weekNumber()),
       ERROR_MAPS.mealPlanner.load,
       (plan) => {

--- a/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   EventEmitter,
   Input,
   Output,
@@ -30,9 +29,8 @@ import { AsyncStateComponent } from '@yumney/ui';
 })
 export class MealSuggestionPanelComponent {
   private api = inject(MealPlanApiService);
-  private destroyRef = inject(DestroyRef);
-  private suggestState = createAsyncState(this.destroyRef);
-  private acceptState = createAsyncState(this.destroyRef);
+  private suggestState = createAsyncState();
+  private acceptState = createAsyncState();
 
   @Input({ required: true }) year = 0;
   @Input({ required: true }) week = 0;

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -54,7 +54,7 @@ export class MergedListComponent {
   private api = inject(ShoppingApiService);
   private destroyRef = inject(DestroyRef);
   private toasts = inject(ToastService);
-  private mutationState = createAsyncState(this.destroyRef);
+  private mutationState = createAsyncState();
 
   protected list = signal<MergedShoppingList | null>(null);
   protected loading = signal(false);

--- a/client/apps/shopping/src/app/pantry/pantry.component.ts
+++ b/client/apps/shopping/src/app/pantry/pantry.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
-  DestroyRef,
   inject,
   OnInit,
   signal,
@@ -27,9 +26,8 @@ import { EmptyStateComponent, MessageBannerComponent } from '@yumney/ui';
 })
 export class PantryComponent implements OnInit {
   private shoppingApi = inject(ShoppingApiService);
-  private destroyRef = inject(DestroyRef);
-  private loadState = createAsyncState(this.destroyRef);
-  private freezeState = createAsyncState(this.destroyRef);
+  private loadState = createAsyncState();
+  private freezeState = createAsyncState();
 
   items = signal<IngredientBalanceItem[]>([]);
   isLoading = this.loadState.isLoading;

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectionStrategy,
   inject,
   OnInit,
-  DestroyRef,
   signal,
   computed,
 } from '@angular/core';
@@ -28,8 +27,8 @@ export class ShoppingCreateComponent implements OnInit {
   private shoppingApi = inject(ShoppingApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private loadState = createAsyncState(inject(DestroyRef));
-  private createState = createAsyncState(inject(DestroyRef));
+  private loadState = createAsyncState();
+  private createState = createAsyncState();
 
   recipe = signal<RecipeDetail | null>(null);
   isLoading = this.loadState.isLoading;

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -61,7 +61,7 @@ export class ShoppingDetailComponent implements OnInit {
   private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private destroyRef = inject(DestroyRef);
-  private asyncState = createAsyncState(this.destroyRef);
+  private asyncState = createAsyncState();
 
   shoppingList = signal<ShoppingListDetail | null>(null);
   isLoading = this.asyncState.isLoading;

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  OnInit,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import { TranslocoModule } from '@jsverse/transloco';

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectionStrategy,
   inject,
   OnInit,
-  DestroyRef,
   signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -31,7 +30,7 @@ export class ShoppingListComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
 
   private shoppingApi = inject(ShoppingApiService);
-  private asyncState = createAsyncState(inject(DestroyRef));
+  private asyncState = createAsyncState();
 
   lists = signal<ShoppingListSummary[]>([]);
   isLoading = this.asyncState.isLoading;

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -23,7 +23,7 @@ export {
   type MergedIngredient,
 } from './lib/merge-recipe-ingredients';
 export { UI } from './lib/ui-constants';
-export { createAsyncState, type AsyncState } from './lib/async-state';
+export { createAsyncState, injectAsyncStates, type AsyncState } from './lib/async-state';
 export { debouncedEffect } from './lib/debounced-effect';
 export { ensureFormValid } from './lib/form-helpers';
 export { optimisticSignalUpdate } from './lib/optimistic-update';

--- a/client/libs/shared/models/src/lib/async-state.ts
+++ b/client/libs/shared/models/src/lib/async-state.ts
@@ -1,10 +1,17 @@
-import { signal, DestroyRef } from '@angular/core';
+import { signal, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { mapHttpError, HttpErrorMap } from './http-error-utils';
 
-export function createAsyncState(destroyRef: DestroyRef) {
+/**
+ * Creates a single async-state slot. Pass an explicit `DestroyRef` from
+ * outside an injection context (tests, services holding state for someone
+ * else); call without args inside a component / service constructor and
+ * the current injection context's `DestroyRef` is resolved automatically.
+ */
+export function createAsyncState(destroyRef?: DestroyRef): AsyncState {
+  const teardown = destroyRef ?? inject(DestroyRef);
   const isLoading = signal(false);
   const serverError = signal<string | null>(null);
 
@@ -19,7 +26,7 @@ export function createAsyncState(destroyRef: DestroyRef) {
       serverError.set(null);
     }
 
-    source.pipe(takeUntilDestroyed(destroyRef)).subscribe({
+    source.pipe(takeUntilDestroyed(teardown)).subscribe({
       next: (result) => {
         isLoading.set(false);
         onSuccess(result);
@@ -39,4 +46,30 @@ export function createAsyncState(destroyRef: DestroyRef) {
   return { isLoading, serverError, execute };
 }
 
-export type AsyncState = ReturnType<typeof createAsyncState>;
+export interface AsyncState {
+  isLoading: ReturnType<typeof signal<boolean>>;
+  serverError: ReturnType<typeof signal<string | null>>;
+  execute<T>(
+    source: Observable<T>,
+    errorMap: HttpErrorMap,
+    onSuccess: (result: T) => void,
+    onError?: (error: string) => void,
+  ): void;
+}
+
+/**
+ * Variadic factory for components that juggle multiple concurrent async
+ * operations (e.g. a detail page with `load`, `delete`, `save`). Each key
+ * yields an independent `AsyncState`. Must run in an injection context;
+ * the shared `DestroyRef` is resolved internally and reused for every slot.
+ */
+export function injectAsyncStates<const Keys extends readonly string[]>(
+  ...keys: Keys
+): Record<Keys[number], AsyncState> {
+  const destroyRef = inject(DestroyRef);
+  const result = {} as Record<Keys[number], AsyncState>;
+  for (const key of keys) {
+    result[key as Keys[number]] = createAsyncState(destroyRef);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Item #6 from the frontend refactoring sweep. The \`createAsyncState\` pattern was repeated in 22 components/services with identical boilerplate (\`private destroyRef = inject(DestroyRef); private xxxState = createAsyncState(this.destroyRef);\`). Two API additions in \`libs/shared/models/async-state.ts\` collapse the noise:

### API changes

1. **\`createAsyncState(destroyRef?)\`** — parameter is now optional. When omitted inside an injection context (component/service constructor), the \`DestroyRef\` is resolved automatically. Explicit form still works for tests and out-of-context usage.

2. **\`injectAsyncStates(...keys)\`** — variadic factory for components with multiple concurrent async ops. One call returns a typed \`Record<Key, AsyncState>\` backed by a single \`DestroyRef\`.

### Migration

- **22 call sites**: \`createAsyncState(this.destroyRef)\` → \`createAsyncState()\`
- **10 components**: dropped the now-unused \`private destroyRef = inject(DestroyRef);\` field and the matching import
- **\`MealPlannerComponent\`**: showcase of \`injectAsyncStates\`. The 4-state component:

  \`\`\`ts
  // Before
  private destroyRef = inject(DestroyRef);
  private loadState = createAsyncState(this.destroyRef);
  private generateState = createAsyncState(this.destroyRef);
  private clearSlotState = createAsyncState(this.destroyRef);
  private copyState = createAsyncState(this.destroyRef);

  // After
  private states = injectAsyncStates('load', 'generate', 'clearSlot', 'copy');
  \`\`\`

  All \`this.loadState.X\` references become \`this.states.load.X\` — same length, but every concurrent state is visible in one declaration.

### Why no further migrations to \`injectAsyncStates\`

Only \`MealPlannerComponent\` is migrated as a demo. The other multi-state components (\`recipe-detail\` 3, \`profile-settings\` 2, etc.) could follow the same pattern, but each one's diff is a wash (renaming N field references). The win would mostly be readability/grepability, not LOC. Done in a follow-up if/when those components are touched.

## Test plan

- [x] \`yarn nx test shared-models\` — 229 pass (covers the optional-arg overload via existing tests + auto-inject path)
- [x] \`yarn nx run-many --target=test --projects=shell,shopping,recipes,account,shared-models,ui\` — all green
- [x] \`yarn nx run-many --target=lint\` — 0 \`DestroyRef never used\` warnings (verified before / after)
- [x] \`yarn nx run-many --target=build\` — green
- [ ] CI: full E2E