### PR TITLE
refactor(mealplan): collapse 5-param projection-handler helpers via SlotCoordinate VO

### DIFF
--- a/src/Yumney.MealPlan.Domain/WeeklyPlan/WeekIdentifier.cs
+++ b/src/Yumney.MealPlan.Domain/WeeklyPlan/WeekIdentifier.cs
@@ -23,6 +23,28 @@ public sealed record WeekIdentifier : IValueObject<string>
 
 	public static WeekIdentifier From(int year, int weekNumber) => new(year, weekNumber);
 
+	/// <summary>
+	/// Parses the canonical "YYYY-Wnn" string produced by <see cref="Value"/>.
+	/// Used by JSON / EF round-trips and by callers that receive the week as a
+	/// primitive on integration-event payloads (where the contract carries
+	/// strings, not value objects).
+	/// </summary>
+	/// <param name="value">A week string in the canonical "YYYY-Wnn" format.</param>
+	/// <returns>The parsed <see cref="WeekIdentifier"/>.</returns>
+	public static WeekIdentifier From(string value)
+	{
+		Ensure.That(value).IsNotNullOrWhiteSpace();
+		var parts = value.Split("-W");
+		if (parts.Length != 2
+			|| !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var year)
+			|| !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var weekNumber))
+		{
+			throw new FormatException($"Expected week format 'YYYY-Wnn', got '{value}'.");
+		}
+
+		return new WeekIdentifier(year, weekNumber);
+	}
+
 	public static WeekIdentifier FromDate(DateOnly date)
 	{
 		var cal = CultureInfo.InvariantCulture.Calendar;

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierJsonConverter.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/Converters/WeekIdentifierJsonConverter.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
@@ -7,14 +6,8 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.Converter
 
 internal sealed class WeekIdentifierJsonConverter : JsonConverter<WeekIdentifier>
 {
-	public override WeekIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-	{
-		var value = reader.GetString()!;
-		var parts = value.Split("-W");
-		var year = int.Parse(parts[0], CultureInfo.InvariantCulture);
-		var weekNumber = int.Parse(parts[1], CultureInfo.InvariantCulture);
-		return WeekIdentifier.From(year, weekNumber);
-	}
+	public override WeekIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+		WeekIdentifier.From(reader.GetString()!);
 
 	public override void Write(Utf8JsonWriter writer, WeekIdentifier value, JsonSerializerOptions options) =>
 		writer.WriteStringValue(value.Value);

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
@@ -46,7 +46,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in WeekDays.MondayToSunday)
 		{
-			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Dinner), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Dinner), defaultServings, cancellationToken);
 		}
 	}
 
@@ -66,8 +66,8 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in WeekDays.MondayToSunday)
 		{
-			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Breakfast), defaultServings, cancellationToken);
-			await UpsertSlotAsync(ownerId, week, day.ToString(), nameof(MealType.Lunch), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Breakfast), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Lunch), defaultServings, cancellationToken);
 		}
 	}
 
@@ -84,7 +84,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(RecipeAssignedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Recipe);
 		slot.RecipeIdentifier = inner.Recipe.Identifier.Value;
@@ -105,7 +105,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSetAsFreetextModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Freetext);
 		slot.FreetextLabel = inner.Label.Value;
@@ -121,7 +121,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(LeftoverAssignedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Leftover);
 		slot.LeftoverLabel = LeftoverLabel.ForRecipe(inner.SourceRecipeTitle).Value;
@@ -142,7 +142,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSlotClearedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Empty);
 		slot.RecipeIdentifier = null;
