### PR TITLE
refactor(infra): bind MigrationWorker dashboard flags to a typed PersistenceOptions

### DIFF
--- a/src/Yumney.MigrationRunner/MigrationWorker.cs
+++ b/src/Yumney.MigrationRunner/MigrationWorker.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Recipes.Infrastructure.Persistence;
 using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
@@ -13,33 +14,40 @@ namespace SmartSolutionsLab.Yumney.MigrationRunner;
 /// Background worker that applies EF Core migrations for all modules on startup.
 /// Uses PostgreSQL advisory locks to prevent concurrent migration from multiple instances.
 ///
-/// Dashboard-driven modes (set via configuration before start):
+/// Dashboard-driven modes (toggled via <see cref="PersistenceOptions"/>, bound from
+/// the <c>Persistence</c> configuration section):
 /// <list type="bullet">
-///   <item><c>Persistence:ResetMealPlanOnly=true</c> — drops and re-migrates the
-///   MealPlan database only. Wipes the event-sourced MealPlan store.</item>
-///   <item><c>Persistence:ResetShoppingOnly=true</c> — drops and re-migrates the
-///   Shopping database only. Wipes events, metadata, projections, and legacy
+///   <item><see cref="PersistenceOptions.ResetMealPlanOnly"/> — drops and re-migrates
+///   the MealPlan database only. Wipes the event-sourced MealPlan store.</item>
+///   <item><see cref="PersistenceOptions.ResetShoppingOnly"/> — drops and re-migrates
+///   the Shopping database only. Wipes events, metadata, projections, and legacy
 ///   lists in one shot.</item>
-///   <item><c>Persistence:RebuildShoppingProjections=true</c> — truncates the
+///   <item><see cref="PersistenceOptions.RebuildShoppingProjections"/> — truncates the
 ///   ShoppingList projection tables and replays the event store into them.
 ///   Events and metadata are untouched.</item>
 /// </list>
 /// </summary>
