### PR TITLE
fix(recipes): RecipeScalingService computeds re-track when attach() swaps signal

### DIFF
--- a/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.spec.ts
@@ -1,0 +1,113 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { UserPreferencesService } from '@yumney/shared/models';
+import { RecipeDetail } from '../api';
+import { RecipeScalingService } from './recipe-scaling.service';
+
+function buildRecipe(overrides: Partial<RecipeDetail> = {}): RecipeDetail {
+  return {
+    identifier: 'r1',
+    title: 'Test',
+    description: null,
+    ingredients: [
+      { name: 'flour', amount: 200, unit: 'g' },
+      { name: 'eggs', amount: 2, unit: null },
+    ],
+    steps: [],
+    servings: 4,
+    prepTimeMinutes: null,
+    cookTimeMinutes: null,
+    difficulty: null,
+    imageUrl: null,
+    rating: null,
+    isFavorite: false,
+    notes: null,
+    sourceUrl: null,
+    tags: [],
+    ...overrides,
+  } as RecipeDetail;
+}
+
+describe('RecipeScalingService', () => {
+  function createService(): RecipeScalingService {
+    TestBed.configureTestingModule({
+      providers: [RecipeScalingService, { provide: UserPreferencesService, useValue: { preferredUnitSystem: signal('metric') } }],
+    });
+    return TestBed.inject(RecipeScalingService);
+  }
+
+  // Regression: the original implementation reassigned a `private recipe`
+  // field inside `attach()`, leaving the `scaledIngredients` / `isScaled`
+  // computeds bound to the placeholder signal created at field-init time
+  // (or to whichever signal happened to be the first one the computed
+  // evaluated against). On staging this surfaced as recipe-detail rendering
+  // with an empty ingredients list — never recovering even after the API
+  // returned the recipe payload.
+  it('scaledIngredients reacts to changes on the attached recipe signal', () => {
+    const service = createService();
+    const recipeRef = signal<RecipeDetail | null>(null);
+
+    service.attach(recipeRef);
+    expect(service.scaledIngredients()).toEqual([]);
+
+    recipeRef.set(buildRecipe({ servings: 4 }));
+
+    expect(service.scaledIngredients()).toHaveLength(2);
+    expect(service.scaledIngredients()[0].name).toBe('flour');
+  });
+
+  it('isScaled tracks servings changes after attach + recipe load', () => {
+    const service = createService();
+    const recipeRef = signal<RecipeDetail | null>(null);
+
+    service.attach(recipeRef);
+    recipeRef.set(buildRecipe({ servings: 4 }));
+    service.initFor(buildRecipe({ servings: 4 }));
+
+    expect(service.isScaled()).toBe(false);
+
+    service.desiredServings.set(8);
+
+    expect(service.isScaled()).toBe(true);
+  });
+
+  it('scaling halves ingredient amounts when desired servings is half the original', () => {
+    const service = createService();
+    const recipeRef = signal<RecipeDetail | null>(null);
+    service.attach(recipeRef);
+    const recipe = buildRecipe({ servings: 4 });
+    recipeRef.set(recipe);
+    service.initFor(recipe);
+
+    service.desiredServings.set(2);
+
+    const flour = service.scaledIngredients().find((entry) => entry.name === 'flour');
+    expect(flour?.amount).toBe(100);
+  });
+
+  it('reset() restores the original servings count', () => {
+    const service = createService();
+    const recipeRef = signal<RecipeDetail | null>(null);
+    service.attach(recipeRef);
+    const recipe = buildRecipe({ servings: 4 });
+    recipeRef.set(recipe);
+    service.initFor(recipe);
+    service.desiredServings.set(10);
+
+    service.reset();
+
+    expect(service.desiredServings()).toBe(4);
+  });
+
+  it('attach() with a different signal swaps the source the computeds track', () => {
+    const service = createService();
+    const firstRef = signal<RecipeDetail | null>(buildRecipe({ ingredients: [{ name: 'first', amount: 1, unit: 'g' }] }));
+    const secondRef = signal<RecipeDetail | null>(buildRecipe({ ingredients: [{ name: 'second', amount: 2, unit: 'g' }] }));
+
+    service.attach(firstRef);
+    expect(service.scaledIngredients()[0].name).toBe('first');
+
+    service.attach(secondRef);
+    expect(service.scaledIngredients()[0].name).toBe('second');
+  });
+});