@@ -158,7 +158,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(ServingsAdjustedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.Servings = inner.Servings.Value;
 		slot.LastUpdated = DateTime.UtcNow;
@@ -168,7 +168,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealMarkedAsCookedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Cooked);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -178,7 +178,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealMarkedAsSkippedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Skipped);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -188,7 +188,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealResetToPlannedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day, inner.MealType, cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Planned);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -198,8 +198,8 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSlotsSwappedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot1 = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day1, inner.MealType, cancellationToken);
-		var slot2 = await GetOrCreateTrackedSlotAsync(@event.OwnerId, @event.Week, inner.Day2, inner.MealType, cancellationToken);
+		var slot1 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day1, inner.MealType), cancellationToken);
+		var slot2 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day2, inner.MealType), cancellationToken);
 
 		(slot1.ContentType, slot2.ContentType) = (slot2.ContentType, slot1.ContentType);
 		(slot1.RecipeIdentifier, slot2.RecipeIdentifier) = (slot2.RecipeIdentifier, slot1.RecipeIdentifier);
@@ -221,17 +221,19 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	// without throwing. Used both by the week-seeding handlers
 	// (WeeklyPlanCreated, ExtendedModeEnabled) and by the on-demand
 	// materialisation in GetOrCreateTrackedSlotAsync.
-	private Task<int> UpsertSlotAsync(string ownerId, string week, string day, string mealType, int defaultServings, CancellationToken cancellationToken)
+	private Task<int> UpsertSlotAsync(SlotCoordinate slot, int defaultServings, CancellationToken cancellationToken)
 	{
 		var newId = Guid.CreateVersion7();
 		var emptyContent = SlotContentType.Empty.ToString();
 		var plannedState = MealState.Planned.ToString();
 		var now = DateTime.UtcNow;
+		var dayName = slot.DayName;
+		var mealTypeName = slot.MealTypeName;
 
 		return context.Database.ExecuteSqlInterpolatedAsync(
 			$@"INSERT INTO ""MealPlanSlotReadItems""
 				(""Id"", ""OwnerId"", ""Week"", ""Day"", ""MealType"", ""ContentType"", ""Servings"", ""State"", ""LastUpdated"")
-			   VALUES ({newId}, {ownerId}, {week}, {day}, {mealType}, {emptyContent}, {defaultServings}, {plannedState}, {now})
+			   VALUES ({newId}, {slot.OwnerId}, {slot.Week}, {dayName}, {mealTypeName}, {emptyContent}, {defaultServings}, {plannedState}, {now})
 			   ON CONFLICT (""OwnerId"", ""Week"", ""Day"", ""MealType"") DO NOTHING",
 			cancellationToken);
 	}
@@ -239,16 +241,16 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	private Task<MealPlanWeekReadItem?> GetTrackedWeekAsync(string ownerId, string week, CancellationToken cancellationToken) =>
 		context.MealPlanWeekReadItems
 			.AsTracking()
-			.FirstOrDefaultAsync(w => w.OwnerId == ownerId && w.Week == week, cancellationToken);
+			.FirstOrDefaultAsync(row => row.OwnerId == ownerId && row.Week == week, cancellationToken);
 
-	private Task<MealPlanSlotReadItem?> GetTrackedSlotAsync(string ownerId, string week, DayOfWeek day, MealType mealType, CancellationToken cancellationToken)
+	private Task<MealPlanSlotReadItem?> GetTrackedSlotAsync(SlotCoordinate slot, CancellationToken cancellationToken)
 	{
-		var dayName = day.ToString();
-		var mealTypeName = mealType.ToString();
+		var dayName = slot.DayName;
+		var mealTypeName = slot.MealTypeName;
 		return context.MealPlanSlotReadItems
 			.AsTracking()
 			.FirstOrDefaultAsync(
-				slot => slot.OwnerId == ownerId && slot.Week == week && slot.Day == dayName && slot.MealType == mealTypeName,
+				row => row.OwnerId == slot.OwnerId && row.Week == slot.Week && row.Day == dayName && row.MealType == mealTypeName,
 				cancellationToken);
 	}
 
@@ -263,20 +265,15 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	// CONFLICT DO NOTHING gives us a guaranteed-present row without throwing
 	// duplicate-key exceptions, which would otherwise abort the WeeklyPlanCreated
 	// handler's batched 7-slot insert and dead-letter that message.
