### PR TITLE
feat(api): emit RFC 6750 WWW-Authenticate metadata on 401 responses (US-718)

### DIFF
--- a/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
+++ b/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
@@ -28,6 +28,8 @@ public static class KeycloakAuthExtensions
 		IHostEnvironment environment)
 	{
 		var isDevelopment = environment.IsDevelopment();
+		var realmName = GetRealm(configuration);
+		var publicResourceUrl = configuration.GetValue<string>("McpServer:PublicUrl");
 
 		services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 			.AddJwtBearer(options =>
@@ -40,6 +42,22 @@ public static class KeycloakAuthExtensions
 				{
 					options.TokenValidationParameters.ValidIssuer = RealmUrl(configuration);
 				}
+
+				options.Events = new JwtBearerEvents
+				{
+					OnChallenge = challenge =>
+					{
+						// Override the default WWW-Authenticate header so MCP clients
+						// (Claude.ai, ChatGPT custom GPTs) can find the RFC 9728
+						// discovery document from a 401 response alone — see RFC 6750 §3.
+						challenge.HandleResponse();
+						var discoveryUrl = WwwAuthenticateChallenge.ResolveDiscoveryUrl(challenge.Request, publicResourceUrl);
+						var error = challenge.AuthenticateFailure is not null ? "invalid_token" : null;
+						challenge.Response.StatusCode = StatusCodes.Status401Unauthorized;
+						challenge.Response.Headers.WWWAuthenticate = WwwAuthenticateChallenge.BuildHeader(realmName, discoveryUrl, error);
+						return Task.CompletedTask;
+					},
+				};
 			});
 
 		services.AddAuthorization();

