### PR TITLE
chore(infra): raise max line length to 140 (backend + frontend)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 
 [*.cs]
 indent_style = tab
-max_line_length = 120
+max_line_length = 140
 
 # StyleCop suppressions
 dotnet_diagnostic.SA0001.severity = none
@@ -78,7 +78,7 @@ generated_code = true
 
 [*.{ts,tsx,js,jsx}]
 indent_size = 2
-max_line_length = 100
+max_line_length = 140
 
 [*.{json,yml,yaml}]
 indent_size = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ namespace `SmartSolutionsLab.Yumney.{Module}.Api`.
 ### Backend
 - `.editorconfig` + `dotnet format` + StyleCop.Analyzers
 - File-scoped namespaces
-- Max 120 chars per line
+- Max 140 chars per line
 
 #### Braces – ALWAYS required, except short guard clauses
 
@@ -565,7 +565,7 @@ var slot = FindSlot(day, mealType);
 - ESLint + @angular-eslint + Prettier
 - Single quotes, trailing commas, 2-space indent
 - Component prefix: `yn-`
-- Max 100 chars per line
+- Max 140 chars per line
 
 ### Limits (both)
 

--- a/Yumney.sln.DotSettings
+++ b/Yumney.sln.DotSettings
@@ -1,2 +1,8 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ConvertIfStatementToSwitchStatement/AssumeOpenTypeHierarchy/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ConvertIfStatementToSwitchStatement/AssumeOpenTypeHierarchy/@EntryValue">True</s:Boolean>
+	<!-- Right-margin / soft-wrap column for the ReSharper / Rider formatter. Aligned with `.editorconfig` max_line_length = 140. -->
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/RIGHT_MARGIN/@EntryValue">140</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/WRAP_LIMIT/@EntryValue">140</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/TypeScriptCodeStyle/WRAP_LIMIT/@EntryValue">140</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/HtmlCodeStyle/WRAP_LIMIT/@EntryValue">140</s:Int64>
+</wpf:ResourceDictionary>

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -2,5 +2,5 @@
   "singleQuote": true,
   "trailingComma": "all",
   "tabWidth": 2,
-  "printWidth": 100
+  "printWidth": 140
 }

