### PR TITLE
refactor(recipes): extract chat-search + scaling services from oversized components

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -12,17 +12,8 @@ import {
   ShoppingApiService,
 } from '../api';
 import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
-import {
-  createAsyncState,
-  scaleIngredients,
-  toSystem,
-  type UnitSystem,
-  ERROR_MAPS,
-  ROUTES,
-  UserPreferencesService,
-  VALIDATION,
-  toggleFavoriteOnItem,
-} from '@yumney/shared/models';
+import { RecipeScalingService } from './recipe-scaling.service';
+import { createAsyncState, type UnitSystem, ERROR_MAPS, ROUTES, UserPreferencesService, toggleFavoriteOnItem } from '@yumney/shared/models';
 import {
   BackLinkComponent,
   ButtonComponent,
@@ -54,7 +45,7 @@ import { CreateShoppingListDialogComponent } from './create-shopping-list-dialog
   templateUrl: './recipe-detail.component.html',
   styleUrl: './recipe-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [RecipeNotesAutosaveService],
+  providers: [RecipeNotesAutosaveService, RecipeScalingService],
 })
 export class RecipeDetailComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
@@ -69,6 +60,7 @@ export class RecipeDetailComponent implements OnInit {
   private deleteState = createAsyncState();
   private createShoppingListState = createAsyncState();
   private notesAutosave = inject(RecipeNotesAutosaveService);
+  private scaling = inject(RecipeScalingService);
   private preferences = inject(UserPreferencesService);
 
   recipe = signal<RecipeDetail | null>(null);
@@ -77,53 +69,18 @@ export class RecipeDetailComponent implements OnInit {
   isDeleting = this.deleteState.isLoading;
   isCreatingShoppingList = this.createShoppingListState.isLoading;
   serverError = signal<string | null>(null);
-  desiredServings = signal<number | null>(null);
-  // User's preferred unit system from their profile (US-125). The toggle
-  // exposes a per-view override that wins over the profile default but is
-  // NOT persisted — leaves the saved preference unchanged when a user
-  // flips imperial → metric just for this one recipe.
-  private userUnitOverride = signal<UnitSystem | null>(null);
-  unitSystem = computed<UnitSystem>(() => this.userUnitOverride() ?? this.preferences.preferredUnitSystem());
+
+  desiredServings = this.scaling.desiredServings;
+  scaledIngredients = this.scaling.scaledIngredients;
+  displayedIngredients = this.scaling.displayedIngredients;
+  isScaled = this.scaling.isScaled;
+  unitSystem = this.scaling.unitSystem;
+
   showDeleteConfirm = signal(false);
   showCreateShoppingListConfirm = signal(false);
 
   notesDraft = this.notesAutosave.draft;
   notesSaved = this.notesAutosave.saved;
-
-  scaledIngredients = computed(() => {
-    const recipe = this.recipe();
-    if (!recipe) {
-      return [];
-    }
-    const { ingredients, servings } = recipe;
-    const desired = this.desiredServings();
-    if (!desired || !servings) {
-      return ingredients;
-    }
-    return scaleIngredients(ingredients, servings, desired);
-  });
-
-  // Final ingredient list rendered in the template — applies the unit-system
-  // toggle on top of the servings-scaled list. When the system is metric the
-  // recipe ships as-stored; flipping to imperial routes each amount/unit pair
-  // through unit-conversion (no-op for count/unknown units like "pinch" or
-  // "clove", smart-rounded for grams/litres/etc.).
-  displayedIngredients = computed(() => {
-    const ingredients = this.scaledIngredients();
-    const system = this.unitSystem();
-    if (system === 'metric') return ingredients;
-    return ingredients.map((ingredient) => {
-      if (ingredient.amount == null) return ingredient;
-      const converted = toSystem(ingredient.amount, ingredient.unit, system);
-      return { ...ingredient, amount: converted.amount, unit: converted.unit || null };
-    });
-  });
-
-  isScaled = computed(() => {
-    const recipe = this.recipe();
-    const desired = this.desiredServings();
-    return recipe?.servings != null && desired != null && desired !== recipe.servings;
-  });
 
   lastCookedRelative = computed(() => {
     const stats = this.recipeStats();
@@ -137,6 +94,15 @@ export class RecipeDetailComponent implements OnInit {
     return { key: 'recipes.detail.stats.lastCookedWeeks', value: weeks };
   });
 
+  totalTime = computed(() => {
+    const recipe = this.recipe();
+    if (!recipe) return null;
+    const { prepTimeMinutes, cookTimeMinutes } = recipe;
+    const prep = prepTimeMinutes ?? 0;
+    const cook = cookTimeMinutes ?? 0;
+    return prep === 0 && cook === 0 ? null : prep + cook;
+  });
+
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
     if (!identifier) {
@@ -147,6 +113,7 @@ export class RecipeDetailComponent implements OnInit {
     // Trigger the profile fetch so `preferredUnitSystem` populates. The
     // `unitSystem` computed re-evaluates when the signal lands.
     this.preferences.ensureLoaded();
+    this.scaling.attach(this.recipe);
 
     // Stats can fail silently — the page is still useful without the badge.
     this.activityApi
@@ -162,7 +129,7 @@ export class RecipeDetailComponent implements OnInit {
       ERROR_MAPS.recipes.detail,
       (recipe) => {
         this.recipe.set(recipe);
-        this.desiredServings.set(recipe.servings);
+        this.scaling.initFor(recipe);
         this.notesAutosave.attach(this.recipe);
       },
       (error) => this.serverError.set(error),
@@ -186,50 +153,26 @@ export class RecipeDetailComponent implements OnInit {
     this.notesAutosave.update(value);
   }
 
-  totalTime = computed(() => {
-    const recipe = this.recipe();
-    if (!recipe) {
-      return null;
-    }
-    const { prepTimeMinutes, cookTimeMinutes } = recipe;
-    const prep = prepTimeMinutes ?? 0;
-    const cook = cookTimeMinutes ?? 0;
-    return prep === 0 && cook === 0 ? null : prep + cook;
-  });
-
   onIncreaseServings(): void {
-    const current = this.desiredServings();
-    if (current !== null) {
-      this.desiredServings.set(current + 1);
-    }
+    this.scaling.increase();
   }
 
   onDecreaseServings(): void {
-    const current = this.desiredServings();
-    if (current !== null && current > VALIDATION.RECIPES.SERVINGS.MIN_VALUE) {
-      this.desiredServings.set(current - 1);
-    }
+    this.scaling.decrease();
   }
 
   onResetServings(): void {
-    const recipe = this.recipe();
-    if (recipe?.servings != null) {
-      this.desiredServings.set(recipe.servings);
-    }
+    this.scaling.reset();
   }
 
   onDelete(): void {
-    if (!this.recipe()) {
-      return;
-    }
+    if (!this.recipe()) return;
     this.showDeleteConfirm.set(true);
   }
 
   onDeleteConfirmed(): void {
     const recipe = this.recipe();
-    if (!recipe) {
-      return;
-    }
+    if (!recipe) return;
 
     this.showDeleteConfirm.set(false);
     this.serverError.set(null);
@@ -251,29 +194,23 @@ export class RecipeDetailComponent implements OnInit {
   }
 
   onUnitSystemChange(system: UnitSystem): void {
-    this.userUnitOverride.set(system);
+    this.scaling.setUnitSystem(system);
   }
 
   onCreateShoppingList(): void {
-    if (!this.recipe()) {
-      return;
-    }
+    if (!this.recipe()) return;
     this.serverError.set(null);
     this.showCreateShoppingListConfirm.set(true);
   }
 
   onCreateShoppingListCancelled(): void {
-    if (this.isCreatingShoppingList()) {
-      return;
-    }
+    if (this.isCreatingShoppingList()) return;
     this.showCreateShoppingListConfirm.set(false);
   }
 
   onCreateShoppingListConfirmed(): void {
     const recipe = this.recipe();
-    if (!recipe) {
-      return;
-    }
+    if (!recipe) return;
 
     const desired = this.desiredServings();
     const items: CreateShoppingListItem[] = this.scaledIngredients().map(({ name, amount, unit }) => ({

--- a/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, Signal, computed, inject, signal } from '@angular/core';
+import { UserPreferencesService, scaleIngredients, toSystem, type UnitSystem, VALIDATION } from '@yumney/shared/models';
+import { RecipeDetail } from '../api';
+
+/**
+ * Owns the servings-scaling + unit-system view state for the recipe-detail
+ * screen. The recipe-detail component drives identity (route → load), this
+ * service owns the toggles and the derived ingredient list:
+ *
+ * - desiredServings (writable, defaults to the recipe's saved servings)
+ * - userUnitOverride (writable, transient — per-view override that wins
+ *   over the user's profile default but is never persisted)
+ * - scaledIngredients / displayedIngredients / isScaled (computed)
+ *
+ * `attach(recipe)` wires the upstream recipe signal. `initFor(recipe)` seeds
+ * `desiredServings` from the loaded recipe.
+ */
+@Injectable()
+export class RecipeScalingService {
+  private preferences = inject(UserPreferencesService);
+
+  private recipe: Signal<RecipeDetail | null> = signal(null);
+  private userUnitOverride = signal<UnitSystem | null>(null);
+
+  readonly desiredServings = signal<number | null>(null);
+  readonly unitSystem = computed<UnitSystem>(() => this.userUnitOverride() ?? this.preferences.preferredUnitSystem());
+
+  readonly scaledIngredients = computed(() => {
+    const recipe = this.recipe();
+    if (!recipe) return [];
+    const { ingredients, servings } = recipe;
+    const desired = this.desiredServings();
+    if (!desired || !servings) return ingredients;
+    return scaleIngredients(ingredients, servings, desired);
+  });
+
+  /**
+   * Final ingredient list rendered in the template — applies the unit-system
+   * toggle on top of the servings-scaled list. When the system is metric the
+   * recipe ships as-stored; flipping to imperial routes each amount/unit pair
+   * through unit-conversion (no-op for count/unknown units like "pinch" or
+   * "clove", smart-rounded for grams/litres/etc.).
+   */
+  readonly displayedIngredients = computed(() => {
+    const ingredients = this.scaledIngredients();
+    const system = this.unitSystem();
+    if (system === 'metric') return ingredients;
+    return ingredients.map((ingredient) => {
+      if (ingredient.amount == null) return ingredient;
+      const converted = toSystem(ingredient.amount, ingredient.unit, system);
+      return { ...ingredient, amount: converted.amount, unit: converted.unit || null };
+    });
+  });
+
+  readonly isScaled = computed(() => {
+    const recipe = this.recipe();
+    const desired = this.desiredServings();
+    return recipe?.servings != null && desired != null && desired !== recipe.servings;
+  });
+
+  attach(recipeRef: Signal<RecipeDetail | null>): void {
+    this.recipe = recipeRef;
+  }
+
+  initFor(recipe: RecipeDetail): void {
+    this.desiredServings.set(recipe.servings);
+  }
+
+  setUnitSystem(system: UnitSystem): void {
+    this.userUnitOverride.set(system);
+  }
+
+  increase(): void {
+    const current = this.desiredServings();
+    if (current !== null) {
+      this.desiredServings.set(current + 1);
+    }
+  }
+
+  decrease(): void {
+    const current = this.desiredServings();
+    if (current !== null && current > VALIDATION.RECIPES.SERVINGS.MIN_VALUE) {
+      this.desiredServings.set(current - 1);
+    }
+  }
+
+  reset(): void {
+    const recipe = this.recipe();
+    if (recipe?.servings != null) {
+      this.desiredServings.set(recipe.servings);
+    }
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-chat-search.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-chat-search.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { ChatApiService, RecipeApiService, RecipeListItem, type ChatRecipeSuggestion } from '../api';
+
+interface FallbackParams {
+  pageSize: number;
+  sortBy: 'Name' | 'Date' | 'Rating';
+  sortDirection: 'Ascending' | 'Descending';
+}
+
+export interface RecipeChatSearchResult {
+  items: RecipeListItem[];
+  fellBack: boolean;
+}
+
+@Injectable()
+export class RecipeChatSearchService {
+  private recipeApi = inject(RecipeApiService);
+  private chatApi = inject(ChatApiService);
+
+  /**
+   * Conversational-query detector. Triggers the chat path when the user
+   * types something that looks like an intent rather than a keyword: more
+   * than 3 words, more than 20 chars, or contains a question/intent phrase.
+   * Single-word queries like "Bolognese" stay on the keyword path.
+   */
+  isConversational(value: string): boolean {
+    const wordCount = value.split(/\s+/).filter((word) => word.length > 0).length;
+    if (wordCount > 3) return true;
+    if (value.length > 20) return true;
+    const lower = value.toLowerCase();
+    const intentPhrases = ['what', 'how', 'show me', 'find me', 'i want', 'something', 'with'];
+    return intentPhrases.some((phrase) => lower.includes(phrase));
+  }
+
+  /**
+   * Conversational search: routes the query through the chat service (which
+   * invokes the search_recipes SK tool internally) and hydrates each returned
+   * suggestion into a full RecipeListItem for the grid. Falls back to keyword
+   * search if the chat call fails — a transient LLM outage must not regress
+   * baseline search. `fellBack` lets the caller turn off the AI-powered UI hint
+   * when the fallback fires.
+   */
+  search(query: string, fallback: FallbackParams): Observable<RecipeChatSearchResult> {
+    return this.chatApi.send({ message: query, history: [] }).pipe(
+      switchMap((response) => this.hydrateSuggestions(response.suggestions)),
+      map((items) => ({ items, fellBack: false }) satisfies RecipeChatSearchResult),
+      catchError(() =>
+        this.recipeApi
+          .getRecipes({
+            page: 1,
+            pageSize: fallback.pageSize,
+            sortBy: fallback.sortBy,
+            sortDirection: fallback.sortDirection,
+            search: query,
+          })
+          .pipe(map((response) => ({ items: response.items, fellBack: true }) satisfies RecipeChatSearchResult)),
+      ),
+    );
+  }
+
+  private hydrateSuggestions(suggestions: ChatRecipeSuggestion[]): Observable<RecipeListItem[]> {
+    const validIds = suggestions.map((suggestion) => suggestion.recipeIdentifier).filter((id): id is string => id !== null);
+
+    if (validIds.length === 0) return of([] as RecipeListItem[]);
+
+    return forkJoin(
+      validIds.map((id) =>
+        this.recipeApi.getRecipeById(id).pipe(
+          map(
+            (detail): RecipeListItem => ({
+              identifier: detail.identifier,
+              title: detail.title,
+              description: detail.description,
+              servings: detail.servings,
+              prepTimeMinutes: detail.prepTimeMinutes,
+              cookTimeMinutes: detail.cookTimeMinutes,
+              difficulty: detail.difficulty,
+              imageUrl: detail.imageUrl,
+              createdAt: detail.createdAt,
+              tags: detail.tags,
+              isFavorite: detail.isFavorite,
+              rating: detail.rating,
+              hasNotes: detail.notes !== null,
+            }),
+          ),
+          // Per-suggestion failure shouldn't tank the AI search — skip the
+          // missing one and surface the rest.
+          catchError(() => of(null)),
+        ),
+      ),
+    ).pipe(map((items) => items.filter((item): item is RecipeListItem => item !== null)));
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -1,9 +1,7 @@
 import { Component, ChangeDetectionStrategy, computed, inject, OnInit, DestroyRef, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { forkJoin, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
-import { RecipeApiService, RecipeListItem, GetRecipesParams, ChatApiService, type ChatRecipeSuggestion } from '../api';
+import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
 import { createAsyncState, debouncedEffect, ERROR_MAPS, ROUTES, UI, toggleFavoriteInList } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
 import {
@@ -21,6 +19,7 @@ import { SortMenuComponent, SortMenuOption } from './sort-menu/sort-menu.compone
 import { RecipeAssignmentService } from './recipe-assignment.service';
 import { MultiRecipePreviewDialogComponent } from './multi-recipe-preview-dialog/multi-recipe-preview-dialog.component';
 import { MultiRecipeShoppingListService } from './multi-recipe-shopping-list.service';
+import { RecipeChatSearchService } from './recipe-chat-search.service';
 
 interface SortOption extends SortMenuOption {
   by: 'Name' | 'Date' | 'Rating';
@@ -43,7 +42,7 @@ interface SortOption extends SortMenuOption {
     SortMenuComponent,
     MultiRecipePreviewDialogComponent,
   ],
-  providers: [RecipeAssignmentService, MultiRecipeShoppingListService],
+  providers: [RecipeAssignmentService, MultiRecipeShoppingListService, RecipeChatSearchService],
   templateUrl: './recipe-list.component.html',
   styleUrl: './recipe-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -56,22 +55,12 @@ export class RecipeListComponent implements OnInit {
     { value: 'date-asc', by: 'Date', dir: 'Ascending', labelKey: 'recipes.list.sort.dateAsc' },
     { value: 'name-asc', by: 'Name', dir: 'Ascending', labelKey: 'recipes.list.sort.nameAsc' },
     { value: 'name-desc', by: 'Name', dir: 'Descending', labelKey: 'recipes.list.sort.nameDesc' },
-    {
-      value: 'rating-desc',
-      by: 'Rating',
-      dir: 'Descending',
-      labelKey: 'recipes.list.sort.ratingDesc',
-    },
-    {
-      value: 'rating-asc',
-      by: 'Rating',
-      dir: 'Ascending',
-      labelKey: 'recipes.list.sort.ratingAsc',
-    },
+    { value: 'rating-desc', by: 'Rating', dir: 'Descending', labelKey: 'recipes.list.sort.ratingDesc' },
+    { value: 'rating-asc', by: 'Rating', dir: 'Ascending', labelKey: 'recipes.list.sort.ratingAsc' },
   ];
 
   private recipeApi = inject(RecipeApiService);
-  private chatApi = inject(ChatApiService);
+  private chatSearch = inject(RecipeChatSearchService);
   private destroyRef = inject(DestroyRef);
   private asyncState = createAsyncState();
   private searchInput = signal('');
@@ -81,7 +70,7 @@ export class RecipeListComponent implements OnInit {
     debouncedEffect(this.searchInput, UI.SEARCH_DEBOUNCE_MS, (value) => {
       const trimmed = value.trim();
       this.activeSearch.set(trimmed);
-      if (trimmed === '' || !isConversationalQuery(trimmed)) {
+      if (trimmed === '' || !this.chatSearch.isConversational(trimmed)) {
         this.isAiPowered.set(false);
         this.resetAndReload();
         return;
@@ -184,11 +173,6 @@ export class RecipeListComponent implements OnInit {
     this.loadRecipes(false);
   }
 
-  // Conversational query path: send the query through the chat service
-  // (which calls the search_recipes SK tool internally) and hydrate each
-  // returned suggestion's identifier into a full RecipeListItem for the
-  // grid. Falls back to keyword search if the chat call fails — a transient
-  // LLM outage must not regress baseline search.
   private searchViaChat(query: string): void {
     const requestId = ++this.loadRequestId;
     this.isAiPowered.set(true);
@@ -198,62 +182,20 @@ export class RecipeListComponent implements OnInit {
     this.multiSelect.clearSelection();
 
     this.asyncState.execute(
-      this.chatApi.send({ message: query, history: [] }).pipe(
-        switchMap((response) => this.hydrateSuggestions(response.suggestions)),
-        catchError(() => {
-          this.isAiPowered.set(false);
-          return this.recipeApi
-            .getRecipes({
-              page: 1,
-              pageSize: this.pageSize(),
-              sortBy: this.sortBy(),
-              sortDirection: this.sortDirection(),
-              search: query,
-            })
-            .pipe(map((response) => response.items));
-        }),
-      ),
+      this.chatSearch.search(query, {
+        pageSize: this.pageSize(),
+        sortBy: this.sortBy(),
+        sortDirection: this.sortDirection(),
+      }),
       ERROR_MAPS.recipes.list,
-      (items) => {
+      ({ items, fellBack }) => {
         if (requestId !== this.loadRequestId) return;
+        if (fellBack) this.isAiPowered.set(false);
         this.recipes.set(items);
         this.totalCount.set(items.length);
         this.collectAvailableTags(items);
       },
     );
-  }
-
-  private hydrateSuggestions(suggestions: ChatRecipeSuggestion[]) {
-    const validIds = suggestions.map((suggestion) => suggestion.recipeIdentifier).filter((id): id is string => id !== null);
-
-    if (validIds.length === 0) return of([] as RecipeListItem[]);
-
-    return forkJoin(
-      validIds.map((id) =>
-        this.recipeApi.getRecipeById(id).pipe(
-          map(
-            (detail): RecipeListItem => ({
-              identifier: detail.identifier,
-              title: detail.title,
-              description: detail.description,
-              servings: detail.servings,
-              prepTimeMinutes: detail.prepTimeMinutes,
-              cookTimeMinutes: detail.cookTimeMinutes,
-              difficulty: detail.difficulty,
-              imageUrl: detail.imageUrl,
-              createdAt: detail.createdAt,
-              tags: detail.tags,
-              isFavorite: detail.isFavorite,
-              rating: detail.rating,
-              hasNotes: detail.notes !== null,
-            }),
-          ),
-          // Per-suggestion failure shouldn't tank the AI search — skip the
-          // missing one and surface the rest.
-          catchError(() => of(null)),
-        ),
-      ),
-    ).pipe(map((items) => items.filter((item): item is RecipeListItem => item !== null)));
   }
 
   private loadRecipes(append: boolean): void {
@@ -294,17 +236,4 @@ export class RecipeListComponent implements OnInit {
     }
     this.availableTags.set([...existing].sort((a, b) => a.localeCompare(b)));
   }
-}
-
-// Conversational-query detector. Triggers the chat path when the user
-// types something that looks like an intent rather than a keyword: more
-// than 3 words, more than 20 chars, or contains a question/intent phrase.
-// Single-word queries like "Bolognese" stay on the keyword path.
-function isConversationalQuery(value: string): boolean {
-  const wordCount = value.split(/\s+/).filter((word) => word.length > 0).length;
-  if (wordCount > 3) return true;
-  if (value.length > 20) return true;
-  const lower = value.toLowerCase();
-  const intentPhrases = ['what', 'how', 'show me', 'find me', 'i want', 'something', 'with'];
-  return intentPhrases.some((phrase) => lower.includes(phrase));
 }


### PR DESCRIPTION
## Summary

Items #8-11 of the frontend refactoring sweep. The original scan flagged four components over CLAUDE.md's 300-line limit:

| Component | Status |
| --- | --- |
| \`merged-list.component.ts\` (was 307) | already under (280) after async-state + line-length refactors — no change needed |
| \`dashboard.component.ts\` (was 301) | already under (291) — no change needed |
| \`recipe-list.component.ts\` (was 310) | **split in this PR** → 239 |
| \`recipe-detail.component.ts\` (was 303) | **split in this PR** → 247 |

### \`recipe-list\` — \`RecipeChatSearchService\` extraction

The conversational-search path (the \"if the user types a question, route through the chat-tool instead of keyword search\" feature) is now a dedicated service:

- \`isConversational(query)\` — the heuristic that decides which path
- \`search(query, fallbackParams)\` — fires the chat request, hydrates each suggestion id into a full \`RecipeListItem\`, falls back to keyword search on chat failure. Returns \`{ items, fellBack }\` so the component can flip its \`isAiPowered\` UI hint off when fallback kicks in.

The component just calls \`chatSearch.search(...)\` inside its async-state \`execute\`. ~70 lines of RxJS pipe + forkJoin hydration leave the view layer.

### \`recipe-detail\` — \`RecipeScalingService\` extraction

The servings-scaling + unit-system view state is now a dedicated service:

- \`desiredServings\` writable signal
- \`userUnitOverride\` transient signal (never persisted)
- \`unitSystem\` computed (override ?? profile preference)
- \`scaledIngredients\` / \`displayedIngredients\` / \`isScaled\` computed
- \`increase()\` / \`decrease()\` / \`reset()\` / \`setUnitSystem()\` mutators
- \`attach(recipeSignal)\` wires upstream, \`initFor(recipe)\` seeds desired servings

The component re-exposes the service's signals at the same property names so the template doesn't have to change. ~56 lines of computed/handler boilerplate leave the component.

Both extractions follow the same shape \`RecipeNotesAutosaveService\` already uses (\`attach(recipeSignal)\` + signals re-exposed on the component).

## Test plan

- [x] \`yarn nx run-many --target=lint --projects=recipes\` — clean (one pre-existing warning unrelated)
- [x] \`yarn nx test recipes\` — all 11 spec files / 203 tests pass
- [x] \`yarn prettier --check\` — clean
- [ ] CI: full backend + frontend + E2E (the recipe-detail screen is heavily exercised by E2E specs — a wiring slip in scaling or unit toggle would surface there)