### PR TITLE
refactor(shared): extract event-sourced user-data purger drain into Shared.Persistence

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/AggregateMetadata.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/EventStore/AggregateMetadata.cs
@@ -5,7 +5,7 @@ namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.EventStor
 /// <summary>
 /// Tracks aggregate identity and ownership. One row per (owner, week) — i.e. one weekly plan.
 /// </summary>
-public sealed class AggregateMetadata : IAggregateMetadata
+public sealed class AggregateMetadata : IOwnerScopedAggregateMetadata
 {
 	public Guid AggregateId { get; set; }
 

--- a/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanUserDataPurger.cs
+++ b/src/Yumney.MealPlan.Infrastructure/Persistence/MealPlanUserDataPurger.cs
@@ -2,13 +2,15 @@ using Microsoft.EntityFrameworkCore;
 using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
 using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence.ReadModel;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 
 /// <summary>
-/// EF-backed implementation of <see cref="IMealPlanUserDataPurger"/>. Resolves
-/// the owner's aggregate IDs from the metadata table, deletes their event
-/// streams, then drops the metadata rows and the owner-scoped read models.
+/// EF-backed implementation of <see cref="IMealPlanUserDataPurger"/>. Drains the
+/// owner's event stream + metadata via the shared
+/// <see cref="EventSourcedAggregateDraining"/> helper, then deletes the
+/// owner-scoped read-model rows.
 /// </summary>
 public sealed class MealPlanUserDataPurger(MealPlanDbContext writeContext, MealPlanReadDbContext readContext)
 	: IMealPlanUserDataPurger
@@ -17,21 +19,10 @@ public sealed class MealPlanUserDataPurger(MealPlanDbContext writeContext, MealP
 	{
 		var ownerValue = owner.Value;
 
-		var aggregateIds = await writeContext.MealPlanAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.Select(aggregate => aggregate.AggregateId)
-			.ToListAsync(cancellationToken);
-
-		if (aggregateIds.Count > 0)
-		{
-			await writeContext.MealPlanEvents
-				.Where(stored => aggregateIds.Contains(stored.AggregateId))
-				.ExecuteDeleteAsync(cancellationToken);
-		}
-
-		await writeContext.MealPlanAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.ExecuteDeleteAsync(cancellationToken);
+		await writeContext.MealPlanAggregates.DrainOwnerAggregatesAsync(
+			writeContext.MealPlanEvents,
+			ownerValue,
+			cancellationToken);
 
 		await readContext.Set<MealPlanSlotReadItem>()
 			.Where(slot => slot.OwnerId == ownerValue)

--- a/src/Yumney.Shared.Persistence/EventStore/EventSourcedAggregateDraining.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EventSourcedAggregateDraining.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+
+/// <summary>
+/// Bulk-purge helpers for the event-sourced "user account deleted" path.
+/// Used by every module that owns an event store (MealPlan, Shopping) to
+/// satisfy the GDPR cascade — resolves the owner's aggregate ids, drops
+/// the matching event streams, then drops the metadata rows. Read-model
+/// rows stay the caller's responsibility because their schema varies per
+/// module.
+/// </summary>
+public static class EventSourcedAggregateDraining
+{
+	public static async Task DrainOwnerAggregatesAsync<TMetadata, TStoredEvent>(
+		this DbSet<TMetadata> metadataSet,
+		DbSet<TStoredEvent> eventsSet,
+		string ownerValue,
+		CancellationToken cancellationToken)
+		where TMetadata : class, IOwnerScopedAggregateMetadata
+		where TStoredEvent : class, IStoredEvent
+	{
+		var aggregateIds = await metadataSet
+			.Where(metadata => metadata.OwnerId == ownerValue)
+			.Select(metadata => metadata.AggregateId)
+			.ToListAsync(cancellationToken);
+
+		if (aggregateIds.Count > 0)
+		{
+			await eventsSet
+				.Where(stored => aggregateIds.Contains(stored.AggregateId))
+				.ExecuteDeleteAsync(cancellationToken);
+		}
+
+		await metadataSet
+			.Where(metadata => metadata.OwnerId == ownerValue)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+}

--- a/src/Yumney.Shared.Persistence/EventStore/IOwnerScopedAggregateMetadata.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/IOwnerScopedAggregateMetadata.cs
@@ -1,0 +1,12 @@
+namespace SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+
+/// <summary>
+/// Marker for aggregate-metadata rows whose ownership row uses the
+/// keycloak-user-id string. Together with <see cref="IStoredEvent"/>, this
+/// is the contract <see cref="EventSourcedAggregateDraining"/> needs to
+/// purge a user's data across an event-sourced module.
+/// </summary>
+public interface IOwnerScopedAggregateMetadata : IAggregateMetadata
+{
+	string OwnerId { get; set; }
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AggregateMetadata.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/AggregateMetadata.cs
@@ -5,7 +5,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStor
 /// <summary>
 /// Tracks aggregate identity and ownership. One row per aggregate.
 /// </summary>
-public sealed class AggregateMetadata : IAggregateMetadata
+public sealed class AggregateMetadata : IOwnerScopedAggregateMetadata
 {
 	public Guid AggregateId { get; set; }
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingListAggregateMetadata.cs
@@ -6,7 +6,7 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStor
 /// Tracks identity and ownership for one <see cref="SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.ShoppingList"/>
 /// aggregate. Multiple rows per owner (one per list).
 /// </summary>
-public sealed class ShoppingListAggregateMetadata : IAggregateMetadata
+public sealed class ShoppingListAggregateMetadata : IOwnerScopedAggregateMetadata
 {
 	public Guid AggregateId { get; set; }
 

--- a/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUserDataPurger.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/ShoppingUserDataPurger.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
@@ -6,9 +7,10 @@ using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.ReadModel;
 namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence;
 
 /// <summary>
-/// EF-backed implementation of <see cref="IShoppingUserDataPurger"/>. Resolves
-/// the owner's aggregate IDs from the metadata tables, deletes their event
-/// streams, then drops the metadata rows and every owner-scoped read-model row.
+/// EF-backed implementation of <see cref="IShoppingUserDataPurger"/>. Drains the
+/// owner's two event streams (ShoppingList aggregates + Shopping aggregates) via
+/// the shared <see cref="EventSourcedAggregateDraining"/> helper, then deletes
+/// every owner-scoped read-model row.
 /// </summary>
 public sealed class ShoppingUserDataPurger(ShoppingDbContext writeContext, ShoppingReadDbContext readContext)
 	: IShoppingUserDataPurger
@@ -17,37 +19,15 @@ public sealed class ShoppingUserDataPurger(ShoppingDbContext writeContext, Shopp
 	{
 		var ownerValue = owner.Value;
 
-		var shoppingListAggregateIds = await writeContext.ShoppingListAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.Select(aggregate => aggregate.AggregateId)
-			.ToListAsync(cancellationToken);
+		await writeContext.ShoppingListAggregates.DrainOwnerAggregatesAsync(
+			writeContext.ShoppingListEvents,
+			ownerValue,
+			cancellationToken);
 
-		if (shoppingListAggregateIds.Count > 0)
-		{
-			await writeContext.ShoppingListEvents
-				.Where(stored => shoppingListAggregateIds.Contains(stored.AggregateId))
-				.ExecuteDeleteAsync(cancellationToken);
-		}
-
-		await writeContext.ShoppingListAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.ExecuteDeleteAsync(cancellationToken);
-
-		var shoppingAggregateIds = await writeContext.ShoppingAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.Select(aggregate => aggregate.AggregateId)
-			.ToListAsync(cancellationToken);
-
-		if (shoppingAggregateIds.Count > 0)
-		{
-			await writeContext.ShoppingEvents
-				.Where(stored => shoppingAggregateIds.Contains(stored.AggregateId))
-				.ExecuteDeleteAsync(cancellationToken);
-		}
-
-		await writeContext.ShoppingAggregates
-			.Where(aggregate => aggregate.OwnerId == ownerValue)
-			.ExecuteDeleteAsync(cancellationToken);
+		await writeContext.ShoppingAggregates.DrainOwnerAggregatesAsync(
+			writeContext.ShoppingEvents,
+			ownerValue,
+			cancellationToken);
 
 		await readContext.Set<ShoppingListItemReadItem>()
 			.Where(item => item.OwnerId == ownerValue)


### PR DESCRIPTION
## Summary

Item #7 of the backend refactoring sweep. \`MealPlanUserDataPurger\` and \`ShoppingUserDataPurger\` repeated the same 3-step "drain owner aggregates" choreography for every event-sourced aggregate root they own:

1. Load aggregate ids from metadata \`WHERE OwnerId = X\`
2. If any: \`ExecuteDelete\` on stored events \`WHERE AggregateId IN (...)\`
3. \`ExecuteDelete\` on metadata \`WHERE OwnerId = X\`

That's now one extension call:

\`\`\`csharp
await metadataSet.DrainOwnerAggregatesAsync(eventsSet, ownerValue, ct);
\`\`\`

### What's new

- \`Yumney.Shared.Persistence/EventStore/IOwnerScopedAggregateMetadata.cs\` — extends \`IAggregateMetadata\` with the \`OwnerId\` member EF needs to translate the predicate.
- \`Yumney.Shared.Persistence/EventStore/EventSourcedAggregateDraining.cs\` — generic over \`<TMetadata, TStoredEvent>\` constrained to \`IOwnerScopedAggregateMetadata\` + \`IStoredEvent\`. Single \`DrainOwnerAggregatesAsync\` extension method.

### Touched concrete metadata types

| File | Change |
| --- | --- |
| \`MealPlan.AggregateMetadata\` | now implements \`IOwnerScopedAggregateMetadata\` (no property change) |
| \`Shopping.AggregateMetadata\` | same |
| \`Shopping.ShoppingListAggregateMetadata\` | same |

### Purgers shrunk

| Purger | Before | After |
| --- | --- | --- |
| \`MealPlanUserDataPurger\` | 25 LOC, manual drain choreography | 1 drain call + 2 read-model deletes |
| \`ShoppingUserDataPurger\` | 53 LOC, drain repeated for two aggregates | 2 drain calls + 4 read-model deletes |

\`RecipesUserDataPurger\` is **not** affected — Recipes is state-based, no event store, no aggregate-metadata table to drain.

## Behaviour

Pure refactor. Same 3-step sequence per aggregate, same \`ExecuteDelete\` calls, just centralised. Read-model deletes stay in the per-module purger because their schemas vary.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.MealPlan.Infrastructure.Tests\` — 31 pass
- [x] \`Yumney.Shopping.Infrastructure.Tests\` — 28 pass
- [x] \`Yumney.Architecture.Tests\` — 146 pass
- [ ] CI: full backend + integration (the GDPR cascade tests in \`Yumney.Integration.Tests/CrossModule/AccountDeletionCascadeTests.cs\` exercise both purgers end-to-end)