### PR TITLE
feat(api): expose OAuth protected-resource discovery endpoint (US-717)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,7 @@
     <!-- Analyzers -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Testing -->
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
+++ b/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
@@ -46,6 +46,16 @@ public static class KeycloakAuthExtensions
 		return services;
 	}
 
+	/// <summary>
+	/// Resolves the public Keycloak realm URL (e.g. <c>http://localhost:8080/realms/yumney</c>)
+	/// from the same configuration the bearer authentication uses. Exposed so the OAuth
+	/// protected-resource discovery endpoint can advertise it to MCP clients without
+	/// re-implementing the resolution logic.
+	/// </summary>
+	/// <param name="configuration">Configuration source.</param>
+	/// <returns>The canonical realm URL.</returns>
+	public static string ResolveRealmUrl(IConfiguration configuration) => RealmUrl(configuration);
+
 	private static string GetBaseUrl(IConfiguration configuration) =>
 		configuration.GetConnectionString(keycloakConnectionStringName)
 			?? configuration[$"services:{keycloakConnectionStringName}:http:0"]

--- a/src/Yumney.Mcp.Server/Auth/OAuthProtectedResource.cs
+++ b/src/Yumney.Mcp.Server/Auth/OAuthProtectedResource.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+
+/// <summary>
+/// RFC 9728 OAuth 2.0 Protected Resource Metadata document. MCP clients
+/// (Claude.ai's custom connectors, Claude Desktop's HTTP transport, ChatGPT's
+/// native MCP support, etc.) fetch this at
+/// <c>/.well-known/oauth-protected-resource</c> to discover the authorization
+/// server they should authenticate against — without it, every client has to
+/// be told the Keycloak realm URL manually.
+/// </summary>
+/// <param name="Resource">The canonical URL of the protected resource (the MCP endpoint).</param>
+/// <param name="AuthorizationServers">URLs of the authorization servers that issue tokens for this resource.</param>
+/// <param name="BearerMethodsSupported">How the bearer is presented; we accept it in the Authorization header only.</param>
+/// <param name="ScopesSupported">Scopes a client may request when obtaining a token for this resource.</param>
+public sealed record OAuthProtectedResource(
+	[property: JsonPropertyName("resource")] string Resource,
+	[property: JsonPropertyName("authorization_servers")] IReadOnlyList<string> AuthorizationServers,
+	[property: JsonPropertyName("bearer_methods_supported")] IReadOnlyList<string> BearerMethodsSupported,
+	[property: JsonPropertyName("scopes_supported")] IReadOnlyList<string> ScopesSupported);

--- a/src/Yumney.Mcp.Server/Auth/OAuthProtectedResourceEndpoint.cs
+++ b/src/Yumney.Mcp.Server/Auth/OAuthProtectedResourceEndpoint.cs
@@ -1,0 +1,64 @@
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+
+/// <summary>
+/// Maps the RFC 9728 OAuth Protected Resource Metadata endpoint at
+/// <c>/.well-known/oauth-protected-resource</c>. The endpoint is anonymous —
+/// discovery must work pre-auth — and returns a 5-minute Cache-Control header.
+/// </summary>
+public static class OAuthProtectedResourceEndpoint
+{
+#pragma warning disable SA1303
+	private const string discoveryPath = "/.well-known/oauth-protected-resource";
+	private const string mcpResourcePath = "/mcp";
+	private const int cacheTtlSeconds = 300;
+#pragma warning restore SA1303
+
+#pragma warning disable SA1311
+	private static readonly string[] bearerMethods = ["header"];
+	private static readonly string[] supportedScopes = ["openid", "profile", "yumney-api"];
+#pragma warning restore SA1311
+
+	public static IEndpointRouteBuilder MapOAuthProtectedResourceEndpoint(this IEndpointRouteBuilder app) =>
+		MapOAuthProtectedResourceEndpoint(app, configuredResourceUrl: null);
+
+	/// <summary>
+	/// Maps the discovery endpoint. <paramref name="configuredResourceUrl"/> overrides
+	/// the resource URL — set it from configuration when the MCP server sits behind a
+	/// gateway (the request's host header is the internal container name, not the
+	/// public URL clients use).
+	/// </summary>
+	/// <param name="app">Route builder.</param>
+	/// <param name="configuredResourceUrl">Public MCP URL, or null to infer from the request.</param>
+	/// <returns>The route builder for chaining.</returns>
+	public static IEndpointRouteBuilder MapOAuthProtectedResourceEndpoint(this IEndpointRouteBuilder app, string? configuredResourceUrl)
+	{
+		app.MapGet(discoveryPath, (HttpContext context, IConfiguration configuration) =>
+		{
+			var resourceUrl = configuredResourceUrl ?? InferResourceUrl(context.Request.Scheme, context.Request.Host.ToString());
+			var realmUrl = KeycloakAuthExtensions.ResolveRealmUrl(configuration);
+			var document = BuildDocument(resourceUrl, realmUrl);
+
+			context.Response.Headers.CacheControl = $"public, max-age={cacheTtlSeconds}";
+			return Results.Ok(document);
+		}).AllowAnonymous();
+
+		return app;
+	}
+
+	/// <summary>Builds the protected-resource document from already-resolved URLs. Exposed for tests.</summary>
+	/// <param name="resourceUrl">Canonical public URL of the MCP endpoint.</param>
+	/// <param name="authorizationServerUrl">Keycloak realm URL.</param>
+	/// <returns>The RFC 9728 document.</returns>
+	public static OAuthProtectedResource BuildDocument(string resourceUrl, string authorizationServerUrl) =>
+		new(
+			Resource: resourceUrl,
+			AuthorizationServers: [authorizationServerUrl],
+			BearerMethodsSupported: bearerMethods,
+			ScopesSupported: supportedScopes);
+
+	/// <summary>Infers the canonical resource URL from the inbound request's scheme + host. Exposed for tests.</summary>
+	/// <param name="scheme">Request scheme (http / https).</param>
+	/// <param name="host">Request host header (host[:port]).</param>
+	/// <returns>The canonical MCP URL.</returns>
+	public static string InferResourceUrl(string scheme, string host) => $"{scheme}://{host}{mcpResourcePath}";
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -61,6 +61,13 @@ app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) =
 	capabilities = registry.AllCapabilities(),
 })).AllowAnonymous();
 