-	private async Task<MealPlanSlotReadItem> GetOrCreateTrackedSlotAsync(
-		string ownerId,
-		string week,
-		DayOfWeek day,
-		MealType mealType,
-		CancellationToken cancellationToken)
+	private async Task<MealPlanSlotReadItem> GetOrCreateTrackedSlotAsync(SlotCoordinate slot, CancellationToken cancellationToken)
 	{
-		var existing = await GetTrackedSlotAsync(ownerId, week, day, mealType, cancellationToken);
+		var existing = await GetTrackedSlotAsync(slot, cancellationToken);
 		if (existing is not null) return existing;
 
-		await UpsertSlotAsync(ownerId, week, day.ToString(), mealType.ToString(), SlotServings.DefaultValue, cancellationToken);
+		await UpsertSlotAsync(slot, SlotServings.DefaultValue, cancellationToken);
 
-		var slot = await GetTrackedSlotAsync(ownerId, week, day, mealType, cancellationToken);
-		return slot ?? throw new InvalidOperationException(
-			$"Slot upsert succeeded but no row is visible for {ownerId}/{week}/{day}/{mealType}.");
+		var materialised = await GetTrackedSlotAsync(slot, cancellationToken);
+		return materialised ?? throw new InvalidOperationException(
+			$"Slot upsert succeeded but no row is visible for {slot.OwnerId}/{slot.Week}/{slot.Day}/{slot.MealType}.");
 	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/MealPlanProjectionHandler.cs
@@ -46,7 +46,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in WeekDays.MondayToSunday)
 		{
-			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Dinner), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(OwnerIdentifier.From(ownerId), WeekIdentifier.From(week), day, MealType.Dinner), defaultServings, cancellationToken);
 		}
 	}
 
@@ -66,8 +66,8 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		foreach (var day in WeekDays.MondayToSunday)
 		{
-			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Breakfast), defaultServings, cancellationToken);
-			await UpsertSlotAsync(new SlotCoordinate(ownerId, week, day, MealType.Lunch), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(OwnerIdentifier.From(ownerId), WeekIdentifier.From(week), day, MealType.Breakfast), defaultServings, cancellationToken);
+			await UpsertSlotAsync(new SlotCoordinate(OwnerIdentifier.From(ownerId), WeekIdentifier.From(week), day, MealType.Lunch), defaultServings, cancellationToken);
 		}
 	}
 
@@ -84,7 +84,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(RecipeAssignedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Recipe);
 		slot.RecipeIdentifier = inner.Recipe.Identifier.Value;
@@ -105,7 +105,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSetAsFreetextModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Freetext);
 		slot.FreetextLabel = inner.Label.Value;
@@ -121,7 +121,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(LeftoverAssignedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Leftover);
 		slot.LeftoverLabel = LeftoverLabel.ForRecipe(inner.SourceRecipeTitle).Value;
@@ -142,7 +142,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSlotClearedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.ContentType = nameof(SlotContentType.Empty);
 		slot.RecipeIdentifier = null;
@@ -158,7 +158,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(ServingsAdjustedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.Servings = inner.Servings.Value;
 		slot.LastUpdated = DateTime.UtcNow;
@@ -168,7 +168,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealMarkedAsCookedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Cooked);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -178,7 +178,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealMarkedAsSkippedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Skipped);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -188,7 +188,7 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealResetToPlannedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day, inner.MealType), cancellationToken);
+		var slot = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(OwnerIdentifier.From(@event.OwnerId), WeekIdentifier.From(@event.Week), inner.Day, inner.MealType), cancellationToken);
 
 		slot.State = nameof(MealState.Planned);
 		slot.LastUpdated = DateTime.UtcNow;