--- a/client/apps/account/src/app/activity/activity.component.ts
+++ b/client/apps/account/src/app/activity/activity.component.ts
@@ -64,8 +64,7 @@ export class ActivityComponent {
     if (cursor === null) return;
 
     const type = this.activeFilter();
-    const options =
-      type === 'all' ? { limit: PAGE_SIZE, cursor } : { limit: PAGE_SIZE, type, cursor };
+    const options = type === 'all' ? { limit: PAGE_SIZE, cursor } : { limit: PAGE_SIZE, type, cursor };
 
     this.state.execute(this.api.getActivity(options), ERROR_MAPS.account.load, (page) => {
       this.entries.update((current) => [...current, ...page.items]);

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.html
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.html
@@ -35,13 +35,7 @@
       (retry)="onDelete()"
     />
 
-    <button
-      type="button"
-      class="danger-zone__btn"
-      [disabled]="!canDelete()"
-      (click)="onDelete()"
-      data-testid="delete-account-btn"
-    >
+    <button type="button" class="danger-zone__btn" [disabled]="!canDelete()" (click)="onDelete()" data-testid="delete-account-btn">
       {{ deleting() ? t('account.danger.deleting') : t('account.danger.deleteAccount') }}
     </button>
   </div>

--- a/client/apps/account/src/app/danger-zone/danger-zone.component.ts
+++ b/client/apps/account/src/app/danger-zone/danger-zone.component.ts
@@ -27,9 +27,7 @@ export class DangerZoneComponent {
   protected deleting = this.deleteState.isLoading;
   protected error = this.deleteState.serverError;
 
-  protected canDelete = computed(
-    () => this.confirmationInput().trim() === CONFIRMATION_TOKEN && !this.deleting(),
-  );
+  protected canDelete = computed(() => this.confirmationInput().trim() === CONFIRMATION_TOKEN && !this.deleting());
 
   protected onDelete(): void {
     if (!this.canDelete()) return;

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.html
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.html
@@ -4,11 +4,7 @@
     @if (saving()) {
       <span class="profile-settings__status" role="status">{{ t('account.settings.saving') }}</span>
     } @else if (saved()) {
-      <span
-        class="profile-settings__status profile-settings__status--saved"
-        data-testid="profile-saved-indicator"
-        role="status"
-      >
+      <span class="profile-settings__status profile-settings__status--saved" data-testid="profile-saved-indicator" role="status">
         {{ t('account.settings.saved') }}
       </span>
     }
@@ -24,10 +20,7 @@
 
   @if (profile()) {
     <form class="profile-settings__form" (submit)="$event.preventDefault()">
-      <yn-settings-card
-        titleKey="account.settings.identity"
-        descriptionKey="account.settings.identityHint"
-      >
+      <yn-settings-card titleKey="account.settings.identity" descriptionKey="account.settings.identityHint">
         <div class="form-field">
           <label for="displayName">{{ t('account.settings.displayName') }}</label>
           <input
@@ -41,22 +34,12 @@
         </div>
         <div class="form-field">
           <label for="email">{{ t('account.settings.email') }}</label>
-          <input
-            id="email"
-            type="email"
-            [value]="email()"
-            readonly
-            name="email"
-            [attr.aria-readonly]="true"
-          />
+          <input id="email" type="email" [value]="email()" readonly name="email" [attr.aria-readonly]="true" />
           <small class="form-field__hint">{{ t('account.settings.emailHint') }}</small>
         </div>
       </yn-settings-card>
 
-      <yn-settings-card
-        titleKey="account.settings.languageUnits"
-        descriptionKey="account.settings.languageUnitsHint"
-      >
+      <yn-settings-card titleKey="account.settings.languageUnits" descriptionKey="account.settings.languageUnitsHint">
         <div class="form-field">
           <label for="preferredLanguage">{{ t('account.settings.preferredLanguage') }}</label>
           <select
@@ -85,18 +68,10 @@
         </div>
       </yn-settings-card>
 
-      <yn-settings-card
-        titleKey="account.settings.appearance"
-        descriptionKey="account.settings.appearanceHint"
-      >
+      <yn-settings-card titleKey="account.settings.appearance" descriptionKey="account.settings.appearanceHint">
         <div class="form-field">
           <label for="theme">{{ t('account.settings.theme') }}</label>
-          <select
-            id="theme"
-            [ngModel]="themeChoice()"
-            (ngModelChange)="themeChoice.set($event); onChange()"
-            name="theme"
-          >
+          <select id="theme" [ngModel]="themeChoice()" (ngModelChange)="themeChoice.set($event); onChange()" name="theme">
             @for (option of themes; track option) {
               <option [value]="option">{{ t('account.settings.themes.' + option) }}</option>
             }
@@ -104,10 +79,7 @@
         </div>
       </yn-settings-card>
 
-      <yn-settings-card
-        titleKey="account.settings.cooking"
-        descriptionKey="account.settings.cookingHint"
-      >
+      <yn-settings-card titleKey="account.settings.cooking" descriptionKey="account.settings.cookingHint">
         <div class="form-field">
           <label for="servings">{{ t('account.settings.defaultServings') }}</label>
           <input
@@ -122,12 +94,7 @@
         </div>
         <div class="form-field">
           <label for="dietaryType">{{ t('account.settings.dietaryType') }}</label>
-          <select
-            id="dietaryType"
-            [ngModel]="dietaryType()"
-            (ngModelChange)="dietaryType.set($event); onChange()"
-            name="dietaryType"
-          >
+          <select id="dietaryType" [ngModel]="dietaryType()" (ngModelChange)="dietaryType.set($event); onChange()" name="dietaryType">
             <option value="">{{ t('account.settings.none') }}</option>
             @for (type of dietaryTypes; track type) {
               <option [value]="type">{{ t('account.settings.dietaryTypes.' + type) }}</option>
@@ -139,11 +106,7 @@
           <div class="checkbox-group">
             @for (r of availableRestrictions; track r) {
               <label class="checkbox-label">
-                <input
-                  type="checkbox"
-                  [checked]="restrictions().includes(r)"
-                  (change)="onToggleRestriction(r)"
-                />
+                <input type="checkbox" [checked]="restrictions().includes(r)" (change)="onToggleRestriction(r)" />
                 {{ t('account.settings.restriction.' + r) }}
               </label>
             }
@@ -193,16 +156,9 @@
         </div>
       </yn-settings-card>
 
-      <yn-settings-card
-        titleKey="account.settings.voice"
-        descriptionKey="account.settings.voiceHint"
-      >
+      <yn-settings-card titleKey="account.settings.voice" descriptionKey="account.settings.voiceHint">
         <label class="checkbox-label">
-          <input
-            type="checkbox"
-            [checked]="voiceEnabled()"
-            (change)="voiceEnabled.set($any($event.target).checked); onChange()"
-          />
+          <input type="checkbox" [checked]="voiceEnabled()" (change)="voiceEnabled.set($any($event.target).checked); onChange()" />
           {{ t('account.settings.voiceEnabled') }}
         </label>
         <div class="form-field">
@@ -230,24 +186,13 @@
         </label>
       </yn-settings-card>
 
-      <yn-settings-card
-        titleKey="account.settings.notifications"
-        descriptionKey="account.settings.notificationsHint"
-      >
+      <yn-settings-card titleKey="account.settings.notifications" descriptionKey="account.settings.notificationsHint">
         <label class="checkbox-label">
-          <input
-            type="checkbox"
-            [checked]="timerHaptic()"
-            (change)="timerHaptic.set($any($event.target).checked); onChange()"
-          />
+          <input type="checkbox" [checked]="timerHaptic()" (change)="timerHaptic.set($any($event.target).checked); onChange()" />
           {{ t('account.settings.timerHaptic') }}
         </label>
         <label class="checkbox-label">
-          <input
-            type="checkbox"
-            [checked]="timerSound()"
-            (change)="timerSound.set($any($event.target).checked); onChange()"
-          />
+          <input type="checkbox" [checked]="timerSound()" (change)="timerSound.set($any($event.target).checked); onChange()" />
           {{ t('account.settings.timerSound') }}
         </label>
       </yn-settings-card>

--- a/client/apps/account/src/app/profile-settings/profile-settings.component.ts
+++ b/client/apps/account/src/app/profile-settings/profile-settings.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import {
@@ -78,13 +71,7 @@ export class ProfileSettingsComponent {
   protected readonly unitSystems: Array<'metric' | 'imperial'> = ['metric', 'imperial'];
   protected readonly themes: Array<'light' | 'dark' | 'system'> = ['light', 'dark', 'system'];
   protected readonly voiceSpeeds: Array<'slow' | 'normal' | 'fast'> = ['slow', 'normal', 'fast'];
-  protected readonly dietaryTypes = [
-    'omnivore',
-    'vegetarian',
-    'vegan',
-    'pescatarian',
-    'flexitarian',
-  ];
+  protected readonly dietaryTypes = ['omnivore', 'vegetarian', 'vegan', 'pescatarian', 'flexitarian'];
   protected readonly availableRestrictions = [
     'gluten-free',
     'lactose-free',
@@ -122,9 +109,7 @@ export class ProfileSettingsComponent {
 
   protected onToggleRestriction(restriction: string): void {
     const current = this.restrictions();
-    const next = current.includes(restriction)
-      ? current.filter((entry) => entry !== restriction)
-      : [...current, restriction];
+    const next = current.includes(restriction) ? current.filter((entry) => entry !== restriction) : [...current, restriction];
     this.restrictions.set(next);
     this.onChange();
   }
@@ -173,11 +158,7 @@ export class ProfileSettingsComponent {
       this.displayName.set(profile.displayName);
       this.email.set(profile.email);
       this.preferredLanguage.set((profile.preferredLanguage === 'de' ? 'de' : 'en') as 'en' | 'de');
-      this.preferredUnitSystem.set(
-        (profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric') as
-          | 'metric'
-          | 'imperial',
-      );
+      this.preferredUnitSystem.set((profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric') as 'metric' | 'imperial');
       this.themeChoice.set(profile.theme);
       this.defaultServings.set(profile.defaultServings);
       this.dietaryType.set(profile.dietaryProfile.dietaryType ?? '');

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.html
@@ -14,12 +14,7 @@
       </button>
       <h1 class="cook-title">{{ currentRecipe.title }}</h1>
       <div class="header-actions">
-        <button
-          type="button"
-          class="header-action"
-          (click)="toggleMute()"
-          [attr.aria-pressed]="voice.muted()"
-        >
+        <button type="button" class="header-action" (click)="toggleMute()" [attr.aria-pressed]="voice.muted()">
           {{ voice.muted() ? t('recipes.cook.unmute') : t('recipes.cook.mute') }}
         </button>
         <button type="button" class="header-action" (click)="toggleIngredientsPanel()">
@@ -29,49 +24,26 @@
     </header>
 
     @if (currentStep(); as step) {
-      <yn-step-display
-        [stepNumber]="currentStepIndex() + 1"
-        [totalSteps]="totalSteps()"
-        [text]="step.description"
-      />
+      <yn-step-display [stepNumber]="currentStepIndex() + 1" [totalSteps]="totalSteps()" [text]="step.description" />
     }
 
     <div class="step-controls">
-      <button
-        type="button"
-        class="nav-button"
-        (click)="previous()"
-        [disabled]="currentStepIndex() === 0"
-      >
+      <button type="button" class="nav-button" (click)="previous()" [disabled]="currentStepIndex() === 0">
         {{ t('recipes.cook.previous') }}
       </button>
       <button type="button" class="nav-button repeat" (click)="repeat()">
         {{ t('recipes.cook.repeat') }}
       </button>
-      <button
-        type="button"
-        class="nav-button"
-        (click)="next()"
-        [disabled]="currentStepIndex() >= totalSteps() - 1"
-      >
+      <button type="button" class="nav-button" (click)="next()" [disabled]="currentStepIndex() >= totalSteps() - 1">
         {{ t('recipes.cook.next') }}
       </button>
     </div>
 
     @if (voice.sttSupported()) {
-      <button
-        type="button"
-        class="voice-toggle"
-        (click)="toggleListening()"
-        [attr.aria-label]="t('recipes.cook.voiceToggle')"
-      >
+      <button type="button" class="voice-toggle" (click)="toggleListening()" [attr.aria-label]="t('recipes.cook.voiceToggle')">
         <yn-voice-indicator [listening]="voice.isListening()" />
         <span>
-          {{
-            voice.isListening()
-              ? t('recipes.cook.voiceListening')
-              : t('recipes.cook.voiceTapToTalk')
-          }}
+          {{ voice.isListening() ? t('recipes.cook.voiceListening') : t('recipes.cook.voiceTapToTalk') }}
         </span>
       </button>
     }
@@ -86,18 +58,10 @@
 
     @if (ingredientsPanelOpen()) {
       @defer {
-        <yn-side-sheet
-          labelledBy="cook-mode-ingredients-title"
-          (cancelled)="toggleIngredientsPanel()"
-        >
+        <yn-side-sheet labelledBy="cook-mode-ingredients-title" (cancelled)="toggleIngredientsPanel()">
           <div class="panel-header">
             <h2 id="cook-mode-ingredients-title">{{ t('recipes.cook.ingredients') }}</h2>
-            <button
-              type="button"
-              class="panel-close"
-              (click)="toggleIngredientsPanel()"
-              [attr.aria-label]="t('recipes.cook.closePanel')"
-            >
+            <button type="button" class="panel-close" (click)="toggleIngredientsPanel()" [attr.aria-label]="t('recipes.cook.closePanel')">
               <lucide-icon name="x" [size]="18" />
             </button>
           </div>

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
@@ -4,13 +4,7 @@ import { of } from 'rxjs';
 import { signal } from '@angular/core';
 import { CookModeComponent } from './cook-mode.component';
 import { ChatApiService, RecipeApiService, type RecipeDetail } from '../api';
-import {
-  UserPreferencesService,
-  VoiceService,
-  WakeLockService,
-  CookingTimerService,
-  setupTranslocoTesting,
-} from '@yumney/shared/models';
+import { UserPreferencesService, VoiceService, WakeLockService, CookingTimerService, setupTranslocoTesting } from '@yumney/shared/models';
 import { provideYumneyIcons } from '@yumney/ui';
 
 const mockRecipe: RecipeDetail = {
@@ -100,10 +94,7 @@ describe('CookModeComponent', () => {
     applyProfile: ReturnType<typeof vi.fn>;
   };
 
-  function setupTestBed(
-    getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(),
-    identifier = 'test-id',
-  ) {
+  function setupTestBed(getRecipeByIdReturn: ReturnType<typeof vi.fn> = vi.fn(), identifier = 'test-id') {
     recipeApiMock = { getRecipeById: getRecipeByIdReturn };
 
     voiceMock = {
@@ -295,9 +286,7 @@ describe('CookModeComponent', () => {
     fixture.detectChanges();
     tick();
 
-    const onTranscript = voiceMock.startListeningWithFallback.mock.calls[0][1] as (
-      text: string,
-    ) => void;
+    const onTranscript = voiceMock.startListeningWithFallback.mock.calls[0][1] as (text: string) => void;
     onTranscript('add butter to shopping list');
     tick();
 

--- a/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.html
+++ b/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.html
@@ -88,12 +88,7 @@
     </div>
   }
 
-  <div
-    ynInfiniteScroll
-    class="scroll-sentinel"
-    [enabled]="hasMore() && !isLoading()"
-    (loadMore)="onLoadMore()"
-  ></div>
+  <div ynInfiniteScroll class="scroll-sentinel" [enabled]="hasMore() && !isLoading()" (loadMore)="onLoadMore()"></div>
 
   @if (isLoading()) {
     <div class="skeleton-grid">

--- a/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.scss
+++ b/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.scss
@@ -181,12 +181,7 @@
 .skeleton-card {
   height: 280px;
   border-radius: var(--yn-radius-card);
-  background: linear-gradient(
-    90deg,
-    var(--yn-glass-bg) 25%,
-    var(--yn-glass-bg-elevated) 50%,
-    var(--yn-glass-bg) 75%
-  );
+  background: linear-gradient(90deg, var(--yn-glass-bg) 25%, var(--yn-glass-bg-elevated) 50%, var(--yn-glass-bg) 75%);
   background-size: 200% 100%;
   animation: yn-shimmer 1.5s ease-in-out infinite;
   border: 1px solid var(--yn-glass-border-subtle);

--- a/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.spec.ts
+++ b/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.spec.ts
@@ -117,11 +117,7 @@ describe('CookableRecipesComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [CookableRecipesComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: RecipeApiService, useValue: recipeApiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: RecipeApiService, useValue: recipeApiMock }],
     });
 
     fixture = TestBed.createComponent(CookableRecipesComponent);

--- a/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.ts
+++ b/client/apps/recipes/src/app/cookable-recipes/cookable-recipes.component.ts
@@ -1,19 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  computed,
-  inject,
-  OnInit,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  RecipeApiService,
-  type CookableRecipeListItem,
-  type GetCookableRecipesParams,
-} from '../api';
+import { RecipeApiService, type CookableRecipeListItem, type GetCookableRecipesParams } from '../api';
 import { createAsyncState, ERROR_MAPS, ROUTES, UI } from '@yumney/shared/models';
 import {
   ButtonComponent,
@@ -85,18 +74,14 @@ export class CookableRecipesComponent implements OnInit {
       ...(this.fullMatchOnly() && { fullMatchOnly: true }),
     };
 
-    this.asyncState.execute(
-      this.recipeApi.getCookableRecipes(params),
-      ERROR_MAPS.recipes.cookable,
-      (response) => {
-        if (requestId !== this.loadRequestId) return;
-        this.totalCount.set(response.totalCount);
-        if (append) {
-          this.recipes.update((existing) => [...existing, ...response.items]);
-        } else {
-          this.recipes.set(response.items);
-        }
-      },
-    );
+    this.asyncState.execute(this.recipeApi.getCookableRecipes(params), ERROR_MAPS.recipes.cookable, (response) => {
+      if (requestId !== this.loadRequestId) return;
+      this.totalCount.set(response.totalCount);
+      if (append) {
+        this.recipes.update((existing) => [...existing, ...response.items]);
+      } else {
+        this.recipes.set(response.items);
+      }
+    });
   }
 }

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.html
@@ -49,25 +49,11 @@
   </section>
 
   <div class="dialog-actions">
-    <yn-button
-      variant="secondary"
-      testId="create-shopping-list-cancel"
-      [disabled]="isCreating()"
-      (click)="onCancel()"
-    >
+    <yn-button variant="secondary" testId="create-shopping-list-cancel" [disabled]="isCreating()" (click)="onCancel()">
       {{ t('recipes.detail.createShoppingList.cancel') }}
     </yn-button>
-    <yn-button
-      variant="primary"
-      testId="create-shopping-list-confirm"
-      [disabled]="isCreating()"
-      (click)="onConfirm()"
-    >
-      {{
-        isCreating()
-          ? t('recipes.detail.createShoppingList.creating')
-          : t('recipes.detail.createShoppingList.confirm')
-      }}
+    <yn-button variant="primary" testId="create-shopping-list-confirm" [disabled]="isCreating()" (click)="onConfirm()">
+      {{ isCreating() ? t('recipes.detail.createShoppingList.creating') : t('recipes.detail.createShoppingList.confirm') }}
     </yn-button>
   </div>
 </yn-dialog-shell>

--- a/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/create-shopping-list-dialog/create-shopping-list-dialog.component.spec.ts
@@ -78,12 +78,8 @@ describe('CreateShoppingListDialogComponent', () => {
   it('should disable buttons and show creating label while in flight', () => {
     setup(true);
 
-    const confirm = fixture.nativeElement.querySelector(
-      '[data-testid="create-shopping-list-confirm"]',
-    );
-    const cancel = fixture.nativeElement.querySelector(
-      '[data-testid="create-shopping-list-cancel"]',
-    );
+    const confirm = fixture.nativeElement.querySelector('[data-testid="create-shopping-list-confirm"]');
+    const cancel = fixture.nativeElement.querySelector('[data-testid="create-shopping-list-cancel"]');
     expect(confirm.disabled).toBe(true);
     expect(cancel.disabled).toBe(true);
     expect(confirm.textContent).toContain('Creating...');
@@ -144,9 +140,7 @@ describe('CreateShoppingListDialogComponent', () => {
     fixture.detectChanges();
 
     expect(component.suggestedTitle()).toBe('Pasta Carbonara');
-    const subtitle = fixture.nativeElement.querySelector(
-      '[data-testid="create-shopping-list-suggested-title"]',
-    );
+    const subtitle = fixture.nativeElement.querySelector('[data-testid="create-shopping-list-suggested-title"]');
     expect(subtitle.textContent.trim()).toBe('Pasta Carbonara');
     const heading = fixture.nativeElement.querySelector('.preview-heading');
     expect(heading.textContent).toContain('3 ingredients');

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.html
@@ -40,9 +40,7 @@
     <div class="meta-bar">
       @if (recipe.servings) {
         <div class="meta-item servings-adjuster">
-          <span class="meta-label">{{
-            t('recipes.detail.servings', { count: desiredServings() })
-          }}</span>
+          <span class="meta-label">{{ t('recipes.detail.servings', { count: desiredServings() }) }}</span>
           <div class="servings-control">
             <button
               class="servings-button"
@@ -53,11 +51,7 @@
               &minus;
             </button>
             <span class="servings-value" aria-live="polite">{{ desiredServings() }}</span>
-            <button
-              class="servings-button"
-              (click)="onIncreaseServings()"
-              [attr.aria-label]="t('recipes.detail.a11y.increaseServings')"
-            >
+            <button class="servings-button" (click)="onIncreaseServings()" [attr.aria-label]="t('recipes.detail.a11y.increaseServings')">
               +
             </button>
           </div>
@@ -71,25 +65,19 @@
       @if (recipe.prepTimeMinutes) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.prepTime') }}</span>
-          <span class="meta-value">{{
-            t('recipes.detail.minutes', { minutes: recipe.prepTimeMinutes })
-          }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.prepTimeMinutes }) }}</span>
         </div>
       }
       @if (recipe.cookTimeMinutes) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.cookTime') }}</span>
-          <span class="meta-value">{{
-            t('recipes.detail.minutes', { minutes: recipe.cookTimeMinutes })
-          }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: recipe.cookTimeMinutes }) }}</span>
         </div>
       }
       @if (totalTime()) {
         <div class="meta-item">
           <span class="meta-label">{{ t('recipes.detail.totalTime') }}</span>
-          <span class="meta-value">{{
-            t('recipes.detail.minutes', { minutes: totalTime() })
-          }}</span>
+          <span class="meta-value">{{ t('recipes.detail.minutes', { minutes: totalTime() }) }}</span>
         </div>
       }
       @if (recipe.difficulty) {
@@ -153,15 +141,8 @@
       <yn-button variant="primary" [routerLink]="ROUTES.recipes.edit(recipe.identifier)">
         {{ t('recipes.detail.actions.edit') }}
       </yn-button>
-      <yn-button
-        variant="danger"
-        testId="recipe-delete-btn"
-        [disabled]="isDeleting()"
-        (click)="onDelete()"
-      >
-        {{
-          isDeleting() ? t('recipes.detail.delete.deleting') : t('recipes.detail.actions.delete')
-        }}
+      <yn-button variant="danger" testId="recipe-delete-btn" [disabled]="isDeleting()" (click)="onDelete()">
+        {{ isDeleting() ? t('recipes.detail.delete.deleting') : t('recipes.detail.actions.delete') }}
       </yn-button>
       <yn-button
         variant="secondary"

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.spec.ts
@@ -3,13 +3,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter, ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError, EMPTY } from 'rxjs';
 import { RecipeDetailComponent } from './recipe-detail.component';
-import {
-  ActivityApiService,
-  RecipeApiService,
-  RecipeDetail,
-  ShoppingApiService,
-  ShoppingListDetail,
-} from '../api';
+import { ActivityApiService, RecipeApiService, RecipeDetail, ShoppingApiService, ShoppingListDetail } from '../api';
 import { HttpErrorResponse } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { setupTranslocoTesting, UserPreferencesService } from '@yumney/shared/models';
@@ -174,9 +168,7 @@ describe('RecipeDetailComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const title =
-      fixture.nativeElement.querySelector('.hero-title') ??
-      fixture.nativeElement.querySelector('.recipe-title');
+    const title = fixture.nativeElement.querySelector('.hero-title') ?? fixture.nativeElement.querySelector('.recipe-title');
     expect(title.textContent).toContain('Pasta Carbonara');
   }));
 
@@ -358,9 +350,7 @@ describe('RecipeDetailComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const trigger = fixture.nativeElement.querySelector(
-      '[data-testid="recipe-create-shopping-list-btn"]',
-    );
+    const trigger = fixture.nativeElement.querySelector('[data-testid="recipe-create-shopping-list-btn"]');
     expect(trigger).toBeTruthy();
     expect(trigger.tagName).toBe('BUTTON');
     expect(trigger.textContent).toContain('Shopping List');
@@ -632,16 +622,12 @@ describe('RecipeDetailComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const trigger = fixture.nativeElement.querySelector(
-      '[data-testid="recipe-create-shopping-list-btn"]',
-    );
+    const trigger = fixture.nativeElement.querySelector('[data-testid="recipe-create-shopping-list-btn"]');
     trigger.click();
     fixture.detectChanges();
 
     expect(component.showCreateShoppingListConfirm()).toBe(true);
-    const dialog = fixture.nativeElement.querySelector(
-      '[data-testid="create-shopping-list-dialog"]',
-    );
+    const dialog = fixture.nativeElement.querySelector('[data-testid="create-shopping-list-dialog"]');
     expect(dialog).toBeTruthy();
   }));
 
@@ -667,9 +653,7 @@ describe('RecipeDetailComponent', () => {
     component.onCreateShoppingList();
     fixture.detectChanges();
 
-    const subtitle = fixture.nativeElement.querySelector(
-      '[data-testid="create-shopping-list-suggested-title"]',
-    );
+    const subtitle = fixture.nativeElement.querySelector('[data-testid="create-shopping-list-suggested-title"]');
     expect(subtitle.textContent.trim()).toBe('Pasta Carbonara (x6)');
   }));
 
@@ -707,9 +691,7 @@ describe('RecipeDetailComponent', () => {
     tick();
     component.onCreateShoppingList();
 
-    shoppingApiMock.createShoppingList.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
-    );
+    shoppingApiMock.createShoppingList.mockReturnValue(of({ identifier: 'list-1' } as unknown as ShoppingListDetail));
     component.onCreateShoppingListConfirmed();
     tick();
 
@@ -726,9 +708,7 @@ describe('RecipeDetailComponent', () => {
     component.desiredServings.set(1);
     component.onCreateShoppingList();
 
-    shoppingApiMock.createShoppingList.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
-    );
+    shoppingApiMock.createShoppingList.mockReturnValue(of({ identifier: 'list-1' } as unknown as ShoppingListDetail));
     component.onCreateShoppingListConfirmed();
     tick();
 
@@ -744,9 +724,7 @@ describe('RecipeDetailComponent', () => {
     tick();
     component.onCreateShoppingList();
 
-    shoppingApiMock.createShoppingList.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
-    );
+    shoppingApiMock.createShoppingList.mockReturnValue(of({ identifier: 'list-1' } as unknown as ShoppingListDetail));
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
@@ -783,9 +761,7 @@ describe('RecipeDetailComponent', () => {
     component.onCreateShoppingListConfirmed();
     fixture.detectChanges();
 
-    const triggers = fixture.nativeElement.querySelectorAll(
-      '[data-testid="recipe-create-shopping-list-btn"]',
-    );
+    const triggers = fixture.nativeElement.querySelectorAll('[data-testid="recipe-create-shopping-list-btn"]');
     expect(triggers.length).toBeGreaterThan(0);
     triggers.forEach((trigger: HTMLButtonElement) => {
       expect(trigger.disabled).toBe(true);
@@ -802,9 +778,7 @@ describe('RecipeDetailComponent', () => {
     tick();
     component.onCreateShoppingList();
 
-    shoppingApiMock.createShoppingList.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
-    );
+    shoppingApiMock.createShoppingList.mockReturnValue(of({ identifier: 'list-1' } as unknown as ShoppingListDetail));
 
     component.onCreateShoppingListConfirmed();
     tick();

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  OnInit,
-  DestroyRef,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnInit, DestroyRef, signal, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -91,9 +83,7 @@ export class RecipeDetailComponent implements OnInit {
   // NOT persisted — leaves the saved preference unchanged when a user
   // flips imperial → metric just for this one recipe.
   private userUnitOverride = signal<UnitSystem | null>(null);
-  unitSystem = computed<UnitSystem>(
-    () => this.userUnitOverride() ?? this.preferences.preferredUnitSystem(),
-  );
+  unitSystem = computed<UnitSystem>(() => this.userUnitOverride() ?? this.preferences.preferredUnitSystem());
   showDeleteConfirm = signal(false);
   showCreateShoppingListConfirm = signal(false);
 
@@ -286,15 +276,12 @@ export class RecipeDetailComponent implements OnInit {
     }
 
     const desired = this.desiredServings();
-    const items: CreateShoppingListItem[] = this.scaledIngredients().map(
-      ({ name, amount, unit }) => ({
-        name,
-        amount,
-        unit,
-      }),
-    );
-    const title =
-      recipe.servings !== null && desired !== null ? `${recipe.title} (x${desired})` : recipe.title;
+    const items: CreateShoppingListItem[] = this.scaledIngredients().map(({ name, amount, unit }) => ({
+      name,
+      amount,
+      unit,
+    }));
+    const title = recipe.servings !== null && desired !== null ? `${recipe.title} (x${desired})` : recipe.title;
 
     this.createShoppingListState.execute(
       this.shoppingApi.createShoppingList({

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.spec.ts
@@ -256,10 +256,7 @@ describe('RecipeEditComponent', () => {
   }));
 
   it('should call updateRecipe on save', fakeAsync(() => {
-    setupTestBed(
-      vi.fn().mockReturnValue(of(mockRecipeDetail)),
-      vi.fn().mockReturnValue(of(mockRecipeDetail)),
-    );
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)), vi.fn().mockReturnValue(of(mockRecipeDetail)));
     fixture.detectChanges();
     tick();
 
@@ -290,10 +287,7 @@ describe('RecipeEditComponent', () => {
   }));
 
   it('should navigate to detail on successful update', fakeAsync(() => {
-    setupTestBed(
-      vi.fn().mockReturnValue(of(mockRecipeDetail)),
-      vi.fn().mockReturnValue(of(mockRecipeDetail)),
-    );
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)), vi.fn().mockReturnValue(of(mockRecipeDetail)));
     fixture.detectChanges();
     tick();
 
@@ -315,10 +309,7 @@ describe('RecipeEditComponent', () => {
 
   it('should show error on update failure', fakeAsync(() => {
     const httpError = new HttpErrorResponse({ status: 500 });
-    setupTestBed(
-      vi.fn().mockReturnValue(of(mockRecipeDetail)),
-      vi.fn().mockReturnValue(throwError(() => httpError)),
-    );
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipeDetail)), vi.fn().mockReturnValue(throwError(() => httpError)));
     fixture.detectChanges();
     tick();
 

--- a/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
+++ b/client/apps/recipes/src/app/recipe-edit/recipe-edit.component.ts
@@ -1,21 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  computed,
-  inject,
-  OnInit,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '../api';
-import {
-  createAsyncState,
-  mapToUpdateRecipeRequest,
-  mapDetailToImportResponse,
-  ERROR_MAPS,
-  ROUTES,
-} from '@yumney/shared/models';
+import { createAsyncState, mapToUpdateRecipeRequest, mapDetailToImportResponse, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
 import {
   BackLinkComponent,
   ConfirmDialogComponent,
@@ -51,9 +38,7 @@ export class RecipeEditComponent implements OnInit {
   showDiscardConfirm = signal(false);
 
   private notFoundError = signal<string | null>(null);
-  serverError = computed(
-    () => this.notFoundError() ?? this.loadState.serverError() ?? this.saveState.serverError(),
-  );
+  serverError = computed(() => this.notFoundError() ?? this.loadState.serverError() ?? this.saveState.serverError());
 
   identifier = signal('');
 
@@ -64,20 +49,16 @@ export class RecipeEditComponent implements OnInit {
       return;
     }
 
-    this.loadState.execute(
-      this.recipeApi.getRecipeById(this.identifier()),
-      ERROR_MAPS.recipes.edit,
-      (recipe) => this.recipeData.set(mapDetailToImportResponse(recipe)),
+    this.loadState.execute(this.recipeApi.getRecipeById(this.identifier()), ERROR_MAPS.recipes.edit, (recipe) =>
+      this.recipeData.set(mapDetailToImportResponse(recipe)),
     );
   }
 
   onSave(recipe: ImportRecipeResponse): void {
     const request = mapToUpdateRecipeRequest(recipe);
 
-    this.saveState.execute(
-      this.recipeApi.updateRecipe(this.identifier(), request),
-      ERROR_MAPS.recipes.edit,
-      () => this.router.navigate([ROUTES.recipes.list, this.identifier()]),
+    this.saveState.execute(this.recipeApi.updateRecipe(this.identifier(), request), ERROR_MAPS.recipes.edit, () =>
+      this.router.navigate([ROUTES.recipes.list, this.identifier()]),
     );
   }
 

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.html
@@ -21,11 +21,7 @@
       <yn-loading-spinner label="recipes.list.multiSelect.preview.loading" />
     </div>
   } @else {
-    <section
-      class="dialog-recipes"
-      aria-labelledby="multi-preview-recipes-heading"
-      data-testid="multi-recipe-preview-recipes"
-    >
+    <section class="dialog-recipes" aria-labelledby="multi-preview-recipes-heading" data-testid="multi-recipe-preview-recipes">
       <h3 id="multi-preview-recipes-heading" class="section-heading">
         {{ t('recipes.list.multiSelect.preview.recipesHeading') }}
       </h3>
@@ -74,11 +70,7 @@
       </ul>
     </section>
 
-    <section
-      class="dialog-merged"
-      aria-labelledby="multi-preview-merged-heading"
-      data-testid="multi-recipe-preview-merged"
-    >
+    <section class="dialog-merged" aria-labelledby="multi-preview-merged-heading" data-testid="multi-recipe-preview-merged">
       <h3 id="multi-preview-merged-heading" class="section-heading">
         {{
           t('recipes.list.multiSelect.preview.mergedHeading', {
@@ -103,12 +95,7 @@
   }
 
   <div class="dialog-actions">
-    <yn-button
-      variant="secondary"
-      testId="multi-recipe-preview-cancel"
-      [disabled]="isCreating()"
-      (click)="onCancel()"
-    >
+    <yn-button variant="secondary" testId="multi-recipe-preview-cancel" [disabled]="isCreating()" (click)="onCancel()">
       {{ t('recipes.list.multiSelect.preview.cancel') }}
     </yn-button>
     <yn-button
@@ -117,11 +104,7 @@
       [disabled]="isCreating() || isLoading() || mergedIngredients().length === 0"
       (click)="onConfirm()"
     >
-      {{
-        isCreating()
-          ? t('recipes.list.multiSelect.preview.creating')
-          : t('recipes.list.multiSelect.preview.confirm')
-      }}
+      {{ isCreating() ? t('recipes.list.multiSelect.preview.creating') : t('recipes.list.multiSelect.preview.confirm') }}
     </yn-button>
   </div>
 </yn-dialog-shell>

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.spec.ts
@@ -1,9 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTranslocoTesting } from '@yumney/shared/models';
-import {
-  MultiRecipePreviewDialogComponent,
-  type MultiRecipeSelection,
-} from './multi-recipe-preview-dialog.component';
+import { MultiRecipePreviewDialogComponent, type MultiRecipeSelection } from './multi-recipe-preview-dialog.component';
 
 const en = {
   recipes: {
@@ -93,9 +90,7 @@ describe('MultiRecipePreviewDialogComponent', () => {
   it('should show a loading state and skip the merged section', () => {
     setup({ isLoading: true });
     expect(fixture.nativeElement.querySelector('.dialog-loading')).toBeTruthy();
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-merged"]'),
-    ).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-merged"]')).toBeNull();
     expect(component.mergedIngredients()).toHaveLength(0);
   });
 
@@ -144,26 +139,20 @@ describe('MultiRecipePreviewDialogComponent', () => {
 
   it('should disable the confirm button while creating', () => {
     setup({ isCreating: true });
-    const confirm = fixture.nativeElement.querySelector(
-      '[data-testid="multi-recipe-preview-confirm"]',
-    );
+    const confirm = fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-confirm"]');
     expect(confirm.disabled).toBe(true);
     expect(confirm.textContent).toContain('Creating...');
   });
 
   it('should disable the confirm button while loading', () => {
     setup({ isLoading: true });
-    const confirm = fixture.nativeElement.querySelector(
-      '[data-testid="multi-recipe-preview-confirm"]',
-    );
+    const confirm = fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-confirm"]');
     expect(confirm.disabled).toBe(true);
   });
 
   it('should disable the confirm button when there are no merged ingredients', () => {
     setup({ recipes: [{ ...sampleRecipes[0], ingredients: [] }] });
-    const confirm = fixture.nativeElement.querySelector(
-      '[data-testid="multi-recipe-preview-confirm"]',
-    );
+    const confirm = fixture.nativeElement.querySelector('[data-testid="multi-recipe-preview-confirm"]');
     expect(confirm.disabled).toBe(true);
   });
 
@@ -192,9 +181,7 @@ describe('MultiRecipePreviewDialogComponent', () => {
     let count = 0;
     component.cancelled.subscribe(() => count++);
 
-    fixture.nativeElement
-      .querySelector('.yn-dialog-overlay')
-      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.nativeElement.querySelector('.yn-dialog-overlay').dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(count).toBe(1);
   });

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component.ts
@@ -1,11 +1,6 @@
 import { Component, ChangeDetectionStrategy, computed, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  mergeRecipeIngredients,
-  type MergedIngredient,
-  type RecipeForMerge,
-  type ScalableIngredient,
-} from '@yumney/shared/models';
+import { mergeRecipeIngredients, type MergedIngredient, type RecipeForMerge, type ScalableIngredient } from '@yumney/shared/models';
 import { ButtonComponent, DialogShellComponent, LoadingSpinnerComponent } from '@yumney/ui';
 
 export interface MultiRecipeSelection {

--- a/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/multi-recipe-shopping-list.service.ts
@@ -102,9 +102,7 @@ export class MultiRecipeShoppingListService {
 
   changeServings(identifier: string, servings: number): void {
     this.previewSelections.update((selections) =>
-      selections.map((entry) =>
-        entry.identifier === identifier ? { ...entry, desiredServings: servings } : entry,
-      ),
+      selections.map((entry) => (entry.identifier === identifier ? { ...entry, desiredServings: servings } : entry)),
     );
   }
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-assignment.service.spec.ts
@@ -23,10 +23,7 @@ describe('RecipeAssignmentService', () => {
   let navigate: ReturnType<typeof vi.fn>;
   let assignToParam: string | null;
 
-  const setup = (
-    initialParam: string | null = null,
-    apiResponse: ReturnType<typeof of> | ReturnType<typeof throwError> = of({}),
-  ) => {
+  const setup = (initialParam: string | null = null, apiResponse: ReturnType<typeof of> | ReturnType<typeof throwError> = of({})) => {
     assignToParam = initialParam;
     assignRecipe = vi.fn().mockReturnValue(apiResponse);
     navigate = vi.fn();

--- a/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-card/recipe-card.component.html
@@ -9,24 +9,13 @@
     *transloco="let t"
   >
     @if (recipe().imageUrl) {
-      <img
-        [src]="recipe().imageUrl"
-        [alt]="recipe().title"
-        class="recipe-image"
-        loading="lazy"
-        width="400"
-        height="225"
-      />
+      <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" width="400" height="225" />
     } @else {
       <div class="recipe-image-placeholder"></div>
     }
     <div
       class="select-indicator"
-      [attr.aria-label]="
-        selected()
-          ? t('recipes.list.multiSelect.deselectAriaLabel')
-          : t('recipes.list.multiSelect.selectAriaLabel')
-      "
+      [attr.aria-label]="selected() ? t('recipes.list.multiSelect.deselectAriaLabel') : t('recipes.list.multiSelect.selectAriaLabel')"
     >
       @if (selected()) {
         <i-lucide name="check" size="20" aria-hidden="true"></i-lucide>
@@ -36,34 +25,18 @@
       <h3 class="recipe-title">{{ recipe().title }}</h3>
       <div class="recipe-meta">
         @if (recipe().servings) {
-          <span class="meta-item">{{
-            t('recipes.list.servings', { count: recipe().servings })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.servings', { count: recipe().servings }) }}</span>
         }
         @if (recipe().prepTimeMinutes) {
-          <span class="meta-item">{{
-            t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes }) }}</span>
         }
       </div>
     </div>
   </button>
 } @else if (assignMode()) {
-  <div
-    class="recipe-card assign-card"
-    data-testid="recipe-card"
-    (click)="onAssign($event)"
-    *transloco="let t"
-  >
+  <div class="recipe-card assign-card" data-testid="recipe-card" (click)="onAssign($event)" *transloco="let t">
     @if (recipe().imageUrl) {
-      <img
-        [src]="recipe().imageUrl"
-        [alt]="recipe().title"
-        class="recipe-image"
-        loading="lazy"
-        width="400"
-        height="225"
-      />
+      <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" width="400" height="225" />
     } @else {
       <div class="recipe-image-placeholder"></div>
     }
@@ -74,34 +47,18 @@
       <h3 class="recipe-title">{{ recipe().title }}</h3>
       <div class="recipe-meta">
         @if (recipe().servings) {
-          <span class="meta-item">{{
-            t('recipes.list.servings', { count: recipe().servings })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.servings', { count: recipe().servings }) }}</span>
         }
         @if (recipe().prepTimeMinutes) {
-          <span class="meta-item">{{
-            t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes }) }}</span>
         }
       </div>
     </div>
   </div>
 } @else {
-  <a
-    class="recipe-card"
-    data-testid="recipe-card"
-    [routerLink]="ROUTES.recipes.detail(recipe().identifier)"
-    *transloco="let t"
-  >
+  <a class="recipe-card" data-testid="recipe-card" [routerLink]="ROUTES.recipes.detail(recipe().identifier)" *transloco="let t">
     @if (recipe().imageUrl) {
-      <img
-        [src]="recipe().imageUrl"
-        [alt]="recipe().title"
-        class="recipe-image"
-        loading="lazy"
-        width="400"
-        height="225"
-      />
+      <img [src]="recipe().imageUrl" [alt]="recipe().title" class="recipe-image" loading="lazy" width="400" height="225" />
     } @else {
       <div class="recipe-image-placeholder"></div>
     }
@@ -115,28 +72,19 @@
       }
       <div class="recipe-meta">
         @if (recipe().servings) {
-          <span class="meta-item">{{
-            t('recipes.list.servings', { count: recipe().servings })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.servings', { count: recipe().servings }) }}</span>
         }
         @if (recipe().prepTimeMinutes) {
-          <span class="meta-item">{{
-            t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.prepTime', { minutes: recipe().prepTimeMinutes }) }}</span>
         }
         @if (recipe().cookTimeMinutes) {
-          <span class="meta-item">{{
-            t('recipes.list.cookTime', { minutes: recipe().cookTimeMinutes })
-          }}</span>
+          <span class="meta-item">{{ t('recipes.list.cookTime', { minutes: recipe().cookTimeMinutes }) }}</span>
         }
         @if (recipe().difficulty) {
           <span class="meta-item">{{ recipe().difficulty }}</span>
         }
         @if (recipe().rating) {
-          <span
-            class="meta-item meta-item--rating"
-            [attr.aria-label]="t('recipes.list.ratingAria', { value: recipe().rating })"
-          >
+          <span class="meta-item meta-item--rating" [attr.aria-label]="t('recipes.list.ratingAria', { value: recipe().rating })">
             <i-lucide name="star" size="14" aria-hidden="true"></i-lucide>
             {{ recipe().rating }}
           </span>

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -2,11 +2,7 @@
   <div class="list-header">
     @if (assignment.assignMode()) {
       <div class="assign-header">
-        <button
-          class="btn-back"
-          (click)="assignment.cancel()"
-          [attr.aria-label]="t('recipes.list.back')"
-        >
+        <button class="btn-back" (click)="assignment.cancel()" [attr.aria-label]="t('recipes.list.back')">
           <lucide-icon name="arrow-left" [size]="20" />
         </button>
         <h1>{{ t('recipes.list.assignTitle') }}</h1>
@@ -33,16 +29,10 @@
         [attr.aria-label]="t('recipes.list.search.label')"
       />
       @if (isAiPowered()) {
-        <span class="search-ai-badge" data-testid="recipe-list-ai-badge">{{
-          t('recipes.list.search.aiBadge')
-        }}</span>
+        <span class="search-ai-badge" data-testid="recipe-list-ai-badge">{{ t('recipes.list.search.aiBadge') }}</span>
       }
       @if (searchQuery()) {
-        <button
-          class="search-clear"
-          (click)="onSearchClear()"
-          [attr.aria-label]="t('recipes.list.search.clear')"
-        >
+        <button class="search-clear" (click)="onSearchClear()" [attr.aria-label]="t('recipes.list.search.clear')">
           <lucide-icon name="x" [size]="18" />
         </button>
       }
@@ -68,11 +58,7 @@
         [attr.aria-pressed]="multiSelect.multiSelectMode()"
         (click)="multiSelect.toggleMode()"
       >
-        {{
-          multiSelect.multiSelectMode()
-            ? t('recipes.list.multiSelect.exit')
-            : t('recipes.list.multiSelect.enter')
-        }}
+        {{ multiSelect.multiSelectMode() ? t('recipes.list.multiSelect.exit') : t('recipes.list.multiSelect.enter') }}
       </button>
     }
   </div>
@@ -96,11 +82,7 @@
 
   @if (!isLoading() && recipes().length === 0 && !serverError()) {
     @if (activeSearch(); as query) {
-      <yn-empty-state
-        title="recipes.list.search.noResults"
-        message="recipes.list.search.noResultsMessage"
-        [messageParams]="{ query }"
-      />
+      <yn-empty-state title="recipes.list.search.noResults" message="recipes.list.search.noResultsMessage" [messageParams]="{ query }" />
     } @else {
       <yn-empty-state title="recipes.list.empty.title" message="recipes.list.empty.message">
         <yn-button variant="primary" [routerLink]="ROUTES.dashboard">
@@ -126,9 +108,7 @@
     </div>
   }
 
-  @if (
-    multiSelect.multiSelectMode() && multiSelect.hasSelection() && !multiSelect.showPreviewDialog()
-  ) {
+  @if (multiSelect.multiSelectMode() && multiSelect.hasSelection() && !multiSelect.showPreviewDialog()) {
     <button
       type="button"
       class="multi-select-fab"
@@ -151,12 +131,7 @@
     />
   }
 
-  <div
-    ynInfiniteScroll
-    class="scroll-sentinel"
-    [enabled]="hasMore() && !isLoading()"
-    (loadMore)="onLoadMore()"
-  ></div>
+  <div ynInfiniteScroll class="scroll-sentinel" [enabled]="hasMore() && !isLoading()" (loadMore)="onLoadMore()"></div>
 
   @if (isLoading()) {
     <div class="skeleton-grid">

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -177,12 +177,7 @@ yn-recipe-card {
 .skeleton-card {
   height: 280px;
   border-radius: var(--yn-radius-card);
-  background: linear-gradient(
-    90deg,
-    var(--yn-glass-bg) 25%,
-    var(--yn-glass-bg-elevated) 50%,
-    var(--yn-glass-bg) 75%
-  );
+  background: linear-gradient(90deg, var(--yn-glass-bg) 25%, var(--yn-glass-bg-elevated) 50%, var(--yn-glass-bg) 75%);
   background-size: 200% 100%;
   animation: yn-shimmer 1.5s ease-in-out infinite;
   border: 1px solid var(--yn-glass-border-subtle);

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.spec.ts
@@ -3,13 +3,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { provideRouter } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { RecipeListComponent } from './recipe-list.component';
-import {
-  ChatApiService,
-  RecipeApiService,
-  RecipeListResponse,
-  ShoppingApiService,
-  ShoppingListDetail,
-} from '../api';
+import { ChatApiService, RecipeApiService, RecipeListResponse, ShoppingApiService, ShoppingListDetail } from '../api';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 import { Router } from '@angular/router';
 
@@ -188,10 +182,7 @@ describe('RecipeListComponent', () => {
   }
 
   function triggerIntersection(isIntersecting: boolean): void {
-    intersectionCallback(
-      [{ isIntersecting } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+    intersectionCallback([{ isIntersecting } as IntersectionObserverEntry], {} as IntersectionObserver);
   }
 
   it('should create the component', fakeAsync(() => {
@@ -300,9 +291,7 @@ describe('RecipeListComponent', () => {
     component.onSortSelect('name-asc');
     tick();
 
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.objectContaining({ sortBy: 'Name', sortDirection: 'Ascending' }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.objectContaining({ sortBy: 'Name', sortDirection: 'Ascending' }));
   }));
 
   it('should reset page on sort change', fakeAsync(() => {
@@ -547,9 +536,7 @@ describe('RecipeListComponent', () => {
     expect(recipeApiMock.getRecipes).not.toHaveBeenCalled();
 
     tick(300);
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.objectContaining({ search: 'pasta' }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.objectContaining({ search: 'pasta' }));
   }));
 
   it('should reset pagination when searching', fakeAsync(() => {
@@ -595,9 +582,7 @@ describe('RecipeListComponent', () => {
 
     expect(component.searchQuery()).toBe('');
     expect(component.activeSearch()).toBe('');
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.not.objectContaining({ search: expect.anything() }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.not.objectContaining({ search: expect.anything() }));
   }));
 
   it('should not include search param when search is empty', fakeAsync(() => {
@@ -617,9 +602,7 @@ describe('RecipeListComponent', () => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
-    recipeApiMock.toggleFavorite.mockReturnValue(
-      new Subject<{ recipeIdentifier: string; isFavorite: boolean }>(),
-    );
+    recipeApiMock.toggleFavorite.mockReturnValue(new Subject<{ recipeIdentifier: string; isFavorite: boolean }>());
 
     component.onToggleFavorite('abc-123');
 
@@ -631,9 +614,7 @@ describe('RecipeListComponent', () => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
-    recipeApiMock.toggleFavorite.mockReturnValue(
-      of({ recipeIdentifier: 'abc-123', isFavorite: true }),
-    );
+    recipeApiMock.toggleFavorite.mockReturnValue(of({ recipeIdentifier: 'abc-123', isFavorite: true }));
 
     component.onToggleFavorite('abc-123');
     tick();
@@ -657,9 +638,7 @@ describe('RecipeListComponent', () => {
     setupTestBed(vi.fn().mockReturnValue(of(mockResponse)));
     fixture.detectChanges();
     tick();
-    recipeApiMock.toggleFavorite.mockReturnValue(
-      of({ recipeIdentifier: 'abc-123', isFavorite: true }),
-    );
+    recipeApiMock.toggleFavorite.mockReturnValue(of({ recipeIdentifier: 'abc-123', isFavorite: true }));
 
     component.onToggleFavorite('abc-123');
     tick();
@@ -708,9 +687,7 @@ describe('RecipeListComponent', () => {
     });
     tick();
 
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.objectContaining({ favorites: true }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.objectContaining({ favorites: true }));
   }));
 
   it('should not show the FAB until recipes are selected', fakeAsync(() => {
@@ -722,9 +699,7 @@ describe('RecipeListComponent', () => {
     component.multiSelect.toggleMode();
     fixture.detectChanges();
 
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-fab"]'),
-    ).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-fab"]')).toBeNull();
   }));
 
   it('should show the FAB with the selection count once a recipe is selected', fakeAsync(() => {
@@ -812,9 +787,7 @@ describe('RecipeListComponent', () => {
         ingredients: [{ name: 'Flour', amount: 200, unit: 'g' }],
       }),
     );
-    shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(
-      of({ identifier: 'list-1' } as unknown as ShoppingListDetail),
-    );
+    shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(of({ identifier: 'list-1' } as unknown as ShoppingListDetail));
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
@@ -887,9 +860,7 @@ describe('RecipeListComponent', () => {
         ingredients: [],
       }),
     );
-    shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(
-      throwError(() => ({ status: 500 })),
-    );
+    shoppingApiMock.createShoppingListFromRecipes.mockReturnValue(throwError(() => ({ status: 500 })));
 
     component.multiSelect.toggleMode();
     component.multiSelect.toggleSelection('abc-123');
@@ -945,16 +916,12 @@ describe('RecipeListComponent', () => {
     tick();
     fixture.detectChanges();
 
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-toggle"]'),
-    ).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-toggle"]')).toBeTruthy();
 
     component['assignment'].assignTo.set('2026-W18-monday');
     fixture.detectChanges();
 
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-toggle"]'),
-    ).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="recipe-list-multi-select-toggle"]')).toBeNull();
   }));
 
   it('should keep keyword path for short single-word search', fakeAsync(() => {
@@ -969,9 +936,7 @@ describe('RecipeListComponent', () => {
     tick(300);
 
     expect(chatApiMock.send).not.toHaveBeenCalled();
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.objectContaining({ search: 'pasta' }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.objectContaining({ search: 'pasta' }));
     expect(component.isAiPowered()).toBe(false);
   }));
 
@@ -1044,9 +1009,7 @@ describe('RecipeListComponent', () => {
     tick();
 
     expect(chatApiMock.send).toHaveBeenCalled();
-    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(
-      expect.objectContaining({ search: 'show me something with tomatoes please' }),
-    );
+    expect(recipeApiMock.getRecipes).toHaveBeenCalledWith(expect.objectContaining({ search: 'show me something with tomatoes please' }));
     expect(component.isAiPowered()).toBe(false);
   }));
 

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -1,31 +1,10 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  computed,
-  inject,
-  OnInit,
-  DestroyRef,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, DestroyRef, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { forkJoin, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
-import {
-  RecipeApiService,
-  RecipeListItem,
-  GetRecipesParams,
-  ChatApiService,
-  type ChatRecipeSuggestion,
-} from '../api';
-import {
-  createAsyncState,
-  debouncedEffect,
-  ERROR_MAPS,
-  ROUTES,
-  UI,
-  toggleFavoriteInList,
-} from '@yumney/shared/models';
+import { RecipeApiService, RecipeListItem, GetRecipesParams, ChatApiService, type ChatRecipeSuggestion } from '../api';
+import { createAsyncState, debouncedEffect, ERROR_MAPS, ROUTES, UI, toggleFavoriteInList } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
 import {
   ButtonComponent,
@@ -189,9 +168,7 @@ export class RecipeListComponent implements OnInit {
   }
 
   onToggleFavorite(identifier: string): void {
-    toggleFavoriteInList(this.recipes, identifier, this.destroyRef, (id) =>
-      this.recipeApi.toggleFavorite(id),
-    );
+    toggleFavoriteInList(this.recipes, identifier, this.destroyRef, (id) => this.recipeApi.toggleFavorite(id));
   }
 
   onFilterChange(value: RecipeFilterValue): void {
@@ -247,9 +224,7 @@ export class RecipeListComponent implements OnInit {
   }
 
   private hydrateSuggestions(suggestions: ChatRecipeSuggestion[]) {
-    const validIds = suggestions
-      .map((suggestion) => suggestion.recipeIdentifier)
-      .filter((id): id is string => id !== null);
+    const validIds = suggestions.map((suggestion) => suggestion.recipeIdentifier).filter((id): id is string => id !== null);
 
     if (validIds.length === 0) return of([] as RecipeListItem[]);
 
@@ -298,20 +273,16 @@ export class RecipeListComponent implements OnInit {
       ...(filter.favoritesOnly && { favorites: true }),
     };
 
-    this.asyncState.execute(
-      this.recipeApi.getRecipes(params),
-      ERROR_MAPS.recipes.list,
-      (response) => {
-        if (requestId !== this.loadRequestId) return;
-        this.totalCount.set(response.totalCount);
-        if (append) {
-          this.recipes.update((existing) => [...existing, ...response.items]);
-        } else {
-          this.recipes.set(response.items);
-        }
-        this.collectAvailableTags(response.items);
-      },
-    );
+    this.asyncState.execute(this.recipeApi.getRecipes(params), ERROR_MAPS.recipes.list, (response) => {
+      if (requestId !== this.loadRequestId) return;
+      this.totalCount.set(response.totalCount);
+      if (append) {
+        this.recipes.update((existing) => [...existing, ...response.items]);
+      } else {
+        this.recipes.set(response.items);
+      }
+      this.collectAvailableTags(response.items);
+    });
   }
 
   private collectAvailableTags(items: RecipeListItem[]): void {

--- a/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
+++ b/client/apps/recipes/src/app/recipe-list/sort-menu/sort-menu.component.html
@@ -1,10 +1,4 @@
-<div
-  class="sort-dropdown"
-  ynClickOutside
-  (clickOutside)="onDismiss()"
-  (escape)="onDismiss()"
-  *transloco="let t"
->
+<div class="sort-dropdown" ynClickOutside (clickOutside)="onDismiss()" (escape)="onDismiss()" *transloco="let t">
   <button
     type="button"
     class="sort-toggle"
@@ -15,9 +9,7 @@
     [attr.aria-expanded]="open()"
   >
     {{ t(currentLabelKey()) }}
-    <span class="sort-chevron" [class.open]="open()"
-      ><lucide-icon name="chevron-down" [size]="18"
-    /></span>
+    <span class="sort-chevron" [class.open]="open()"><lucide-icon name="chevron-down" [size]="18" /></span>
   </button>
   @if (open()) {
     <ul class="sort-menu" role="listbox">

--- a/client/apps/shell-e2e/src/auth.setup.ts
+++ b/client/apps/shell-e2e/src/auth.setup.ts
@@ -32,9 +32,7 @@ setup('authenticate via pre-fetched Keycloak tokens', async ({ page }) => {
   const idClaims = decodeJwtPayload(tokens.id_token);
   const now = Date.now();
   const expiresAt = (now + tokens.expires_in * 1000).toString();
-  const idTokenExpiresAt = (
-    typeof idClaims['exp'] === 'number' ? idClaims['exp'] * 1000 : now + tokens.expires_in * 1000
-  ).toString();
+  const idTokenExpiresAt = (typeof idClaims['exp'] === 'number' ? idClaims['exp'] * 1000 : now + tokens.expires_in * 1000).toString();
 
   // Navigate to the origin once so sessionStorage is scoped correctly.
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 });

--- a/client/apps/shell-e2e/src/auth/register.spec.ts
+++ b/client/apps/shell-e2e/src/auth/register.spec.ts
@@ -54,9 +54,7 @@ test.describe('Register Page (US-001)', () => {
     await registerPage.passwordInput.fill('alllowercase');
     await registerPage.passwordInput.blur();
 
-    await expect(
-      registerPage.fieldError('Password must contain uppercase, lowercase, and a digit'),
-    ).toBeVisible();
+    await expect(registerPage.fieldError('Password must contain uppercase, lowercase, and a digit')).toBeVisible();
   });
 
   test('should show passwords mismatch error', async () => {

--- a/client/apps/shell-e2e/src/auth/session-lifecycle.spec.ts
+++ b/client/apps/shell-e2e/src/auth/session-lifecycle.spec.ts
@@ -52,15 +52,11 @@ test.describe('Auth Session Lifecycle (#407)', () => {
     });
   });
 
-  test('explicit logout clears session and bounces protected nav', async ({
-    authenticatedPage,
-  }) => {
+  test('explicit logout clears session and bounces protected nav', async ({ authenticatedPage }) => {
     // Open the user menu, click Logout. The lib navigates to Keycloak's
     // logout endpoint then back to origin — point both at a stub so the
     // test does not depend on the real Keycloak being reachable.
-    await authenticatedPage.route('**/realms/yumney/protocol/openid-connect/logout*', (route) =>
-      route.fulfill({ status: 200, body: '' }),
-    );
+    await authenticatedPage.route('**/realms/yumney/protocol/openid-connect/logout*', (route) => route.fulfill({ status: 200, body: '' }));
 
     const header = new HeaderPage(authenticatedPage);
     await header.logout();

--- a/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
+++ b/client/apps/shell-e2e/src/dashboard/save-recipe-error-paths.spec.ts
@@ -41,8 +41,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     // Wait for the POST response before asserting the banner so we know
     // the click actually fired the request the mock is supposed to fulfill.
     const savePost = authenticatedPage.waitForResponse(
-      (res) =>
-        new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
+      (res) => new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
       { timeout: TIMEOUTS.default },
     );
     await dashboard.previewSaveButton.click();
@@ -53,9 +52,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await expect(editForm.titleInput).toHaveValue('E2E 500 Test');
   });
 
-  test('shows error banner when save returns 422 with validation errors', async ({
-    authenticatedPage,
-  }) => {
+  test('shows error banner when save returns 422 with validation errors', async ({ authenticatedPage }) => {
     await mockApiError(authenticatedPage, '**/api/v1/recipes', 422, {
       errors: {
         title: ["'Title' must not be empty."],
@@ -70,8 +67,7 @@ test.describe('Dashboard — Save Recipe Error Paths (#408)', () => {
     await editForm.fillMinimal('E2E 422 Test');
 
     const savePost = authenticatedPage.waitForResponse(
-      (res) =>
-        new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
+      (res) => new URL(res.url()).pathname === '/api/v1/recipes' && res.request().method() === 'POST',
       { timeout: TIMEOUTS.default },
     );
     await dashboard.previewSaveButton.click();

--- a/client/apps/shell-e2e/src/global-teardown.ts
+++ b/client/apps/shell-e2e/src/global-teardown.ts
@@ -47,10 +47,7 @@ export default async function globalTeardown(): Promise<void> {
     if (ok) deleted += 1;
     else failed += 1;
   }
-  console.log(
-    `[global-teardown] swept ${deleted} orphaned E2E recipes` +
-      (failed > 0 ? ` (${failed} delete failures, ignored)` : ''),
-  );
+  console.log(`[global-teardown] swept ${deleted} orphaned E2E recipes` + (failed > 0 ? ` (${failed} delete failures, ignored)` : ''));
 }
 
 function readAccessToken(file: string): string | null {

--- a/client/apps/shell-e2e/src/helpers/env-guard.ts
+++ b/client/apps/shell-e2e/src/helpers/env-guard.ts
@@ -24,9 +24,7 @@ function assertLocalHostname(varName: string, rawUrl: string): void {
   try {
     parsed = new URL(rawUrl);
   } catch {
-    throw new Error(
-      `[e2e-guard] ${varName}=${rawUrl} is not a valid URL. Expected http(s)://localhost:port`,
-    );
+    throw new Error(`[e2e-guard] ${varName}=${rawUrl} is not a valid URL. Expected http(s)://localhost:port`);
   }
 
   if (!LOCAL_HOSTNAMES.has(parsed.hostname)) {

--- a/client/apps/shell-e2e/src/helpers/pwa.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/pwa.helper.ts
@@ -21,9 +21,7 @@ export async function setupKeycloakMock(page: Page): Promise<void> {
       }),
     }),
   );
-  await page.route('**/realms/yumney/protocol/openid-connect/auth*', (route) =>
-    route.fulfill({ status: 200, body: '' }),
-  );
+  await page.route('**/realms/yumney/protocol/openid-connect/auth*', (route) => route.fulfill({ status: 200, body: '' }));
   await page.route('**/realms/yumney/protocol/openid-connect/certs', (route) =>
     route.fulfill({
       status: 200,
@@ -45,9 +43,7 @@ export async function waitForServiceWorker(page: Page, timeout = 40_000): Promis
     const deadline = Date.now() + ms;
     while (Date.now() < deadline) {
       const registrations = await navigator.serviceWorker.getRegistrations();
-      const active = registrations.find(
-        (registration) => registration.active?.state === 'activated',
-      );
+      const active = registrations.find((registration) => registration.active?.state === 'activated');
       if (active) return;
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
@@ -160,10 +156,7 @@ export async function waitForServiceWorkerControl(page: Page, timeout = 120_000)
   }, timeout);
 
   if (!result.ok) {
-    throw new Error(
-      `waitForServiceWorkerControl failed: ${result.reason}\n` +
-        `details: ${JSON.stringify(result, null, 2)}`,
-    );
+    throw new Error(`waitForServiceWorkerControl failed: ${result.reason}\n` + `details: ${JSON.stringify(result, null, 2)}`);
   }
 }
 

--- a/client/apps/shell-e2e/src/helpers/shared-recipe.ts
+++ b/client/apps/shell-e2e/src/helpers/shared-recipe.ts
@@ -1,10 +1,5 @@
 import { type TestType } from '@playwright/test';
-import {
-  uniqueTitle,
-  openAuthenticatedPage,
-  createTestRecipe,
-  deleteTestRecipe,
-} from './test-data.helper';
+import { uniqueTitle, openAuthenticatedPage, createTestRecipe, deleteTestRecipe } from './test-data.helper';
 
 export interface SharedRecipe {
   title: string;

--- a/client/apps/shell-e2e/src/helpers/test-data.helper.ts
+++ b/client/apps/shell-e2e/src/helpers/test-data.helper.ts
@@ -136,22 +136,19 @@ export async function assignMealSlot(
   await page.evaluate(
     async ({ assignOptions, gatewayUrl }) => {
       const token = localStorage.getItem('access_token');
-      const res = await fetch(
-        `${gatewayUrl}/api/v1/meal-plans/${assignOptions.year}/w/${assignOptions.weekNumber}/slots`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({
-            day: assignOptions.day,
-            recipeIdentifier: assignOptions.recipeIdentifier,
-            recipeTitle: assignOptions.recipeTitle,
-            mealType: assignOptions.mealType ?? 'Dinner',
-          }),
+      const res = await fetch(`${gatewayUrl}/api/v1/meal-plans/${assignOptions.year}/w/${assignOptions.weekNumber}/slots`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
-      );
+        body: JSON.stringify({
+          day: assignOptions.day,
+          recipeIdentifier: assignOptions.recipeIdentifier,
+          recipeTitle: assignOptions.recipeTitle,
+          mealType: assignOptions.mealType ?? 'Dinner',
+        }),
+      });
       if (!res.ok) {
         throw new Error(`assignMealSlot failed: ${res.status} ${await res.text()}`);
       }

--- a/client/apps/shell-e2e/src/i18n/i18n-parity.spec.ts
+++ b/client/apps/shell-e2e/src/i18n/i18n-parity.spec.ts
@@ -38,10 +38,7 @@ async function readH1(page: import('@playwright/test').Page): Promise<string> {
   return text;
 }
 
-async function setLanguage(
-  page: import('@playwright/test').Page,
-  lang: 'en' | 'de',
-): Promise<void> {
+async function setLanguage(page: import('@playwright/test').Page, lang: 'en' | 'de'): Promise<void> {
   await page.evaluate((value) => {
     localStorage.setItem('yn-language', value);
   }, lang);

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner-generate-error.spec.ts
@@ -39,23 +39,19 @@ test.describe('Meal Planner — generate shopping list error path', () => {
     }
   });
 
-  test('surfaces server error when generate-shopping-list returns 500', async ({
-    authenticatedPage,
-  }) => {
-    await authenticatedPage
-      .context()
-      .route('**/api/v1/meal-plans/*/w/*/generate-shopping-list', (route) =>
-        route.fulfill({
+  test('surfaces server error when generate-shopping-list returns 500', async ({ authenticatedPage }) => {
+    await authenticatedPage.context().route('**/api/v1/meal-plans/*/w/*/generate-shopping-list', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/problem+json',
+        body: JSON.stringify({
+          type: 'about:blank',
+          title: 'Internal Server Error',
           status: 500,
-          contentType: 'application/problem+json',
-          body: JSON.stringify({
-            type: 'about:blank',
-            title: 'Internal Server Error',
-            status: 500,
-            detail: 'Synthetic failure injected by E2E to exercise the error path.',
-          }),
+          detail: 'Synthetic failure injected by E2E to exercise the error path.',
         }),
-      );
+      }),
+    );
 
     await authenticatedPage.goto(`/meal-planner?year=${seededYear}&week=${seededWeek}`);
 

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner-interactions.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner-interactions.spec.ts
@@ -55,9 +55,7 @@ test.describe('Meal Planner Interactions', () => {
     }
   });
 
-  test('should show empty slot with plus icon for unassigned days', async ({
-    authenticatedPage,
-  }) => {
+  test('should show empty slot with plus icon for unassigned days', async ({ authenticatedPage }) => {
     const planner = new MealPlannerPage(authenticatedPage);
     await planner.goto();
     await expect(planner.dayCards.first()).toBeVisible({ timeout: TIMEOUTS.default });

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner-shopping.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner-shopping.spec.ts
@@ -3,9 +3,7 @@ import { MealPlannerPage } from '../pages/meal-planner.page';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Meal Planner Shopping Integration (US-325)', () => {
-  test('should not show generate button when no recipes are assigned', async ({
-    authenticatedPage,
-  }) => {
+  test('should not show generate button when no recipes are assigned', async ({ authenticatedPage }) => {
     const planner = new MealPlannerPage(authenticatedPage);
 
     // Navigate to a far-future week that likely has no recipes

--- a/client/apps/shell-e2e/src/meal-planner/meal-planner.spec.ts
+++ b/client/apps/shell-e2e/src/meal-planner/meal-planner.spec.ts
@@ -27,15 +27,7 @@ test.describe('Meal Planner (US-320)', () => {
 
     await expect(planner.dayCards.first()).toBeVisible({ timeout: TIMEOUTS.default });
 
-    for (const day of [
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-      'Sunday',
-    ]) {
+    for (const day of ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']) {
       await expect(planner.dayCard(day)).toBeVisible();
     }
   });

--- a/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-detail.page.ts
@@ -33,9 +33,7 @@ export class RecipeDetailPage {
     this.resetServingsButton = page.getByRole('button', { name: /reset/i });
     this.editButton = page.getByRole('link', { name: /edit/i });
     this.deleteButton = page.locator('.btn-danger');
-    this.shoppingListButton = page
-      .locator('[data-testid="recipe-create-shopping-list-btn"]')
-      .first();
+    this.shoppingListButton = page.locator('[data-testid="recipe-create-shopping-list-btn"]').first();
     this.sourceLink = page.locator('.source-link a');
     // Target the overlay div inside yn-dialog-shell rather than the host
     // yn-confirm-dialog. The host has 0x0 dimensions because its child is

--- a/client/apps/shell-e2e/src/pages/recipe-edit.page.ts
+++ b/client/apps/shell-e2e/src/pages/recipe-edit.page.ts
@@ -26,9 +26,7 @@ export class RecipeEditPage {
     this.firstIngredientNameInput = page.locator('input[formControlName="name"]').first();
     // Step description must be scoped to .step-fields — there is also
     // a recipe-level description textarea with the same formControlName.
-    this.firstStepDescriptionInput = page
-      .locator('.step-fields textarea[formControlName="description"]')
-      .first();
+    this.firstStepDescriptionInput = page.locator('.step-fields textarea[formControlName="description"]').first();
     // Save button lives inside <yn-recipe-preview>; callers should scope
     // via DashboardPage.recipePreview when there could be other .save-btns.
     this.saveButton = page.locator('.save-btn');

--- a/client/apps/shell-e2e/src/pages/register.page.ts
+++ b/client/apps/shell-e2e/src/pages/register.page.ts
@@ -31,12 +31,7 @@ export class RegisterPage {
     await this.page.goto('/auth/register');
   }
 
-  async fillForm(data: {
-    email: string;
-    displayName: string;
-    password: string;
-    confirmPassword: string;
-  }): Promise<void> {
+  async fillForm(data: { email: string; displayName: string; password: string; confirmPassword: string }): Promise<void> {
     await this.emailInput.fill(data.email);
     await this.displayNameInput.fill(data.displayName);
     await this.passwordInput.fill(data.password);

--- a/client/apps/shell-e2e/src/pwa/offline.spec.ts
+++ b/client/apps/shell-e2e/src/pwa/offline.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { AppShellPage } from '../pages/app-shell.page';
-import {
-  setupKeycloakMock,
-  waitForServiceWorker,
-  waitForServiceWorkerControl,
-} from '../helpers/pwa.helper';
+import { setupKeycloakMock, waitForServiceWorker, waitForServiceWorkerControl } from '../helpers/pwa.helper';
 import { TIMEOUTS } from '../helpers/timeouts';
 
 test.describe('Offline Caching', () => {

--- a/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-chat.spec.ts
@@ -29,9 +29,7 @@ test.describe('Recipe Chat (US-230, US-303, US-306)', () => {
     await expect(chat.panel).not.toBeVisible();
   });
 
-  test('should close chat panel when backdrop is tapped on mobile', async ({
-    authenticatedPage,
-  }) => {
+  test('should close chat panel when backdrop is tapped on mobile', async ({ authenticatedPage }) => {
     await authenticatedPage.setViewportSize({ width: 375, height: 812 });
     const chat = new ChatPage(authenticatedPage);
     await chat.open();
@@ -43,9 +41,7 @@ test.describe('Recipe Chat (US-230, US-303, US-306)', () => {
     await expect(chat.panel).not.toBeVisible();
   });
 
-  test('should show welcome message with examples when panel first opens', async ({
-    authenticatedPage,
-  }) => {
+  test('should show welcome message with examples when panel first opens', async ({ authenticatedPage }) => {
     const chat = new ChatPage(authenticatedPage);
     await chat.open();
     await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });

--- a/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-detail.spec.ts
@@ -39,9 +39,7 @@ test.describe('Recipe Detail (US-031, US-050, US-032, US-033)', () => {
     await expect(authenticatedPage).toHaveURL(new RegExp(`/recipes/${recipe().identifier}/edit`));
   });
 
-  test('should show and dismiss delete confirmation dialog (US-033)', async ({
-    authenticatedPage,
-  }) => {
+  test('should show and dismiss delete confirmation dialog (US-033)', async ({ authenticatedPage }) => {
     const detail = new RecipeDetailPage(authenticatedPage);
     await detail.goto(recipe().identifier);
 

--- a/client/apps/shell-e2e/src/recipes/recipe-edit.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-edit.spec.ts
@@ -16,9 +16,7 @@ import { TIMEOUTS } from '../helpers/timeouts';
 test.describe('Recipe Edit Flow', () => {
   const recipe = setupSharedRecipe(test, 'E2E Edit Test');
 
-  test('navigates from list card to detail page with edit button', async ({
-    authenticatedPage,
-  }) => {
+  test('navigates from list card to detail page with edit button', async ({ authenticatedPage }) => {
     const list = new RecipeListPage(authenticatedPage);
     const detail = new RecipeDetailPage(authenticatedPage);
     await list.goto();

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite-cross-route.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite-cross-route.spec.ts
@@ -31,10 +31,7 @@ test.describe('Favorite cross-route consistency (US-071)', () => {
     // fetch can race the unfinished write and miss the new state (see #419
     // on the existing favorite spec).
     const favoriteCommitted = authenticatedPage.waitForResponse(
-      (res) =>
-        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
-        res.request().method() === 'POST' &&
-        res.ok(),
+      (res) => /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) && res.request().method() === 'POST' && res.ok(),
       { timeout: TIMEOUTS.default },
     );
     await detail.favoriteButton.click();

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite-rollback.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite-rollback.spec.ts
@@ -79,9 +79,7 @@ test.describe('Favorite Recipes — Optimistic Rollback (#409)', () => {
 
     // Wait for the (failed) POST to complete before asserting the revert.
     const favoritePost = authenticatedPage.waitForResponse(
-      (res) =>
-        new RegExp(`/api/v1/recipes/${recipe().identifier}/favorite$`).test(res.url()) &&
-        res.request().method() === 'POST',
+      (res) => new RegExp(`/api/v1/recipes/${recipe().identifier}/favorite$`).test(res.url()) && res.request().method() === 'POST',
       { timeout: TIMEOUTS.default },
     );
     await heart.click();
@@ -95,9 +93,7 @@ test.describe('Favorite Recipes — Optimistic Rollback (#409)', () => {
     const response = await favoritePost;
     // Diagnostic: confirm the response was actually our mock.
     // eslint-disable-next-line no-console
-    console.log(
-      `[#409 mock] favorite response status=${response.status()} handlerFireCount=${handlerFireCount}`,
-    );
+    console.log(`[#409 mock] favorite response status=${response.status()} handlerFireCount=${handlerFireCount}`);
     expect(handlerFireCount, 'route handler should have intercepted the POST').toBeGreaterThan(0);
     expect(response.status(), 'mocked response should be 500').toBe(500);
 

--- a/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/recipe-favorite.spec.ts
@@ -33,10 +33,7 @@ test.describe('Favorite Recipes (US-071)', () => {
     // …) refetch from the server and would race the un-committed write
     // otherwise — see #419.
     const favoriteCommitted = authenticatedPage.waitForResponse(
-      (res) =>
-        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
-        res.request().method() === 'POST' &&
-        res.ok(),
+      (res) => /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) && res.request().method() === 'POST' && res.ok(),
       { timeout: TIMEOUTS.default },
     );
     await heart.click();
@@ -62,9 +59,7 @@ test.describe('Favorite Recipes (US-071)', () => {
     await expect(heart).toHaveAttribute('aria-pressed', 'true');
   });
 
-  test('should narrow list when "Show only favorites" filter is enabled', async ({
-    authenticatedPage,
-  }) => {
+  test('should narrow list when "Show only favorites" filter is enabled', async ({ authenticatedPage }) => {
     const list = new RecipeListPage(authenticatedPage);
     await list.goto();
     await expect(list.recipeCard(recipe().title).first()).toBeVisible({
@@ -98,10 +93,7 @@ test.describe('Favorite Recipes (US-071)', () => {
     // Same race as in test 1 (#419): without waiting on the POST commit,
     // a subsequent reload could still see aria-pressed='true'.
     const favoriteCommitted = authenticatedPage.waitForResponse(
-      (res) =>
-        /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) &&
-        res.request().method() === 'POST' &&
-        res.ok(),
+      (res) => /\/api\/v1\/recipes\/.+\/favorite$/.test(res.url()) && res.request().method() === 'POST' && res.ok(),
       { timeout: TIMEOUTS.default },
     );
     await detail.favoriteButton.click();

--- a/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
+++ b/client/apps/shell-e2e/src/shopping/shopping-list.spec.ts
@@ -44,9 +44,7 @@ test.describe('Shopping List — Generate from Recipe (US-040)', () => {
     }
   });
 
-  test('should disable create button when no ingredients selected', async ({
-    authenticatedPage,
-  }) => {
+  test('should disable create button when no ingredients selected', async ({ authenticatedPage }) => {
     const createPage = new ShoppingCreatePage(authenticatedPage);
     await createPage.goto(recipe().identifier);
 

--- a/client/apps/shell/src/app/app.config.ts
+++ b/client/apps/shell/src/app/app.config.ts
@@ -28,10 +28,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
     provideYumneyIcons(),
-    provideHttpClient(
-      withFetch(),
-      withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor]),
-    ),
+    provideHttpClient(withFetch(), withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor])),
     provideAuth(),
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
@@ -48,8 +45,7 @@ export const appConfig: ApplicationConfig = {
     }),
     {
       provide: APP_INITIALIZER,
-      useFactory: (lang: LanguageService, theme: ThemeService) => () =>
-        Promise.all([lang.initialize(), theme.initialize()]),
+      useFactory: (lang: LanguageService, theme: ThemeService) => () => Promise.all([lang.initialize(), theme.initialize()]),
       deps: [LanguageService, ThemeService],
       multi: true,
     },

--- a/client/apps/shell/src/app/auth/register/register.component.html
+++ b/client/apps/shell/src/app/auth/register/register.component.html
@@ -5,9 +5,7 @@
         <h2>{{ t('auth.register.success.title') }}</h2>
         <p>{{ t('auth.register.success.message') }}</p>
         <p class="resend-link">
-          <a [routerLink]="ROUTES.auth.resendVerification">{{
-            t('auth.register.success.resendLink')
-          }}</a>
+          <a [routerLink]="ROUTES.auth.resendVerification">{{ t('auth.register.success.resendLink') }}</a>
         </p>
       </div>
     } @else {
@@ -26,13 +24,7 @@
             maxlength: 'auth.register.errors.emailMaxLength',
           }"
         >
-          <input
-            id="email"
-            type="email"
-            formControlName="email"
-            autocomplete="email"
-            [placeholder]="t('auth.register.emailPlaceholder')"
-          />
+          <input id="email" type="email" formControlName="email" autocomplete="email" [placeholder]="t('auth.register.emailPlaceholder')" />
         </yn-form-field>
 
         <yn-form-field
@@ -63,12 +55,7 @@
             pattern: 'auth.register.errors.passwordPattern',
           }"
         >
-          <input
-            id="password"
-            type="password"
-            formControlName="password"
-            autocomplete="new-password"
-          />
+          <input id="password" type="password" formControlName="password" autocomplete="new-password" />
         </yn-form-field>
 
         <yn-form-field
@@ -79,19 +66,10 @@
           [group]="form"
           [groupErrors]="{ passwordsMismatch: 'auth.register.errors.passwordsMismatch' }"
         >
-          <input
-            id="confirmPassword"
-            type="password"
-            formControlName="confirmPassword"
-            autocomplete="new-password"
-          />
+          <input id="confirmPassword" type="password" formControlName="confirmPassword" autocomplete="new-password" />
         </yn-form-field>
 
-        <yn-submit-button
-          [loading]="isLoading()"
-          label="auth.register.submit"
-          loadingLabel="auth.register.submitting"
-        />
+        <yn-submit-button [loading]="isLoading()" label="auth.register.submit" loadingLabel="auth.register.submitting" />
       </form>
     }
   </yn-card>

--- a/client/apps/shell/src/app/auth/register/register.component.spec.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.spec.ts
@@ -186,9 +186,7 @@ describe('RegisterComponent', () => {
 
     it('should clear serverError on new submission', fakeAsync(() => {
       fillValidForm();
-      authApiMock.register.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 500 })),
-      );
+      authApiMock.register.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
       component.onSubmit();
       tick();
@@ -201,9 +199,7 @@ describe('RegisterComponent', () => {
 
     it('should set serverError for 409 conflict', fakeAsync(() => {
       fillValidForm();
-      authApiMock.register.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 409 })),
-      );
+      authApiMock.register.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 409 })));
 
       component.onSubmit();
       tick();
@@ -213,9 +209,7 @@ describe('RegisterComponent', () => {
 
     it('should set serverError for 422 validation error', fakeAsync(() => {
       fillValidForm();
-      authApiMock.register.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 422 })),
-      );
+      authApiMock.register.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 422 })));
 
       component.onSubmit();
       tick();
@@ -225,9 +219,7 @@ describe('RegisterComponent', () => {
 
     it('should set generic serverError for 500', fakeAsync(() => {
       fillValidForm();
-      authApiMock.register.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 500 })),
-      );
+      authApiMock.register.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
       component.onSubmit();
       tick();

--- a/client/apps/shell/src/app/auth/register/register.component.ts
+++ b/client/apps/shell/src/app/auth/register/register.component.ts
@@ -3,20 +3,8 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthApiService } from '@yumney/shared/api-client';
-import {
-  passwordsMatchValidator,
-  createAsyncState,
-  ensureFormValid,
-  VALIDATION,
-  ERROR_MAPS,
-  ROUTES,
-} from '@yumney/shared/models';
-import {
-  CardComponent,
-  FormFieldComponent,
-  MessageBannerComponent,
-  SubmitButtonComponent,
-} from '@yumney/ui';
+import { passwordsMatchValidator, createAsyncState, ensureFormValid, VALIDATION, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
+import { CardComponent, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-register',
@@ -46,14 +34,7 @@ export class RegisterComponent {
 
   form = this.formBuilder.nonNullable.group(
     {
-      email: [
-        '',
-        [
-          Validators.required,
-          Validators.email,
-          Validators.maxLength(VALIDATION.USERS.EMAIL.MAX_LENGTH),
-        ],
-      ],
+      email: ['', [Validators.required, Validators.email, Validators.maxLength(VALIDATION.USERS.EMAIL.MAX_LENGTH)]],
       password: [
         '',
         [
@@ -65,10 +46,7 @@ export class RegisterComponent {
         ],
       ],
       confirmPassword: ['', [Validators.required]],
-      displayName: [
-        '',
-        [Validators.required, Validators.maxLength(VALIDATION.USERS.DISPLAY_NAME.MAX_LENGTH)],
-      ],
+      displayName: ['', [Validators.required, Validators.maxLength(VALIDATION.USERS.DISPLAY_NAME.MAX_LENGTH)]],
     },
     { validators: [passwordsMatchValidator] },
   );
@@ -78,13 +56,9 @@ export class RegisterComponent {
 
     const { email, password, displayName } = this.form.getRawValue();
 
-    this.asyncState.execute(
-      this.authApi.register({ email, password, displayName }),
-      ERROR_MAPS.auth.register,
-      () => {
-        this.isSuccess.set(true);
-        this.form.reset();
-      },
-    );
+    this.asyncState.execute(this.authApi.register({ email, password, displayName }), ERROR_MAPS.auth.register, () => {
+      this.isSuccess.set(true);
+      this.form.reset();
+    });
   }
 }

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.spec.ts
@@ -105,9 +105,7 @@ describe('ResendVerificationComponent', () => {
 
     it('should clear serverError on new submission', fakeAsync(() => {
       component.form.controls.email.setValue('test@example.com');
-      authApiMock.resendVerificationEmail.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 500 })),
-      );
+      authApiMock.resendVerificationEmail.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
       component.onSubmit();
       tick();
@@ -130,9 +128,7 @@ describe('ResendVerificationComponent', () => {
 
     it('should set serverError for 503 service unavailable', fakeAsync(() => {
       component.form.controls.email.setValue('test@example.com');
-      authApiMock.resendVerificationEmail.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 503 })),
-      );
+      authApiMock.resendVerificationEmail.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 503 })));
 
       component.onSubmit();
       tick();
@@ -142,9 +138,7 @@ describe('ResendVerificationComponent', () => {
 
     it('should set generic serverError for other errors', fakeAsync(() => {
       component.form.controls.email.setValue('test@example.com');
-      authApiMock.resendVerificationEmail.mockReturnValue(
-        throwError(() => new HttpErrorResponse({ status: 500 })),
-      );
+      authApiMock.resendVerificationEmail.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
       component.onSubmit();
       tick();

--- a/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
+++ b/client/apps/shell/src/app/auth/resend-verification/resend-verification.component.ts
@@ -3,19 +3,8 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { AuthApiService } from '@yumney/shared/api-client';
-import {
-  createAsyncState,
-  ensureFormValid,
-  VALIDATION,
-  ERROR_MAPS,
-  ROUTES,
-} from '@yumney/shared/models';
-import {
-  CardComponent,
-  FormFieldComponent,
-  MessageBannerComponent,
-  SubmitButtonComponent,
-} from '@yumney/ui';
+import { createAsyncState, ensureFormValid, VALIDATION, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
+import { CardComponent, FormFieldComponent, MessageBannerComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-resend-verification',
@@ -44,14 +33,7 @@ export class ResendVerificationComponent {
   serverError = this.asyncState.serverError;
 
   form = this.formBuilder.nonNullable.group({
-    email: [
-      '',
-      [
-        Validators.required,
-        Validators.email,
-        Validators.maxLength(VALIDATION.USERS.EMAIL.MAX_LENGTH),
-      ],
-    ],
+    email: ['', [Validators.required, Validators.email, Validators.maxLength(VALIDATION.USERS.EMAIL.MAX_LENGTH)]],
   });
 
   onSubmit(): void {
@@ -59,10 +41,8 @@ export class ResendVerificationComponent {
 
     const { email } = this.form.getRawValue();
 
-    this.asyncState.execute(
-      this.authApi.resendVerificationEmail({ email }),
-      ERROR_MAPS.auth.resendVerification,
-      () => this.isSuccess.set(true),
+    this.asyncState.execute(this.authApi.resendVerificationEmail({ email }), ERROR_MAPS.auth.resendVerification, () =>
+      this.isSuccess.set(true),
     );
   }
 }

--- a/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.spec.ts
@@ -41,9 +41,7 @@ describe('DashboardSuggestionsService', () => {
 
     expect(result).toEqual({ initialDataIsEmpty: false });
     expect(service.loading()).toBe(false);
-    expect(service.quickActions()).toEqual([
-      { key: 'cook_now', labelKey: 'dashboard.quickActions.cook_now' },
-    ]);
+    expect(service.quickActions()).toEqual([{ key: 'cook_now', labelKey: 'dashboard.quickActions.cook_now' }]);
     expect(service.suggestions()?.suggestions).toHaveLength(1);
   });
 

--- a/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard-suggestions.service.ts
@@ -1,11 +1,7 @@
 import { DestroyRef, Injectable, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { catchError, map, Observable, of, tap } from 'rxjs';
-import {
-  DashboardApiService,
-  type SuggestionsResponse,
-  type UserActivityItem,
-} from '@yumney/shared/api-client';
+import { DashboardApiService, type SuggestionsResponse, type UserActivityItem } from '@yumney/shared/api-client';
 import type { QuickAction } from '@yumney/ui';
 
 @Injectable()

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -6,11 +6,7 @@
   <h1>{{ t('dashboard.title') }}</h1>
   <p>{{ t('dashboard.welcome') }}</p>
 
-  <a
-    class="cookable-shortcut"
-    data-testid="dashboard-cookable-shortcut"
-    [routerLink]="ROUTES.recipes.cookable"
-  >
+  <a class="cookable-shortcut" data-testid="dashboard-cookable-shortcut" [routerLink]="ROUTES.recipes.cookable">
     <lucide-icon name="chef-hat" [size]="24" class="cookable-shortcut-icon" />
     <span class="cookable-shortcut-body">
       <span class="cookable-shortcut-title">{{ t('dashboard.cookable.title') }}</span>
@@ -50,11 +46,7 @@
     </section>
   }
 
-  <section
-    class="import-section"
-    data-testid="import-section"
-    [class.expanded]="importSectionExpanded()"
-  >
+  <section class="import-section" data-testid="import-section" [class.expanded]="importSectionExpanded()">
     <button
       class="import-toggle"
       data-testid="import-toggle"
@@ -81,26 +73,14 @@
           <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
           <div class="photo-import-actions">
             @if (camera.cameraSupported()) {
-              <yn-button
-                variant="dashed"
-                [disabled]="isLoading() || isSaving()"
-                (click)="onOpenCamera()"
-              >
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
                 {{ t('dashboard.photoImport.scanRecipe') }}
               </yn-button>
-              <yn-button
-                variant="dashed"
-                [disabled]="isLoading() || isSaving()"
-                (click)="onOpenScanner()"
-              >
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
                 {{ t('dashboard.photoImport.scanIngredients') }}
               </yn-button>
             }
-            <label
-              class="btn-dashed"
-              data-testid="photo-upload-btn"
-              [class.disabled]="isLoading() || isSaving()"
-            >
+            <label class="btn-dashed" data-testid="photo-upload-btn" [class.disabled]="isLoading() || isSaving()">
               <input
                 type="file"
                 data-testid="photo-upload-input"
@@ -140,12 +120,7 @@
 
   @if (saveSuccess(); as savedTitle) {
     <div class="save-success">
-      <yn-message-banner
-        tone="success"
-        message="dashboard.save.success"
-        [params]="{ title: savedTitle }"
-        testId="success-banner"
-      />
+      <yn-message-banner tone="success" message="dashboard.save.success" [params]="{ title: savedTitle }" testId="success-banner" />
       <yn-button variant="ghost" extraClass="import-another" (click)="onImportAnother()">
         {{ t('dashboard.save.importAnother') }}
       </yn-button>
@@ -177,17 +152,11 @@
 
   @if (scannerActive()) {
     @defer {
-      <yn-ingredient-scanner
-        (ingredientsConfirmed)="onIngredientsConfirmed($event)"
-        (cancelled)="onScannerCancelled()"
-      />
+      <yn-ingredient-scanner (ingredientsConfirmed)="onIngredientsConfirmed($event)" (cancelled)="onScannerCancelled()" />
     }
   }
 
   @if (recognizedIngredients(); as ingredients) {
-    <yn-ingredients-toast
-      [ingredients]="ingredients"
-      (dismissed)="dismissRecognizedIngredients()"
-    />
+    <yn-ingredients-toast [ingredients]="ingredients" (dismissed)="dismissRecognizedIngredients()" />
   }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -248,12 +248,7 @@
   min-width: 200px;
   height: 180px;
   border-radius: var(--yn-radius-card);
-  background: linear-gradient(
-    90deg,
-    var(--yn-glass-bg) 25%,
-    var(--yn-glass-bg-elevated) 50%,
-    var(--yn-glass-bg) 75%
-  );
+  background: linear-gradient(90deg, var(--yn-glass-bg) 25%, var(--yn-glass-bg-elevated) 50%, var(--yn-glass-bg) 75%);
   background-size: 200% 100%;
   animation: yn-shimmer 1.5s ease-in-out infinite;
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -5,12 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
 import { setupTranslocoTesting, UI } from '@yumney/shared/models';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  SavedRecipeResponse,
-  DashboardApiService,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse, SavedRecipeResponse, DashboardApiService } from '@yumney/shared/api-client';
 
 const mockRecipe: ImportRecipeResponse = {
   title: 'Pasta Carbonara',
@@ -254,9 +249,7 @@ describe('DashboardComponent', () => {
   }));
 
   it('should show duplicate error on 409 response', fakeAsync(() => {
-    recipeApiMock.saveRecipe.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 409 })),
-    );
+    recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 409 })));
 
     component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     component.onSaveRecipe(mockRecipe);
@@ -266,9 +259,7 @@ describe('DashboardComponent', () => {
   }));
 
   it('should show generic save error on 500 response', fakeAsync(() => {
-    recipeApiMock.saveRecipe.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 500 })),
-    );
+    recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
     component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     component.onSaveRecipe(mockRecipe);
@@ -308,9 +299,7 @@ describe('DashboardComponent', () => {
     component.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
-      expect.not.objectContaining({ sourceUrl: expect.anything() }),
-    );
+    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.not.objectContaining({ sourceUrl: expect.anything() }));
   }));
 
   it('should include sourceUrl in save request', fakeAsync(() => {
@@ -325,9 +314,7 @@ describe('DashboardComponent', () => {
     component.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceUrl: 'https://example.com/recipe' }),
-    );
+    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.objectContaining({ sourceUrl: 'https://example.com/recipe' }));
   }));
 
   it('should map recipe fields to save request correctly', fakeAsync(() => {
@@ -363,9 +350,7 @@ describe('DashboardComponent', () => {
   }));
 
   it('should set isSaving to false after save error', fakeAsync(() => {
-    recipeApiMock.saveRecipe.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 500 })),
-    );
+    recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
     component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     component.onSaveRecipe(mockRecipe);
@@ -376,9 +361,7 @@ describe('DashboardComponent', () => {
 
   it('should clear serverError when starting a save', fakeAsync(() => {
     component.serverError.set('previous error');
-    recipeApiMock.saveRecipe.mockReturnValue(
-      of({ identifier: '1', title: 'X', createdAt: '2026-03-10T00:00:00Z' } as SavedRecipeResponse),
-    );
+    recipeApiMock.saveRecipe.mockReturnValue(of({ identifier: '1', title: 'X', createdAt: '2026-03-10T00:00:00Z' } as SavedRecipeResponse));
 
     component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     component.onSaveRecipe(mockRecipe);
@@ -471,9 +454,7 @@ describe('DashboardComponent', () => {
     component.onSaveRecipe({ ...draft, title: 'My Recipe' });
     tick(UI.SAVED_INDICATOR_MS);
 
-    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
-      expect.not.objectContaining({ sourceUrl: expect.anything() }),
-    );
+    expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.not.objectContaining({ sourceUrl: expect.anything() }));
     expect(routerMock.navigate).toHaveBeenCalledWith(['/recipes/456']);
   }));
 
@@ -584,9 +565,7 @@ describe('DashboardComponent – Share Intent', () => {
   beforeEach(() => {
     recipeApiMock = {
       importRecipe: vi.fn(),
-      importRecipeStream: vi
-        .fn()
-        .mockReturnValue(of({ type: 'done' as const, data: JSON.stringify(mockRecipe) })),
+      importRecipeStream: vi.fn().mockReturnValue(of({ type: 'done' as const, data: JSON.stringify(mockRecipe) })),
       importFromPhotos: vi.fn(),
       saveRecipe: vi.fn(),
     };

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,24 +1,9 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  signal,
-  inject,
-  DestroyRef,
-  OnInit,
-  effect,
-  viewChild,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef, OnInit, effect, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-client';
-import {
-  createAsyncState,
-  mapToSaveRecipeRequest,
-  ERROR_MAPS,
-  ROUTES,
-  UI,
-} from '@yumney/shared/models';
+import { createAsyncState, mapToSaveRecipeRequest, ERROR_MAPS, ROUTES, UI } from '@yumney/shared/models';
 import { LucideAngularModule } from 'lucide-angular';
 import {
   ButtonComponent,

--- a/client/apps/shell/src/app/dashboard/url-import.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/url-import.component.spec.ts
@@ -5,11 +5,7 @@ import { of, Subject, throwError } from 'rxjs';
 import { UrlImportComponent } from './url-import.component';
 import { FormFieldComponent } from '@yumney/ui';
 import { setupTranslocoTesting } from '@yumney/shared/models';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  ImportStreamEvent,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, ImportRecipeResponse, ImportStreamEvent } from '@yumney/shared/api-client';
 
 const mockRecipe: ImportRecipeResponse = {
   title: 'Pasta Carbonara',
@@ -253,9 +249,7 @@ describe('UrlImportComponent', () => {
   }));
 
   it('should emit noRecipe error key on 404 from the stream', fakeAsync(() => {
-    recipeApiMock.importRecipeStream.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })),
-    );
+    recipeApiMock.importRecipeStream.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })));
     const failedSpy = vi.fn();
     component.failed.subscribe(failedSpy);
 
@@ -267,9 +261,7 @@ describe('UrlImportComponent', () => {
   }));
 
   it('should fall back to generic error key for an unmapped HTTP status', fakeAsync(() => {
-    recipeApiMock.importRecipeStream.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server error' })),
-    );
+    recipeApiMock.importRecipeStream.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server error' })));
     const failedSpy = vi.fn();
     component.failed.subscribe(failedSpy);
 
@@ -293,9 +285,7 @@ describe('UrlImportComponent', () => {
   }));
 
   it('should set isLoading to false after error', fakeAsync(() => {
-    recipeApiMock.importRecipeStream.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 502 })),
-    );
+    recipeApiMock.importRecipeStream.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 502 })));
 
     component.form.controls.url.setValue('https://example.com/recipe');
     component.onSubmit();
@@ -306,10 +296,7 @@ describe('UrlImportComponent', () => {
 
   it('should emit failed on fail stream event', fakeAsync(() => {
     recipeApiMock.importRecipeStream.mockReturnValue(
-      of(
-        { type: 'status' as const, data: 'Fetching page...' },
-        { type: 'fail' as const, data: 'Server error' },
-      ),
+      of({ type: 'status' as const, data: 'Fetching page...' }, { type: 'fail' as const, data: 'Server error' }),
     );
     const failedSpy = vi.fn();
     component.failed.subscribe(failedSpy);
@@ -360,9 +347,7 @@ describe('UrlImportComponent', () => {
   }));
 
   it('should emit failed when done event has invalid JSON', fakeAsync(() => {
-    recipeApiMock.importRecipeStream.mockReturnValue(
-      of({ type: 'done' as const, data: 'not-valid-json{' }),
-    );
+    recipeApiMock.importRecipeStream.mockReturnValue(of({ type: 'done' as const, data: 'not-valid-json{' }));
     const failedSpy = vi.fn();
     component.failed.subscribe(failedSpy);
 
@@ -379,8 +364,6 @@ describe('UrlImportComponent', () => {
     component.importUrl('https://shared.example.com/recipe');
     tick();
 
-    expect(recipeApiMock.importRecipeStream).toHaveBeenCalledWith(
-      'https://shared.example.com/recipe',
-    );
+    expect(recipeApiMock.importRecipeStream).toHaveBeenCalledWith('https://shared.example.com/recipe');
   }));
 });

--- a/client/apps/shell/src/app/dashboard/url-import.component.ts
+++ b/client/apps/shell/src/app/dashboard/url-import.component.ts
@@ -1,28 +1,10 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  signal,
-  inject,
-  DestroyRef,
-  output,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef, output, input } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  RecipeApiService,
-  ImportRecipeResponse,
-  ImportStreamEvent,
-} from '@yumney/shared/api-client';
-import {
-  ERROR_MAPS,
-  urlValidator,
-  VALIDATION,
-  ensureFormValid,
-  mapHttpError,
-} from '@yumney/shared/models';
+import { RecipeApiService, ImportRecipeResponse, ImportStreamEvent } from '@yumney/shared/api-client';
+import { ERROR_MAPS, urlValidator, VALIDATION, ensureFormValid, mapHttpError } from '@yumney/shared/models';
 import { FormFieldComponent, SubmitButtonComponent } from '@yumney/ui';
 
 @Component({
@@ -53,14 +35,7 @@ export class UrlImportComponent {
   streamingChunks = signal('');
 
   form = this.formBuilder.nonNullable.group({
-    url: [
-      '',
-      [
-        Validators.required,
-        Validators.maxLength(VALIDATION.RECIPES.RECIPE_URL.MAX_LENGTH),
-        urlValidator,
-      ],
-    ],
+    url: ['', [Validators.required, Validators.maxLength(VALIDATION.RECIPES.RECIPE_URL.MAX_LENGTH), urlValidator]],
   });
 
   /** Programmatic entry point for the share-target / external trigger flow. */
@@ -88,9 +63,7 @@ export class UrlImportComponent {
           this.isLoading.set(false);
           this.streamingStatus.set(null);
           this.failed.emit(
-            err instanceof HttpErrorResponse
-              ? mapHttpError(err, ERROR_MAPS.dashboard.import)
-              : ERROR_MAPS.dashboard.import.default,
+            err instanceof HttpErrorResponse ? mapHttpError(err, ERROR_MAPS.dashboard.import) : ERROR_MAPS.dashboard.import.default,
           );
         },
       });

--- a/client/apps/shell/src/app/layout/header/header.component.spec.ts
+++ b/client/apps/shell/src/app/layout/header/header.component.spec.ts
@@ -4,12 +4,7 @@ import { provideRouter } from '@angular/router';
 import { signal } from '@angular/core';
 import { HeaderComponent } from '@yumney/ui';
 import { AuthService } from '@yumney/shared/auth';
-import {
-  LanguageService,
-  ThemeService,
-  ChatStateService,
-  setupTranslocoTesting,
-} from '@yumney/shared/models';
+import { LanguageService, ThemeService, ChatStateService, setupTranslocoTesting } from '@yumney/shared/models';
 
 const en = {
   layout: {

--- a/client/apps/shell/src/app/layout/offline-indicator/offline-status.service.spec.ts
+++ b/client/apps/shell/src/app/layout/offline-indicator/offline-status.service.spec.ts
@@ -12,10 +12,7 @@ describe('OfflineStatusService', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    originalDescriptor = Object.getOwnPropertyDescriptor(
-      Object.getPrototypeOf(navigator),
-      'onLine',
-    );
+    originalDescriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(navigator), 'onLine');
     onLineValue = true;
     Object.defineProperty(navigator, 'onLine', {
       configurable: true,

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.html
@@ -1,11 +1,6 @@
 <div class="meal-analytics" *transloco="let t">
   <header class="analytics-header">
-    <a
-      class="back-btn"
-      data-testid="meal-analytics-back"
-      routerLink="/meal-planner"
-      [attr.aria-label]="t('mealPlanner.analytics.back')"
-    >
+    <a class="back-btn" data-testid="meal-analytics-back" routerLink="/meal-planner" [attr.aria-label]="t('mealPlanner.analytics.back')">
       <lucide-icon name="arrow-left" [size]="20" />
     </a>
     <h1>{{ t('mealPlanner.analytics.title') }}</h1>
@@ -97,12 +92,7 @@
       <section class="distribution-card" data-testid="meal-analytics-distribution">
         <h2>{{ t('mealPlanner.analytics.categoryDistribution') }}</h2>
         <div class="distribution-layout">
-          <svg
-            class="donut"
-            viewBox="0 0 140 140"
-            role="img"
-            [attr.aria-label]="t('mealPlanner.analytics.categoryDistribution')"
-          >
+          <svg class="donut" viewBox="0 0 140 140" role="img" [attr.aria-label]="t('mealPlanner.analytics.categoryDistribution')">
             <circle class="donut-track" cx="70" cy="70" [attr.r]="donutRadius" />
             @for (segment of donutSegments(); track segment.category) {
               <circle
@@ -120,9 +110,7 @@
             @for (segment of donutSegments(); track segment.category) {
               <li class="legend-item">
                 <span class="legend-swatch" [class]="'legend-swatch--' + segment.category"></span>
-                <span class="legend-name">{{
-                  t('mealPlanner.analytics.categories.' + segment.category)
-                }}</span>
+                <span class="legend-name">{{ t('mealPlanner.analytics.categories.' + segment.category) }}</span>
                 <span class="legend-share">{{ segment.count }} · {{ segment.percentage }}%</span>
               </li>
             }
@@ -138,9 +126,7 @@
           @for (recipe of data.topRecipes; track recipe.recipeIdentifier) {
             <li class="top-item">
               <span class="top-title">{{ recipe.recipeTitle }}</span>
-              <span class="top-count">{{
-                t('mealPlanner.analytics.timesCooked', { count: recipe.cookCount })
-              }}</span>
+              <span class="top-count">{{ t('mealPlanner.analytics.timesCooked', { count: recipe.cookCount }) }}</span>
             </li>
           }
         </ol>

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.spec.ts
@@ -65,11 +65,7 @@ describe('MealAnalyticsComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [MealAnalyticsComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: MealPlanApiService, useValue: apiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: MealPlanApiService, useValue: apiMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MealAnalyticsComponent);
@@ -83,10 +79,7 @@ describe('MealAnalyticsComponent', () => {
   });
 
   it('renders total cooked stat', () => {
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="meal-analytics-total-cooked"]')
-        .textContent,
-    ).toContain('12');
+    expect(fixture.nativeElement.querySelector('[data-testid="meal-analytics-total-cooked"]').textContent).toContain('12');
   });
 
   it('renders the category-distribution legend with segments per category', () => {
@@ -130,15 +123,11 @@ describe('MealAnalyticsComponent', () => {
   });
 
   it('shows the empty hint when there are no cooked meals', () => {
-    apiMock.getMealAnalytics.mockReturnValue(
-      of(makeAnalytics({ totalCooked: 0, topRecipes: [], categoryDistribution: [] })),
-    );
+    apiMock.getMealAnalytics.mockReturnValue(of(makeAnalytics({ totalCooked: 0, topRecipes: [], categoryDistribution: [] })));
     fixture.componentInstance['onRetry']();
     fixture.detectChanges();
 
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="meal-analytics-empty"]'),
-    ).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="meal-analytics-empty"]')).toBeTruthy();
   });
 
   it('surfaces errors from the API', () => {

--- a/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-analytics/meal-analytics.component.ts
@@ -99,10 +99,8 @@ export class MealAnalyticsComponent {
 
   private loadAnalytics(): void {
     const month = this.viewMode() === 'month' ? this.month() : undefined;
-    this.loadState.execute(
-      this.api.getMealAnalytics(this.year(), month),
-      ERROR_MAPS.mealPlanner.analytics,
-      (result) => this.analytics.set(result),
+    this.loadState.execute(this.api.getMealAnalytics(this.year(), month), ERROR_MAPS.mealPlanner.analytics, (result) =>
+      this.analytics.set(result),
     );
   }
 }

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.html
@@ -1,11 +1,6 @@
 <div class="meal-history" *transloco="let t">
   <header class="history-header">
-    <a
-      class="back-btn"
-      data-testid="meal-history-back"
-      routerLink="/meal-planner"
-      [attr.aria-label]="t('mealPlanner.history.back')"
-    >
+    <a class="back-btn" data-testid="meal-history-back" routerLink="/meal-planner" [attr.aria-label]="t('mealPlanner.history.back')">
       <lucide-icon name="arrow-left" [size]="20" />
     </a>
     <h1>{{ t('mealPlanner.history.title') }}</h1>

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.spec.ts
@@ -57,11 +57,7 @@ describe('MealHistoryComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [MealHistoryComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: MealPlanApiService, useValue: apiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: MealPlanApiService, useValue: apiMock }],
     }).compileComponents();
 
     router = TestBed.inject(Router);
@@ -70,9 +66,7 @@ describe('MealHistoryComponent', () => {
   });
 
   it('loads recent history on init with no term', () => {
-    expect(apiMock.searchHistory).toHaveBeenCalledWith(
-      expect.objectContaining({ term: undefined, pageSize: 50 }),
-    );
+    expect(apiMock.searchHistory).toHaveBeenCalledWith(expect.objectContaining({ term: undefined, pageSize: 50 }));
   });
 
   it('renders results', () => {

--- a/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-history/meal-history.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DestroyRef,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
@@ -22,13 +15,7 @@ const RESULTS_PAGE_SIZE = 50;
 @Component({
   selector: 'yn-meal-history',
   standalone: true,
-  imports: [
-    TranslocoModule,
-    ReactiveFormsModule,
-    RouterLink,
-    LucideAngularModule,
-    AsyncStateComponent,
-  ],
+  imports: [TranslocoModule, ReactiveFormsModule, RouterLink, LucideAngularModule, AsyncStateComponent],
   templateUrl: './meal-history.component.html',
   styleUrl: './meal-history.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -48,11 +35,7 @@ export class MealHistoryComponent {
   constructor() {
     this.runSearch('');
     this.term.valueChanges
-      .pipe(
-        debounceTime(SEARCH_DEBOUNCE_MS),
-        distinctUntilChanged(),
-        takeUntilDestroyed(this.destroyRef),
-      )
+      .pipe(debounceTime(SEARCH_DEBOUNCE_MS), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.runSearch(value));
   }
 

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.html
@@ -15,12 +15,7 @@
         {{ t('mealPlanner.history.pastWeek') }}
       </span>
     }
-    <button
-      class="nav-btn"
-      data-testid="meal-planner-nav-next"
-      (click)="onNextWeek()"
-      [attr.aria-label]="t('mealPlanner.nextWeek')"
-    >
+    <button class="nav-btn" data-testid="meal-planner-nav-next" (click)="onNextWeek()" [attr.aria-label]="t('mealPlanner.nextWeek')">
       <lucide-icon name="chevron-right" [size]="20" />
     </button>
     <button
@@ -50,20 +45,14 @@
   />
 
   @if (canSuggest()) {
-    <yn-meal-suggestion-panel
-      [year]="year()"
-      [week]="weekNumber()"
-      (planAccepted)="onSuggestionAccepted()"
-    />
+    <yn-meal-suggestion-panel [year]="year()" [week]="weekNumber()" (planAccepted)="onSuggestionAccepted()" />
   }
 
   @if (hasRecipeSlots() && !isPastWeek()) {
     <div class="planner-actions">
       <button class="generate-btn" [disabled]="generatingList()" (click)="onGenerateShoppingList()">
         <lucide-icon name="shopping-cart" [size]="16" />
-        {{
-          generatingList() ? t('mealPlanner.generatingList') : t('mealPlanner.generateShoppingList')
-        }}
+        {{ generatingList() ? t('mealPlanner.generatingList') : t('mealPlanner.generateShoppingList') }}
       </button>
       @if (shoppingResult(); as result) {
         <span class="shopping-result">
@@ -78,29 +67,16 @@
 
   @if (isPastWeek() && hasRecipeSlots()) {
     <div class="planner-actions">
-      <button
-        class="copy-btn"
-        data-testid="meal-planner-copy-to-current"
-        [disabled]="copyingToCurrent()"
-        (click)="onCopyToCurrentWeek()"
-      >
+      <button class="copy-btn" data-testid="meal-planner-copy-to-current" [disabled]="copyingToCurrent()" (click)="onCopyToCurrentWeek()">
         <lucide-icon name="copy" [size]="16" />
-        {{
-          copyingToCurrent()
-            ? t('mealPlanner.history.copying')
-            : t('mealPlanner.history.copyToCurrent')
-        }}
+        {{ copyingToCurrent() ? t('mealPlanner.history.copying') : t('mealPlanner.history.copyToCurrent') }}
       </button>
     </div>
   }
 
   <div class="week-grid">
     @for (entry of dinnerSlots(); track entry.day) {
-      <div
-        class="day-card"
-        [class.today]="isToday(entry.day)"
-        [class.has-meal]="entry.slot && !entry.slot.isEmpty"
-      >
+      <div class="day-card" [class.today]="isToday(entry.day)" [class.has-meal]="entry.slot && !entry.slot.isEmpty">
         <div class="day-header">{{ entry.day }}</div>
 
         @if (entry.slot && !entry.slot.isEmpty) {
@@ -108,9 +84,7 @@
             @switch (entry.slot.contentType) {
               @case ('Recipe') {
                 <div class="meal-title">{{ entry.slot.recipeTitle }}</div>
-                <div class="meal-servings">
-                  {{ entry.slot.servings }} {{ t('mealPlanner.servings') }}
-                </div>
+                <div class="meal-servings">{{ entry.slot.servings }} {{ t('mealPlanner.servings') }}</div>
               }
               @case ('Freetext') {
                 <div class="meal-freetext">{{ entry.slot.freetextLabel }}</div>
@@ -127,11 +101,7 @@
             }
 
             @if (!isPastWeek()) {
-              <button
-                class="clear-btn"
-                (click)="onClearSlot(entry.day)"
-                [attr.aria-label]="t('mealPlanner.clearSlot')"
-              >
+              <button class="clear-btn" (click)="onClearSlot(entry.day)" [attr.aria-label]="t('mealPlanner.clearSlot')">
                 <lucide-icon name="x" [size]="14" />
               </button>
             }

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.spec.ts
@@ -151,11 +151,7 @@ describe('MealPlannerComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [MealPlannerComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: MealPlanApiService, useValue: apiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: MealPlanApiService, useValue: apiMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MealPlannerComponent);
@@ -188,11 +184,7 @@ describe('MealPlannerComponent', () => {
   it('should show recipe when slot has content', async () => {
     const planWithRecipe = {
       ...emptyPlan,
-      slots: emptyPlan.slots.map((s) =>
-        s.day === 'Monday'
-          ? { ...s, contentType: 'Recipe', recipeTitle: 'Pasta', isEmpty: false }
-          : s,
-      ),
+      slots: emptyPlan.slots.map((s) => (s.day === 'Monday' ? { ...s, contentType: 'Recipe', recipeTitle: 'Pasta', isEmpty: false } : s)),
     };
     apiMock.getWeeklyPlan.mockReturnValue(of(planWithRecipe));
 
@@ -242,12 +234,8 @@ describe('MealPlannerComponent', () => {
     const initialCalls = apiMock.getWeeklyPlan.mock.calls.length;
     const host: HTMLElement = fixture.nativeElement;
 
-    host.dispatchEvent(
-      new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 300, clientY: 100 }),
-    );
-    host.dispatchEvent(
-      new PointerEvent('pointerup', { pointerType: 'touch', clientX: 200, clientY: 105 }),
-    );
+    host.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 300, clientY: 100 }));
+    host.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'touch', clientX: 200, clientY: 105 }));
 
     expect(apiMock.getWeeklyPlan.mock.calls.length).toBeGreaterThan(initialCalls);
   });
@@ -256,12 +244,8 @@ describe('MealPlannerComponent', () => {
     const initialCalls = apiMock.getWeeklyPlan.mock.calls.length;
     const host: HTMLElement = fixture.nativeElement;
 
-    host.dispatchEvent(
-      new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 100, clientY: 100 }),
-    );
-    host.dispatchEvent(
-      new PointerEvent('pointerup', { pointerType: 'touch', clientX: 220, clientY: 95 }),
-    );
+    host.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 100, clientY: 100 }));
+    host.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'touch', clientX: 220, clientY: 95 }));
 
     expect(apiMock.getWeeklyPlan.mock.calls.length).toBeGreaterThan(initialCalls);
   });
@@ -270,12 +254,8 @@ describe('MealPlannerComponent', () => {
     const initialCalls = apiMock.getWeeklyPlan.mock.calls.length;
     const host: HTMLElement = fixture.nativeElement;
 
-    host.dispatchEvent(
-      new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 300, clientY: 100 }),
-    );
-    host.dispatchEvent(
-      new PointerEvent('pointerup', { pointerType: 'mouse', clientX: 150, clientY: 100 }),
-    );
+    host.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 300, clientY: 100 }));
+    host.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'mouse', clientX: 150, clientY: 100 }));
 
     expect(apiMock.getWeeklyPlan.mock.calls.length).toBe(initialCalls);
   });
@@ -284,12 +264,8 @@ describe('MealPlannerComponent', () => {
     const initialCalls = apiMock.getWeeklyPlan.mock.calls.length;
     const host: HTMLElement = fixture.nativeElement;
 
-    host.dispatchEvent(
-      new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 200, clientY: 100 }),
-    );
-    host.dispatchEvent(
-      new PointerEvent('pointerup', { pointerType: 'touch', clientX: 260, clientY: 300 }),
-    );
+    host.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 200, clientY: 100 }));
+    host.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'touch', clientX: 260, clientY: 300 }));
 
     expect(apiMock.getWeeklyPlan.mock.calls.length).toBe(initialCalls);
   });
@@ -303,9 +279,7 @@ describe('MealPlannerComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.clear-btn')).toBeNull();
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="meal-planner-past-badge"]'),
-    ).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="meal-planner-past-badge"]')).toBeTruthy();
   });
 
   it('should show the copy-to-current button on past weeks with recipes', () => {
@@ -316,9 +290,7 @@ describe('MealPlannerComponent', () => {
     fixture.componentInstance['loadPlan']();
     fixture.detectChanges();
 
-    const copyBtn = fixture.nativeElement.querySelector(
-      '[data-testid="meal-planner-copy-to-current"]',
-    );
+    const copyBtn = fixture.nativeElement.querySelector('[data-testid="meal-planner-copy-to-current"]');
     expect(copyBtn).toBeTruthy();
   });
 
@@ -332,12 +304,7 @@ describe('MealPlannerComponent', () => {
 
     fixture.componentInstance['onCopyToCurrentWeek']();
 
-    expect(apiMock.copyPlanToWeek).toHaveBeenCalledWith(
-      2024,
-      1,
-      expect.any(Number),
-      expect.any(Number),
-    );
+    expect(apiMock.copyPlanToWeek).toHaveBeenCalledWith(2024, 1, expect.any(Number), expect.any(Number));
   });
 
   it('should hide the generate-shopping-list button on past weeks', () => {
@@ -354,11 +321,7 @@ describe('MealPlannerComponent', () => {
   it('should render a clickable clear button for populated slots', () => {
     const planWithRecipe = {
       ...emptyPlan,
-      slots: emptyPlan.slots.map((s) =>
-        s.day === 'Monday'
-          ? { ...s, contentType: 'Recipe', recipeTitle: 'Pasta', isEmpty: false }
-          : s,
-      ),
+      slots: emptyPlan.slots.map((s) => (s.day === 'Monday' ? { ...s, contentType: 'Recipe', recipeTitle: 'Pasta', isEmpty: false } : s)),
     };
     apiMock.getWeeklyPlan.mockReturnValue(of(planWithRecipe));
     fixture.componentInstance['loadPlan']();

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -1,21 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ElementRef,
-  HostListener,
-  inject,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, HostListener, inject, signal, computed } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  MealPlanApiService,
-  type WeeklyPlan,
-  type MealSlot,
-  type GenerateShoppingListResult,
-} from '@yumney/shared/api-client';
+import { MealPlanApiService, type WeeklyPlan, type MealSlot, type GenerateShoppingListResult } from '@yumney/shared/api-client';
 import { injectAsyncStates, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 import { MealSuggestionPanelComponent } from './meal-suggestion-panel/meal-suggestion-panel.component';
@@ -30,12 +17,7 @@ const JS_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'F
 @Component({
   selector: 'yn-meal-planner',
   standalone: true,
-  imports: [
-    TranslocoModule,
-    LucideAngularModule,
-    AsyncStateComponent,
-    MealSuggestionPanelComponent,
-  ],
+  imports: [TranslocoModule, LucideAngularModule, AsyncStateComponent, MealSuggestionPanelComponent],
   templateUrl: './meal-planner.component.html',
   styleUrl: './meal-planner.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -62,9 +44,7 @@ export class MealPlannerComponent {
   protected copyingToCurrent = this.states.copy.isLoading;
   protected shoppingResult = signal<GenerateShoppingListResult | null>(null);
 
-  protected weekLabel = computed(
-    () => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`,
-  );
+  protected weekLabel = computed(() => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`);
 
   private currentYear = new Date().getFullYear();
   private currentWeekNumber = this.getCurrentWeek();
@@ -126,13 +106,9 @@ export class MealPlannerComponent {
     this.loadPlan();
   }
 
-  protected hasRecipeSlots = computed(
-    () => this.plan()?.slots.some((slot) => slot.contentType === 'Recipe') ?? false,
-  );
+  protected hasRecipeSlots = computed(() => this.plan()?.slots.some((slot) => slot.contentType === 'Recipe') ?? false);
 
-  protected canSuggest = computed(
-    () => this.plan() !== null && !this.isPastWeek() && !this.hasRecipeSlots(),
-  );
+  protected canSuggest = computed(() => this.plan() !== null && !this.isPastWeek() && !this.hasRecipeSlots());
 
   protected onSuggestionAccepted(): void {
     this.loadPlan();
@@ -162,10 +138,8 @@ export class MealPlannerComponent {
 
   protected onClearSlot(day: string): void {
     if (this.isPastWeek()) return;
-    this.states.clearSlot.execute(
-      this.api.clearSlot(this.year(), this.weekNumber(), { day }),
-      ERROR_MAPS.mealPlanner.clearSlot,
-      (plan) => this.plan.set(plan),
+    this.states.clearSlot.execute(this.api.clearSlot(this.year(), this.weekNumber(), { day }), ERROR_MAPS.mealPlanner.clearSlot, (plan) =>
+      this.plan.set(plan),
     );
   }
 
@@ -185,14 +159,10 @@ export class MealPlannerComponent {
   }
 
   private loadPlan(): void {
-    this.states.load.execute(
-      this.api.getWeeklyPlan(this.year(), this.weekNumber()),
-      ERROR_MAPS.mealPlanner.load,
-      (plan) => {
-        this.plan.set(plan);
-        queueMicrotask(() => this.scrollTodayIntoView());
-      },
-    );
+    this.states.load.execute(this.api.getWeeklyPlan(this.year(), this.weekNumber()), ERROR_MAPS.mealPlanner.load, (plan) => {
+      this.plan.set(plan);
+      queueMicrotask(() => this.scrollTodayIntoView());
+    });
   }
 
   private scrollTodayIntoView(): void {

--- a/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.html
+++ b/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.html
@@ -1,11 +1,6 @@
 <div class="meal-suggestion-panel" *transloco="let t">
   @if (!hasSuggestion() && !loading() && !error()) {
-    <button
-      class="suggest-cta"
-      type="button"
-      data-testid="meal-suggestion-cta"
-      (click)="onSuggest()"
-    >
+    <button class="suggest-cta" type="button" data-testid="meal-suggestion-cta" (click)="onSuggest()">
       <lucide-icon name="sparkles" [size]="18" />
       {{ t('mealPlanner.suggest.cta') }}
     </button>
@@ -45,13 +40,7 @@
       </ul>
 
       <div class="suggestion-actions">
-        <button
-          class="action-btn primary"
-          type="button"
-          data-testid="meal-suggestion-accept"
-          [disabled]="accepting()"
-          (click)="onAccept()"
-        >
+        <button class="action-btn primary" type="button" data-testid="meal-suggestion-accept" [disabled]="accepting()" (click)="onAccept()">
           <lucide-icon name="check" [size]="16" />
           {{ accepting() ? t('mealPlanner.suggest.accepting') : t('mealPlanner.suggest.accept') }}
         </button>
@@ -65,13 +54,7 @@
           <lucide-icon name="refresh-cw" [size]="16" />
           {{ t('mealPlanner.suggest.regenerate') }}
         </button>
-        <button
-          class="action-btn ghost"
-          type="button"
-          data-testid="meal-suggestion-dismiss"
-          [disabled]="accepting()"
-          (click)="onDismiss()"
-        >
+        <button class="action-btn ghost" type="button" data-testid="meal-suggestion-dismiss" [disabled]="accepting()" (click)="onDismiss()">
           {{ t('mealPlanner.suggest.dismiss') }}
         </button>
       </div>

--- a/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.spec.ts
@@ -1,10 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import {
-  MealPlanApiService,
-  type WeekSuggestion,
-  type WeeklyPlan,
-} from '@yumney/shared/api-client';
+import { MealPlanApiService, type WeekSuggestion, type WeeklyPlan } from '@yumney/shared/api-client';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 import { provideYumneyIcons } from '@yumney/ui';
 import { MealSuggestionPanelComponent } from './meal-suggestion-panel.component';
@@ -110,11 +106,7 @@ describe('MealSuggestionPanelComponent', () => {
     fixture.componentInstance['onAccept']();
 
     expect(apiMock.assignRecipe).toHaveBeenCalledTimes(2);
-    expect(apiMock.assignRecipe).toHaveBeenCalledWith(
-      2026,
-      20,
-      expect.objectContaining({ day: 'Monday', recipeTitle: 'Lasagna' }),
-    );
+    expect(apiMock.assignRecipe).toHaveBeenCalledWith(2026, 20, expect.objectContaining({ day: 'Monday', recipeTitle: 'Lasagna' }));
     expect(emitted).toBe(true);
   });
 
@@ -126,9 +118,7 @@ describe('MealSuggestionPanelComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('[data-testid="meal-suggestion-cta"]')).toBeTruthy();
-    expect(
-      fixture.nativeElement.querySelector('[data-testid="meal-suggestion-result"]'),
-    ).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="meal-suggestion-result"]')).toBeNull();
   });
 
   it('shows the error state when suggestion API fails', () => {

--- a/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
@@ -1,21 +1,8 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { concat, last, toArray } from 'rxjs';
-import {
-  MealPlanApiService,
-  type WeekSuggestion,
-  type WeekSuggestionEntry,
-} from '@yumney/shared/api-client';
+import { MealPlanApiService, type WeekSuggestion, type WeekSuggestionEntry } from '@yumney/shared/api-client';
 import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 
@@ -40,17 +27,13 @@ export class MealSuggestionPanelComponent {
   protected suggestion = signal<WeekSuggestion | null>(null);
   protected loading = this.suggestState.isLoading;
   protected accepting = this.acceptState.isLoading;
-  protected error = computed(
-    () => this.suggestState.serverError() ?? this.acceptState.serverError(),
-  );
+  protected error = computed(() => this.suggestState.serverError() ?? this.acceptState.serverError());
   protected hasSuggestion = computed(() => (this.suggestion()?.entries.length ?? 0) > 0);
 
   protected onSuggest(): void {
     this.suggestion.set(null);
-    this.suggestState.execute(
-      this.api.suggestWeekPlan(this.year, this.week),
-      ERROR_MAPS.mealPlanner.suggestWeek,
-      (result) => this.suggestion.set(result),
+    this.suggestState.execute(this.api.suggestWeekPlan(this.year, this.week), ERROR_MAPS.mealPlanner.suggestWeek, (result) =>
+      this.suggestion.set(result),
     );
   }
 
@@ -75,14 +58,10 @@ export class MealSuggestionPanelComponent {
       }),
     );
 
-    this.acceptState.execute(
-      concat(...assignments).pipe(toArray(), last()),
-      ERROR_MAPS.mealPlanner.assign,
-      () => {
-        this.suggestion.set(null);
-        this.planAccepted.emit();
-      },
-    );
+    this.acceptState.execute(concat(...assignments).pipe(toArray(), last()), ERROR_MAPS.mealPlanner.assign, () => {
+      this.suggestion.set(null);
+      this.planAccepted.emit();
+    });
   }
 
   protected onDismiss(): void {

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.html
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.html
@@ -12,20 +12,14 @@
       >
         <lucide-icon name="history" [size]="18" />
       </button>
-      <button
-        class="export-btn"
-        (click)="onExport()"
-        [attr.aria-label]="t('shopping.export.button')"
-      >
+      <button class="export-btn" (click)="onExport()" [attr.aria-label]="t('shopping.export.button')">
         <lucide-icon name="share" [size]="18" />
       </button>
     </div>
   </div>
 
   @if (totalItems() > 0) {
-    <div class="progress-bar" data-testid="shopping-progress-bar">
-      {{ boughtItems() }} / {{ totalItems() }} {{ t('shopping.checked') }}
-    </div>
+    <div class="progress-bar" data-testid="shopping-progress-bar">{{ boughtItems() }} / {{ totalItems() }} {{ t('shopping.checked') }}</div>
   }
 
   <div class="add-item">
@@ -38,37 +32,18 @@
       class="add-input"
       data-testid="shopping-add-input"
     />
-    <button
-      class="add-btn"
-      (click)="onAddItem()"
-      [disabled]="!newItemName().trim()"
-      [attr.aria-label]="t('shopping.addItem')"
-    >
+    <button class="add-btn" (click)="onAddItem()" [disabled]="!newItemName().trim()" [attr.aria-label]="t('shopping.addItem')">
       <lucide-icon name="plus" [size]="18" />
     </button>
   </div>
 
-  <yn-async-state
-    [loading]="loading()"
-    [error]="error()"
-    loadingKey="shopping.loading"
-    retryKey="shopping.retry"
-    (retry)="onRetry()"
-  />
+  <yn-async-state [loading]="loading()" [error]="error()" loadingKey="shopping.loading" retryKey="shopping.retry" (retry)="onRetry()" />
 
   @for (group of categoryGroups(); track group.category) {
-    <yn-category-section
-      [category]="group.category"
-      [itemCount]="group.items.length"
-      data-testid="shopping-category-group"
-    >
+    <yn-category-section [category]="group.category" [itemCount]="group.items.length" data-testid="shopping-category-group">
       @for (item of group.items; track item.itemName + '|' + item.unit) {
         <div class="item-card" data-testid="shopping-item-card">
-          <div
-            class="item-row-container"
-            [class.bought]="item.isBought"
-            [class.expanded]="isExpanded(item)"
-          >
+          <div class="item-row-container" [class.bought]="item.isBought" [class.expanded]="isExpanded(item)">
             <button
               type="button"
               class="item-row"
@@ -78,29 +53,15 @@
               data-testid="shopping-item-row"
             >
               <span class="item-info">
-                <span class="item-quantity"
-                  >{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span
-                >
+                <span class="item-quantity">{{ item.displayQuantity }}{{ item.unit ? ' ' + item.unit : '' }}</span>
                 <span class="item-name">{{ item.itemName }}</span>
               </span>
               <span class="item-meta">
-                <span class="source-count" [attr.aria-hidden]="true">{{
-                  item.sources.length || 1
-                }}</span>
-                <lucide-icon
-                  name="chevron-down"
-                  [size]="16"
-                  class="chevron"
-                  [attr.aria-hidden]="true"
-                />
+                <span class="source-count" [attr.aria-hidden]="true">{{ item.sources.length || 1 }}</span>
+                <lucide-icon name="chevron-down" [size]="16" class="chevron" [attr.aria-hidden]="true" />
               </span>
             </button>
-            <button
-              type="button"
-              class="remove-btn"
-              (click)="onRemoveItem(item.itemName)"
-              [attr.aria-label]="t('shopping.remove')"
-            >
+            <button type="button" class="remove-btn" (click)="onRemoveItem(item.itemName)" [attr.aria-label]="t('shopping.remove')">
               <lucide-icon name="x" [size]="14" />
             </button>
           </div>

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.spec.ts
@@ -85,11 +85,7 @@ describe('MergedListComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [MergedListComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: ShoppingApiService, useValue: apiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: ShoppingApiService, useValue: apiMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MergedListComponent);
@@ -105,9 +101,7 @@ describe('MergedListComponent', () => {
   });
 
   it('should display items grouped by category', () => {
-    const groups = fixture.nativeElement.querySelectorAll(
-      '[data-testid="shopping-category-group"]',
-    );
+    const groups = fixture.nativeElement.querySelectorAll('[data-testid="shopping-category-group"]');
     expect(groups.length).toBe(2);
   });
 
@@ -349,9 +343,7 @@ describe('MergedListComponent', () => {
     });
 
     it('starts collapsed — no source-breakdown panel visible', () => {
-      const panels = fixture.nativeElement.querySelectorAll(
-        '[data-testid="shopping-sources-panel"]',
-      );
+      const panels = fixture.nativeElement.querySelectorAll('[data-testid="shopping-sources-panel"]');
       expect(panels.length).toBe(0);
     });
 
@@ -372,9 +364,7 @@ describe('MergedListComponent', () => {
       rows[0].click();
       fixture.detectChanges();
 
-      expect(
-        fixture.nativeElement.querySelectorAll('[data-testid="shopping-sources-panel"]').length,
-      ).toBe(0);
+      expect(fixture.nativeElement.querySelectorAll('[data-testid="shopping-sources-panel"]').length).toBe(0);
     });
 
     it('renders one source row per ItemSource entry', () => {
@@ -382,9 +372,7 @@ describe('MergedListComponent', () => {
       rows[0].click();
       fixture.detectChanges();
 
-      const sourceRows = fixture.nativeElement.querySelectorAll(
-        '[data-testid="shopping-source-row"]',
-      );
+      const sourceRows = fixture.nativeElement.querySelectorAll('[data-testid="shopping-source-row"]');
       expect(sourceRows.length).toBe(2);
       const text = fixture.nativeElement.textContent;
       expect(text).toContain('Lasagne');

--- a/client/apps/shopping/src/app/merged-list/merged-list.component.ts
+++ b/client/apps/shopping/src/app/merged-list/merged-list.component.ts
@@ -1,30 +1,11 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  DestroyRef,
-  inject,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, inject, signal, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  ShoppingApiService,
-  type MergedShoppingList,
-  type MergedShoppingItem,
-  type AddedItem,
-  type ItemSource,
-} from '../api';
-import {
-  createAsyncState,
-  ERROR_MAPS,
-  groupByCategory,
-  type CategoryGroup,
-  ToastService,
-} from '@yumney/shared/models';
+import { ShoppingApiService, type MergedShoppingList, type MergedShoppingItem, type AddedItem, type ItemSource } from '../api';
+import { createAsyncState, ERROR_MAPS, groupByCategory, type CategoryGroup, ToastService } from '@yumney/shared/models';
 import {
   AsyncStateComponent,
   CATEGORY_KEYS,
@@ -74,9 +55,7 @@ export class MergedListComponent {
   });
 
   protected totalItems = computed(() => this.list()?.items.length ?? 0);
-  protected boughtItems = computed(
-    () => this.list()?.items.filter((item) => item.isBought).length ?? 0,
-  );
+  protected boughtItems = computed(() => this.list()?.items.filter((item) => item.isBought).length ?? 0);
 
   constructor() {
     this.loadList();
@@ -223,8 +202,7 @@ export class MergedListComponent {
   private applyOptimisticAdd(added: AddedItem): void {
     const current = this.list() ?? { items: [] };
     const matchIndex = current.items.findIndex(
-      (item) =>
-        item.itemName.toLowerCase() === added.itemName.toLowerCase() && item.unit === added.unit,
+      (item) => item.itemName.toLowerCase() === added.itemName.toLowerCase() && item.unit === added.unit,
     );
 
     let nextItems: MergedShoppingItem[];
@@ -280,10 +258,7 @@ export class MergedListComponent {
             return;
           }
 
-          setTimeout(
-            () => this.refreshUntilContains(added, attempt + 1),
-            Math.min(1600, 200 * (attempt + 1)),
-          );
+          setTimeout(() => this.refreshUntilContains(added, attempt + 1), Math.min(1600, 200 * (attempt + 1)));
         },
         error: () => {
           if (requestId !== this.loadRequestId) return;
@@ -295,9 +270,7 @@ export class MergedListComponent {
   private containsAddedItem(list: MergedShoppingList, added: AddedItem): boolean {
     return list.items.some(
       (item) =>
-        item.itemName.toLowerCase() === added.itemName.toLowerCase() &&
-        item.unit === added.unit &&
-        item.totalQuantity >= added.quantity,
+        item.itemName.toLowerCase() === added.itemName.toLowerCase() && item.unit === added.unit && item.totalQuantity >= added.quantity,
     );
   }
 }

--- a/client/apps/shopping/src/app/pantry/pantry.component.html
+++ b/client/apps/shopping/src/app/pantry/pantry.component.html
@@ -32,9 +32,7 @@
           <li class="pantry-item" data-testid="pantry-item">
             <div class="pantry-item-main">
               @if (item.quantity != null) {
-                <span class="pantry-item-quantity">
-                  {{ item.quantity }}{{ item.unit ? ' ' + item.unit : '' }}
-                </span>
+                <span class="pantry-item-quantity"> {{ item.quantity }}{{ item.unit ? ' ' + item.unit : '' }} </span>
               }
               <span class="pantry-item-name">{{ item.itemName }}</span>
               @if (item.source === 'Staple') {
@@ -44,11 +42,7 @@
 
             <div class="pantry-item-meta">
               @if (freshnessTone(item.freshness); as tone) {
-                <span
-                  class="freshness-chip"
-                  [class]="'freshness-chip--' + tone"
-                  data-testid="freshness-chip"
-                >
+                <span class="freshness-chip" [class]="'freshness-chip--' + tone" data-testid="freshness-chip">
                   {{ t('shopping.pantry.freshness.' + tone) }}
                 </span>
               }

--- a/client/apps/shopping/src/app/pantry/pantry.component.scss
+++ b/client/apps/shopping/src/app/pantry/pantry.component.scss
@@ -172,12 +172,7 @@
 .skeleton-row {
   height: 48px;
   border-radius: var(--yn-radius-card);
-  background: linear-gradient(
-    90deg,
-    var(--yn-glass-bg) 25%,
-    var(--yn-glass-bg-elevated) 50%,
-    var(--yn-glass-bg) 75%
-  );
+  background: linear-gradient(90deg, var(--yn-glass-bg) 25%, var(--yn-glass-bg-elevated) 50%, var(--yn-glass-bg) 75%);
   background-size: 200% 100%;
   animation: yn-shimmer 1.5s ease-in-out infinite;
   border: 1px solid var(--yn-glass-border-subtle);

--- a/client/apps/shopping/src/app/pantry/pantry.component.spec.ts
+++ b/client/apps/shopping/src/app/pantry/pantry.component.spec.ts
@@ -90,11 +90,7 @@ describe('PantryComponent', () => {
     };
     TestBed.configureTestingModule({
       imports: [PantryComponent, setupTranslocoTesting(en)],
-      providers: [
-        provideYumneyIcons(),
-        provideRouter([]),
-        { provide: ShoppingApiService, useValue: shoppingApiMock },
-      ],
+      providers: [provideYumneyIcons(), provideRouter([]), { provide: ShoppingApiService, useValue: shoppingApiMock }],
     });
     fixture = TestBed.createComponent(PantryComponent);
     component = fixture.componentInstance;
@@ -144,9 +140,7 @@ describe('PantryComponent', () => {
     shoppingApiMock.getIngredientBalance.mockClear();
     shoppingApiMock.getIngredientBalance.mockReturnValue(of(empty));
 
-    const button = fixture.nativeElement.querySelector(
-      '[data-testid="pantry-freeze-btn"]',
-    ) as HTMLButtonElement;
+    const button = fixture.nativeElement.querySelector('[data-testid="pantry-freeze-btn"]') as HTMLButtonElement;
     button.click();
     tick();
 

--- a/client/apps/shopping/src/app/pantry/pantry.component.ts
+++ b/client/apps/shopping/src/app/pantry/pantry.component.ts
@@ -1,19 +1,7 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  computed,
-  inject,
-  OnInit,
-  signal,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  ShoppingApiService,
-  type Freshness,
-  type IngredientBalanceItem,
-  type MarkAsFrozenRequest,
-} from '../api';
+import { ShoppingApiService, type Freshness, type IngredientBalanceItem, type MarkAsFrozenRequest } from '../api';
 import { createAsyncState, ERROR_MAPS, groupByCategory } from '@yumney/shared/models';
 import { EmptyStateComponent, MessageBannerComponent } from '@yumney/ui';
 
@@ -60,11 +48,7 @@ export class PantryComponent implements OnInit {
 
   onFreeze(item: IngredientBalanceItem): void {
     const request: MarkAsFrozenRequest = { name: item.itemName, unit: item.unit };
-    this.freezeState.execute(
-      this.shoppingApi.markAsFrozen(request),
-      ERROR_MAPS.shopping.pantry.freeze,
-      () => this.load(),
-    );
+    this.freezeState.execute(this.shoppingApi.markAsFrozen(request), ERROR_MAPS.shopping.pantry.freeze, () => this.load());
   }
 
   onRetry(): void {
@@ -72,10 +56,8 @@ export class PantryComponent implements OnInit {
   }
 
   private load(): void {
-    this.loadState.execute(
-      this.shoppingApi.getIngredientBalance(),
-      ERROR_MAPS.shopping.pantry.load,
-      (response) => this.items.set(response.items),
+    this.loadState.execute(this.shoppingApi.getIngredientBalance(), ERROR_MAPS.shopping.pantry.load, (response) =>
+      this.items.set(response.items),
     );
   }
 }

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.html
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.html
@@ -40,11 +40,7 @@
         @for (ingredient of recipe.ingredients; track ingredient.name; let i = $index) {
           <li>
             <label class="ingredient-check">
-              <input
-                type="checkbox"
-                [checked]="ingredientSelections()[i]"
-                (change)="onToggleIngredient(i)"
-              />
+              <input type="checkbox" [checked]="ingredientSelections()[i]" (change)="onToggleIngredient(i)" />
               <span class="ingredient-text">
                 @if (ingredient.amount) {
                   <span class="ingredient-amount">{{ ingredient.amount }}</span>
@@ -61,11 +57,7 @@
     </section>
 
     <div class="actions-bar">
-      <button
-        class="create-button"
-        [disabled]="isCreating() || !hasSelectedIngredients()"
-        (click)="onCreateShoppingList()"
-      >
+      <button class="create-button" [disabled]="isCreating() || !hasSelectedIngredients()" (click)="onCreateShoppingList()">
         {{ isCreating() ? t('shopping.create.creating') : t('shopping.create.submit') }}
       </button>
     </div>

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  OnInit,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { RecipeApiService, RecipeDetail } from '../api';

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.html
@@ -15,10 +15,7 @@
     <div class="progress-bar-container">
       <div class="progress-text">{{ checkedCount() }} / {{ totalItemCount() }}</div>
       <div class="progress-track">
-        <div
-          class="progress-fill"
-          [style.width.%]="totalItemCount() > 0 ? (checkedCount() / totalItemCount()) * 100 : 0"
-        ></div>
+        <div class="progress-fill" [style.width.%]="totalItemCount() > 0 ? (checkedCount() / totalItemCount()) * 100 : 0"></div>
       </div>
     </div>
 
@@ -29,12 +26,7 @@
       <yn-button variant="secondary" (click)="onReset()">
         {{ t('shopping.detail.reset') }}
       </yn-button>
-      <yn-button
-        variant="secondary"
-        testId="send-to-bring-btn"
-        [disabled]="uncheckedItems().length === 0"
-        (click)="onSendToBring()"
-      >
+      <yn-button variant="secondary" testId="send-to-bring-btn" [disabled]="uncheckedItems().length === 0" (click)="onSendToBring()">
         {{ t('shopping.detail.bring.sendButton') }}
       </yn-button>
     </div>
@@ -51,12 +43,7 @@
         <ul class="items-list">
           @for (item of group.items; track item.identifier) {
             <li [class.checked]="item.isChecked">
-              <input
-                type="checkbox"
-                [checked]="item.isChecked"
-                [attr.aria-label]="item.name"
-                (change)="onToggleItem(item)"
-              />
+              <input type="checkbox" [checked]="item.isChecked" [attr.aria-label]="item.name" (change)="onToggleItem(item)" />
               @if (item.amount) {
                 <span class="item-amount">{{ item.amount }}</span>
               }

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.spec.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.spec.ts
@@ -44,10 +44,7 @@ describe('ShoppingDetailComponent', () => {
   let fixture: ComponentFixture<ShoppingDetailComponent>;
   let shoppingApiMock: { getShoppingListById: ReturnType<typeof vi.fn> };
 
-  function setupTestBed(
-    apiReturn = vi.fn().mockReturnValue(of(mockDetail)),
-    identifier: string | null = 'list-123',
-  ) {
+  function setupTestBed(apiReturn = vi.fn().mockReturnValue(of(mockDetail)), identifier: string | null = 'list-123') {
     shoppingApiMock = { getShoppingListById: apiReturn };
 
     TestBed.configureTestingModule({
@@ -160,9 +157,7 @@ describe('ShoppingDetailComponent', () => {
       tick();
       fixture.detectChanges();
 
-      const btn: HTMLButtonElement = fixture.nativeElement.querySelector(
-        '[data-testid="send-to-bring-btn"]',
-      );
+      const btn: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="send-to-bring-btn"]');
       expect(btn.disabled).toBe(true);
     }));
 

--- a/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
+++ b/client/apps/shopping/src/app/shopping-detail/shopping-detail.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  OnInit,
-  DestroyRef,
-  signal,
-  computed,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, OnInit, DestroyRef, signal, computed } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { ShoppingApiService, ShoppingListDetail, ShoppingListItemResponse } from '../api';
@@ -67,9 +59,7 @@ export class ShoppingDetailComponent implements OnInit {
   isLoading = this.asyncState.isLoading;
   serverError = this.asyncState.serverError;
 
-  checkedCount = computed(
-    () => this.shoppingList()?.items.filter((item) => item.isChecked).length ?? 0,
-  );
+  checkedCount = computed(() => this.shoppingList()?.items.filter((item) => item.isChecked).length ?? 0);
 
   totalItemCount = computed(() => this.shoppingList()?.items.length ?? 0);
 
@@ -83,9 +73,7 @@ export class ShoppingDetailComponent implements OnInit {
 
   // Items still to buy — already-checked items have been added to the cart, so
   // sending them to Bring! would re-add things the user has already grabbed.
-  uncheckedItems = computed(
-    () => this.shoppingList()?.items.filter((item) => !item.isChecked) ?? [],
-  );
+  uncheckedItems = computed(() => this.shoppingList()?.items.filter((item) => !item.isChecked) ?? []);
 
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
@@ -94,10 +82,8 @@ export class ShoppingDetailComponent implements OnInit {
       return;
     }
 
-    this.asyncState.execute(
-      this.shoppingApi.getShoppingListById(identifier),
-      ERROR_MAPS.shopping.detail,
-      (list) => this.shoppingList.set(list),
+    this.asyncState.execute(this.shoppingApi.getShoppingListById(identifier), ERROR_MAPS.shopping.detail, (list) =>
+      this.shoppingList.set(list),
     );
   }
 

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.html
@@ -18,9 +18,7 @@
           <a class="list-card" [routerLink]="ROUTES.shopping.detail(list.identifier)">
             <h3 class="list-title">{{ list.title }}</h3>
             <div class="list-meta">
-              <span class="item-count">{{
-                t('shopping.list.itemCount', { count: list.itemCount })
-              }}</span>
+              <span class="item-count">{{ t('shopping.list.itemCount', { count: list.itemCount }) }}</span>
               <span class="list-date">{{ list.createdAt | date: 'mediumDate' }}</span>
             </div>
           </a>

--- a/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
+++ b/client/apps/shopping/src/app/shopping-list/shopping-list.component.ts
@@ -8,14 +8,7 @@ import { EmptyStateComponent, LoadingSpinnerComponent, MessageBannerComponent } 
 
 @Component({
   selector: 'yn-shopping-list',
-  imports: [
-    TranslocoModule,
-    RouterLink,
-    DatePipe,
-    EmptyStateComponent,
-    LoadingSpinnerComponent,
-    MessageBannerComponent,
-  ],
+  imports: [TranslocoModule, RouterLink, DatePipe, EmptyStateComponent, LoadingSpinnerComponent, MessageBannerComponent],
   templateUrl: './shopping-list.component.html',
   styleUrl: './shopping-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,10 +24,6 @@ export class ShoppingListComponent implements OnInit {
   serverError = this.asyncState.serverError;
 
   ngOnInit(): void {
-    this.asyncState.execute(
-      this.shoppingApi.getShoppingLists(),
-      ERROR_MAPS.shopping.list,
-      (lists) => this.lists.set(lists),
-    );
+    this.asyncState.execute(this.shoppingApi.getShoppingLists(), ERROR_MAPS.shopping.list, (lists) => this.lists.set(lists));
   }
 }

--- a/client/libs/shared/api-client/src/index.ts
+++ b/client/libs/shared/api-client/src/index.ts
@@ -22,10 +22,7 @@ export type { FavoriteState } from './lib/favorite-state';
 export type { RecipeDetail } from './lib/recipe-detail';
 export type { RecipeIngredient } from './lib/recipe-ingredient';
 export type { RecipeStep } from './lib/recipe-step';
-export type {
-  RecognizedIngredient,
-  RecognizedIngredientsResponse,
-} from './lib/recognized-ingredient';
+export type { RecognizedIngredient, RecognizedIngredientsResponse } from './lib/recognized-ingredient';
 export type {
   CookableRecipeListItem,
   CookableRecipeListResponse,
@@ -59,14 +56,7 @@ export type {
 
 // --- Chat ---
 export { ChatApiService } from './lib/chat-api.service';
-export type {
-  ChatAction,
-  ChatActionType,
-  ChatMessage,
-  ChatRecipeSuggestion,
-  ChatRequest,
-  ChatResponse,
-} from './lib/chat-message';
+export type { ChatAction, ChatActionType, ChatMessage, ChatRecipeSuggestion, ChatRequest, ChatResponse } from './lib/chat-message';
 
 // --- Meal Plan ---
 export { MealPlanApiService } from './lib/meal-plan-api.service';
@@ -93,12 +83,7 @@ export type {
 
 // --- Dashboard ---
 export { DashboardApiService } from './lib/dashboard-api.service';
-export type {
-  UserActivityItem,
-  UserActivityPage,
-  ActivityTypeKey,
-  RecipeActivityStats,
-} from './lib/user-activity';
+export type { UserActivityItem, UserActivityPage, ActivityTypeKey, RecipeActivityStats } from './lib/user-activity';
 export type { SuggestionItem, SuggestionsResponse } from './lib/suggestion';
 
 // --- Activity ---

--- a/client/libs/shared/api-client/src/lib/activity-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.spec.ts
@@ -53,11 +53,9 @@ describe('ActivityApiService', () => {
     });
 
     it('forwards limit, type and cursor as query params when supplied', () => {
-      service
-        .getActivity({ limit: 20, type: 'recipe_cooked', cursor: 'opaque-cursor' })
-        .subscribe((result) => {
-          expect(result).toEqual(mockPage);
-        });
+      service.getActivity({ limit: 20, type: 'recipe_cooked', cursor: 'opaque-cursor' }).subscribe((result) => {
+        expect(result).toEqual(mockPage);
+      });
 
       const req = httpTesting.expectOne((r) => r.url === API_ENDPOINTS.users.activity);
       expect(req.request.params.get('limit')).toBe('20');

--- a/client/libs/shared/api-client/src/lib/activity-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/activity-api.service.ts
@@ -8,9 +8,7 @@ import type { ActivityTypeKey, RecipeActivityStats, UserActivityPage } from './u
 export class ActivityApiService {
   private http = inject(HttpClient);
 
-  getActivity(
-    options: { type?: ActivityTypeKey; limit?: number; cursor?: string } = {},
-  ): Observable<UserActivityPage> {
+  getActivity(options: { type?: ActivityTypeKey; limit?: number; cursor?: string } = {}): Observable<UserActivityPage> {
     let params = new HttpParams();
     if (options.limit != null) params = params.set('limit', options.limit.toString());
     if (options.type != null) params = params.set('type', options.type);
@@ -19,8 +17,6 @@ export class ActivityApiService {
   }
 
   getRecipeStats(recipeIdentifier: string): Observable<RecipeActivityStats> {
-    return this.http.get<RecipeActivityStats>(
-      API_ENDPOINTS.users.activityRecipeStats(recipeIdentifier),
-    );
+    return this.http.get<RecipeActivityStats>(API_ENDPOINTS.users.activityRecipeStats(recipeIdentifier));
   }
 }

--- a/client/libs/shared/api-client/src/lib/api-endpoints.ts
+++ b/client/libs/shared/api-client/src/lib/api-endpoints.ts
@@ -4,8 +4,7 @@ export const API_ENDPOINTS = {
   recipes: {
     base: `${API_BASE}/recipes`,
     import: `${API_BASE}/recipes/import`,
-    importStream: (url: string) =>
-      `${API_BASE}/recipes/import/stream?url=${encodeURIComponent(url)}`,
+    importStream: (url: string) => `${API_BASE}/recipes/import/stream?url=${encodeURIComponent(url)}`,
     importFromPhotos: `${API_BASE}/recipes/import-from-photos`,
     recognizeIngredients: `${API_BASE}/recipes/recognize-ingredients`,
     chat: `${API_BASE}/recipes/chat`,
@@ -38,20 +37,13 @@ export const API_ENDPOINTS = {
   mealPlans: {
     byWeek: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}`,
     slots: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/slots`,
-    slotsSwap: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/slots/swap`,
-    slotsServings: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/slots/servings`,
-    slotsConfirm: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/slots/confirm`,
-    extendedMode: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/extended-mode`,
-    cookWithLeftovers: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/cook-with-leftovers`,
-    plannedRecipes: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/planned-recipes`,
-    generateShoppingList: (year: number, week: number) =>
-      `${API_BASE}/meal-plans/${year}/w/${week}/generate-shopping-list`,
+    slotsSwap: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/slots/swap`,
+    slotsServings: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/slots/servings`,
+    slotsConfirm: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/slots/confirm`,
+    extendedMode: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/extended-mode`,
+    cookWithLeftovers: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/cook-with-leftovers`,
+    plannedRecipes: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/planned-recipes`,
+    generateShoppingList: (year: number, week: number) => `${API_BASE}/meal-plans/${year}/w/${week}/generate-shopping-list`,
     historySearch: `${API_BASE}/meal-plans/history/search`,
     copyTo: (srcYear: number, srcWeek: number, dstYear: number, dstWeek: number) =>
       `${API_BASE}/meal-plans/${srcYear}/w/${srcWeek}/copy-to/${dstYear}/${dstWeek}`,
@@ -64,8 +56,7 @@ export const API_ENDPOINTS = {
   },
   users: {
     activity: `${API_BASE}/users/me/activity`,
-    activityRecipeStats: (identifier: string) =>
-      `${API_BASE}/users/me/activity/recipes/${identifier}/stats`,
+    activityRecipeStats: (identifier: string) => `${API_BASE}/users/me/activity/recipes/${identifier}/stats`,
     suggestions: `${API_BASE}/users/me/suggestions`,
     profile: `${API_BASE}/users/me/profile`,
     me: `${API_BASE}/users/me`,

--- a/client/libs/shared/api-client/src/lib/auth-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/auth-api.service.ts
@@ -15,12 +15,7 @@ export class AuthApiService {
     return this.http.post<RegisterResponse>(API_ENDPOINTS.auth.register, request);
   }
 
-  resendVerificationEmail(
-    request: ResendVerificationRequest,
-  ): Observable<ResendVerificationResponse> {
-    return this.http.post<ResendVerificationResponse>(
-      API_ENDPOINTS.auth.resendVerificationEmail,
-      request,
-    );
+  resendVerificationEmail(request: ResendVerificationRequest): Observable<ResendVerificationResponse> {
+    return this.http.post<ResendVerificationResponse>(API_ENDPOINTS.auth.resendVerificationEmail, request);
   }
 }

--- a/client/libs/shared/api-client/src/lib/meal-plan-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan-api.service.spec.ts
@@ -262,9 +262,7 @@ describe('MealPlanApiService', () => {
         expect(result).toEqual(mockHistory);
       });
 
-      const req = httpTesting.expectOne(
-        (request) => request.url === API_ENDPOINTS.mealPlans.historySearch,
-      );
+      const req = httpTesting.expectOne((request) => request.url === API_ENDPOINTS.mealPlans.historySearch);
       expect(req.request.method).toBe('GET');
       expect(req.request.params.keys().length).toBe(0);
       req.flush(mockHistory);
@@ -274,9 +272,7 @@ describe('MealPlanApiService', () => {
       service.searchHistory({ term: 'lasagna', page: 2, pageSize: 25 }).subscribe();
 
       const req = httpTesting.expectOne(
-        (request) =>
-          request.url === API_ENDPOINTS.mealPlans.historySearch &&
-          request.params.get('term') === 'lasagna',
+        (request) => request.url === API_ENDPOINTS.mealPlans.historySearch && request.params.get('term') === 'lasagna',
       );
       expect(req.request.params.get('page')).toBe('2');
       expect(req.request.params.get('pageSize')).toBe('25');
@@ -286,9 +282,7 @@ describe('MealPlanApiService', () => {
     it('omits empty term from query string', () => {
       service.searchHistory({ term: '', pageSize: 10 }).subscribe();
 
-      const req = httpTesting.expectOne(
-        (request) => request.url === API_ENDPOINTS.mealPlans.historySearch,
-      );
+      const req = httpTesting.expectOne((request) => request.url === API_ENDPOINTS.mealPlans.historySearch);
       expect(req.request.params.has('term')).toBe(false);
       expect(req.request.params.get('pageSize')).toBe('10');
       req.flush(mockHistory);
@@ -351,9 +345,7 @@ describe('MealPlanApiService', () => {
       service.getMealAnalytics(2026).subscribe();
 
       const req = httpTesting.expectOne(
-        (request) =>
-          request.url === API_ENDPOINTS.mealPlans.analytics &&
-          request.params.get('year') === '2026',
+        (request) => request.url === API_ENDPOINTS.mealPlans.analytics && request.params.get('year') === '2026',
       );
       expect(req.request.params.has('month')).toBe(false);
       req.flush(mockAnalytics);
@@ -362,9 +354,7 @@ describe('MealPlanApiService', () => {
     it('passes month as a query param when provided', () => {
       service.getMealAnalytics(2026, 5).subscribe();
 
-      const req = httpTesting.expectOne(
-        (request) => request.url === API_ENDPOINTS.mealPlans.analytics,
-      );
+      const req = httpTesting.expectOne((request) => request.url === API_ENDPOINTS.mealPlans.analytics);
       expect(req.request.params.get('year')).toBe('2026');
       expect(req.request.params.get('month')).toBe('5');
       req.flush(mockAnalytics);

--- a/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/meal-plan-api.service.ts
@@ -41,11 +41,7 @@ export class MealPlanApiService {
     return this.http.put<WeeklyPlan>(API_ENDPOINTS.mealPlans.slotsSwap(year, week), request);
   }
 
-  adjustServings(
-    year: number,
-    week: number,
-    request: AdjustServingsRequest,
-  ): Observable<WeeklyPlan> {
+  adjustServings(year: number, week: number, request: AdjustServingsRequest): Observable<WeeklyPlan> {
     return this.http.put<WeeklyPlan>(API_ENDPOINTS.mealPlans.slotsServings(year, week), request);
   }
 
@@ -59,15 +55,8 @@ export class MealPlanApiService {
     });
   }
 
-  cookWithLeftovers(
-    year: number,
-    week: number,
-    request: CookWithLeftoversRequest,
-  ): Observable<WeeklyPlan> {
-    return this.http.post<WeeklyPlan>(
-      API_ENDPOINTS.mealPlans.cookWithLeftovers(year, week),
-      request,
-    );
+  cookWithLeftovers(year: number, week: number, request: CookWithLeftoversRequest): Observable<WeeklyPlan> {
+    return this.http.post<WeeklyPlan>(API_ENDPOINTS.mealPlans.cookWithLeftovers(year, week), request);
   }
 
   getPlannedRecipes(year: number, week: number): Observable<WeeklyPlannedRecipes> {
@@ -75,10 +64,7 @@ export class MealPlanApiService {
   }
 
   generateShoppingList(year: number, week: number): Observable<GenerateShoppingListResult> {
-    return this.http.post<GenerateShoppingListResult>(
-      API_ENDPOINTS.mealPlans.generateShoppingList(year, week),
-      {},
-    );
+    return this.http.post<GenerateShoppingListResult>(API_ENDPOINTS.mealPlans.generateShoppingList(year, week), {});
   }
 
   searchHistory(params: SearchHistoryParams = {}): Observable<PagedResponse<MealHistoryEntry>> {
@@ -93,16 +79,8 @@ export class MealPlanApiService {
     });
   }
 
-  copyPlanToWeek(
-    srcYear: number,
-    srcWeek: number,
-    dstYear: number,
-    dstWeek: number,
-  ): Observable<WeeklyPlan> {
-    return this.http.post<WeeklyPlan>(
-      API_ENDPOINTS.mealPlans.copyTo(srcYear, srcWeek, dstYear, dstWeek),
-      {},
-    );
+  copyPlanToWeek(srcYear: number, srcWeek: number, dstYear: number, dstWeek: number): Observable<WeeklyPlan> {
+    return this.http.post<WeeklyPlan>(API_ENDPOINTS.mealPlans.copyTo(srcYear, srcWeek, dstYear, dstWeek), {});
   }
 
   suggestWeekPlan(year: number, week: number): Observable<WeekSuggestion> {

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.spec.ts
@@ -52,11 +52,7 @@ describe('RecipeApiService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        { provide: AuthService, useValue: { gatewayUrl: () => '' } },
-      ],
+      providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AuthService, useValue: { gatewayUrl: () => '' } }],
     });
 
     service = TestBed.inject(RecipeApiService);

--- a/client/libs/shared/api-client/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/recipe-api.service.ts
@@ -77,9 +77,7 @@ export class RecipeApiService {
     }
 
     if (!response.ok || !response.body) {
-      subscriber.error(
-        new HttpErrorResponse({ status: response.status, statusText: response.statusText }),
-      );
+      subscriber.error(new HttpErrorResponse({ status: response.status, statusText: response.statusText }));
       return;
     }
 
@@ -134,10 +132,7 @@ export class RecipeApiService {
     }
   }
 
-  private parseSseBuffer(
-    lines: string[],
-    subscriber: import('rxjs').Subscriber<ImportStreamEvent>,
-  ): boolean {
+  private parseSseBuffer(lines: string[], subscriber: import('rxjs').Subscriber<ImportStreamEvent>): boolean {
     let eventType: string | null = null;
 
     for (const line of lines) {
@@ -166,10 +161,7 @@ export class RecipeApiService {
   recognizeIngredients(photo: Blob): Observable<RecognizedIngredientsResponse> {
     const formData = new FormData();
     formData.append('photo', photo, 'scan.jpg');
-    return this.http.post<RecognizedIngredientsResponse>(
-      API_ENDPOINTS.recipes.recognizeIngredients,
-      formData,
-    );
+    return this.http.post<RecognizedIngredientsResponse>(API_ENDPOINTS.recipes.recognizeIngredients, formData);
   }
 
   saveRecipe(request: SaveRecipeRequest): Observable<SavedRecipeResponse> {
@@ -183,19 +175,12 @@ export class RecipeApiService {
   }
 
   deleteRecipe(identifier: string): Observable<void> {
-    return this.http
-      .delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier))
-      .pipe(tap(() => this.invalidateRecipeCache(identifier)));
+    return this.http.delete<void>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(tap(() => this.invalidateRecipeCache(identifier)));
   }
 
   getRecipeById(identifier: string): Observable<RecipeDetail> {
     if (!this.recipeCache.has(identifier)) {
-      this.recipeCache.set(
-        identifier,
-        this.http
-          .get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier))
-          .pipe(shareReplay(1)),
-      );
+      this.recipeCache.set(identifier, this.http.get<RecipeDetail>(API_ENDPOINTS.recipes.byIdentifier(identifier)).pipe(shareReplay(1)));
     }
     return this.recipeCache.get(identifier)!;
   }
@@ -204,9 +189,7 @@ export class RecipeApiService {
     this.recipeCache.delete(identifier);
   }
 
-  getCookableRecipes(
-    params: GetCookableRecipesParams = {},
-  ): Observable<CookableRecipeListResponse> {
+  getCookableRecipes(params: GetCookableRecipesParams = {}): Observable<CookableRecipeListResponse> {
     return this.http.get<CookableRecipeListResponse>(API_ENDPOINTS.recipes.whatCanICook, {
       params: {
         ...(params.page != null && { page: params.page }),
@@ -246,9 +229,7 @@ export class RecipeApiService {
   }
 
   updateRecipeNotes(identifier: string, notes: string | null): Observable<void> {
-    return this.http
-      .put<void>(API_ENDPOINTS.recipes.notes(identifier), { notes })
-      .pipe(tap(() => this.invalidateRecipeCache(identifier)));
+    return this.http.put<void>(API_ENDPOINTS.recipes.notes(identifier), { notes }).pipe(tap(() => this.invalidateRecipeCache(identifier)));
   }
 
   toggleFavorite(identifier: string): Observable<FavoriteState> {

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.spec.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.spec.ts
@@ -1,12 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import {
-  ShoppingApiService,
-  CreateShoppingListRequest,
-  ShoppingListDetail,
-  ShoppingListSummary,
-} from './shopping-api.service';
+import { ShoppingApiService, CreateShoppingListRequest, ShoppingListDetail, ShoppingListSummary } from './shopping-api.service';
 
 const mockDetail: ShoppingListDetail = {
   identifier: 'list-123',

--- a/client/libs/shared/api-client/src/lib/shopping-api.service.ts
+++ b/client/libs/shared/api-client/src/lib/shopping-api.service.ts
@@ -7,12 +7,7 @@ import type { CreateShoppingListFromRecipesRequest } from './create-shopping-lis
 import type { ShoppingListDetail } from './shopping-list-detail';
 import type { ShoppingListSummary } from './shopping-list-summary';
 import type { PagedResponse } from '@yumney/shared/models';
-import type {
-  MergedShoppingList,
-  AddItemRequest,
-  AddedItem,
-  RemoveItemRequest,
-} from './merged-shopping-list';
+import type { MergedShoppingList, AddItemRequest, AddedItem, RemoveItemRequest } from './merged-shopping-list';
 import type { IngredientBalance, MarkAsFrozenRequest } from './ingredient-balance';
 
 @Injectable({ providedIn: 'root' })
@@ -23,31 +18,20 @@ export class ShoppingApiService {
     return this.http.post<ShoppingListDetail>(API_ENDPOINTS.shoppingLists.base, request);
   }
 
-  createShoppingListFromRecipes(
-    request: CreateShoppingListFromRecipesRequest,
-  ): Observable<ShoppingListDetail> {
+  createShoppingListFromRecipes(request: CreateShoppingListFromRecipesRequest): Observable<ShoppingListDetail> {
     return this.http.post<ShoppingListDetail>(API_ENDPOINTS.shoppingLists.fromRecipes, request);
   }
 
   getShoppingLists(): Observable<ShoppingListSummary[]> {
-    return this.http
-      .get<PagedResponse<ShoppingListSummary>>(API_ENDPOINTS.shoppingLists.base)
-      .pipe(map((response) => response.items));
+    return this.http.get<PagedResponse<ShoppingListSummary>>(API_ENDPOINTS.shoppingLists.base).pipe(map((response) => response.items));
   }
 
   getShoppingListById(identifier: string): Observable<ShoppingListDetail> {
     return this.http.get<ShoppingListDetail>(API_ENDPOINTS.shoppingLists.byIdentifier(identifier));
   }
 
-  checkOffItem(
-    listIdentifier: string,
-    itemIdentifier: string,
-    isChecked: boolean,
-  ): Observable<void> {
-    return this.http.put<void>(
-      API_ENDPOINTS.shoppingLists.checkItem(listIdentifier, itemIdentifier),
-      { isChecked },
-    );
+  checkOffItem(listIdentifier: string, itemIdentifier: string, isChecked: boolean): Observable<void> {
+    return this.http.put<void>(API_ENDPOINTS.shoppingLists.checkItem(listIdentifier, itemIdentifier), { isChecked });
   }
 
   checkOffAllItems(listIdentifier: string, isChecked: boolean): Observable<void> {
@@ -56,15 +40,8 @@ export class ShoppingApiService {
     });
   }
 
-  changeItemCategory(
-    listIdentifier: string,
-    itemIdentifier: string,
-    category: string,
-  ): Observable<void> {
-    return this.http.post<void>(
-      API_ENDPOINTS.shoppingLists.itemCategory(listIdentifier, itemIdentifier),
-      { category },
-    );
+  changeItemCategory(listIdentifier: string, itemIdentifier: string, category: string): Observable<void> {
+    return this.http.post<void>(API_ENDPOINTS.shoppingLists.itemCategory(listIdentifier, itemIdentifier), { category });
   }
 
   getMergedList(includePastBought = false): Observable<MergedShoppingList> {

--- a/client/libs/shared/auth/src/lib/auth-config.ts
+++ b/client/libs/shared/auth/src/lib/auth-config.ts
@@ -7,12 +7,7 @@ export interface AppConfig {
   gatewayUrl?: string;
 }
 
-export function createAuthConfig(
-  keycloakUrl: string,
-  realm: string,
-  clientId: string,
-  gatewayUrl?: string,
-): AuthConfig {
+export function createAuthConfig(keycloakUrl: string, realm: string, clientId: string, gatewayUrl?: string): AuthConfig {
   const realmUrl = `${keycloakUrl}/realms/${realm}`;
   const tokenBaseUrl = gatewayUrl ?? keycloakUrl;
   return {

--- a/client/libs/shared/auth/src/lib/auth.service.ts
+++ b/client/libs/shared/auth/src/lib/auth.service.ts
@@ -19,9 +19,7 @@ export class AuthService {
   isLoading = signal(true);
   isAuthenticated = signal(false);
   currentUser = signal<AuthUser | null>(null);
-  displayName = computed(
-    () => this.currentUser()?.preferredUsername ?? this.currentUser()?.email ?? null,
-  );
+  displayName = computed(() => this.currentUser()?.preferredUsername ?? this.currentUser()?.email ?? null);
   shortName = computed(() => {
     const name = this.displayName();
     if (!name) return null;

--- a/client/libs/shared/auth/src/lib/provide-auth.ts
+++ b/client/libs/shared/auth/src/lib/provide-auth.ts
@@ -4,10 +4,7 @@ import { AppConfigService } from './app-config.service';
 import { AuthService } from './auth.service';
 import { authStorageFactory } from './auth-storage.factory';
 
-function initializeAuth(
-  appConfig: AppConfigService,
-  authService: AuthService,
-): () => Promise<void> {
+function initializeAuth(appConfig: AppConfigService, authService: AuthService): () => Promise<void> {
   // Load app-config.json first so AuthService and apiBaseInterceptor both
   // see the resolved gatewayUrl at runtime. Sequencing matters: if a
   // component fires an HTTP request during AuthService.initialize(), the

--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -17,11 +17,7 @@ export {
   type ConvertedAmount,
   type UnitSystem,
 } from './lib/unit-conversion';
-export {
-  mergeRecipeIngredients,
-  type RecipeForMerge,
-  type MergedIngredient,
-} from './lib/merge-recipe-ingredients';
+export { mergeRecipeIngredients, type RecipeForMerge, type MergedIngredient } from './lib/merge-recipe-ingredients';
 export { UI } from './lib/ui-constants';
 export { createAsyncState, injectAsyncStates, type AsyncState } from './lib/async-state';
 export { debouncedEffect } from './lib/debounced-effect';
@@ -33,20 +29,9 @@ export { TranslocoHttpLoader } from './lib/transloco-loader';
 export { LanguageService } from './lib/language.service';
 export { UserPreferencesService } from './lib/user-preferences.service';
 export { type LanguageCode, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './lib/language-code';
-export {
-  mapToSaveRecipeRequest,
-  mapToUpdateRecipeRequest,
-  mapDetailToImportResponse,
-} from './lib/recipe-mapping';
+export { mapToSaveRecipeRequest, mapToUpdateRecipeRequest, mapDetailToImportResponse } from './lib/recipe-mapping';
 export { createMfeAppConfig } from './lib/mfe-app-config';
-export {
-  KNOWN_UNITS,
-  UNIT_GROUPS,
-  getGroupedUnits,
-  type KnownUnit,
-  type UnitGroup,
-  type UnitGroupInfo,
-} from './lib/known-units';
+export { KNOWN_UNITS, UNIT_GROUPS, getGroupedUnits, type KnownUnit, type UnitGroup, type UnitGroupInfo } from './lib/known-units';
 export { ROUTES } from './lib/route-paths';
 export { ThemeService, type Theme, type ThemePreference } from './lib/theme.service';
 export { CameraService, type FacingMode } from './lib/camera.service';
@@ -56,10 +41,5 @@ export { ChatHintService } from './lib/chat-hint.service';
 export { VoiceService, type VoiceCommand } from './lib/voice.service';
 export { WakeLockService } from './lib/wake-lock.service';
 export { CookingTimerService, type CookingTimer } from './lib/cooking-timer.service';
-export {
-  ToastService,
-  type Toast,
-  type ToastKind,
-  type ShowToastOptions,
-} from './lib/toast.service';
+export { ToastService, type Toast, type ToastKind, type ShowToastOptions } from './lib/toast.service';
 export { globalErrorInterceptor } from './lib/global-error.interceptor';

--- a/client/libs/shared/models/src/lib/async-state.ts
+++ b/client/libs/shared/models/src/lib/async-state.ts
@@ -49,12 +49,7 @@ export function createAsyncState(destroyRef?: DestroyRef): AsyncState {
 export interface AsyncState {
   isLoading: ReturnType<typeof signal<boolean>>;
   serverError: ReturnType<typeof signal<string | null>>;
-  execute<T>(
-    source: Observable<T>,
-    errorMap: HttpErrorMap,
-    onSuccess: (result: T) => void,
-    onError?: (error: string) => void,
-  ): void;
+  execute<T>(source: Observable<T>, errorMap: HttpErrorMap, onSuccess: (result: T) => void, onError?: (error: string) => void): void;
 }
 
 /**
@@ -63,9 +58,7 @@ export interface AsyncState {
  * yields an independent `AsyncState`. Must run in an injection context;
  * the shared `DestroyRef` is resolved internally and reused for every slot.
  */
-export function injectAsyncStates<const Keys extends readonly string[]>(
-  ...keys: Keys
-): Record<Keys[number], AsyncState> {
+export function injectAsyncStates<const Keys extends readonly string[]>(...keys: Keys): Record<Keys[number], AsyncState> {
   const destroyRef = inject(DestroyRef);
   const result = {} as Record<Keys[number], AsyncState>;
   for (const key of keys) {

--- a/client/libs/shared/models/src/lib/camera.service.spec.ts
+++ b/client/libs/shared/models/src/lib/camera.service.spec.ts
@@ -69,10 +69,7 @@ describe('CameraService', () => {
       const stopSpy1 = vi.fn();
       const stopSpy2 = vi.fn();
       const fakeStream = {
-        getTracks: () => [
-          { stop: stopSpy1 } as MediaStreamTrack,
-          { stop: stopSpy2 } as MediaStreamTrack,
-        ],
+        getTracks: () => [{ stop: stopSpy1 } as MediaStreamTrack, { stop: stopSpy2 } as MediaStreamTrack],
       } as MediaStream;
 
       mockGetUserMedia(fakeStream);
@@ -92,9 +89,7 @@ describe('CameraService', () => {
       });
       const unsupportedService = new CameraService();
 
-      await expect(firstValueFrom(unsupportedService.openCamera())).rejects.toThrow(
-        'Camera not supported',
-      );
+      await expect(firstValueFrom(unsupportedService.openCamera())).rejects.toThrow('Camera not supported');
     });
 
     it('should request stream with environment facing mode by default', async () => {

--- a/client/libs/shared/models/src/lib/cooking-timer.service.ts
+++ b/client/libs/shared/models/src/lib/cooking-timer.service.ts
@@ -66,18 +66,14 @@ export class CookingTimerService {
     if (next <= 0) {
       this.complete(id);
     } else {
-      this.timers.update((list) =>
-        list.map((timer) => (timer.id === id ? { ...timer, remainingSeconds: next } : timer)),
-      );
+      this.timers.update((list) => list.map((timer) => (timer.id === id ? { ...timer, remainingSeconds: next } : timer)));
     }
   }
 
   private complete(id: string): void {
     this.clearInterval(id);
     this.timers.update((list) =>
-      list.map((timer) =>
-        timer.id === id ? { ...timer, remainingSeconds: 0, status: 'completed' as const } : timer,
-      ),
+      list.map((timer) => (timer.id === id ? { ...timer, remainingSeconds: 0, status: 'completed' as const } : timer)),
     );
     if (this.preferences.timerHapticFeedback()) {
       this.triggerHaptics();

--- a/client/libs/shared/models/src/lib/debounced-effect.ts
+++ b/client/libs/shared/models/src/lib/debounced-effect.ts
@@ -9,11 +9,7 @@ import { Signal, effect } from '@angular/core';
  * its lifetime to the surrounding injector. Pending timeouts are cleared
  * on each re-run and on teardown.
  */
-export function debouncedEffect<T>(
-  source: Signal<T>,
-  ms: number,
-  callback: (value: T) => void,
-): void {
+export function debouncedEffect<T>(source: Signal<T>, ms: number, callback: (value: T) => void): void {
   let firstRun = true;
   effect((onCleanup) => {
     const value = source();

--- a/client/libs/shared/models/src/lib/error-maps.spec.ts
+++ b/client/libs/shared/models/src/lib/error-maps.spec.ts
@@ -6,18 +6,10 @@ interface ErrorLeaf {
 }
 
 function isLeaf(value: unknown): value is ErrorLeaf {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'default' in value &&
-    typeof (value as { default: unknown }).default === 'string'
-  );
+  return typeof value === 'object' && value !== null && 'default' in value && typeof (value as { default: unknown }).default === 'string';
 }
 
-function* walkLeaves(
-  node: unknown,
-  path: string[] = [],
-): Generator<{ path: string[]; leaf: ErrorLeaf }> {
+function* walkLeaves(node: unknown, path: string[] = []): Generator<{ path: string[]; leaf: ErrorLeaf }> {
   if (!node || typeof node !== 'object') return;
   if (isLeaf(node)) {
     yield { path, leaf: node };
@@ -33,9 +25,7 @@ describe('ERROR_MAPS', () => {
 
   it('finds at least one error leaf per top-level area', () => {
     const topLevels = new Set(leaves.map((entry) => entry.path[0]));
-    expect(topLevels).toEqual(
-      new Set(['dashboard', 'recipes', 'shopping', 'mealPlanner', 'account', 'auth']),
-    );
+    expect(topLevels).toEqual(new Set(['dashboard', 'recipes', 'shopping', 'mealPlanner', 'account', 'auth']));
   });
 
   it('every leaf has a non-empty default fallback key', () => {

--- a/client/libs/shared/models/src/lib/group-by-category.ts
+++ b/client/libs/shared/models/src/lib/group-by-category.ts
@@ -22,9 +22,7 @@ export function groupByCategory<TItem, TCategory extends string = string>(
 
   const { order } = options;
   if (order) {
-    return order
-      .filter((category) => buckets.has(category))
-      .map((category) => ({ category, items: buckets.get(category) ?? [] }));
+    return order.filter((category) => buckets.has(category)).map((category) => ({ category, items: buckets.get(category) ?? [] }));
   }
 
   return Array.from(buckets.entries()).map(([category, bucketItems]) => ({

--- a/client/libs/shared/models/src/lib/ingredient-recognition.service.spec.ts
+++ b/client/libs/shared/models/src/lib/ingredient-recognition.service.spec.ts
@@ -23,12 +23,8 @@ describe('IngredientRecognitionService', () => {
     });
 
     it('should deduplicate by case-insensitive name', () => {
-      const existing: RecognizedIngredient[] = [
-        { name: 'Tomato', confidence: 0.7, category: 'produce' },
-      ];
-      const incoming: RecognizedIngredient[] = [
-        { name: 'tomato', confidence: 0.9, category: 'produce' },
-      ];
+      const existing: RecognizedIngredient[] = [{ name: 'Tomato', confidence: 0.7, category: 'produce' }];
+      const incoming: RecognizedIngredient[] = [{ name: 'tomato', confidence: 0.9, category: 'produce' }];
 
       const result = service.mergeIngredients(existing, incoming);
 
@@ -36,12 +32,8 @@ describe('IngredientRecognitionService', () => {
     });
 
     it('should keep the higher confidence on duplicate', () => {
-      const existing: RecognizedIngredient[] = [
-        { name: 'Tomato', confidence: 0.6, category: 'produce' },
-      ];
-      const incoming: RecognizedIngredient[] = [
-        { name: 'Tomato', confidence: 0.95, category: 'produce' },
-      ];
+      const existing: RecognizedIngredient[] = [{ name: 'Tomato', confidence: 0.6, category: 'produce' }];
+      const incoming: RecognizedIngredient[] = [{ name: 'Tomato', confidence: 0.95, category: 'produce' }];
 
       const result = service.mergeIngredients(existing, incoming);
 
@@ -49,12 +41,8 @@ describe('IngredientRecognitionService', () => {
     });
 
     it('should not lower confidence on duplicate with lower score', () => {
-      const existing: RecognizedIngredient[] = [
-        { name: 'Tomato', confidence: 0.95, category: 'produce' },
-      ];
-      const incoming: RecognizedIngredient[] = [
-        { name: 'Tomato', confidence: 0.6, category: 'produce' },
-      ];
+      const existing: RecognizedIngredient[] = [{ name: 'Tomato', confidence: 0.95, category: 'produce' }];
+      const incoming: RecognizedIngredient[] = [{ name: 'Tomato', confidence: 0.6, category: 'produce' }];
 
       const result = service.mergeIngredients(existing, incoming);
 

--- a/client/libs/shared/models/src/lib/ingredient-recognition.service.ts
+++ b/client/libs/shared/models/src/lib/ingredient-recognition.service.ts
@@ -1,10 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import {
-  RecipeApiService,
-  type RecognizedIngredientsResponse,
-  type RecognizedIngredient,
-} from '@yumney/shared/api-client';
+import { RecipeApiService, type RecognizedIngredientsResponse, type RecognizedIngredient } from '@yumney/shared/api-client';
 
 @Injectable({ providedIn: 'root' })
 export class IngredientRecognitionService {
@@ -18,10 +14,7 @@ export class IngredientRecognitionService {
    * Merge a new recognition result into an existing list, deduplicating by name
    * (case-insensitive) and keeping the highest confidence score.
    */
-  mergeIngredients(
-    existing: RecognizedIngredient[],
-    incoming: RecognizedIngredient[],
-  ): RecognizedIngredient[] {
+  mergeIngredients(existing: RecognizedIngredient[], incoming: RecognizedIngredient[]): RecognizedIngredient[] {
     const map = new Map<string, RecognizedIngredient>();
 
     for (const item of existing) {

--- a/client/libs/shared/models/src/lib/merge-recipe-ingredients.spec.ts
+++ b/client/libs/shared/models/src/lib/merge-recipe-ingredients.spec.ts
@@ -43,9 +43,7 @@ describe('mergeRecipeIngredients', () => {
   });
 
   it('rounds non-integer scaled amounts to two decimals', () => {
-    const result = mergeRecipeIngredients([
-      recipe([{ name: 'Olive Oil', amount: 1.5, unit: 'tbsp' }], 4, 6),
-    ]);
+    const result = mergeRecipeIngredients([recipe([{ name: 'Olive Oil', amount: 1.5, unit: 'tbsp' }], 4, 6)]);
 
     expect(result[0].amount).toBe(2.25);
   });

--- a/client/libs/shared/models/src/lib/mfe-app-config.ts
+++ b/client/libs/shared/models/src/lib/mfe-app-config.ts
@@ -27,10 +27,7 @@ export interface MfeAppConfigOptions {
   extraProviders?: Provider[];
 }
 
-export function createMfeAppConfig(
-  routes: Routes,
-  options: MfeAppConfigOptions | Provider[] = {},
-): ApplicationConfig {
+export function createMfeAppConfig(routes: Routes, options: MfeAppConfigOptions | Provider[] = {}): ApplicationConfig {
   // Back-compat: accept the old `Provider[]` second arg while call sites migrate.
   const opts: MfeAppConfigOptions = Array.isArray(options) ? { extraProviders: options } : options;
 
@@ -38,10 +35,7 @@ export function createMfeAppConfig(
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(
-      withFetch(),
-      withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor]),
-    ),
+    provideHttpClient(withFetch(), withInterceptors([apiBaseInterceptor, authInterceptor, globalErrorInterceptor])),
     provideAuth(),
     provideTransloco({
       config: {

--- a/client/libs/shared/models/src/lib/optimistic-update.spec.ts
+++ b/client/libs/shared/models/src/lib/optimistic-update.spec.ts
@@ -45,9 +45,7 @@ describe('optimisticSignalUpdate', () => {
       value.count = 1;
     });
 
-    optimisticSignalUpdate(state, noopDestroyRef, apply, rollback, () =>
-      throwError(() => new Error('boom')),
-    );
+    optimisticSignalUpdate(state, noopDestroyRef, apply, rollback, () => throwError(() => new Error('boom')));
 
     expect(rollback).toHaveBeenCalled();
     expect(state()!.count).toBe(1);

--- a/client/libs/shared/models/src/lib/recipe-mapping.spec.ts
+++ b/client/libs/shared/models/src/lib/recipe-mapping.spec.ts
@@ -1,9 +1,5 @@
 import type { ImportRecipeResponse, RecipeDetail } from '@yumney/shared/api-client';
-import {
-  mapDetailToImportResponse,
-  mapToSaveRecipeRequest,
-  mapToUpdateRecipeRequest,
-} from './recipe-mapping';
+import { mapDetailToImportResponse, mapToSaveRecipeRequest, mapToUpdateRecipeRequest } from './recipe-mapping';
 
 const imported: ImportRecipeResponse = {
   title: 'Pasta Carbonara',

--- a/client/libs/shared/models/src/lib/recipe-mapping.ts
+++ b/client/libs/shared/models/src/lib/recipe-mapping.ts
@@ -1,9 +1,4 @@
-import type {
-  ImportRecipeResponse,
-  RecipeDetail,
-  SaveRecipeRequest,
-  UpdateRecipeRequest,
-} from '@yumney/shared/api-client';
+import type { ImportRecipeResponse, RecipeDetail, SaveRecipeRequest, UpdateRecipeRequest } from '@yumney/shared/api-client';
 
 function extractRecipeFields(recipe: ImportRecipeResponse) {
   return {
@@ -19,10 +14,7 @@ function extractRecipeFields(recipe: ImportRecipeResponse) {
   };
 }
 
-export function mapToSaveRecipeRequest(
-  recipe: ImportRecipeResponse,
-  sourceUrl?: string,
-): SaveRecipeRequest {
+export function mapToSaveRecipeRequest(recipe: ImportRecipeResponse, sourceUrl?: string): SaveRecipeRequest {
   return { ...extractRecipeFields(recipe), ...(sourceUrl != null && { sourceUrl }) };
 }
 

--- a/client/libs/shared/models/src/lib/scale-ingredients.ts
+++ b/client/libs/shared/models/src/lib/scale-ingredients.ts
@@ -22,7 +22,6 @@ export function scaleIngredients(
   const ratio = desiredServings / originalServings;
   return ingredients.map((ingredient) => ({
     ...ingredient,
-    amount:
-      ingredient.amount !== null ? roundAmount(ingredient.amount * ratio, ingredient.amount) : null,
+    amount: ingredient.amount !== null ? roundAmount(ingredient.amount * ratio, ingredient.amount) : null,
   }));
 }

--- a/client/libs/shared/models/src/lib/unit-conversion.spec.ts
+++ b/client/libs/shared/models/src/lib/unit-conversion.spec.ts
@@ -1,11 +1,4 @@
-import {
-  celsiusToFahrenheit,
-  fahrenheitToCelsius,
-  smartRound,
-  toImperial,
-  toMetric,
-  toSystem,
-} from './unit-conversion';
+import { celsiusToFahrenheit, fahrenheitToCelsius, smartRound, toImperial, toMetric, toSystem } from './unit-conversion';
 
 describe('unit-conversion', () => {
   describe('toImperial', () => {

--- a/client/libs/shared/models/src/lib/unit-conversion.ts
+++ b/client/libs/shared/models/src/lib/unit-conversion.ts
@@ -65,11 +65,7 @@ export function smartRound(value: number): number {
   return roundToStep(value, 10);
 }
 
-function apply(
-  amount: number,
-  unit: string | null,
-  table: Map<string, ConversionRule>,
-): ConvertedAmount {
+function apply(amount: number, unit: string | null, table: Map<string, ConversionRule>): ConvertedAmount {
   const normalized = (unit ?? '').trim();
   if (normalized.length === 0) {
     return { amount: smartRound(amount), unit: '' };

--- a/client/libs/shared/models/src/lib/user-preferences.service.spec.ts
+++ b/client/libs/shared/models/src/lib/user-preferences.service.spec.ts
@@ -137,9 +137,7 @@ describe('UserPreferencesService', () => {
     // The API field is a free-form string at the wire; defensively coerce
     // anything we don't recognise to 'metric' so the toggle never lands in
     // an undefined state.
-    const { service } = configure(
-      of(makeProfile({ preferredUnitSystem: 'gallons-per-fortnight' })),
-    );
+    const { service } = configure(of(makeProfile({ preferredUnitSystem: 'gallons-per-fortnight' })));
 
     service.ensureLoaded();
 

--- a/client/libs/shared/models/src/lib/user-preferences.service.ts
+++ b/client/libs/shared/models/src/lib/user-preferences.service.ts
@@ -59,8 +59,6 @@ export class UserPreferencesService {
     this.voiceEnabled.set(profile.voiceSettings.enabled);
     this.voiceSpeed.set(profile.voiceSettings.speed);
     this.voiceAutoReadInCookMode.set(profile.voiceSettings.autoReadInCookMode);
-    this.preferredUnitSystem.set(
-      profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric',
-    );
+    this.preferredUnitSystem.set(profile.preferredUnitSystem === 'imperial' ? 'imperial' : 'metric');
   }
 }

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -109,15 +109,14 @@ function configureSpeak(prefs: PrefsStub): {
     configurable: true,
     value: { speak, cancel },
   });
-  (globalThis as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance =
-    class implements UtteranceShape {
-      lang = '';
-      rate = 1;
-      onstart: (() => void) | null = null;
-      onend: (() => void) | null = null;
-      onerror: (() => void) | null = null;
-      constructor(public text: string) {}
-    };
+  (globalThis as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = class implements UtteranceShape {
+    lang = '';
+    rate = 1;
+    onstart: (() => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor(public text: string) {}
+  };
 
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -157,10 +157,7 @@ export class VoiceService {
    * Cook-mode precedence is intentional: AC TC-362-03 — "timer 5 minutes" must
    * fire the local timer, not a chat round-trip.
    */
-  startListeningWithFallback(
-    onCommand: (command: VoiceCommand) => void,
-    onTranscript: (transcript: string) => void,
-  ): void {
+  startListeningWithFallback(onCommand: (command: VoiceCommand) => void, onTranscript: (transcript: string) => void): void {
     if (!this.sttSupported() || this.isListening()) {
       return;
     }
@@ -246,10 +243,8 @@ export class VoiceService {
 
   private createRecognition(): SpeechRecognitionLike | null {
     const ctor =
-      (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor })
-        .SpeechRecognition ??
-      (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor })
-        .webkitSpeechRecognition;
+      (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor }).SpeechRecognition ??
+      (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor }).webkitSpeechRecognition;
     return ctor ? new ctor() : null;
   }
 
@@ -259,9 +254,6 @@ export class VoiceService {
 
   private detectSttSupport(): boolean {
     if (typeof window === 'undefined') return false;
-    return (
-      'SpeechRecognition' in window ||
-      'webkitSpeechRecognition' in (window as unknown as Record<string, unknown>)
-    );
+    return 'SpeechRecognition' in window || 'webkitSpeechRecognition' in (window as unknown as Record<string, unknown>);
   }
 }

--- a/client/libs/ui/src/index.ts
+++ b/client/libs/ui/src/index.ts
@@ -1,29 +1,11 @@
 export { BackLinkComponent } from './lib/back-link/back-link.component';
-export {
-  ButtonComponent,
-  type ButtonVariant,
-  type ButtonType,
-} from './lib/button/button.component';
+export { ButtonComponent, type ButtonVariant, type ButtonType } from './lib/button/button.component';
 export { CardComponent, type CardVariant } from './lib/card/card.component';
-export {
-  DialogShellComponent,
-  type DialogRole,
-  type DialogSize,
-} from './lib/dialog-shell/dialog-shell.component';
-export {
-  SideSheetComponent,
-  type SideSheetPosition,
-  type SideSheetSize,
-} from './lib/side-sheet/side-sheet.component';
-export {
-  EmptyStateComponent,
-  type EmptyStateVariant,
-} from './lib/empty-state/empty-state.component';
+export { DialogShellComponent, type DialogRole, type DialogSize } from './lib/dialog-shell/dialog-shell.component';
+export { SideSheetComponent, type SideSheetPosition, type SideSheetSize } from './lib/side-sheet/side-sheet.component';
+export { EmptyStateComponent, type EmptyStateVariant } from './lib/empty-state/empty-state.component';
 export { FormFieldComponent } from './lib/form-field/form-field.component';
-export {
-  MessageBannerComponent,
-  type MessageBannerTone,
-} from './lib/message-banner/message-banner.component';
+export { MessageBannerComponent, type MessageBannerTone } from './lib/message-banner/message-banner.component';
 export { SubmitButtonComponent } from './lib/submit-button/submit-button.component';
 export { RecipePreviewComponent } from './lib/recipe-preview/recipe-preview.component';
 export { EditableListItemComponent } from './lib/editable-list-item/editable-list-item.component';
@@ -46,10 +28,7 @@ export { AsyncStateComponent } from './lib/async-state/async-state.component';
 export { springPress, staggerFadeIn, prefersReducedMotion } from './lib/animation/gsap-utils';
 
 // Dashboard components
-export {
-  QuickActionsComponent,
-  type QuickAction,
-} from './lib/quick-actions/quick-actions.component';
+export { QuickActionsComponent, type QuickAction } from './lib/quick-actions/quick-actions.component';
 export { SuggestionCardComponent } from './lib/suggestion-card/suggestion-card.component';
 export { RecentActivityComponent } from './lib/recent-activity/recent-activity.component';
 

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.spec.ts
@@ -1,11 +1,7 @@
 import { provideYumneyIcons } from '../icons/provide-icons';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, signal } from '@angular/core';
-import {
-  ActivityTimelineComponent,
-  type ActivityEntry,
-  relativeTimeFromNow,
-} from './activity-timeline.component';
+import { ActivityTimelineComponent, type ActivityEntry, relativeTimeFromNow } from './activity-timeline.component';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 
 const en = {

--- a/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
+++ b/client/libs/ui/src/lib/activity-timeline/activity-timeline.component.ts
@@ -62,8 +62,7 @@ export function relativeTimeFromNow(
 } {
   const diff = now.getTime() - when.getTime();
   if (diff < MINUTE) return { key: 'shared.activity.relative.justNow', value: 0 };
-  if (diff < HOUR)
-    return { key: 'shared.activity.relative.minutes', value: Math.floor(diff / MINUTE) };
+  if (diff < HOUR) return { key: 'shared.activity.relative.minutes', value: Math.floor(diff / MINUTE) };
   if (diff < DAY) return { key: 'shared.activity.relative.hours', value: Math.floor(diff / HOUR) };
   if (diff < WEEK) return { key: 'shared.activity.relative.days', value: Math.floor(diff / DAY) };
   return { key: 'shared.activity.relative.weeks', value: Math.floor(diff / WEEK) };

--- a/client/libs/ui/src/lib/animation/gsap-utils.ts
+++ b/client/libs/ui/src/lib/animation/gsap-utils.ts
@@ -21,11 +21,7 @@ export function staggerFadeIn(
   options: { stagger?: number; duration?: number; y?: number } = {},
 ): gsap.core.Tween {
   const { stagger = 0.05, duration = 0.4, y = 16 } = options;
-  return gsap.fromTo(
-    elements,
-    { opacity: 0, y },
-    { opacity: 1, y: 0, duration, stagger, ease: 'power2.out' },
-  );
+  return gsap.fromTo(elements, { opacity: 0, y }, { opacity: 1, y: 0, duration, stagger, ease: 'power2.out' });
 }
 
 /**

--- a/client/libs/ui/src/lib/back-link/back-link.component.ts
+++ b/client/libs/ui/src/lib/back-link/back-link.component.ts
@@ -6,9 +6,7 @@ import { LucideAngularModule } from 'lucide-angular';
 @Component({
   selector: 'yn-back-link',
   imports: [RouterLink, TranslocoPipe, LucideAngularModule],
-  template: `<a [routerLink]="route()" class="back-link"
-    ><lucide-icon name="arrow-left" [size]="20" /> {{ label() | transloco }}</a
-  >`,
+  template: `<a [routerLink]="route()" class="back-link"><lucide-icon name="arrow-left" [size]="20" /> {{ label() | transloco }}</a>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BackLinkComponent {

--- a/client/libs/ui/src/lib/button/button.component.ts
+++ b/client/libs/ui/src/lib/button/button.component.ts
@@ -1,21 +1,8 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
-export type ButtonVariant =
-  | 'primary'
-  | 'secondary'
-  | 'ghost'
-  | 'danger'
-  | 'danger-filled'
-  | 'dashed'
-  | 'link';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'danger-filled' | 'dashed' | 'link';
 
 export type ButtonType = 'button' | 'submit' | 'reset';
 

--- a/client/libs/ui/src/lib/camera-capture/camera-capture.component.html
+++ b/client/libs/ui/src/lib/camera-capture/camera-capture.component.html
@@ -18,20 +18,10 @@
     <button class="control-btn cancel-btn" (click)="onCancel()">
       {{ t('camera.cancel') }}
     </button>
-    <button
-      #captureBtn
-      class="capture-btn"
-      (click)="onCapture()"
-      [disabled]="!isStreaming()"
-      [attr.aria-label]="t('camera.capture')"
-    >
+    <button #captureBtn class="capture-btn" (click)="onCapture()" [disabled]="!isStreaming()" [attr.aria-label]="t('camera.capture')">
       <span class="capture-ring"></span>
     </button>
-    <button
-      class="control-btn flip-btn"
-      (click)="onToggleFacing()"
-      [attr.aria-label]="t('camera.flipCamera')"
-    >
+    <button class="control-btn flip-btn" (click)="onToggleFacing()" [attr.aria-label]="t('camera.flipCamera')">
       <lucide-icon name="refresh-cw" [size]="20" />
     </button>
   </div>
@@ -42,11 +32,7 @@
         @for (photo of captures(); track photo.id) {
           <div class="thumbnail">
             <img [src]="photo.url" alt="" />
-            <button
-              class="thumbnail-delete"
-              (click)="onDeleteCapture(photo.id)"
-              [attr.aria-label]="t('camera.deletePhoto')"
-            >
+            <button class="thumbnail-delete" (click)="onDeleteCapture(photo.id)" [attr.aria-label]="t('camera.deletePhoto')">
               <lucide-icon name="x" [size]="18" />
             </button>
           </div>

--- a/client/libs/ui/src/lib/camera-capture/camera-capture.component.spec.ts
+++ b/client/libs/ui/src/lib/camera-capture/camera-capture.component.spec.ts
@@ -37,16 +37,11 @@ function createMock(): CameraServiceMock {
     stopCamera: vi.fn(),
     blobToFile: vi
       .fn()
-      .mockImplementation(
-        (blob: Blob, name: string) =>
-          new File([blob], name, { type: blob.type, lastModified: Date.now() }),
-      ),
+      .mockImplementation((blob: Blob, name: string) => new File([blob], name, { type: blob.type, lastModified: Date.now() })),
   };
 }
 
-async function setupComponent(
-  cameraServiceMock: CameraServiceMock,
-): Promise<ComponentFixture<CameraCaptureComponent>> {
+async function setupComponent(cameraServiceMock: CameraServiceMock): Promise<ComponentFixture<CameraCaptureComponent>> {
   await TestBed.resetTestingModule()
     .configureTestingModule({
       imports: [CameraCaptureComponent, setupTranslocoTesting(en)],

--- a/client/libs/ui/src/lib/camera-capture/camera-capture.component.ts
+++ b/client/libs/ui/src/lib/camera-capture/camera-capture.component.ts
@@ -97,9 +97,7 @@ export class CameraCaptureComponent implements AfterViewInit, OnDestroy {
     const photos = this.captures();
     if (photos.length === 0) return;
 
-    const files = photos.map((photo, index) =>
-      this.camera.blobToFile(photo.blob, `scan-${index + 1}.jpg`),
-    );
+    const files = photos.map((photo, index) => this.camera.blobToFile(photo.blob, `scan-${index + 1}.jpg`));
     this.capturedReady.emit(files);
   }
 

--- a/client/libs/ui/src/lib/card/card.component.ts
+++ b/client/libs/ui/src/lib/card/card.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
 export type CardVariant = 'auth';

--- a/client/libs/ui/src/lib/category-section/category-section.component.ts
+++ b/client/libs/ui/src/lib/category-section/category-section.component.ts
@@ -31,9 +31,7 @@ export const CATEGORY_KEYS: readonly CategoryKey[] = [
 /** Coerce an arbitrary server-supplied category string to a known CategoryKey. */
 export function normalizeCategory(value: string | null | undefined): CategoryKey {
   const candidate = (value ?? 'other').toLowerCase();
-  return (CATEGORY_KEYS as readonly string[]).includes(candidate)
-    ? (candidate as CategoryKey)
-    : 'other';
+  return (CATEGORY_KEYS as readonly string[]).includes(candidate) ? (candidate as CategoryKey) : 'other';
 }
 
 const CATEGORY_ICONS: Record<CategoryKey, string> = {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.html
@@ -1,32 +1,15 @@
 @if (state.isOpen()) {
   <div class="chat-backdrop" data-testid="chat-backdrop" (click)="onBackdropClick()"></div>
-  <div
-    class="chat-panel"
-    data-testid="chat-panel"
-    *transloco="let t"
-    role="dialog"
-    aria-modal="true"
-    [attr.aria-label]="t('chat.title')"
-  >
+  <div class="chat-panel" data-testid="chat-panel" *transloco="let t" role="dialog" aria-modal="true" [attr.aria-label]="t('chat.title')">
     <div class="chat-header">
       <h2>{{ t('chat.title') }}</h2>
       <div class="chat-header-actions">
         @if (state.messages().length > 0) {
-          <button
-            class="chat-clear"
-            data-testid="chat-clear"
-            (click)="onClear()"
-            [attr.aria-label]="t('chat.clearHistory')"
-          >
+          <button class="chat-clear" data-testid="chat-clear" (click)="onClear()" [attr.aria-label]="t('chat.clearHistory')">
             {{ t('chat.clear') }}
           </button>
         }
-        <button
-          class="chat-close"
-          data-testid="chat-close"
-          (click)="onClose()"
-          [attr.aria-label]="t('chat.close')"
-        >
+        <button class="chat-close" data-testid="chat-close" (click)="onClose()" [attr.aria-label]="t('chat.close')">
           <lucide-icon name="x" [size]="18" />
         </button>
       </div>
@@ -64,11 +47,7 @@
         <div class="chat-suggestions">
           @for (s of lastSuggestions(); track s.title) {
             @if (s.recipeIdentifier) {
-              <a
-                class="chat-suggestion-card"
-                [routerLink]="ROUTES.recipes.detail(s.recipeIdentifier)"
-                (click)="onSuggestionClick()"
-              >
+              <a class="chat-suggestion-card" [routerLink]="ROUTES.recipes.detail(s.recipeIdentifier)" (click)="onSuggestionClick()">
                 <strong>{{ s.title }}</strong>
                 @if (s.reason) {
                   <span>{{ s.reason }}</span>
@@ -81,16 +60,8 @@
 
       @if (lastActions().length > 0) {
         <div class="chat-actions" data-testid="chat-actions">
-          @for (
-            action of lastActions();
-            track action.type + ':' + (action.route ?? action.recipeIdentifier ?? '')
-          ) {
-            <button
-              type="button"
-              class="chat-action"
-              data-testid="chat-action"
-              (click)="onActionClick(action)"
-            >
+          @for (action of lastActions(); track action.type + ':' + (action.route ?? action.recipeIdentifier ?? '')) {
+            <button type="button" class="chat-action" data-testid="chat-action" (click)="onActionClick(action)">
               <lucide-icon name="play" [size]="14" />
               {{ t(actionLabelKey(action)) }}
             </button>
@@ -159,12 +130,7 @@
           </button>
         }
       }
-      <button
-        type="submit"
-        class="chat-send btn-primary"
-        data-testid="chat-send"
-        [disabled]="!input().trim() || state.isThinking()"
-      >
+      <button type="submit" class="chat-send btn-primary" data-testid="chat-send" [disabled]="!input().trim() || state.isThinking()">
         {{ t('chat.send') }}
       </button>
     </form>

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -312,8 +312,7 @@ describe('ChatPanelComponent', () => {
     chatState.open();
     fixture.detectChanges();
 
-    const longText =
-      'Pasta Carbonara\n200g spaghetti\n4 eggs\n100g guanciale\nBoil pasta, mix with eggs and cheese';
+    const longText = 'Pasta Carbonara\n200g spaghetti\n4 eggs\n100g guanciale\nBoil pasta, mix with eggs and cheese';
     fixture.componentInstance['input'].set(longText);
     fixture.componentInstance['onSend']();
     await Promise.resolve();
@@ -497,9 +496,7 @@ describe('ChatPanelComponent', () => {
       chatState.open();
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="chat-mic"]',
-      ) as HTMLButtonElement;
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-mic"]') as HTMLButtonElement;
       button.click();
 
       expect(voiceMock.setLanguage).toHaveBeenCalled();
@@ -514,9 +511,7 @@ describe('ChatPanelComponent', () => {
       voiceMock.isListening.set(true);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="chat-mic"]',
-      ) as HTMLButtonElement;
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-mic"]') as HTMLButtonElement;
       button.click();
 
       expect(voiceMock.stopListening).toHaveBeenCalledTimes(1);
@@ -529,9 +524,7 @@ describe('ChatPanelComponent', () => {
       fixture.componentInstance['input'].set('Plan');
 
       fixture.componentInstance['onToggleMic']();
-      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
-        text: string,
-      ) => void;
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (text: string) => void;
       onTranscript('the week');
 
       expect(fixture.componentInstance['input']()).toBe('Plan the week');
@@ -569,9 +562,7 @@ describe('ChatPanelComponent', () => {
 
       // Simulate the mic callback firing — it sets lastInputWasVoice=true.
       fixture.componentInstance['onToggleMic']();
-      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
-        text: string,
-      ) => void;
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (text: string) => void;
       onTranscript('Add milk');
 
       chatApiMock.send.mockReturnValue(of({ reply: 'Added 1 liter milk', suggestions: [] }));
@@ -595,9 +586,7 @@ describe('ChatPanelComponent', () => {
       fixture.detectChanges();
 
       fixture.componentInstance['onToggleMic']();
-      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
-        text: string,
-      ) => void;
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (text: string) => void;
       onTranscript('Add milk');
 
       chatApiMock.send.mockReturnValue(of({ reply: 'Added', suggestions: [] }));
@@ -615,9 +604,7 @@ describe('ChatPanelComponent', () => {
       fixture.detectChanges();
 
       fixture.componentInstance['onToggleMic']();
-      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (
-        text: string,
-      ) => void;
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (text: string) => void;
       onTranscript('Add milk');
 
       // Simulate user typing — ngModelChange path through onInputChange.
@@ -648,9 +635,7 @@ describe('ChatPanelComponent', () => {
       chatState.open();
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="chat-mute"]',
-      ) as HTMLButtonElement;
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-mute"]') as HTMLButtonElement;
       button.click();
 
       expect(voiceMock.setMuted).toHaveBeenCalledWith(true);
@@ -670,9 +655,7 @@ describe('ChatPanelComponent', () => {
       await sendMessage('Hi');
       voiceMock.speak.mockClear();
 
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="chat-replay"]',
-      ) as HTMLButtonElement;
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-replay"]') as HTMLButtonElement;
       button.click();
 
       expect(voiceMock.speak).toHaveBeenCalledWith('Hello there');
@@ -686,9 +669,7 @@ describe('ChatPanelComponent', () => {
       voiceMock.muted.set(true);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="chat-replay"]',
-      ) as HTMLButtonElement;
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-replay"]') as HTMLButtonElement;
       expect(button.disabled).toBe(true);
     });
   });

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -14,12 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  ChatApiService,
-  RecipeApiService,
-  type ChatAction,
-  type ChatRecipeSuggestion,
-} from '@yumney/shared/api-client';
+import { ChatApiService, RecipeApiService, type ChatAction, type ChatRecipeSuggestion } from '@yumney/shared/api-client';
 import { ChatHintService, ChatStateService, ROUTES, VoiceService } from '@yumney/shared/models';
 
 @Component({
@@ -198,11 +193,7 @@ export class ChatPanelComponent implements AfterViewInit {
       });
   }
 
-  private buildRecipeReply(recipe: {
-    title: string;
-    ingredients: unknown[];
-    steps: unknown[];
-  }): string {
+  private buildRecipeReply(recipe: { title: string; ingredients: unknown[]; steps: unknown[] }): string {
     const count = recipe.ingredients.length;
     const steps = recipe.steps.length;
     return `I found a recipe: **${recipe.title}**\n` + `${count} ingredients, ${steps} steps.`;

--- a/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/client/libs/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
@@ -105,9 +105,7 @@ describe('ConfirmDialogComponent', () => {
 });
 
 @Component({
-  template: `
-    <yn-confirm-dialog [message]="'Test message'" (confirmed)="noop()" (cancelled)="noop()" />
-  `,
+  template: ` <yn-confirm-dialog [message]="'Test message'" (confirmed)="noop()" (cancelled)="noop()" /> `,
   imports: [ConfirmDialogComponent],
 })
 class DefaultLabelHostComponent {

--- a/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.ts
+++ b/client/libs/ui/src/lib/dialog-shell/dialog-shell.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-  output,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input, output } from '@angular/core';
 
 export type DialogSize = 'sm' | 'md' | 'lg';
 export type DialogRole = 'dialog' | 'alertdialog';

--- a/client/libs/ui/src/lib/directives/click-outside.directive.spec.ts
+++ b/client/libs/ui/src/lib/directives/click-outside.directive.spec.ts
@@ -5,12 +5,7 @@ import { ClickOutsideDirective } from './click-outside.directive';
 @Component({
   imports: [ClickOutsideDirective],
   template: `
-    <div
-      ynClickOutside
-      (clickOutside)="outsideCount = outsideCount + 1"
-      (escape)="escapeCount = escapeCount + 1"
-      data-testid="wrapper"
-    >
+    <div ynClickOutside (clickOutside)="outsideCount = outsideCount + 1" (escape)="escapeCount = escapeCount + 1" data-testid="wrapper">
       <button data-testid="inner-button">click me</button>
     </div>
     <button data-testid="external-button">outside</button>

--- a/client/libs/ui/src/lib/directives/infinite-scroll.directive.stories.ts
+++ b/client/libs/ui/src/lib/directives/infinite-scroll.directive.stories.ts
@@ -8,9 +8,7 @@ import { InfiniteScrollDirective } from './infinite-scroll.directive';
   standalone: true,
   imports: [InfiniteScrollDirective],
   template: `
-    <div
-      style="height: 240px; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px;"
-    >
+    <div style="height: 240px; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px;">
       @for (n of items(); track n) {
         <div style="padding: 12px 0; border-bottom: 1px solid #f3f4f6;">Item {{ n }}</div>
       }

--- a/client/libs/ui/src/lib/directives/infinite-scroll.directive.ts
+++ b/client/libs/ui/src/lib/directives/infinite-scroll.directive.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  OnDestroy,
-  AfterViewInit,
-  inject,
-  output,
-  input,
-} from '@angular/core';
+import { Directive, ElementRef, OnDestroy, AfterViewInit, inject, output, input } from '@angular/core';
 
 /**
  * Emits `loadMore` whenever the host element scrolls into view, provided

--- a/client/libs/ui/src/lib/docs/glass.stories.ts
+++ b/client/libs/ui/src/lib/docs/glass.stories.ts
@@ -8,9 +8,7 @@ import { Component } from '@angular/core';
     <div class="glass-docs">
       <section>
         <h2>Glass Surfaces — Elevation Levels</h2>
-        <p class="subtitle">
-          Each level increases background opacity, border visibility, and shadow depth.
-        </p>
+        <p class="subtitle">Each level increases background opacity, border visibility, and shadow depth.</p>
         <div class="ambient-bg">
           <div class="glass-grid">
             @for (level of levels; track level.name) {
@@ -98,8 +96,7 @@ import { Component } from '@angular/core';
         background:
           radial-gradient(ellipse 300px 300px at 20% 30%, var(--yn-ambient-orb-1), transparent),
           radial-gradient(ellipse 250px 250px at 75% 60%, var(--yn-ambient-orb-2), transparent),
-          radial-gradient(ellipse 200px 200px at 50% 80%, var(--yn-ambient-orb-3), transparent),
-          var(--yn-background);
+          radial-gradient(ellipse 200px 200px at 50% 80%, var(--yn-ambient-orb-3), transparent), var(--yn-background);
       }
 
       .glass-grid {

--- a/client/libs/ui/src/lib/docs/typography.stories.ts
+++ b/client/libs/ui/src/lib/docs/typography.stories.ts
@@ -11,9 +11,7 @@ import { Component } from '@angular/core';
         <div class="type-samples">
           @for (step of typeScale; track step.token) {
             <div class="type-row">
-              <span class="type-sample" [style.font-size]="'var(' + step.token + ')'">
-                The quick brown fox jumps
-              </span>
+              <span class="type-sample" [style.font-size]="'var(' + step.token + ')'"> The quick brown fox jumps </span>
               <div class="type-meta">
                 <code>{{ step.token }}</code>
                 <span>{{ step.value }}</span>
@@ -28,9 +26,7 @@ import { Component } from '@angular/core';
         <div class="type-samples">
           @for (weight of weights; track weight.token) {
             <div class="type-row">
-              <span class="weight-sample" [style.font-weight]="'var(' + weight.token + ')'">
-                {{ weight.label }} ({{ weight.value }})
-              </span>
+              <span class="weight-sample" [style.font-weight]="'var(' + weight.token + ')'"> {{ weight.label }} ({{ weight.value }}) </span>
               <code>{{ weight.token }}</code>
             </div>
           }
@@ -43,8 +39,7 @@ import { Component } from '@angular/core';
           @for (lh of lineHeights; track lh.token) {
             <div class="type-row">
               <span class="lh-sample" [style.line-height]="'var(' + lh.token + ')'">
-                {{ lh.label }}: Multi-line text sample that wraps to demonstrate line height spacing
-                between lines of text in a paragraph.
+                {{ lh.label }}: Multi-line text sample that wraps to demonstrate line height spacing between lines of text in a paragraph.
               </span>
               <code>{{ lh.token }}: {{ lh.value }}</code>
             </div>

--- a/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.html
+++ b/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.html
@@ -22,12 +22,7 @@
     >
       <lucide-icon name="chevron-down" [size]="18" />
     </button>
-    <button
-      type="button"
-      class="btn-icon btn-icon--danger"
-      (click)="remove.emit()"
-      [attr.aria-label]="t('shared.editableList.remove')"
-    >
+    <button type="button" class="btn-icon btn-icon--danger" (click)="remove.emit()" [attr.aria-label]="t('shared.editableList.remove')">
       <lucide-icon name="x" [size]="18" />
     </button>
   </div>

--- a/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.spec.ts
+++ b/client/libs/ui/src/lib/editable-list-item/editable-list-item.component.spec.ts
@@ -16,13 +16,7 @@ const en = {
 
 @Component({
   template: `
-    <yn-editable-list-item
-      [index]="index()"
-      [total]="total()"
-      (moveUp)="onMoveUp()"
-      (moveDown)="onMoveDown()"
-      (remove)="onRemove()"
-    >
+    <yn-editable-list-item [index]="index()" [total]="total()" (moveUp)="onMoveUp()" (moveDown)="onMoveDown()" (remove)="onRemove()">
       <span class="projected">Projected Content</span>
     </yn-editable-list-item>
   `,

--- a/client/libs/ui/src/lib/empty-state/empty-state.component.ts
+++ b/client/libs/ui/src/lib/empty-state/empty-state.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
 export type EmptyStateVariant = 'card' | 'minimal';

--- a/client/libs/ui/src/lib/favorite-button/favorite-button.component.ts
+++ b/client/libs/ui/src/lib/favorite-button/favorite-button.component.ts
@@ -12,9 +12,7 @@ import { LucideAngularModule } from 'lucide-angular';
       class="favorite-button"
       [class.is-favorite]="isFavorite()"
       [attr.aria-pressed]="isFavorite()"
-      [attr.aria-label]="
-        isFavorite() ? t('recipes.favorite.removeAriaLabel') : t('recipes.favorite.addAriaLabel')
-      "
+      [attr.aria-label]="isFavorite() ? t('recipes.favorite.removeAriaLabel') : t('recipes.favorite.addAriaLabel')"
       (click)="onClick($event)"
       *transloco="let t"
     >

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.html
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.html
@@ -18,12 +18,7 @@
       <label class="filter-label">{{ t('recipes.list.filter.tags') }}</label>
       <div class="chip-row">
         @for (tag of availableTags(); track tag) {
-          <button
-            type="button"
-            class="filter-chip"
-            [class.active]="isTagActive(tag)"
-            (click)="toggleTag(tag)"
-          >
+          <button type="button" class="filter-chip" [class.active]="isTagActive(tag)" (click)="toggleTag(tag)">
             {{ tag }}
           </button>
         }
@@ -34,12 +29,7 @@
   <div class="filter-group">
     <label class="filter-label">{{ t('recipes.list.filter.favorites') }}</label>
     <div class="chip-row">
-      <button
-        type="button"
-        class="filter-chip"
-        [class.active]="value().favoritesOnly"
-        (click)="toggleFavoritesOnly()"
-      >
+      <button type="button" class="filter-chip" [class.active]="value().favoritesOnly" (click)="toggleFavoritesOnly()">
         {{ t('recipes.list.filter.favoritesOnly') }}
       </button>
     </div>
@@ -49,12 +39,7 @@
     <label class="filter-label">{{ t('recipes.list.filter.difficulty') }}</label>
     <div class="chip-row">
       @for (option of difficultyOptions; track option) {
-        <button
-          type="button"
-          class="filter-chip"
-          [class.active]="value().difficulty === option"
-          (click)="toggleDifficulty(option)"
-        >
+        <button type="button" class="filter-chip" [class.active]="value().difficulty === option" (click)="toggleDifficulty(option)">
           {{ t('recipes.list.filter.difficultyOption.' + option) }}
         </button>
       }

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.spec.ts
@@ -1,10 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, signal } from '@angular/core';
-import {
-  FilterPanelComponent,
-  type RecipeFilterValue,
-  EMPTY_FILTER,
-} from './filter-panel.component';
+import { FilterPanelComponent, type RecipeFilterValue, EMPTY_FILTER } from './filter-panel.component';
 import { setupTranslocoTesting } from '@yumney/shared/models';
 import { provideYumneyIcons } from '../icons/provide-icons';
 
@@ -32,13 +28,7 @@ const en = {
 };
 
 @Component({
-  template: `
-    <yn-filter-panel
-      [value]="value()"
-      [availableTags]="availableTags()"
-      (valueChange)="onValueChange($event)"
-    />
-  `,
+  template: ` <yn-filter-panel [value]="value()" [availableTags]="availableTags()" (valueChange)="onValueChange($event)" /> `,
   imports: [FilterPanelComponent],
 })
 class TestHostComponent {
@@ -85,9 +75,7 @@ describe('FilterPanelComponent', () => {
     fixture.detectChanges();
 
     const tagChips = fixture.nativeElement.querySelectorAll('.chip-row .filter-chip');
-    const italianChip = Array.from(tagChips).find(
-      (chip) => (chip as HTMLElement).textContent?.trim() === 'Italian',
-    ) as HTMLElement;
+    const italianChip = Array.from(tagChips).find((chip) => (chip as HTMLElement).textContent?.trim() === 'Italian') as HTMLElement;
     italianChip.click();
 
     expect(host.lastEmitted?.tags).toContain('Italian');
@@ -105,9 +93,7 @@ describe('FilterPanelComponent', () => {
     fixture.detectChanges();
 
     const allChips = fixture.nativeElement.querySelectorAll('.filter-chip');
-    const easyChip = Array.from(allChips).find(
-      (chip) => (chip as HTMLElement).textContent?.trim() === 'Easy',
-    ) as HTMLElement;
+    const easyChip = Array.from(allChips).find((chip) => (chip as HTMLElement).textContent?.trim() === 'Easy') as HTMLElement;
     easyChip.click();
 
     expect(host.lastEmitted?.difficulty).toBe('easy');
@@ -118,9 +104,7 @@ describe('FilterPanelComponent', () => {
     fixture.detectChanges();
 
     const allChips = fixture.nativeElement.querySelectorAll('.filter-chip');
-    const easyChip = Array.from(allChips).find(
-      (chip) => (chip as HTMLElement).textContent?.trim() === 'Easy',
-    ) as HTMLElement;
+    const easyChip = Array.from(allChips).find((chip) => (chip as HTMLElement).textContent?.trim() === 'Easy') as HTMLElement;
     easyChip.click();
 
     expect(host.lastEmitted?.difficulty).toBeNull();
@@ -130,9 +114,7 @@ describe('FilterPanelComponent', () => {
     fixture.detectChanges();
 
     const allChips = fixture.nativeElement.querySelectorAll('.filter-chip');
-    const favChip = Array.from(allChips).find(
-      (chip) => (chip as HTMLElement).textContent?.trim() === 'Favorites only',
-    ) as HTMLElement;
+    const favChip = Array.from(allChips).find((chip) => (chip as HTMLElement).textContent?.trim() === 'Favorites only') as HTMLElement;
     favChip.click();
 
     expect(host.lastEmitted?.favoritesOnly).toBe(true);

--- a/client/libs/ui/src/lib/filter-panel/filter-panel.component.ts
+++ b/client/libs/ui/src/lib/filter-panel/filter-panel.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  HostListener,
-  input,
-  output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, HostListener, input, output } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 
 export type RecipeDifficulty = 'easy' | 'medium' | 'hard';
@@ -70,9 +63,7 @@ export class FilterPanelComponent {
 
   protected toggleTag(tag: string): void {
     const current = this.value();
-    const tags = current.tags.includes(tag)
-      ? current.tags.filter((existing) => existing !== tag)
-      : [...current.tags, tag];
+    const tags = current.tags.includes(tag) ? current.tags.filter((existing) => existing !== tag) : [...current.tags, tag];
     this.valueChange.emit({ ...current, tags });
   }
 

--- a/client/libs/ui/src/lib/form-field/form-field.component.spec.ts
+++ b/client/libs/ui/src/lib/form-field/form-field.component.spec.ts
@@ -102,10 +102,7 @@ describe('FormFieldComponent', () => {
 
   it('should display group errors only when the control is touched', () => {
     const control = new FormControl('');
-    const group = new FormGroup(
-      { password: control },
-      { validators: () => ({ passwordsMismatch: true }) },
-    );
+    const group = new FormGroup({ password: control }, { validators: () => ({ passwordsMismatch: true }) });
     fixture.componentRef.setInput('control', control);
     fixture.componentRef.setInput('group', group);
     fixture.componentRef.setInput('groupErrors', { passwordsMismatch: 'form.passwordsMismatch' });
@@ -119,10 +116,7 @@ describe('FormFieldComponent', () => {
 
   it('should not display group errors when the control is untouched', () => {
     const control = new FormControl('');
-    const group = new FormGroup(
-      { password: control },
-      { validators: () => ({ passwordsMismatch: true }) },
-    );
+    const group = new FormGroup({ password: control }, { validators: () => ({ passwordsMismatch: true }) });
     fixture.componentRef.setInput('control', control);
     fixture.componentRef.setInput('group', group);
     fixture.componentRef.setInput('groupErrors', { passwordsMismatch: 'form.passwordsMismatch' });

--- a/client/libs/ui/src/lib/form-field/form-field.component.ts
+++ b/client/libs/ui/src/lib/form-field/form-field.component.ts
@@ -23,13 +23,9 @@ export class FormFieldComponent {
 
   // Track control/group events so OnPush re-renders on touched/status changes
   // triggered by ancestors (e.g. markAllAsTouched on submit).
-  private readonly controlEvents = toSignal(
-    toObservable(this.control).pipe(switchMap((control) => control.events.pipe(startWith(null)))),
-  );
+  private readonly controlEvents = toSignal(toObservable(this.control).pipe(switchMap((control) => control.events.pipe(startWith(null)))));
   private readonly groupEvents = toSignal(
-    toObservable(this.group).pipe(
-      switchMap((group) => (group ? group.events.pipe(startWith(null)) : of(null))),
-    ),
+    toObservable(this.group).pipe(switchMap((group) => (group ? group.events.pipe(startWith(null)) : of(null)))),
   );
 
   hasControlError(errorKey: string): boolean {

--- a/client/libs/ui/src/lib/header/header.component.html
+++ b/client/libs/ui/src/lib/header/header.component.html
@@ -1,9 +1,4 @@
-<header
-  ynClickOutside
-  (clickOutside)="onDismissMenu()"
-  (escape)="onDismissMenu()"
-  *transloco="let t"
->
+<header ynClickOutside (clickOutside)="onDismissMenu()" (escape)="onDismissMenu()" *transloco="let t">
   <div class="header-content">
     <a class="brand" routerLink="/">Yumney</a>
 
@@ -30,11 +25,7 @@
           <span class="nav-label">{{ t('layout.header.mealPlanner') }}</span>
         </a>
 
-        <button
-          class="icon-button"
-          (click)="onToggleChat()"
-          [attr.aria-label]="t('layout.header.openChat')"
-        >
+        <button class="icon-button" (click)="onToggleChat()" [attr.aria-label]="t('layout.header.openChat')">
           <lucide-icon name="message-square" [size]="20" />
         </button>
 
@@ -81,12 +72,7 @@
 
               <div class="dropdown-divider"></div>
 
-              <button
-                class="dropdown-item dropdown-item--danger"
-                data-testid="logout"
-                (click)="onLogout()"
-                role="menuitem"
-              >
+              <button class="dropdown-item dropdown-item--danger" data-testid="logout" (click)="onLogout()" role="menuitem">
                 <lucide-icon name="log-out" [size]="18" />
                 <span>{{ t('layout.header.logout') }}</span>
               </button>

--- a/client/libs/ui/src/lib/header/header.component.spec.ts
+++ b/client/libs/ui/src/lib/header/header.component.spec.ts
@@ -3,12 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal, computed } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { AuthService } from '@yumney/shared/auth';
-import {
-  LanguageService,
-  ThemeService,
-  ChatStateService,
-  setupTranslocoTesting,
-} from '@yumney/shared/models';
+import { LanguageService, ThemeService, ChatStateService, setupTranslocoTesting } from '@yumney/shared/models';
 import { HeaderComponent } from './header.component';
 
 const en = {
@@ -140,9 +135,7 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
 
     const navLinks = fixture.nativeElement.querySelectorAll('.nav-link');
-    const recipeLink = Array.from(navLinks).find((el) =>
-      (el as HTMLElement).textContent?.includes('My Recipes'),
-    );
+    const recipeLink = Array.from(navLinks).find((el) => (el as HTMLElement).textContent?.includes('My Recipes'));
     expect(recipeLink).toBeTruthy();
   });
 
@@ -152,9 +145,7 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
 
     const navLinks = fixture.nativeElement.querySelectorAll('.nav-link');
-    const shoppingLink = Array.from(navLinks).find((el) =>
-      (el as HTMLElement).textContent?.includes('Shopping Lists'),
-    );
+    const shoppingLink = Array.from(navLinks).find((el) => (el as HTMLElement).textContent?.includes('Shopping Lists'));
     expect(shoppingLink).toBeTruthy();
   });
 
@@ -164,9 +155,7 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
 
     const navLinks = fixture.nativeElement.querySelectorAll('.nav-link');
-    const mealPlannerLink = Array.from(navLinks).find((el) =>
-      (el as HTMLElement).textContent?.includes('Meal Planner'),
-    );
+    const mealPlannerLink = Array.from(navLinks).find((el) => (el as HTMLElement).textContent?.includes('Meal Planner'));
     expect(mealPlannerLink).toBeTruthy();
   });
 

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.html
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.html
@@ -8,11 +8,7 @@
           <div class="result-card" [class]="'confidence-' + confidenceLevel(item.confidence)">
             <span class="result-name">{{ item.name }}</span>
             <span class="result-confidence">{{ (item.confidence * 100).toFixed(0) }}%</span>
-            <button
-              class="result-remove"
-              (click)="onRemoveIngredient(item.name)"
-              [attr.aria-label]="t('scanner.removeIngredient')"
-            >
+            <button class="result-remove" (click)="onRemoveIngredient(item.name)" [attr.aria-label]="t('scanner.removeIngredient')">
               <lucide-icon name="x" [size]="18" />
             </button>
           </div>
@@ -29,23 +25,14 @@
     <button class="control-btn cancel-btn" (click)="onCancel()">
       {{ t('scanner.cancel') }}
     </button>
-    <button
-      class="scan-btn"
-      (click)="onScan()"
-      [disabled]="!isStreaming() || isScanning()"
-      [attr.aria-label]="t('scanner.scan')"
-    >
+    <button class="scan-btn" (click)="onScan()" [disabled]="!isStreaming() || isScanning()" [attr.aria-label]="t('scanner.scan')">
       @if (isScanning()) {
         <span class="scan-spinner"></span>
       } @else {
         {{ t('scanner.scan') }}
       }
     </button>
-    <button
-      class="control-btn flip-btn"
-      (click)="onToggleFacing()"
-      [attr.aria-label]="t('scanner.flipCamera')"
-    >
+    <button class="control-btn flip-btn" (click)="onToggleFacing()" [attr.aria-label]="t('scanner.flipCamera')">
       <lucide-icon name="refresh-cw" [size]="20" />
     </button>
   </div>

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.spec.ts
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.spec.ts
@@ -3,15 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { IngredientScannerComponent } from './ingredient-scanner.component';
-import {
-  CameraService,
-  IngredientRecognitionService,
-  setupTranslocoTesting,
-} from '@yumney/shared/models';
-import type {
-  RecognizedIngredient,
-  RecognizedIngredientsResponse,
-} from '@yumney/shared/api-client';
+import { CameraService, IngredientRecognitionService, setupTranslocoTesting } from '@yumney/shared/models';
+import type { RecognizedIngredient, RecognizedIngredientsResponse } from '@yumney/shared/api-client';
 
 const en = {
   scanner: {
@@ -60,10 +53,7 @@ function createRecognitionMock(): RecognitionServiceMock {
     ),
     mergeIngredients: vi
       .fn()
-      .mockImplementation((existing: RecognizedIngredient[], incoming: RecognizedIngredient[]) => [
-        ...existing,
-        ...incoming,
-      ]),
+      .mockImplementation((existing: RecognizedIngredient[], incoming: RecognizedIngredient[]) => [...existing, ...incoming]),
     confidenceLevel: vi.fn().mockReturnValue('high'),
   };
 }

--- a/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.ts
+++ b/client/libs/ui/src/lib/ingredient-scanner/ingredient-scanner.component.ts
@@ -13,11 +13,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  CameraService,
-  IngredientRecognitionService,
-  type FacingMode,
-} from '@yumney/shared/models';
+import { CameraService, IngredientRecognitionService, type FacingMode } from '@yumney/shared/models';
 import type { RecognizedIngredient } from '@yumney/shared/api-client';
 
 @Component({
@@ -72,10 +68,7 @@ export class IngredientScannerComponent implements AfterViewInit, OnDestroy {
           .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe({
             next: (response) => {
-              const merged = this.recognition.mergeIngredients(
-                this.ingredients(),
-                response.ingredients,
-              );
+              const merged = this.recognition.mergeIngredients(this.ingredients(), response.ingredients);
               this.ingredients.set(merged);
               this.lastScanAt.set(Date.now());
               this.isScanning.set(false);

--- a/client/libs/ui/src/lib/ingredients-toast/ingredients-toast.component.html
+++ b/client/libs/ui/src/lib/ingredients-toast/ingredients-toast.component.html
@@ -7,11 +7,7 @@
       }
     </div>
   </div>
-  <button
-    class="ingredients-toast-dismiss"
-    (click)="dismissed.emit()"
-    [attr.aria-label]="t('dashboard.scanner.dismiss')"
-  >
+  <button class="ingredients-toast-dismiss" (click)="dismissed.emit()" [attr.aria-label]="t('dashboard.scanner.dismiss')">
     <lucide-icon name="x" [size]="18" />
   </button>
 </div>

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.html
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.html
@@ -1,8 +1,3 @@
-<div
-  [class]="bannerClass()"
-  [attr.role]="role()"
-  [attr.aria-live]="ariaLive()"
-  [attr.data-testid]="testId() ?? null"
->
+<div [class]="bannerClass()" [attr.role]="role()" [attr.aria-live]="ariaLive()" [attr.data-testid]="testId() ?? null">
   {{ message() | transloco: params() }}
 </div>

--- a/client/libs/ui/src/lib/message-banner/message-banner.component.ts
+++ b/client/libs/ui/src/lib/message-banner/message-banner.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
 export type MessageBannerTone = 'error' | 'success';

--- a/client/libs/ui/src/lib/recent-activity/recent-activity.component.ts
+++ b/client/libs/ui/src/lib/recent-activity/recent-activity.component.ts
@@ -19,15 +19,10 @@ import type { UserActivityItem } from '@yumney/shared/api-client';
         <ul class="activity-list">
           @for (item of activities(); track item.occurredAt) {
             <li class="activity-item">
-              <span class="activity-icon"
-                ><lucide-icon [name]="getIcon(item.type)" [size]="16"
-              /></span>
+              <span class="activity-icon"><lucide-icon [name]="getIcon(item.type)" [size]="16" /></span>
               <div class="activity-detail">
                 @if (item.recipeIdentifier) {
-                  <a
-                    [routerLink]="ROUTES.recipes.detail(item.recipeIdentifier)"
-                    class="activity-link"
-                  >
+                  <a [routerLink]="ROUTES.recipes.detail(item.recipeIdentifier)" class="activity-link">
                     {{ item.recipeTitle ?? t('dashboard.recentActivity.unknownRecipe') }}
                   </a>
                 } @else {

--- a/client/libs/ui/src/lib/recipe-preview/recipe-form.ts
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-form.ts
@@ -1,9 +1,5 @@
 import { FormBuilder, FormArray, FormGroup, FormControl, Validators } from '@angular/forms';
-import {
-  ImportRecipeResponse,
-  ExtractedIngredient,
-  ExtractedStep,
-} from '@yumney/shared/api-client';
+import { ImportRecipeResponse, ExtractedIngredient, ExtractedStep } from '@yumney/shared/api-client';
 import { VALIDATION } from '@yumney/shared/models';
 
 export interface IngredientFormGroup {
@@ -29,10 +25,7 @@ export class RecipeFormController {
     private readonly source: ImportRecipeResponse,
   ) {
     this.form = fb.nonNullable.group({
-      title: [
-        '',
-        [Validators.required, Validators.maxLength(VALIDATION.RECIPES.RECIPE_TITLE.MAX_LENGTH)],
-      ],
+      title: ['', [Validators.required, Validators.maxLength(VALIDATION.RECIPES.RECIPE_TITLE.MAX_LENGTH)]],
       description: [''],
       servings: [null as number | null],
       prepTimeMinutes: [null as number | null],
@@ -79,16 +72,7 @@ export class RecipeFormController {
 
   /** Builds the API response payload from the current form state. */
   toResponse(): ImportRecipeResponse {
-    const {
-      title,
-      description,
-      servings,
-      prepTimeMinutes,
-      cookTimeMinutes,
-      difficulty,
-      ingredients,
-      steps,
-    } = this.form.getRawValue();
+    const { title, description, servings, prepTimeMinutes, cookTimeMinutes, difficulty, ingredients, steps } = this.form.getRawValue();
     return {
       title,
       description: description || null,

--- a/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.html
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.html
@@ -21,47 +21,27 @@
         <input id="preview-title" type="text" formControlName="title" />
       </yn-form-field>
 
-      <yn-form-field
-        label="dashboard.preview.description"
-        for="preview-description"
-        [control]="form.controls.description"
-      >
+      <yn-form-field label="dashboard.preview.description" for="preview-description" [control]="form.controls.description">
         <textarea id="preview-description" formControlName="description" rows="3"></textarea>
       </yn-form-field>
 
       <div class="form-row">
-        <yn-form-field
-          label="dashboard.preview.servings"
-          for="preview-servings"
-          [control]="form.controls.servings"
-        >
+        <yn-form-field label="dashboard.preview.servings" for="preview-servings" [control]="form.controls.servings">
           <input id="preview-servings" type="number" formControlName="servings" />
         </yn-form-field>
-        <yn-form-field
-          label="dashboard.preview.prepTime"
-          for="preview-prepTime"
-          [control]="form.controls.prepTimeMinutes"
-        >
+        <yn-form-field label="dashboard.preview.prepTime" for="preview-prepTime" [control]="form.controls.prepTimeMinutes">
           <div class="input-with-unit">
             <input id="preview-prepTime" type="number" formControlName="prepTimeMinutes" />
             <span class="input-unit">min</span>
           </div>
         </yn-form-field>
-        <yn-form-field
-          label="dashboard.preview.cookTime"
-          for="preview-cookTime"
-          [control]="form.controls.cookTimeMinutes"
-        >
+        <yn-form-field label="dashboard.preview.cookTime" for="preview-cookTime" [control]="form.controls.cookTimeMinutes">
           <div class="input-with-unit">
             <input id="preview-cookTime" type="number" formControlName="cookTimeMinutes" />
             <span class="input-unit">min</span>
           </div>
         </yn-form-field>
-        <yn-form-field
-          label="dashboard.preview.difficulty"
-          for="preview-difficulty"
-          [control]="form.controls.difficulty"
-        >
+        <yn-form-field label="dashboard.preview.difficulty" for="preview-difficulty" [control]="form.controls.difficulty">
           <select id="preview-difficulty" formControlName="difficulty">
             <option value="">{{ t('dashboard.preview.difficultyPlaceholder') }}</option>
             <option value="easy">{{ t('dashboard.preview.difficultyOption.easy') }}</option>
@@ -91,23 +71,9 @@
                 [errors]="{ required: 'dashboard.preview.errors.ingredientNameRequired' }"
               >
                 <div class="ingredient-compound">
-                  <input
-                    class="compound-name"
-                    type="text"
-                    formControlName="name"
-                    [placeholder]="t('dashboard.preview.ingredientName')"
-                  />
-                  <input
-                    class="compound-amount"
-                    type="number"
-                    formControlName="amount"
-                    [placeholder]="t('dashboard.preview.amount')"
-                  />
-                  <yn-unit-select
-                    class="compound-unit"
-                    formControlName="unit"
-                    [unitGroups]="unitGroups"
-                  />
+                  <input class="compound-name" type="text" formControlName="name" [placeholder]="t('dashboard.preview.ingredientName')" />
+                  <input class="compound-amount" type="number" formControlName="amount" [placeholder]="t('dashboard.preview.amount')" />
+                  <yn-unit-select class="compound-unit" formControlName="unit" [unitGroups]="unitGroups" />
                 </div>
               </yn-form-field>
             </div>
@@ -115,9 +81,7 @@
         }
       </div>
 
-      <button type="button" class="btn-dashed add-btn" (click)="addIngredient()">
-        + {{ t('dashboard.preview.addIngredient') }}
-      </button>
+      <button type="button" class="btn-dashed add-btn" (click)="addIngredient()">+ {{ t('dashboard.preview.addIngredient') }}</button>
     </div>
 
     <div class="list-section">
@@ -139,29 +103,18 @@
                 [control]="steps.at(i).get('description')!"
                 [errors]="{ required: 'dashboard.preview.errors.stepDescriptionRequired' }"
               >
-                <textarea
-                  formControlName="description"
-                  [placeholder]="t('dashboard.preview.stepDescription')"
-                  rows="2"
-                ></textarea>
+                <textarea formControlName="description" [placeholder]="t('dashboard.preview.stepDescription')" rows="2"></textarea>
               </yn-form-field>
             </div>
           </yn-editable-list-item>
         }
       </div>
 
-      <button type="button" class="btn-dashed add-btn" (click)="addStep()">
-        + {{ t('dashboard.preview.addStep') }}
-      </button>
+      <button type="button" class="btn-dashed add-btn" (click)="addStep()">+ {{ t('dashboard.preview.addStep') }}</button>
     </div>
 
     <div class="action-buttons">
-      <button
-        type="button"
-        class="btn-secondary discard-btn"
-        [disabled]="isSaving()"
-        (click)="onDiscard()"
-      >
+      <button type="button" class="btn-secondary discard-btn" [disabled]="isSaving()" (click)="onDiscard()">
         {{ t('dashboard.preview.discard') }}
       </button>
       <yn-submit-button

--- a/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.spec.ts
+++ b/client/libs/ui/src/lib/recipe-preview/recipe-preview.component.spec.ts
@@ -61,14 +61,7 @@ const en = {
 };
 
 @Component({
-  template: `
-    <yn-recipe-preview
-      [recipe]="recipe"
-      [previewTitle]="previewTitle"
-      (save)="onSave($event)"
-      (discard)="onDiscard()"
-    />
-  `,
+  template: ` <yn-recipe-preview [recipe]="recipe" [previewTitle]="previewTitle" (save)="onSave($event)" (discard)="onDiscard()" /> `,
   imports: [RecipePreviewComponent],
 })
 class TestHostComponent {
@@ -111,9 +104,7 @@ describe('RecipePreviewComponent', () => {
   });
 
   it('should populate the description field', () => {
-    const textarea = fixture.nativeElement.querySelector(
-      '#preview-description',
-    ) as HTMLTextAreaElement;
+    const textarea = fixture.nativeElement.querySelector('#preview-description') as HTMLTextAreaElement;
     expect(textarea.value).toBe('A classic Italian pasta dish');
   });
 
@@ -142,9 +133,7 @@ describe('RecipePreviewComponent', () => {
   });
 
   it('should remove an ingredient', () => {
-    const removeBtn = fixture.nativeElement.querySelector(
-      '[formarrayname="ingredients"] [aria-label="Remove"]',
-    );
+    const removeBtn = fixture.nativeElement.querySelector('[formarrayname="ingredients"] [aria-label="Remove"]');
     removeBtn.click();
     fixture.detectChanges();
 
@@ -163,9 +152,7 @@ describe('RecipePreviewComponent', () => {
   });
 
   it('should remove a step', () => {
-    const removeBtn = fixture.nativeElement.querySelector(
-      '[formarrayname="steps"] [aria-label="Remove"]',
-    );
+    const removeBtn = fixture.nativeElement.querySelector('[formarrayname="steps"] [aria-label="Remove"]');
     removeBtn.click();
     fixture.detectChanges();
 
@@ -257,18 +244,14 @@ describe('RecipePreviewComponent', () => {
     form.dispatchEvent(new Event('submit'));
     fixture.detectChanges();
 
-    expect(host.onSave).toHaveBeenCalledWith(
-      expect.objectContaining({ imageUrl: 'https://example.com/image.jpg' }),
-    );
+    expect(host.onSave).toHaveBeenCalledWith(expect.objectContaining({ imageUrl: 'https://example.com/image.jpg' }));
   });
 
   it('should reorder ingredients up', () => {
     preview.moveIngredientUp(1);
     fixture.detectChanges();
 
-    const nameInputs = fixture.nativeElement.querySelectorAll(
-      '.ingredient-row input[formcontrolname="name"]',
-    );
+    const nameInputs = fixture.nativeElement.querySelectorAll('.ingredient-row input[formcontrolname="name"]');
     expect(nameInputs[0].value).toBe('Pancetta');
     expect(nameInputs[1].value).toBe('Spaghetti');
   });
@@ -277,9 +260,7 @@ describe('RecipePreviewComponent', () => {
     preview.moveIngredientDown(0);
     fixture.detectChanges();
 
-    const nameInputs = fixture.nativeElement.querySelectorAll(
-      '.ingredient-row input[formcontrolname="name"]',
-    );
+    const nameInputs = fixture.nativeElement.querySelectorAll('.ingredient-row input[formcontrolname="name"]');
     expect(nameInputs[0].value).toBe('Pancetta');
     expect(nameInputs[1].value).toBe('Spaghetti');
   });
@@ -288,9 +269,7 @@ describe('RecipePreviewComponent', () => {
     preview.moveStepUp(1);
     fixture.detectChanges();
 
-    const textareas = fixture.nativeElement.querySelectorAll(
-      '.step-fields textarea[formcontrolname="description"]',
-    );
+    const textareas = fixture.nativeElement.querySelectorAll('.step-fields textarea[formcontrolname="description"]');
     expect(textareas[0].value).toBe('Fry pancetta');
     expect(textareas[1].value).toBe('Cook pasta');
   });
@@ -299,9 +278,7 @@ describe('RecipePreviewComponent', () => {
     preview.moveStepDown(0);
     fixture.detectChanges();
 
-    const textareas = fixture.nativeElement.querySelectorAll(
-      '.step-fields textarea[formcontrolname="description"]',
-    );
+    const textareas = fixture.nativeElement.querySelectorAll('.step-fields textarea[formcontrolname="description"]');
     expect(textareas[0].value).toBe('Fry pancetta');
     expect(textareas[1].value).toBe('Cook pasta');
   });
@@ -362,9 +339,7 @@ describe('RecipePreviewComponent', () => {
     };
     fixture.detectChanges();
 
-    const textarea = fixture.nativeElement.querySelector(
-      '#preview-description',
-    ) as HTMLTextAreaElement;
+    const textarea = fixture.nativeElement.querySelector('#preview-description') as HTMLTextAreaElement;
     expect(textarea.value).toBe('');
 
     const form = fixture.nativeElement.querySelector('form');

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.html
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.html
@@ -1,10 +1,5 @@
 <section class="settings-card" data-testid="profile-settings-section" *transloco="let t">
-  <button
-    type="button"
-    class="settings-card__header"
-    [attr.aria-expanded]="isOpen()"
-    (click)="onHeaderClick()"
-  >
+  <button type="button" class="settings-card__header" [attr.aria-expanded]="isOpen()" (click)="onHeaderClick()">
     <div class="settings-card__heading">
       <span class="settings-card__title">{{ t(titleKey()) }}</span>
       @if (descriptionKey(); as descKey) {

--- a/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
+++ b/client/libs/ui/src/lib/settings-card/settings-card.component.spec.ts
@@ -35,12 +35,8 @@ describe('SettingsCardComponent', () => {
   });
 
   it('should render title and description from i18n keys', () => {
-    expect(fixture.nativeElement.querySelector('.settings-card__title').textContent.trim()).toBe(
-      'Identity',
-    );
-    expect(
-      fixture.nativeElement.querySelector('.settings-card__description').textContent.trim(),
-    ).toBe('Who you are');
+    expect(fixture.nativeElement.querySelector('.settings-card__title').textContent.trim()).toBe('Identity');
+    expect(fixture.nativeElement.querySelector('.settings-card__description').textContent.trim()).toBe('Who you are');
   });
 
   it('should project body content while open', () => {
@@ -52,8 +48,6 @@ describe('SettingsCardComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.projected')).toBeNull();
-    expect(
-      fixture.nativeElement.querySelector('.settings-card__header').getAttribute('aria-expanded'),
-    ).toBe('false');
+    expect(fixture.nativeElement.querySelector('.settings-card__header').getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/client/libs/ui/src/lib/share-toast/share-toast.component.html
+++ b/client/libs/ui/src/lib/share-toast/share-toast.component.html
@@ -6,11 +6,7 @@
       <span class="share-toast-url">{{ url() }}</span>
     </div>
   </div>
-  <button
-    class="share-toast-dismiss"
-    (click)="dismissed.emit()"
-    [attr.aria-label]="t('dashboard.share.dismiss')"
-  >
+  <button class="share-toast-dismiss" (click)="dismissed.emit()" [attr.aria-label]="t('dashboard.share.dismiss')">
     <lucide-icon name="x" [size]="18" />
   </button>
 </div>

--- a/client/libs/ui/src/lib/side-sheet/side-sheet.component.spec.ts
+++ b/client/libs/ui/src/lib/side-sheet/side-sheet.component.spec.ts
@@ -1,10 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  SideSheetComponent,
-  type SideSheetPosition,
-  type SideSheetSize,
-} from './side-sheet.component';
+import { SideSheetComponent, type SideSheetPosition, type SideSheetSize } from './side-sheet.component';
 
 @Component({
   imports: [SideSheetComponent],

--- a/client/libs/ui/src/lib/side-sheet/side-sheet.component.ts
+++ b/client/libs/ui/src/lib/side-sheet/side-sheet.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  computed,
-  input,
-  output,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation, computed, input, output } from '@angular/core';
 
 export type SideSheetSize = 'sm' | 'md' | 'lg';
 export type SideSheetPosition = 'left' | 'right';
@@ -30,9 +23,7 @@ export class SideSheetComponent {
 
   cancelled = output<void>();
 
-  protected readonly sheetClass = computed(
-    () => `yn-side-sheet yn-side-sheet--${this.size()} yn-side-sheet--${this.position()}`,
-  );
+  protected readonly sheetClass = computed(() => `yn-side-sheet yn-side-sheet--${this.size()} yn-side-sheet--${this.position()}`);
 
   onEscape(): void {
     if (this.cancelOnEscape()) this.cancelled.emit();

--- a/client/libs/ui/src/lib/star-rating/star-rating.component.spec.ts
+++ b/client/libs/ui/src/lib/star-rating/star-rating.component.spec.ts
@@ -14,9 +14,7 @@ const en = {
 };
 
 @Component({
-  template: `
-    <yn-star-rating [rating]="rating()" [readonly]="readonly()" (ratingChange)="onChange($event)" />
-  `,
+  template: ` <yn-star-rating [rating]="rating()" [readonly]="readonly()" (ratingChange)="onChange($event)" /> `,
   imports: [StarRatingComponent],
 })
 class TestHostComponent {
@@ -52,9 +50,7 @@ describe('StarRatingComponent', () => {
     host.rating.set(3);
     fixture.detectChanges();
 
-    const filled = getStars().filter((star) =>
-      star.classList.contains('star-rating__star--filled'),
-    );
+    const filled = getStars().filter((star) => star.classList.contains('star-rating__star--filled'));
     expect(filled).toHaveLength(3);
   });
 
@@ -70,9 +66,7 @@ describe('StarRatingComponent', () => {
     getStars()[4].dispatchEvent(new MouseEvent('mouseenter'));
     fixture.detectChanges();
 
-    const filled = getStars().filter((star) =>
-      star.classList.contains('star-rating__star--filled'),
-    );
+    const filled = getStars().filter((star) => star.classList.contains('star-rating__star--filled'));
     expect(filled).toHaveLength(5);
   });
 

--- a/client/libs/ui/src/lib/star-rating/star-rating.component.ts
+++ b/client/libs/ui/src/lib/star-rating/star-rating.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  computed,
-  input,
-  output,
-  signal,
-  viewChildren,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, computed, input, output, signal, viewChildren } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { prefersReducedMotion, springPress } from '../animation/gsap-utils';

--- a/client/libs/ui/src/lib/styles/_cards.scss
+++ b/client/libs/ui/src/lib/styles/_cards.scss
@@ -45,6 +45,5 @@
   background:
     radial-gradient(ellipse 500px 500px at 15% 25%, var(--yn-ambient-orb-1), transparent),
     radial-gradient(ellipse 400px 400px at 80% 65%, var(--yn-ambient-orb-2), transparent),
-    radial-gradient(ellipse 350px 350px at 50% 85%, var(--yn-ambient-orb-3), transparent),
-    var(--yn-background);
+    radial-gradient(ellipse 350px 350px at 50% 85%, var(--yn-ambient-orb-3), transparent), var(--yn-background);
 }

--- a/client/libs/ui/src/lib/styles/_ingredient-display.scss
+++ b/client/libs/ui/src/lib/styles/_ingredient-display.scss
@@ -5,11 +5,7 @@
 // Usage:
 //   @include ingredient-display('.ingredient-amount', '.ingredient-unit', '.ingredient-name');
 
-@mixin ingredient-display(
-  $amount: '.ingredient-amount',
-  $unit: '.ingredient-unit',
-  $name: '.ingredient-name'
-) {
+@mixin ingredient-display($amount: '.ingredient-amount', $unit: '.ingredient-unit', $name: '.ingredient-name') {
   #{$amount} {
     font-weight: var(--yn-font-semibold);
     color: var(--yn-primary);

--- a/client/libs/ui/src/lib/styles/_motion.scss
+++ b/client/libs/ui/src/lib/styles/_motion.scss
@@ -98,12 +98,7 @@
 }
 
 @mixin skeleton-shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--yn-glass-bg) 25%,
-    var(--yn-glass-bg-elevated) 50%,
-    var(--yn-glass-bg) 75%
-  );
+  background: linear-gradient(90deg, var(--yn-glass-bg) 25%, var(--yn-glass-bg-elevated) 50%, var(--yn-glass-bg) 75%);
   background-size: 200% 100%;
   animation: yn-shimmer 1.5s ease-in-out infinite;
   border-radius: var(--yn-radius-md);

--- a/client/libs/ui/src/lib/styles/_typography.scss
+++ b/client/libs/ui/src/lib/styles/_typography.scss
@@ -5,8 +5,7 @@
 :root {
   // Font Family
   --yn-font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
-    'Helvetica Neue', sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   --yn-font-mono: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
 
   // Font Size Scale

--- a/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
+++ b/client/libs/ui/src/lib/suggestion-card/suggestion-card.component.ts
@@ -8,11 +8,7 @@ import { ROUTES } from '@yumney/shared/models';
   standalone: true,
   imports: [RouterLink, TranslocoModule],
   template: `
-    <a
-      class="suggestion-card"
-      [routerLink]="ROUTES.recipes.detail(identifier())"
-      *transloco="let t"
-    >
+    <a class="suggestion-card" [routerLink]="ROUTES.recipes.detail(identifier())" *transloco="let t">
       @if (imageUrl()) {
         <img class="suggestion-image" [src]="imageUrl()!" [alt]="title()" loading="lazy" />
       } @else {
@@ -21,9 +17,7 @@ import { ROUTES } from '@yumney/shared/models';
       <div class="suggestion-info">
         <h3 class="suggestion-title">{{ title() }}</h3>
         @if (prepTimeMinutes()) {
-          <span class="suggestion-time">{{
-            t('dashboard.suggestions.prepTime', { minutes: prepTimeMinutes() })
-          }}</span>
+          <span class="suggestion-time">{{ t('dashboard.suggestions.prepTime', { minutes: prepTimeMinutes() }) }}</span>
         }
         <span class="suggestion-reason">{{ reason() }}</span>
       </div>

--- a/client/libs/ui/src/lib/toast-host/toast-host.component.html
+++ b/client/libs/ui/src/lib/toast-host/toast-host.component.html
@@ -2,12 +2,7 @@
   @for (toast of toasts(); track toast.id) {
     <div class="toast toast-{{ toast.kind }}" role="status">
       <span class="toast-message">{{ t(toast.messageKey, toast.params) }}</span>
-      <button
-        type="button"
-        class="toast-dismiss"
-        (click)="dismiss(toast.id)"
-        [attr.aria-label]="t('common.toast.dismiss')"
-      >
+      <button type="button" class="toast-dismiss" (click)="dismiss(toast.id)" [attr.aria-label]="t('common.toast.dismiss')">
         <lucide-icon name="x" [size]="16" />
       </button>
     </div>

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.html
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.html
@@ -1,10 +1,4 @@
-<div
-  class="unit-select"
-  ynClickOutside
-  (clickOutside)="onDismiss()"
-  (escape)="onDismiss()"
-  *transloco="let t"
->
+<div class="unit-select" ynClickOutside (clickOutside)="onDismiss()" (escape)="onDismiss()" *transloco="let t">
   <button
     type="button"
     class="unit-toggle"
@@ -21,16 +15,11 @@
       }
     </span>
     @if (selectedValue()) {
-      <span
-        class="unit-clear"
-        (click)="clearSelection($event)"
-        [attr.aria-label]="t('dashboard.preview.clearUnit')"
+      <span class="unit-clear" (click)="clearSelection($event)" [attr.aria-label]="t('dashboard.preview.clearUnit')"
         ><lucide-icon name="x" [size]="18"
       /></span>
     }
-    <span class="unit-chevron" [class.open]="isOpen()"
-      ><lucide-icon name="chevron-down" [size]="18"
-    /></span>
+    <span class="unit-chevron" [class.open]="isOpen()"><lucide-icon name="chevron-down" [size]="18" /></span>
   </button>
 
   @if (isOpen()) {

--- a/client/libs/ui/src/lib/unit-select/unit-select.component.ts
+++ b/client/libs/ui/src/lib/unit-select/unit-select.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  computed,
-  input,
-  signal,
-  forwardRef,
-  HostListener,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, input, signal, forwardRef, HostListener } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.html
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.html
@@ -1,9 +1,4 @@
-<div
-  class="unit-toggle"
-  role="radiogroup"
-  *transloco="let t"
-  [attr.aria-label]="t('shared.unitToggle.label')"
->
+<div class="unit-toggle" role="radiogroup" *transloco="let t" [attr.aria-label]="t('shared.unitToggle.label')">
   <button
     type="button"
     class="unit-toggle-option"

--- a/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.spec.ts
+++ b/client/libs/ui/src/lib/unit-toggle/unit-toggle.component.spec.ts
@@ -25,12 +25,8 @@ describe('UnitToggleComponent', () => {
   });
 
   it('marks the selected system aria-checked', () => {
-    const metric = fixture.nativeElement.querySelector(
-      '[data-testid="unit-toggle-metric"]',
-    ) as HTMLButtonElement;
-    const imperial = fixture.nativeElement.querySelector(
-      '[data-testid="unit-toggle-imperial"]',
-    ) as HTMLButtonElement;
+    const metric = fixture.nativeElement.querySelector('[data-testid="unit-toggle-metric"]') as HTMLButtonElement;
+    const imperial = fixture.nativeElement.querySelector('[data-testid="unit-toggle-imperial"]') as HTMLButtonElement;
     expect(metric.getAttribute('aria-checked')).toBe('true');
     expect(imperial.getAttribute('aria-checked')).toBe('false');
   });
@@ -39,9 +35,7 @@ describe('UnitToggleComponent', () => {
     const handler = vi.fn();
     fixture.componentInstance.systemChange.subscribe(handler);
 
-    const imperial = fixture.nativeElement.querySelector(
-      '[data-testid="unit-toggle-imperial"]',
-    ) as HTMLButtonElement;
+    const imperial = fixture.nativeElement.querySelector('[data-testid="unit-toggle-imperial"]') as HTMLButtonElement;
     imperial.click();
 
     expect(handler).toHaveBeenCalledWith('imperial');
@@ -51,9 +45,7 @@ describe('UnitToggleComponent', () => {
     const handler = vi.fn();
     fixture.componentInstance.systemChange.subscribe(handler);
 
-    const metric = fixture.nativeElement.querySelector(
-      '[data-testid="unit-toggle-metric"]',
-    ) as HTMLButtonElement;
+    const metric = fixture.nativeElement.querySelector('[data-testid="unit-toggle-metric"]') as HTMLButtonElement;
     metric.click();
 
     expect(handler).not.toHaveBeenCalled();
@@ -63,9 +55,7 @@ describe('UnitToggleComponent', () => {
     fixture.componentRef.setInput('system', 'imperial');
     fixture.detectChanges();
 
-    const imperial = fixture.nativeElement.querySelector(
-      '[data-testid="unit-toggle-imperial"]',
-    ) as HTMLButtonElement;
+    const imperial = fixture.nativeElement.querySelector('[data-testid="unit-toggle-imperial"]') as HTMLButtonElement;
     expect(imperial.getAttribute('aria-checked')).toBe('true');
   });
 });

--- a/client/nx.json
+++ b/client/nx.json
@@ -22,12 +22,7 @@
     },
     "@nx/eslint:lint": {
       "cache": true,
-      "inputs": [
-        "default",
-        "{workspaceRoot}/.eslintrc.json",
-        "{workspaceRoot}/.eslintignore",
-        "{workspaceRoot}/eslint.config.mjs"
-      ]
+      "inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/.eslintignore", "{workspaceRoot}/eslint.config.mjs"]
     },
     "@nx/esbuild:esbuild": {
       "cache": true,

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelChatService.cs
@@ -102,14 +102,18 @@ public sealed partial class SemanticKernelChatService(
 		CancellationToken cancellationToken)
 	{
 		var chatCompletion = requestKernel.GetRequiredService<IChatCompletionService>();
-		var executionSettings = new PromptExecutionSettings
+		PromptExecutionSettings executionSettings = new()
 		{
 			FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
 		};
 
 		try
 		{
-			var result = await chatCompletion.GetChatMessageContentAsync(chatHistory, executionSettings, requestKernel, cancellationToken);
+			var result = await chatCompletion.GetChatMessageContentAsync(
+				chatHistory,
+				executionSettings,
+				requestKernel,
+				cancellationToken);
 			var reply = result.Content ?? string.Empty;
 			activity?.SetTag("llm.response_length", reply.Length);
 			return reply;

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeExtractionService.cs
@@ -14,7 +14,10 @@ namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 
 #pragma warning disable SA1601
 #pragma warning disable SA1311
-public sealed partial class SemanticKernelRecipeExtractionService(Kernel kernel, IExtractionResultCache cache, ILogger<SemanticKernelRecipeExtractionService> logger)
+public sealed partial class SemanticKernelRecipeExtractionService(
+	Kernel kernel,
+	IExtractionResultCache cache,
+	ILogger<SemanticKernelRecipeExtractionService> logger)
 	: IRecipeExtractionService
 {
 	private static readonly JsonSerializerOptions jsonOptions = new()

--- a/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeSuggestionService.cs
+++ b/src/Yumney.Recipes.Extraction/Services/SemanticKernelRecipeSuggestionService.cs
@@ -12,9 +12,7 @@ using SmartSolutionsLab.Yumney.Shared.Outcomes;
 namespace SmartSolutionsLab.Yumney.Recipes.Extraction.Services;
 
 #pragma warning disable SA1601, SA1311
-public sealed partial class SemanticKernelRecipeSuggestionService(
-	Kernel kernel,
-	ILogger<SemanticKernelRecipeSuggestionService> logger)
+public sealed partial class SemanticKernelRecipeSuggestionService(Kernel kernel, ILogger<SemanticKernelRecipeSuggestionService> logger)
 	: IRecipeSuggestionService
 {
 	private static readonly JsonSerializerOptions jsonOptions = new()


### PR DESCRIPTION
## Summary

Aligns the line-length limit across every formatter / IDE the repo cares about, from the previous mix (120 backend / 100 frontend) to a single **140 everywhere**. Modern wide screens make the older limits feel artificially cramped — especially with C# 12 primary constructors and TypeScript generics that often want one-line declarations.

## Config changes

| File | Change |
| --- | --- |
| \`.editorconfig\` (root) | \`[*.cs]\` \`max_line_length\` 120 → 140; \`[*.{ts,tsx,js,jsx}]\` 100 → 140 |
| \`client/.prettierrc\` | \`printWidth\` 100 → 140 |
| \`Yumney.sln.DotSettings\` | Rider / ReSharper \`RIGHT_MARGIN\` + \`WRAP_LIMIT\` for CSharpCodeStyle / TypeScriptCodeStyle / HtmlCodeStyle = 140 |
| \`CLAUDE.md\` | Both \"Backend\" and \"Frontend\" code-style sections now say *Max 140 chars per line* |

Visual Studio reads \`.editorconfig\` directly — no VS-specific config needed. Rider / ReSharper read \`.editorconfig\` for editor hints but enforce wrapping via \`*.DotSettings\`, hence the additional Rider entries.

## Mechanical effects

- \`yarn prettier --write \"**/*.{ts,html,scss,json}\"\` re-flowed 192 frontend files. The big -2530 / +650 line-count delta is mostly multi-line tags / signatures collapsing onto single lines that now fit in the wider budget.
- 3 backend files in \`Yumney.Recipes.Extraction/Services/\` were sitting on a prior IDE auto-format that collapsed primary-ctor params onto a single line. Those lines are 134-140 chars — within budget under the new limit, so they land in this PR rather than being reverted.

Pure formatting / config change. **Zero behaviour or runtime impact.**

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`yarn prettier --check\` — \"All matched files use Prettier code style!\"
- [x] \`yarn nx run-many --target=lint\` — clean (only pre-existing warnings)
- [x] \`yarn nx run-many --target=test\` — all 6 affected projects pass
- [ ] CI: full backend + integration + E2E