--- a/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-scaling.service.ts
@@ -4,7 +4,7 @@ import { RecipeDetail } from '../api';
 
 /**
  * Owns the servings-scaling + unit-system view state for the recipe-detail
- * screen. The recipe-detail component drives identity (route → load), this
+ * screen. The recipe-detail component drives identity (route → load); this
  * service owns the toggles and the derived ingredient list:
  *
  * - desiredServings (writable, defaults to the recipe's saved servings)
@@ -12,21 +12,27 @@ import { RecipeDetail } from '../api';
  *   over the user's profile default but is never persisted)
  * - scaledIngredients / displayedIngredients / isScaled (computed)
  *
- * `attach(recipe)` wires the upstream recipe signal. `initFor(recipe)` seeds
- * `desiredServings` from the loaded recipe.
+ * `attach(recipe)` wires the upstream recipe signal. `initFor(recipe)`
+ * seeds `desiredServings` from the loaded recipe.
+ *
+ * The upstream recipe ref is held inside an outer signal (signal-of-signal)
+ * so the computeds correctly re-track when `attach()` swaps the source —
+ * a plain field reassignment leaves the computeds bound to whichever signal
+ * happened to be there at first evaluation.
  */
 @Injectable()
 export class RecipeScalingService {
   private preferences = inject(UserPreferencesService);
+  private static readonly emptyRecipe: Signal<RecipeDetail | null> = signal(null);
 
-  private recipe: Signal<RecipeDetail | null> = signal(null);
+  private recipeRef = signal<Signal<RecipeDetail | null>>(RecipeScalingService.emptyRecipe);
   private userUnitOverride = signal<UnitSystem | null>(null);
 
   readonly desiredServings = signal<number | null>(null);
   readonly unitSystem = computed<UnitSystem>(() => this.userUnitOverride() ?? this.preferences.preferredUnitSystem());
 
   readonly scaledIngredients = computed(() => {
-    const recipe = this.recipe();
+    const recipe = this.recipeRef()();
     if (!recipe) return [];
     const { ingredients, servings } = recipe;
     const desired = this.desiredServings();
@@ -53,13 +59,13 @@ export class RecipeScalingService {
   });
 
   readonly isScaled = computed(() => {
-    const recipe = this.recipe();
+    const recipe = this.recipeRef()();
     const desired = this.desiredServings();
     return recipe?.servings != null && desired != null && desired !== recipe.servings;
   });
 
   attach(recipeRef: Signal<RecipeDetail | null>): void {
-    this.recipe = recipeRef;
+    this.recipeRef.set(recipeRef);
   }
 
   initFor(recipe: RecipeDetail): void {
@@ -85,7 +91,7 @@ export class RecipeScalingService {
   }
 
   reset(): void {
-    const recipe = this.recipe();
+    const recipe = this.recipeRef()();
     if (recipe?.servings != null) {
       this.desiredServings.set(recipe.servings);
     }


### PR DESCRIPTION
## Summary

Hotfix for the staging regression in PR #710. Recipe-detail rendered with an empty ingredient list (and the save / load paths appeared broken) because the scaling service's computed signals never re-tracked when \`attach()\` swapped the source.

## Root cause

\`RecipeScalingService\` held the upstream recipe in a reassignable field:

\`\`\`ts
private recipe: Signal<RecipeDetail | null> = signal(null);

scaledIngredients = computed(() => {
  const r = this.recipe();  // tracks WHICHEVER signal this.recipe pointed to on first read
  ...
});

attach(ref) { this.recipe = ref; }
\`\`\`

Angular's reactive graph tracks signals **on first evaluation**. If change-detection picked up the placeholder \`signal(null)\` before \`attach()\` ran, the computed permanently bound to the placeholder; subsequent \`recipe.set(...)\` on the component's real signal never propagated.

## Fix

Hold the source ref inside an outer signal (signal-of-signal):

\`\`\`ts
private recipeRef = signal<Signal<RecipeDetail | null>>(emptyRecipe);

scaledIngredients = computed(() => {
  const r = this.recipeRef()();  // tracks both outer (fires on attach) and inner (fires on set)
  ...
});

attach(ref) { this.recipeRef.set(ref); }
\`\`\`

The outer signal now fires when \`attach()\` swaps the ref, which re-runs the computed and re-tracks the new inner signal. Subsequent emissions propagate.

## Regression test

\`recipe-scaling.service.spec.ts\` (new file). The canary:

\`\`\`ts
it('scaledIngredients reacts to changes on the attached recipe signal', () => {
  const service = createService();
  const recipeRef = signal<RecipeDetail | null>(null);

  service.attach(recipeRef);
  expect(service.scaledIngredients()).toEqual([]);

  recipeRef.set(buildRecipe({ servings: 4 }));

  expect(service.scaledIngredients()).toHaveLength(2);
});
\`\`\`

Plus an \`attach()\` swap test and three behavioural assertions (scaling, isScaled, reset). 5 new tests, all pass on the fix. Reverting only the service and re-running fails the spec as expected.

## Test plan

- [x] \`yarn nx test recipes\` — 12 spec files, 208 tests pass (was 11/203 → +5 from this spec)
- [x] \`yarn nx run-many --target=lint --projects=recipes\` — clean
- [x] \`yarn prettier --check\` — clean
- [ ] CI: full backend + E2E (the recipe-detail E2E specs exercise the actual rendering path)