@@ -198,8 +198,10 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 	public async Task HandleAsync(MealSlotsSwappedModuleEvent @event, CancellationToken cancellationToken = default)
 	{
 		var inner = @event.Inner;
-		var slot1 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day1, inner.MealType), cancellationToken);
-		var slot2 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(@event.OwnerId, @event.Week, inner.Day2, inner.MealType), cancellationToken);
+		var owner = OwnerIdentifier.From(@event.OwnerId);
+		var week = WeekIdentifier.From(@event.Week);
+		var slot1 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(owner, week, inner.Day1, inner.MealType), cancellationToken);
+		var slot2 = await GetOrCreateTrackedSlotAsync(new SlotCoordinate(owner, week, inner.Day2, inner.MealType), cancellationToken);
 
 		(slot1.ContentType, slot2.ContentType) = (slot2.ContentType, slot1.ContentType);
 		(slot1.RecipeIdentifier, slot2.RecipeIdentifier) = (slot2.RecipeIdentifier, slot1.RecipeIdentifier);
@@ -227,13 +229,15 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 		var emptyContent = SlotContentType.Empty.ToString();
 		var plannedState = MealState.Planned.ToString();
 		var now = DateTime.UtcNow;
+		var ownerValue = slot.OwnerValue;
+		var weekValue = slot.WeekValue;
 		var dayName = slot.DayName;
 		var mealTypeName = slot.MealTypeName;
 
 		return context.Database.ExecuteSqlInterpolatedAsync(
 			$@"INSERT INTO ""MealPlanSlotReadItems""
 				(""Id"", ""OwnerId"", ""Week"", ""Day"", ""MealType"", ""ContentType"", ""Servings"", ""State"", ""LastUpdated"")
-			   VALUES ({newId}, {slot.OwnerId}, {slot.Week}, {dayName}, {mealTypeName}, {emptyContent}, {defaultServings}, {plannedState}, {now})
+			   VALUES ({newId}, {ownerValue}, {weekValue}, {dayName}, {mealTypeName}, {emptyContent}, {defaultServings}, {plannedState}, {now})
 			   ON CONFLICT (""OwnerId"", ""Week"", ""Day"", ""MealType"") DO NOTHING",
 			cancellationToken);
 	}
@@ -245,12 +249,14 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 	private Task<MealPlanSlotReadItem?> GetTrackedSlotAsync(SlotCoordinate slot, CancellationToken cancellationToken)
 	{
+		var ownerValue = slot.OwnerValue;
+		var weekValue = slot.WeekValue;
 		var dayName = slot.DayName;
 		var mealTypeName = slot.MealTypeName;
 		return context.MealPlanSlotReadItems
 			.AsTracking()
 			.FirstOrDefaultAsync(
-				row => row.OwnerId == slot.OwnerId && row.Week == slot.Week && row.Day == dayName && row.MealType == mealTypeName,
+				row => row.OwnerId == ownerValue && row.Week == weekValue && row.Day == dayName && row.MealType == mealTypeName,
 				cancellationToken);
 	}
 
@@ -274,6 +280,6 @@ public sealed class MealPlanProjectionHandler(MealPlanReadDbContext context)
 
 		var materialised = await GetTrackedSlotAsync(slot, cancellationToken);
 		return materialised ?? throw new InvalidOperationException(
-			$"Slot upsert succeeded but no row is visible for {slot.OwnerId}/{slot.Week}/{slot.Day}/{slot.MealType}.");
+			$"Slot upsert succeeded but no row is visible for {slot.OwnerValue}/{slot.WeekValue}/{slot.Day}/{slot.MealType}.");
 	}
 }

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/SlotCoordinate.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/SlotCoordinate.cs
@@ -1,0 +1,17 @@
+using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+
+/// <summary>
+/// Composite key that uniquely identifies a single read-model slot row. Carrying it
+/// as one parameter keeps the projection-handler helpers under CLAUDE.md's 4-param
+/// limit and stops callers from accidentally swapping the owner / week / day / meal
+/// columns at a call site (all four are typed differently than they were when
+/// passed individually as four strings).
+/// </summary>
+internal sealed record SlotCoordinate(string OwnerId, string Week, DayOfWeek Day, MealType MealType)
+{
+	internal string DayName => Day.ToString();
+
+	internal string MealTypeName => MealType.ToString();
+}

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/SlotCoordinate.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/ReadModel/SlotCoordinate.cs
@@ -6,11 +6,15 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel
 /// Composite key that uniquely identifies a single read-model slot row. Carrying it
 /// as one parameter keeps the projection-handler helpers under CLAUDE.md's 4-param
 /// limit and stops callers from accidentally swapping the owner / week / day / meal
