### PR TITLE
chore(infra): bump API minReplicas 0 → 1 to eliminate cross-module cold-starts

### DIFF
--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -204,11 +204,9 @@ if (!options.DatabaseOnly)
 		}
 	}
 
-	// minReplicas = 1 keeps one warm instance per API host so cross-module HTTP
-	// calls (e.g. Recipes → Shopping for ingredient balance, chat-tool fan-out,
-	// dashboard suggestion fetches) don't hit Container Apps cold-starts and
-	// trip the 10s Polly attempt-timeout. The migration runner stays at 0 —
-	// it's a one-shot job that intentionally exits after applying migrations.
+	// minReplicas = 1 on the APIs keeps one warm instance so cross-module HTTP
+	// calls (e.g. Recipes → Shopping/balance, chat-tool fan-out) don't hit ACA
+	// cold-starts and trip the 10 s Polly timeout. Migration runner stays at 0.
 	recipesApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 10, 20));
 	shoppingApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 5, 50));
 	usersApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 3, 50));

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -204,10 +204,15 @@ if (!options.DatabaseOnly)
 		}
 	}
 
+	// minReplicas = 1 keeps one warm instance per API host so cross-module HTTP
+	// calls (e.g. Recipes → Shopping for ingredient balance, chat-tool fan-out,
+	// dashboard suggestion fetches) don't hit Container Apps cold-starts and
+	// trip the 10s Polly attempt-timeout. The migration runner stays at 0 —
+	// it's a one-shot job that intentionally exits after applying migrations.
 	recipesApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 10, 20));
-	shoppingApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 5, 50));
-	usersApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
-	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 3, 50));
+	shoppingApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 5, 50));
+	usersApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 3, 50));
+	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 3, 50));
 	migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
 
 	// MCP server: aggregates the per-host capability manifests on startup and


### PR DESCRIPTION
## Summary

Container Apps was scaling \`shopping-api\` / \`users-api\` / \`mealplan-api\` to zero when idle. Cross-module HTTP calls from \`recipes-api\` (\`HttpIngredientBalanceProvider\` hits \`shopping-api/balance\`, chat tools fan out to all three, dashboard suggestion fetches, etc.) then triggered a cold start that overshot the 10 s Polly attempt-timeout — surfaces in the staging recipes-api logs as:

\`\`\`
GET http://shopping-api/api/v1/shopping-lists/balance
fail: Polly[0]
  Resilience event occurred. EventName: 'OnTimeout'
  Polly.Timeout.TimeoutRejectedException: The operation didn't complete
  within the allowed timeout of '00:00:10'
\`\`\`

## Change

| Host | Before | After |
| --- | --- | --- |
| \`recipes-api\` | min 1, max 10 | min 1, max 10 (no change — already warm) |
| \`shopping-api\` | min 0, max 5 | **min 1**, max 5 |
| \`users-api\` | min 0, max 3 | **min 1**, max 3 |
| \`mealplan-api\` | min 0, max 3 | **min 1**, max 3 |
| \`migration-runner\` | min 0, max 1 | min 0, max 1 (unchanged — one-shot job, scale-to-zero is correct) |

## Trade-off

One always-on replica per host costs a few EUR/month. The alternative — bumping per-client Polly timeouts to 30+ s — would just trade fast cold-start failures for slow ones, and still surface as timeouts whenever the warm-up genuinely exceeds the new ceiling.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [ ] CI: backend + frontend + E2E
- [ ] Post-deploy: cross-module HTTP calls (Recipes → Shopping/balance, chat tools) no longer show cold-start timeouts in the Container Apps logs