### PR TITLE
chore(infra): sync RecipeFavorite snapshot + surface MCP URL on dashboard

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -214,12 +214,18 @@ if (!options.DatabaseOnly)
 	// exposes them as MCP tools at /mcp (Phase 4b). Tool invocation returns a
 	// stub until the OAuth bridge + REST proxy land in Phase 4c. Declared
 	// outside the run/publish branches because both gateways route to it.
+	//
+	// The `WithUrl("/mcp", "MCP Endpoint")` surfaces a clickable link on the
+	// Aspire dashboard pointing at the live MCP HTTP/SSE transport — copy
+	// that into Claude Desktop's config (or any MCP-aware client) to attach
+	// the Yumney toolset.
 	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
 		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
 		.WithReference(keycloak)
 		.WithReference(recipesApi)
 		.WithReference(shoppingApi)
-		.WithReference(mealplanApi);
+		.WithReference(mealplanApi)
+		.WithUrl("/mcp", "MCP Endpoint");
 
 	if (isRunMode)
 	{

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Configurations/RecipeFavoriteConfiguration.cs
@@ -27,7 +27,9 @@ internal sealed class RecipeFavoriteConfiguration : IEntityTypeConfiguration<Rec
 
 		builder.Property(favorite => favorite.FavoritedAt).IsRequired();
 
-		builder.HasIndex(favorite => new { favorite.Owner, favorite.Recipe }).IsUnique();
+		builder.HasIndex(favorite => new { favorite.Owner, favorite.Recipe })
+			.IsUnique()
+			.HasDatabaseName("IX_RecipeFavorites_Owner_RecipeIdentifier");
 		builder.Ignore(favorite => favorite.DomainEvents);
 	}
 }

--- a/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/RecipesDbContextModelSnapshot.cs
+++ b/src/Yumney.Recipes.Infrastructure/Persistence/Migrations/RecipesDbContextModelSnapshot.cs
@@ -104,13 +104,15 @@ namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)");
 
-                    b.Property<Guid>("RecipeIdentifier")
-                        .HasColumnType("uuid");
+                    b.Property<Guid>("Recipe")
+                        .HasColumnType("uuid")
+                        .HasColumnName("RecipeIdentifier");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Owner", "RecipeIdentifier")
-                        .IsUnique();
+                    b.HasIndex("Owner", "Recipe")
+                        .IsUnique()
+                        .HasDatabaseName("IX_RecipeFavorites_Owner_RecipeIdentifier");
 
                     b.ToTable("RecipeFavorites", (string)null);
                 });


### PR DESCRIPTION
## Summary

Two small infra cleanups bundled because they're tiny and touch related operability surfaces.

### 1. RecipeFavorite snapshot drift

PR #697 renamed the C# property \`RecipeFavorite.RecipeIdentifier\` → \`Recipe\` with \`HasColumnName(\"RecipeIdentifier\")\` preserving the column. The EF model snapshot still recorded the old property name though, so a future \`dotnet ef migrations add\` (once EF tooling cooperates on .NET 10) would emit a no-op rename migration.

Tightened both the snapshot and the runtime config so they agree:

- \`RecipesDbContextModelSnapshot.cs\`:
  \`b.Property<Guid>(\"Recipe\").HasColumnName(\"RecipeIdentifier\")\`
- Both snapshot and \`RecipeFavoriteConfiguration\` now pin the index name with
  \`.HasDatabaseName(\"IX_RecipeFavorites_Owner_RecipeIdentifier\")\` so EF's
  auto-derivation doesn't drift to \`..._Owner_Recipe\` next time it regenerates
  the snapshot.

Pure metadata — runtime queries already used the right column via the existing \`HasColumnName\` mapping. No DB migration needed.

### 2. MCP server URL on Aspire dashboard

Added \`.WithUrl(\"/mcp\", \"MCP Endpoint\")\` on the \`mcp-server\` resource (the same pattern \`AsYumneyApi\` uses for the Scalar docs link). The Aspire dashboard now surfaces a clickable link to the live MCP HTTP/SSE endpoint — copy that URL into Claude Desktop's config (or any MCP-aware client) to attach the Yumney toolset.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`Yumney.Recipes.Infrastructure.Tests\` — 165 pass
- [ ] CI: full backend + integration + E2E