-/// columns at a call site (all four are typed differently than they were when
-/// passed individually as four strings).
+/// columns at a call site — every component is a typed value object (or enum), so
+/// the compiler rejects an out-of-order argument list before it reaches the SQL.
 /// </summary>
-internal sealed record SlotCoordinate(string OwnerId, string Week, DayOfWeek Day, MealType MealType)
+internal sealed record SlotCoordinate(OwnerIdentifier Owner, WeekIdentifier Week, DayOfWeek Day, MealType MealType)
 {
+	internal string OwnerValue => Owner.Value;
+
+	internal string WeekValue => Week.Value;
+
 	internal string DayName => Day.ToString();
 
 	internal string MealTypeName => MealType.ToString();


### PR DESCRIPTION
## Summary

Item #5 of the backend refactoring sweep, plus a follow-up VO-typing pass.

### Part 1 — collapse 5-param helpers via `SlotCoordinate` record

\`MealPlanProjectionHandler\` had three private helpers each carrying 5 positional parameters — over CLAUDE.md's 4-param max, and call sites spelled the four key columns (\`ownerId / week / day / mealType\`) in slightly different orders / stringification combos, making argument-swap bugs easy.

| Before | After |
| --- | --- |
| \`UpsertSlotAsync(string ownerId, string week, string day, string mealType, int defaultServings, CT)\` | \`UpsertSlotAsync(SlotCoordinate slot, int defaultServings, CT)\` |
| \`GetTrackedSlotAsync(string ownerId, string week, DayOfWeek day, MealType mealType, CT)\` | \`GetTrackedSlotAsync(SlotCoordinate slot, CT)\` |
| \`GetOrCreateTrackedSlotAsync(string ownerId, string week, DayOfWeek day, MealType mealType, CT)\` | \`GetOrCreateTrackedSlotAsync(SlotCoordinate slot, CT)\` |

11 call sites adjusted.

### Part 2 — \`SlotCoordinate\` carries value objects, not strings

Per CLAUDE.md \"Value Objects EVERYWHERE\":

\`\`\`csharp
internal sealed record SlotCoordinate(
    OwnerIdentifier Owner,
    WeekIdentifier Week,
    DayOfWeek Day,
    MealType MealType)
\`\`\`

Wrap-at-the-boundary at every call site:

\`\`\`csharp
new SlotCoordinate(
    OwnerIdentifier.From(@event.OwnerId),
    WeekIdentifier.From(@event.Week),
    inner.Day, inner.MealType)
\`\`\`

Internal \`OwnerValue\` / \`WeekValue\` properties keep the SQL upsert + EF predicate string-comparable.

### Drive-by: \`WeekIdentifier.From(string)\`

The canonical \"YYYY-Wnn\" parse logic was previously duplicated inside \`WeekIdentifierJsonConverter\`. Now centralised on the VO; the JSON converter collapses to a one-liner.

### Lambda cleanup

While in the file, renamed the single-letter \`w => w.X\` / \`s => s.X\` lambdas inside the two EF query helpers to \`row => row.X\` (CLAUDE.md no-single-letter-lambda rule).

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.MealPlan.Infrastructure.Tests\` — 31 pass
- [x] \`Yumney.MealPlan.Application.Tests\` — 56 pass
- [x] \`Yumney.MealPlan.Domain.Tests\` — 131 pass (covers the new \`WeekIdentifier.From(string)\` round-trip)
- [x] CI on the SlotCoordinate-only commit — all green
- [ ] CI on the VO upgrade — re-running