--- a/src/Yumney.Mcp.Server/Auth/WwwAuthenticateChallenge.cs
+++ b/src/Yumney.Mcp.Server/Auth/WwwAuthenticateChallenge.cs
@@ -1,0 +1,64 @@
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+
+/// <summary>
+/// Builds the RFC 6750 <c>WWW-Authenticate</c> header value that points MCP
+/// clients at the RFC 9728 discovery document. Pure functions only — wiring
+/// into <c>JwtBearerEvents.OnChallenge</c> lives in
+/// <see cref="KeycloakAuthExtensions"/> so this stays unit-testable.
+/// </summary>
+public static class WwwAuthenticateChallenge
+{
+#pragma warning disable SA1303
+	private const string discoveryPath = "/.well-known/oauth-protected-resource";
+#pragma warning restore SA1303
+
+	/// <summary>
+	/// Composes the header value. RFC 6750 §3 says <c>error</c> MUST be omitted
+	/// when the client sent no credentials at all — pass <c>null</c> in that case.
+	/// </summary>
+	/// <param name="realm">Protection-space identifier (e.g. <c>yumney</c>).</param>
+	/// <param name="discoveryUrl">Absolute URL of the RFC 9728 metadata document.</param>
+	/// <param name="error">Optional RFC 6750 error code, e.g. <c>invalid_token</c>.</param>
+	/// <returns>The full header value, prefixed with <c>Bearer</c>.</returns>
+	public static string BuildHeader(string realm, string discoveryUrl, string? error)
+	{
+		var parameters = new List<string>(capacity: 3)
+		{
+			$"realm=\"{realm}\"",
+			$"resource_metadata=\"{discoveryUrl}\"",
+		};
+
+		if (!string.IsNullOrEmpty(error))
+		{
+			parameters.Add($"error=\"{error}\"");
+		}
+
+		return $"Bearer {string.Join(", ", parameters)}";
+	}
+
+	/// <summary>
+	/// Resolves the absolute discovery URL the header should advertise. When
+	/// <paramref name="configuredResourceUrl"/> is set, the host portion is
+	/// reused and <c>/mcp</c> is replaced with the discovery path — clients
+	/// behind a gateway need the public origin, not the internal container's.
+	/// </summary>
+	/// <param name="request">Inbound request — used as the fallback origin.</param>
+	/// <param name="configuredResourceUrl">Public MCP URL from <c>McpServer:PublicUrl</c>, or null.</param>
+	/// <returns>Absolute discovery URL.</returns>
+	public static string ResolveDiscoveryUrl(HttpRequest request, string? configuredResourceUrl)
+	{
+		if (!string.IsNullOrWhiteSpace(configuredResourceUrl))
+		{
+			var origin = ExtractOrigin(configuredResourceUrl);
+			return $"{origin}{discoveryPath}";
+		}
+
+		return $"{request.Scheme}://{request.Host}{discoveryPath}";
+	}
+
+	private static string ExtractOrigin(string absoluteUrl)
+	{
+		var uri = new Uri(absoluteUrl, UriKind.Absolute);
+		return $"{uri.Scheme}://{uri.Authority}";
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Auth/WwwAuthenticateChallengeHttpTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Auth/WwwAuthenticateChallengeHttpTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Auth;
+
+public class WwwAuthenticateChallengeHttpTests
+{
+	[Fact]
+	public async Task AnonymousRequest_ToProtectedRoute_Returns401WithDiscoveryMetadata()
+	{
+		using var server = BuildServer(publicResourceUrl: "https://yumney-mcp.example.com/mcp");
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync("/protected");
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+		var header = response.Headers.GetValues("WWW-Authenticate").Single();
+		header.Should().StartWith("Bearer ");
+		header.Should().Contain("realm=\"yumney\"");
+		header.Should().Contain("resource_metadata=\"https://yumney-mcp.example.com/.well-known/oauth-protected-resource\"");
+	}
+
+	[Fact]
+	public async Task AnonymousRequest_OmitsErrorParameter()
+	{
+		using var server = BuildServer(publicResourceUrl: "https://yumney-mcp.example.com/mcp");
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync("/protected");
+
+		var header = response.Headers.GetValues("WWW-Authenticate").Single();
+		header.Should().NotContain("error=");
+	}
+
+	[Fact]
+	public async Task AnonymousRequest_WithoutPublicUrlConfig_InfersDiscoveryUrlFromRequest()
+	{
+		using var server = BuildServer(publicResourceUrl: null);
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync("/protected");
+
+		var header = response.Headers.GetValues("WWW-Authenticate").Single();
+		header.Should().Contain("resource_metadata=\"http://");
+		header.Should().Contain("/.well-known/oauth-protected-resource\"");
+	}
+
+	[Fact]
+	public async Task AnonymousRequest_AdvertisesRealmFromConfiguration()
+	{
+		using var server = BuildServer(
+			publicResourceUrl: "https://yumney-mcp.example.com/mcp",
+			extraConfig: new Dictionary<string, string?> { ["Keycloak:Realm"] = "yumney-staging" });
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync("/protected");
+
+		var header = response.Headers.GetValues("WWW-Authenticate").Single();
+		header.Should().Contain("realm=\"yumney-staging\"");
+	}
+
+	[Fact]
+	public async Task RequestWithInvalidBearer_AdvertisesInvalidTokenError()
+	{
+		using var server = BuildServer(publicResourceUrl: "https://yumney-mcp.example.com/mcp");
+		using var client = server.CreateClient();
+		client.DefaultRequestHeaders.Authorization = new("Bearer", "not.a.real.jwt");
+
+		var response = await client.GetAsync("/protected");
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+		var header = response.Headers.GetValues("WWW-Authenticate").Single();
+		header.Should().Contain("error=\"invalid_token\"");
+	}
+
+	[Fact]
+	public async Task AnonymousRequest_ToUnprotectedRoute_DoesNotChallenge()
+	{
+		using var server = BuildServer(publicResourceUrl: "https://yumney-mcp.example.com/mcp");
+		using var client = server.CreateClient();
+
+		var response = await client.GetAsync("/open");
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		response.Headers.Contains("WWW-Authenticate").Should().BeFalse();
+	}
+
+	private static TestServer BuildServer(string? publicResourceUrl, IDictionary<string, string?>? extraConfig = null)
+	{
+		var config = new Dictionary<string, string?>
+		{
+			["ConnectionStrings:keycloak"] = "http://keycloak.invalid",
+		};
+		if (publicResourceUrl is not null)
+		{
+			config["McpServer:PublicUrl"] = publicResourceUrl;
+		}
+
+		if (extraConfig is not null)
+		{
+			foreach (var (key, value) in extraConfig)
+			{
+				config[key] = value;
+			}
+		}
+
+		var builder = new HostBuilder()
+			.UseEnvironment("Development")
+			.ConfigureWebHost(webHost =>
+			{
+				webHost.UseTestServer();
+				webHost.ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(config));
+				webHost.ConfigureServices((context, services) =>
+				{
+					services.AddRouting();
+					services.AddKeycloakBearerAuthentication(context.Configuration, context.HostingEnvironment);
+				});
+				webHost.Configure(app =>
+				{
+					app.UseRouting();
+					app.UseAuthentication();
+					app.UseAuthorization();
+					app.UseEndpoints(endpoints =>
+					{
+						endpoints.MapGet("/protected", () => "ok").RequireAuthorization();
+						endpoints.MapGet("/open", () => "ok").AllowAnonymous();
+					});
+				});
+			});
+
+		return builder.Start().GetTestServer();
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Auth/WwwAuthenticateChallengeTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Auth/WwwAuthenticateChallengeTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Auth;
+
+public class WwwAuthenticateChallengeTests
+{
+	[Fact]
+	public void BuildHeader_WithError_IncludesAllThreeParameters()
+	{
+		var header = WwwAuthenticateChallenge.BuildHeader(
+			realm: "yumney",
+			discoveryUrl: "https://yumney-mcp.example.com/.well-known/oauth-protected-resource",
+			error: "invalid_token");
+
+		header.Should().Be(
+			"Bearer realm=\"yumney\", " +
+			"resource_metadata=\"https://yumney-mcp.example.com/.well-known/oauth-protected-resource\", " +
+			"error=\"invalid_token\"");
+	}
+
+	[Fact]
+	public void BuildHeader_WithNullError_OmitsErrorParameter()
+	{
+		var header = WwwAuthenticateChallenge.BuildHeader(
+			realm: "yumney",
+			discoveryUrl: "https://example.com/.well-known/oauth-protected-resource",
+			error: null);
+
+		header.Should().NotContain("error=");
+		header.Should().Be("Bearer realm=\"yumney\", resource_metadata=\"https://example.com/.well-known/oauth-protected-resource\"");
+	}
+
+	[Fact]
+	public void BuildHeader_WithEmptyError_OmitsErrorParameter()
+	{
+		var header = WwwAuthenticateChallenge.BuildHeader("yumney", "https://example.com/disco", string.Empty);
+
+		header.Should().NotContain("error=");
+	}
+
+	[Fact]
+	public void ResolveDiscoveryUrl_WithConfiguredResourceUrl_ReusesOriginAndAppendsDiscoveryPath()
+	{
+		var url = WwwAuthenticateChallenge.ResolveDiscoveryUrl(
+			request: new DefaultHttpContext().Request,
+			configuredResourceUrl: "https://yumney-gateway.example.com/mcp");
+
+		url.Should().Be("https://yumney-gateway.example.com/.well-known/oauth-protected-resource");
+	}
+
+	[Fact]
+	public void ResolveDiscoveryUrl_WithConfiguredUrlIncludingPort_PreservesPort()
+	{
+		var url = WwwAuthenticateChallenge.ResolveDiscoveryUrl(
+			request: new DefaultHttpContext().Request,
+			configuredResourceUrl: "https://yumney.local:8443/mcp");
+
+		url.Should().Be("https://yumney.local:8443/.well-known/oauth-protected-resource");
+	}
+
+	[Fact]
+	public void ResolveDiscoveryUrl_WithoutOverride_BuildsFromRequest()
+	{
+		var context = new DefaultHttpContext();
+		context.Request.Scheme = "https";
+		context.Request.Host = new HostString("yumney.app");
+
+		var url = WwwAuthenticateChallenge.ResolveDiscoveryUrl(context.Request, configuredResourceUrl: null);
+
+		url.Should().Be("https://yumney.app/.well-known/oauth-protected-resource");
+	}
+
+	[Fact]
+	public void ResolveDiscoveryUrl_WithWhitespaceOverride_FallsBackToRequest()
+	{
+		var context = new DefaultHttpContext();
+		context.Request.Scheme = "http";
+		context.Request.Host = new HostString("localhost:5000");
+
+		var url = WwwAuthenticateChallenge.ResolveDiscoveryUrl(context.Request, configuredResourceUrl: "   ");
+
+		url.Should().Be("http://localhost:5000/.well-known/oauth-protected-resource");
+	}
+}


### PR DESCRIPTION
## Summary
- Hooks `JwtBearerEvents.OnChallenge` in `KeycloakAuthExtensions` to replace ASP.NET Core's default 401 header.
- New header advertises the RFC 9728 discovery URL: `Bearer realm=\"yumney\", resource_metadata=\"https://.../.well-known/oauth-protected-resource\"` (+ `error=\"invalid_token\"` when a bearer was sent and failed validation).
- Discovery URL is composed from `McpServer:PublicUrl` (preserves the public origin behind the gateway) or inferred from the inbound request when the override is absent.
- Anonymous requests omit the `error` parameter per RFC 6750 §3.

## Why
Second ticket of the MCP epic (#716). MCP clients that haven't pre-cached the discovery doc hit `/mcp` once with no auth, then bootstrap from the `WWW-Authenticate` header in the 401 — without it they can't recover from an expired token without manual reconfiguration.

## Test plan
- [x] 7 unit tests covering `BuildHeader` (with/without error, whitespace handling) and `ResolveDiscoveryUrl` (override, override+port, request fallback, whitespace override)
- [x] 6 HTTP-level tests: anonymous-to-protected, no-error-on-anonymous, request-fallback discovery URL, realm from config, unprotected route untouched, invalid-bearer triggers `error=\"invalid_token\"`
- [x] Full `Yumney.Mcp.Server.Tests` suite passes (54/54)
- [x] Strict build clean (`-p:TreatWarningsAsErrors=true`), `dotnet format --verify-no-changes` clean

Closes #718