### PR TITLE
refactor(shopping): extract SemanticKernel categorizer into Yumney.Shopping.Extraction

### DIFF
--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -44,6 +44,7 @@
   <Folder Name="/src/Shopping/">
     <Project Path="src/Yumney.Shopping.Domain/Yumney.Shopping.Domain.csproj" />
     <Project Path="src/Yumney.Shopping.Application/Yumney.Shopping.Application.csproj" />
+    <Project Path="src/Yumney.Shopping.Extraction/Yumney.Shopping.Extraction.csproj" />
     <Project Path="src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj" />
     <Project Path="src/Yumney.Shopping.Api/Yumney.Shopping.Api.csproj" />
     <Project Path="src/Yumney.Shopping.Client/Yumney.Shopping.Client.csproj" />

--- a/src/Yumney.Shopping.Api/Program.cs
+++ b/src/Yumney.Shopping.Api/Program.cs
@@ -2,6 +2,7 @@ using SmartSolutionsLab.Yumney.Shared.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Modules;
 using SmartSolutionsLab.Yumney.Shopping.Api;
 using SmartSolutionsLab.Yumney.Shopping.Application;
+using SmartSolutionsLab.Yumney.Shopping.Extraction;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +12,7 @@ IModule[] modules =
 	new ShoppingApiModule(),
 	new ShoppingApplicationModule(),
 	new ShoppingInfrastructureModule(),
+	new ShoppingExtractionModule(),
 ];
 builder.RegisterServices(modules);
 