-public sealed partial class MigrationWorker(IServiceProvider serviceProvider, IHostApplicationLifetime lifetime, IConfiguration configuration, ILogger<MigrationWorker> logger) : BackgroundService
+public sealed partial class MigrationWorker(
+	IServiceProvider serviceProvider,
+	IHostApplicationLifetime lifetime,
+	IOptions<PersistenceOptions> persistence,
+	ILogger<MigrationWorker> logger) : BackgroundService
 {
+	private readonly PersistenceOptions persistence = persistence.Value;
+
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
 		try
 		{
-			if (configuration.GetValue<bool>("Persistence:RebuildShoppingProjections"))
+			if (this.persistence.RebuildShoppingProjections)
 			{
 				await RebuildShoppingProjectionsAsync(stoppingToken);
 			}
-			else if (configuration.GetValue<bool>("Persistence:ResetMealPlanOnly"))
+			else if (this.persistence.ResetMealPlanOnly)
 			{
 				await ApplyMigrationsAsync<MealPlanDbContext>("MealPlan", stoppingToken, reset: true);
 			}
-			else if (configuration.GetValue<bool>("Persistence:ResetShoppingOnly"))
+			else if (this.persistence.ResetShoppingOnly)
 			{
 				await ApplyMigrationsAsync<ShoppingDbContext>("Shopping", stoppingToken, reset: true);
 			}

--- a/src/Yumney.MigrationRunner/PersistenceOptions.cs
+++ b/src/Yumney.MigrationRunner/PersistenceOptions.cs
@@ -1,0 +1,37 @@
+namespace SmartSolutionsLab.Yumney.MigrationRunner;
+
+/// <summary>
+/// Toggles that switch <see cref="MigrationWorker"/> from its default "apply
+/// pending migrations across every module" path into one of the operational
+/// modes driven by the Aspire dashboard reset entries
+/// (<c>DashboardResetEntries</c>).
+///
+/// Bound from configuration section <c>Persistence</c>. Each dashboard entry
+/// flips exactly one flag to <c>true</c> via an environment variable; the
+/// regular CI / staging deploy leaves them all <c>false</c>.
+/// </summary>
+public sealed class PersistenceOptions
+{
+	public const string SectionName = "Persistence";
+
+	/// <summary>
+	/// Gets a value indicating whether the ShoppingList projection tables should
+	/// be truncated and rebuilt from the event store. Events and metadata are
+	/// untouched. Idempotent.
+	/// </summary>
+	public bool RebuildShoppingProjections { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the MealPlan database should be dropped
+	/// and re-migrated. Wipes the event-sourced MealPlan store. Destructive —
+	/// only exposed via the Aspire dashboard reset entry.
+	/// </summary>
+	public bool ResetMealPlanOnly { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the Shopping database should be dropped
+	/// and re-migrated. Wipes events, metadata, projections, and legacy lists in
+	/// one shot. Destructive — only exposed via the Aspire dashboard reset entry.
+	/// </summary>
+	public bool ResetShoppingOnly { get; init; }
+}

--- a/src/Yumney.MigrationRunner/Program.cs
+++ b/src/Yumney.MigrationRunner/Program.cs
@@ -38,6 +38,8 @@ builder.Services.AddDbContext<MealPlanDbContext>(options =>
 builder.Services.AddScoped<ShoppingListProjection>();
 builder.Services.AddScoped<IShoppingListProjectionRebuilder, ShoppingListProjectionRebuilder>();
 
+builder.Services.Configure<PersistenceOptions>(builder.Configuration.GetSection(PersistenceOptions.SectionName));
+
 builder.Services.AddHostedService<MigrationWorker>();
 
 var host = builder.Build();


### PR DESCRIPTION
## Summary

The three operational toggles \`MigrationWorker\` reads — \`Persistence:RebuildShoppingProjections\`, \`:ResetMealPlanOnly\`, \`:ResetShoppingOnly\` — were pulled straight off \`IConfiguration\` via loose string keys. Wrapped them in a typed options class so:

- typos in the option names become compile errors instead of silent no-ops
- a future reader sees the full set of dashboard-driven modes at a glance
- the worker no longer drags \`IConfiguration\` through its constructor for a job that only needs three booleans

### New class

\`\`\`csharp
public sealed class PersistenceOptions
{
    public const string SectionName = \"Persistence\";

    public bool RebuildShoppingProjections { get; init; }
    public bool ResetMealPlanOnly { get; init; }
    public bool ResetShoppingOnly { get; init; }
}
\`\`\`

Bound in \`Program.cs\`:

\`\`\`csharp
builder.Services.Configure<PersistenceOptions>(
    builder.Configuration.GetSection(PersistenceOptions.SectionName));
\`\`\`

### MigrationWorker change

\`\`\`csharp
// Before
public sealed partial class MigrationWorker(
    IServiceProvider serviceProvider,
    IHostApplicationLifetime lifetime,
    IConfiguration configuration,                   // ← loose
    ILogger<MigrationWorker> logger) ...
{
    if (configuration.GetValue<bool>(\"Persistence:RebuildShoppingProjections\")) ...
}

// After
public sealed partial class MigrationWorker(
    IServiceProvider serviceProvider,
    IHostApplicationLifetime lifetime,
    IOptions<PersistenceOptions> persistence,       // ← typed
    ILogger<MigrationWorker> logger) ...
{
    private readonly PersistenceOptions persistence = persistence.Value;

    if (this.persistence.RebuildShoppingProjections) ...
}
\`\`\`

\`DashboardResetEntries.cs\` (AppHost) keeps using \`WithEnvironment(\"Persistence__X\", \"true\")\` — the configuration binder picks those up unchanged, no AppHost side touched.

## Test plan

- [x] \`dotnet build -p:TreatWarningsAsErrors=true\` — green
- [x] \`dotnet format --verify-no-changes\` — clean
- [ ] CI: full backend + integration + E2E (the migration runner is exercised on every deploy; if the binding broke, all subsequent deploys would fail to apply migrations)