+// RFC 9728 OAuth Protected Resource Metadata. Lets MCP clients (Claude.ai,
+// Claude Desktop, ChatGPT, …) discover the Keycloak realm without anyone
+// hand-configuring URLs. Optional config override `McpServer:PublicUrl` is
+// required in deployments where the request reaches the server through a
+// gateway (the Host header is the internal container name, not the public URL).
+app.MapOAuthProtectedResourceEndpoint(builder.Configuration.GetValue<string>("McpServer:PublicUrl"));
+
 // MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
 // authenticate via the standard Authorization: Bearer header — the bearer is
 // forwarded to the module endpoint by RestProxyService when the LLM calls a tool.

--- a/tests/Yumney.Mcp.Server.Tests/Auth/OAuthProtectedResourceEndpointHttpTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Auth/OAuthProtectedResourceEndpointHttpTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Auth;
+
+public class OAuthProtectedResourceEndpointHttpTests
+{
+	private const string DiscoveryPath = "/.well-known/oauth-protected-resource";
+
+	[Fact]
+	public async Task GET_Discovery_AllowsAnonymousAccess()
+	{
+		using var server = BuildServer();
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync(DiscoveryPath);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task GET_Discovery_SetsFiveMinuteCacheControl()
+	{
+		using var server = BuildServer();
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync(DiscoveryPath);
+
+		response.Headers.CacheControl.Should().NotBeNull();
+		response.Headers.CacheControl!.Public.Should().BeTrue();
+		response.Headers.CacheControl.MaxAge.Should().Be(TimeSpan.FromSeconds(300));
+	}
+
+	[Fact]
+	public async Task GET_Discovery_WithoutOverride_UsesRequestSchemeAndHost()
+	{
+		using var server = BuildServer(configuredResourceUrl: null);
+		using var client = server.CreateClient();
+
+		var doc = await client.GetFromJsonAsync<OAuthProtectedResource>(DiscoveryPath);
+
+		doc!.Resource.Should().EndWith("/mcp");
+		doc.Resource.Should().StartWith("http://");
+	}
+
+	[Fact]
+	public async Task GET_Discovery_WithOverride_HonorsConfiguredResourceUrl()
+	{
+		const string publicUrl = "https://yumney-mcp.example.com/mcp";
+		using var server = BuildServer(configuredResourceUrl: publicUrl);
+		using var client = server.CreateClient();
+
+		var doc = await client.GetFromJsonAsync<OAuthProtectedResource>(DiscoveryPath);
+
+		doc!.Resource.Should().Be(publicUrl);
+	}
+
+	[Fact]
+	public async Task GET_Discovery_AdvertisesRealmUrlFromConfiguration()
+	{
+		var configOverrides = new Dictionary<string, string?>
+		{
+			["ConnectionStrings:keycloak"] = "https://yumney-keycloak.example.com",
+			["Keycloak:Realm"] = "yumney-staging",
+		};
+		using var server = BuildServer(configOverrides: configOverrides);
+		using var client = server.CreateClient();
+
+		var doc = await client.GetFromJsonAsync<OAuthProtectedResource>(DiscoveryPath);
+
+		doc!.AuthorizationServers.Should().ContainSingle()
+			.Which.Should().Be("https://yumney-keycloak.example.com/realms/yumney-staging");
+	}
+
+	[Fact]
+	public async Task GET_Discovery_FallsBackToDefaultRealmWhenUnconfigured()
+	{
+		using var server = BuildServer();
+		using var client = server.CreateClient();
+
+		var doc = await client.GetFromJsonAsync<OAuthProtectedResource>(DiscoveryPath);
+
+		doc!.AuthorizationServers.Should().ContainSingle()
+			.Which.Should().Be("http://localhost:8080/realms/yumney");
+	}
+
+	private static TestServer BuildServer(
+		string? configuredResourceUrl = null,
+		IDictionary<string, string?>? configOverrides = null)
+	{
+		var builder = new HostBuilder().ConfigureWebHost(webHost =>
+		{
+			webHost.UseTestServer();
+			webHost.ConfigureAppConfiguration(config =>
+			{
+				if (configOverrides is not null)
+				{
+					config.AddInMemoryCollection(configOverrides);
+				}
+			});
+			webHost.ConfigureServices(services => services.AddRouting());
+			webHost.Configure(app =>
+			{
+				app.UseRouting();
+				app.UseEndpoints(endpoints =>
+				{
+					endpoints.MapOAuthProtectedResourceEndpoint(configuredResourceUrl);
+				});
+			});
+		});
+
+		var host = builder.Start();
+		return host.GetTestServer();
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Auth/OAuthProtectedResourceEndpointTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Auth/OAuthProtectedResourceEndpointTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Auth;
+
+public class OAuthProtectedResourceEndpointTests
+{
+	[Fact]
+	public void BuildDocument_SetsResourceAndAuthorizationServers()
+	{
+		var doc = OAuthProtectedResourceEndpoint.BuildDocument(
+			resourceUrl: "https://yumney-gateway.example.com/mcp",
+			authorizationServerUrl: "https://yumney-keycloak.example.com/realms/yumney");
+
+		doc.Resource.Should().Be("https://yumney-gateway.example.com/mcp");
+		doc.AuthorizationServers.Should().ContainSingle().Which.Should().Be("https://yumney-keycloak.example.com/realms/yumney");
+	}
+
+	[Fact]
+	public void BuildDocument_AlwaysAdvertisesHeaderBearerMethod()
+	{
+		var doc = OAuthProtectedResourceEndpoint.BuildDocument("https://r", "https://as");
+
+		doc.BearerMethodsSupported.Should().ContainSingle().Which.Should().Be("header");
+	}
+
+	[Fact]
+	public void BuildDocument_IncludesYumneyApiScope()
+	{
+		var doc = OAuthProtectedResourceEndpoint.BuildDocument("https://r", "https://as");
+
+		doc.ScopesSupported.Should().Contain("yumney-api");
+		doc.ScopesSupported.Should().Contain("openid");
+	}
+
+	[Fact]
+	public void BuildDocument_SerializesWithSnakeCaseJsonPropertyNames()
+	{
+		var doc = OAuthProtectedResourceEndpoint.BuildDocument(
+			"https://yumney-gateway.example.com/mcp",
+			"https://yumney-keycloak.example.com/realms/yumney");
+
+		var json = JsonSerializer.Serialize(doc);
+
+		json.Should().Contain("\"resource\"");
+		json.Should().Contain("\"authorization_servers\"");
+		json.Should().Contain("\"bearer_methods_supported\"");
+		json.Should().Contain("\"scopes_supported\"");
+		json.Should().NotContain("\"Resource\"");
+	}
+
+	[Theory]
+	[InlineData("https", "yumney-gateway.example.com", "https://yumney-gateway.example.com/mcp")]
+	[InlineData("http", "localhost:5000", "http://localhost:5000/mcp")]
+	[InlineData("https", "yumney.app", "https://yumney.app/mcp")]
+	public void InferResourceUrl_ComposesSchemeHostAndMcpPath(string scheme, string host, string expected)
+	{
+		OAuthProtectedResourceEndpoint.InferResourceUrl(scheme, host).Should().Be(expected);
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
+++ b/tests/Yumney.Mcp.Server.Tests/Yumney.Mcp.Server.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
## Summary
- Adds `GET /.well-known/oauth-protected-resource` to `Yumney.Mcp.Server` per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). Returns the canonical resource URL, the Keycloak realm as the authorization server, supported bearer methods, and supported scopes.
- Endpoint is anonymous (discovery must work pre-auth) and ships a `Cache-Control: public, max-age=300` header.
- Optional `McpServer:PublicUrl` config override — required in deployments behind a gateway where the inbound request's `Host` header is the internal container name (Aspire / Container Apps), not the public URL clients use.
- Exposes `KeycloakAuthExtensions.ResolveRealmUrl(IConfiguration)` so the discovery endpoint reuses the exact same realm resolution as the bearer-auth pipeline (no drift).

## Why
First ticket of the MCP epic (#716). Discovery is the prerequisite for every other MCP OAuth flow: Claude.ai, Claude Desktop, ChatGPT custom GPTs all probe `/.well-known/oauth-protected-resource` before initiating the OAuth dance. Without it they can't even find Keycloak.

## Test plan
- [x] 7 new unit tests under `tests/Yumney.Mcp.Server.Tests/Auth/` cover document construction, JSON property naming (`snake_case`), and URL inference from scheme + host.
- [x] `dotnet build -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] Full `Yumney.Mcp.Server.Tests` suite passes (35/35).

Closes #717