--- a/src/Yumney.Shopping.Api/Yumney.Shopping.Api.csproj
+++ b/src/Yumney.Shopping.Api/Yumney.Shopping.Api.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\Yumney.Shared.Hosting\Yumney.Shared.Hosting.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Web\Yumney.Shared.Web.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
+    <ProjectReference Include="..\Yumney.Shopping.Extraction\Yumney.Shopping.Extraction.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Infrastructure\Yumney.Shopping.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/src/Yumney.Shopping.Extraction/Services/SemanticKernelOptions.cs
+++ b/src/Yumney.Shopping.Extraction/Services/SemanticKernelOptions.cs
@@ -1,4 +1,4 @@
-namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+namespace SmartSolutionsLab.Yumney.Shopping.Extraction.Services;
 
 public sealed class SemanticKernelOptions
 {

--- a/src/Yumney.Shopping.Extraction/Services/SemanticKernelShoppingItemCategorizer.cs
+++ b/src/Yumney.Shopping.Extraction/Services/SemanticKernelShoppingItemCategorizer.cs
@@ -5,12 +5,10 @@ using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+namespace SmartSolutionsLab.Yumney.Shopping.Extraction.Services;
 
 #pragma warning disable SA1601
-public sealed partial class SemanticKernelShoppingItemCategorizer(
-	Kernel kernel,
-	ILogger<SemanticKernelShoppingItemCategorizer> logger)
+public sealed partial class SemanticKernelShoppingItemCategorizer(Kernel kernel, ILogger<SemanticKernelShoppingItemCategorizer> logger)
 	: IShoppingItemCategorizer
 {
 #pragma warning disable SA1303

--- a/src/Yumney.Shopping.Extraction/Services/StubShoppingItemCategorizer.cs
+++ b/src/Yumney.Shopping.Extraction/Services/StubShoppingItemCategorizer.cs
@@ -2,7 +2,7 @@ using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
-namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
+namespace SmartSolutionsLab.Yumney.Shopping.Extraction.Services;
 
 /// <summary>
 /// Deterministic categorizer for E2E tests — relies entirely on the static

--- a/src/Yumney.Shopping.Extraction/ShoppingExtractionModule.cs
+++ b/src/Yumney.Shopping.Extraction/ShoppingExtractionModule.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Hosting;
+using SmartSolutionsLab.Yumney.Shared.Modules;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Extraction;
+
+public sealed class ShoppingExtractionModule : IModule
+{
+	public IHostApplicationBuilder RegisterServices(IHostApplicationBuilder builder)
+	{
+		builder.Services.AddShoppingExtraction(builder.Configuration);
+		return builder;
+	}
+}

--- a/src/Yumney.Shopping.Extraction/ShoppingExtractionServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Extraction/ShoppingExtractionServiceCollectionExtensions.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Extraction.Services;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Extraction;
+
+public static class ShoppingExtractionServiceCollectionExtensions
+{
+	public static IServiceCollection AddShoppingExtraction(this IServiceCollection services, IConfiguration configuration)
+	{
+		if (configuration.GetValue<bool>("E2ETests"))
+		{
+			services.AddSingleton<IShoppingItemCategorizer, StubShoppingItemCategorizer>();
+			return services;
+		}
+
+		services.AddScoped<IShoppingItemCategorizer, SemanticKernelShoppingItemCategorizer>();
+
+		var skOptions = configuration.GetSection(SemanticKernelOptions.SectionName).Get<SemanticKernelOptions>()
+			?? new SemanticKernelOptions();
+		var (provider, modelId, endpoint, apiKey) = skOptions;
+
+		var kernelBuilder = services.AddKernel();
+		switch (provider)
+		{
+			case SemanticKernelOptions.ProviderAzureOpenAI:
+				kernelBuilder.AddAzureOpenAIChatCompletion(modelId, endpoint, apiKey);
+				break;
+			case SemanticKernelOptions.ProviderOllama:
+				var ollama = endpoint.HasValue() ? endpoint : configuration.GetConnectionString("ollama");
+				if (ollama is not null)
+				{
+					kernelBuilder.AddOpenAIChatCompletion(modelId, new Uri(ollama), apiKey: null);
+				}
+
+				break;
+			default:
+				if (apiKey.HasValue())
+				{
+					kernelBuilder.AddOpenAIChatCompletion(modelId, apiKey);
+				}
+
+				break;
+		}
+
+		return services;
+	}
+}

--- a/src/Yumney.Shopping.Extraction/Yumney.Shopping.Extraction.csproj
+++ b/src/Yumney.Shopping.Extraction/Yumney.Shopping.Extraction.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.SemanticKernel;
 using SmartSolutionsLab.Yumney.Recipes.Client;
-using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
@@ -13,7 +11,6 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
-using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Services;
 using SmartSolutionsLab.Yumney.Users.Client;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure;
@@ -48,46 +45,6 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddScoped<IShoppingUserDataPurger, ShoppingUserDataPurger>();
 		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
 
-		AddShoppingItemCategorizer(services, configuration);
-
 		return services;
-	}
-
-	private static void AddShoppingItemCategorizer(IServiceCollection services, IConfiguration configuration)
-	{
-		if (configuration.GetValue<bool>("E2ETests"))
-		{
-			services.AddSingleton<IShoppingItemCategorizer, StubShoppingItemCategorizer>();
-			return;
-		}
-
-		services.AddScoped<IShoppingItemCategorizer, SemanticKernelShoppingItemCategorizer>();
-
-		var skOptions = configuration.GetSection(SemanticKernelOptions.SectionName).Get<SemanticKernelOptions>()
-			?? new SemanticKernelOptions();
-		var (provider, modelId, endpoint, apiKey) = skOptions;
-
-		var kernelBuilder = services.AddKernel();
-		switch (provider)
-		{
-			case SemanticKernelOptions.ProviderAzureOpenAI:
-				kernelBuilder.AddAzureOpenAIChatCompletion(modelId, endpoint, apiKey);
-				break;
-			case SemanticKernelOptions.ProviderOllama:
-				var ollama = endpoint.HasValue() ? endpoint : configuration.GetConnectionString("ollama");
-				if (ollama is not null)
-				{
-					kernelBuilder.AddOpenAIChatCompletion(modelId, new Uri(ollama), apiKey: null);
-				}
-
-				break;
-			default:
-				if (apiKey.HasValue())
-				{
-					kernelBuilder.AddOpenAIChatCompletion(modelId, apiKey);
-				}
-
-				break;
-		}
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
+++ b/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.SemanticKernel" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 

--- a/tests/Yumney.Architecture.Tests/ExternalDependencyIsolationTests.cs
+++ b/tests/Yumney.Architecture.Tests/ExternalDependencyIsolationTests.cs
@@ -11,6 +11,10 @@ public class ExternalDependencyIsolationTests
 	[InlineData("Yumney.Recipes.Domain")]
 	[InlineData("Yumney.Recipes.Application")]
 	[InlineData("Yumney.Recipes.Api")]
+	[InlineData("Yumney.Shopping.Domain")]
+	[InlineData("Yumney.Shopping.Application")]
+	[InlineData("Yumney.Shopping.Infrastructure")]
+	[InlineData("Yumney.Shopping.Api")]
 	public void Layer_ShouldNotDependOn_SemanticKernel(string assemblyName)
 	{
 		var assembly = Assembly.Load(assemblyName);
@@ -22,7 +26,8 @@ public class ExternalDependencyIsolationTests
 
 		result.IsSuccessful.Should().BeTrue(
 			$"{assemblyName} must route LLM calls through abstractions in Application; " +
-			"Semantic Kernel lives in Yumney.Recipes.Extraction only.");
+			"Semantic Kernel lives in the per-module *.Extraction project only " +
+			"(Yumney.Recipes.Extraction, Yumney.Shopping.Extraction).");
 	}
 
 	[Theory]


### PR DESCRIPTION
## Summary

Mirrors the existing \`Yumney.Recipes.Extraction\` and \`Yumney.MealPlan.Extraction\` projects: each module's Semantic Kernel + LLM wiring lives in its own \`*.Extraction\` project so \`Yumney.Shopping.Infrastructure\` stays focused on EF persistence + read-model projections.

### What moved out of \`Yumney.Shopping.Infrastructure\`

| File | New home |
| --- | --- |
| \`Services/SemanticKernelShoppingItemCategorizer.cs\` | \`Yumney.Shopping.Extraction/Services/\` |
| \`Services/SemanticKernelOptions.cs\` | \`Yumney.Shopping.Extraction/Services/\` |
| \`Services/StubShoppingItemCategorizer.cs\` (E2E fallback for the same interface) | \`Yumney.Shopping.Extraction/Services/\` |
| \`AddShoppingItemCategorizer()\` helper inside \`ShoppingInfrastructureServiceCollectionExtensions\` | now \`AddShoppingExtraction()\` in \`ShoppingExtractionServiceCollectionExtensions\` |

### New project

\`src/Yumney.Shopping.Extraction/\` — same shape as \`Yumney.Recipes.Extraction\`:
- References only \`Yumney.Shopping.Application\`
- Packages: \`Microsoft.SemanticKernel\`, \`Microsoft.Extensions.Configuration.Binder\`
- \`ShoppingExtractionModule\` (\`IModule\`) registered in \`Yumney.Shopping.Api/Program.cs\` alongside the existing \`ShoppingInfrastructureModule\`

### Other changes

- \`Microsoft.SemanticKernel\` package reference dropped from \`Yumney.Shopping.Infrastructure.csproj\`
- \`Yumney.slnx\` adds the new project under \`/src/Shopping/\`
- \`ExternalDependencyIsolationTests\` now also asserts that \`Shopping.Domain\`, \`Shopping.Application\`, \`Shopping.Infrastructure\`, and \`Shopping.Api\` have no dependency on \`Microsoft.SemanticKernel\` — guards against future drift

## Behaviour

Pure organizational refactor. \`IShoppingItemCategorizer\` contract and DI lifecycle (Singleton in E2E mode, Scoped in production) are identical. The static-first → SK-fallback chain in \`SemanticKernelShoppingItemCategorizer.CategorizeAsync\` is unchanged.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.Architecture.Tests\` — 146 pass (142 + 4 new \`Shopping\` theory cases)
- [x] \`Yumney.Shopping.Application.Tests\` — 147 pass
- [x] \`Yumney.Shopping.Infrastructure.Tests\` — 28 pass
- [x] \`Yumney.Shopping.Api.Tests\` — 29 pass
- [ ] CI: full backend + integration + E2E