### PR TITLE
style(shared): collapse MigrationWorker primary-ctor onto one line (140-char budget)

### DIFF
--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -25,11 +25,7 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 ///   Events and metadata are untouched.</item>
 /// </list>
 /// </summary>
-public sealed partial class MigrationWorker(
-	IServiceProvider serviceProvider,
-	IHostApplicationLifetime lifetime,
-	IConfiguration configuration,
-	ILogger<MigrationWorker> logger) : BackgroundService
+public sealed partial class MigrationWorker(IServiceProvider serviceProvider, IHostApplicationLifetime lifetime, IConfiguration configuration, ILogger<MigrationWorker> logger) : BackgroundService
 {
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{


### PR DESCRIPTION
Same IDE auto-format follow-up we cleaned up in PR #707 — the multi-line primary-ctor declaration on `MigrationWorker` collapsed onto a single 132-char line that fits comfortably under the 140-char budget set in PR #707. No behaviour change.