### PR TITLE
feat(api): emit MCP tool annotations from CapabilityManifest (US-719)

### DIFF
--- a/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
+++ b/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
@@ -63,5 +63,6 @@ public static class CapabilityToolRegistration
 	{
 		Name = capability.Name,
 		Description = $"{capability.Description} (proxies {capability.HttpMethod} {capability.RoutePattern})",
+		Annotations = ToolAnnotationsBuilder.FromHttpMethod(capability.HttpMethod),
 	};
 }

--- a/src/Yumney.Mcp.Server/Mcp/ToolAnnotationsBuilder.cs
+++ b/src/Yumney.Mcp.Server/Mcp/ToolAnnotationsBuilder.cs
@@ -1,0 +1,36 @@
+using ModelContextProtocol.Protocol;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+
+/// <summary>
+/// Derives MCP <see cref="ToolAnnotations"/> from the HTTP method the
+/// capability proxies. The hints let MCP clients (Claude Desktop, custom
+/// GPTs) skip confirmation for read-only tools, always confirm destructive
+/// ones, and cache results from idempotent calls.
+/// </summary>
+public static class ToolAnnotationsBuilder
+{
+	/// <summary>
+	/// Maps an HTTP method to its annotation profile. <c>OpenWorldHint</c> is
+	/// always false because Yumney tools only touch our own modules — from
+	/// the LLM's perspective there's no external-world reach.
+	/// </summary>
+	/// <remarks>
+	/// HTTP semantics drive the mapping: GET is read-only; DELETE is
+	/// destructive; GET / PUT / DELETE are idempotent per RFC 9110. POST and
+	/// PATCH get the conservative default (all hints false).
+	/// </remarks>
+	/// <param name="httpMethod">HTTP verb (GET, POST, …) — case insensitive.</param>
+	/// <returns>Populated annotations.</returns>
+	public static ToolAnnotations FromHttpMethod(string httpMethod)
+	{
+		var normalized = httpMethod.ToUpperInvariant();
+		return new ToolAnnotations
+		{
+			ReadOnlyHint = normalized == "GET",
+			DestructiveHint = normalized == "DELETE",
+			IdempotentHint = normalized is "GET" or "PUT" or "DELETE",
+			OpenWorldHint = false,
+		};
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
@@ -89,6 +89,37 @@ public class CapabilityToolRegistrationTests
 	}
 
 	[Fact]
+	public void BuildTools_PopulatesAnnotationsBasedOnHttpMethod()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+			new CapabilityDescriptor("get_recipe", "fetch a recipe", CapabilitySurface.Mcp, "GET", "/recipes/{id}"),
+			new CapabilityDescriptor("delete_recipe", "remove a recipe", CapabilitySurface.Mcp, "DELETE", "/recipes/{id}"),
+			new CapabilityDescriptor("save_recipe", "import a recipe", CapabilitySurface.Mcp, "POST", "/recipes/"),
+		]));
+
+		var tools = CapabilityToolRegistration.BuildTools(registry);
+
+		var getTool = tools.Single(tool => tool.Name == "get_recipe");
+		getTool.Annotations!.ReadOnlyHint.Should().BeTrue();
+		getTool.Annotations.IdempotentHint.Should().BeTrue();
+		getTool.Annotations.DestructiveHint.Should().BeFalse();
+		getTool.Annotations.OpenWorldHint.Should().BeFalse();
+
+		var deleteTool = tools.Single(tool => tool.Name == "delete_recipe");
+		deleteTool.Annotations!.DestructiveHint.Should().BeTrue();
+		deleteTool.Annotations.IdempotentHint.Should().BeTrue();
+		deleteTool.Annotations.ReadOnlyHint.Should().BeFalse();
+
+		var postTool = tools.Single(tool => tool.Name == "save_recipe");
+		postTool.Annotations!.ReadOnlyHint.Should().BeFalse();
+		postTool.Annotations.IdempotentHint.Should().BeFalse();
+		postTool.Annotations.DestructiveHint.Should().BeFalse();
+	}
+
+	[Fact]
 	public void BuildTools_UnionsAcrossManifestsFromMultipleServices()
 	{
 		var registry = new AggregatedCapabilityRegistry();

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/ToolAnnotationsBuilderTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/ToolAnnotationsBuilderTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Mcp;
+
+public class ToolAnnotationsBuilderTests
+{
+	[Theory]
+	[InlineData("GET")]
+	[InlineData("get")]
+	[InlineData("Get")]
+	public void FromHttpMethod_Get_IsReadOnlyAndIdempotent(string method)
+	{
+		var annotations = ToolAnnotationsBuilder.FromHttpMethod(method);
+
+		annotations.ReadOnlyHint.Should().BeTrue();
+		annotations.IdempotentHint.Should().BeTrue();
+		annotations.DestructiveHint.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("DELETE")]
+	[InlineData("delete")]
+	public void FromHttpMethod_Delete_IsDestructiveAndIdempotentButNotReadOnly(string method)
+	{
+		var annotations = ToolAnnotationsBuilder.FromHttpMethod(method);
+
+		annotations.DestructiveHint.Should().BeTrue();
+		annotations.IdempotentHint.Should().BeTrue();
+		annotations.ReadOnlyHint.Should().BeFalse();
+	}
+
+	[Fact]
+	public void FromHttpMethod_Put_IsIdempotentButNotReadOnlyOrDestructive()
+	{
+		var annotations = ToolAnnotationsBuilder.FromHttpMethod("PUT");
+
+		annotations.IdempotentHint.Should().BeTrue();
+		annotations.ReadOnlyHint.Should().BeFalse();
+		annotations.DestructiveHint.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("POST")]
+	[InlineData("PATCH")]
+	public void FromHttpMethod_PostOrPatch_HasNoHintsOtherThanOpenWorld(string method)
+	{
+		var annotations = ToolAnnotationsBuilder.FromHttpMethod(method);
+
+		annotations.ReadOnlyHint.Should().BeFalse();
+		annotations.IdempotentHint.Should().BeFalse();
+		annotations.DestructiveHint.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("GET")]
+	[InlineData("POST")]
+	[InlineData("PUT")]
+	[InlineData("DELETE")]
+	[InlineData("PATCH")]
+	public void FromHttpMethod_OpenWorldHint_IsAlwaysFalse(string method)
+	{
+		var annotations = ToolAnnotationsBuilder.FromHttpMethod(method);
+
+		annotations.OpenWorldHint.Should().BeFalse();
+	}
+}


### PR DESCRIPTION
## Summary
- New `ToolAnnotationsBuilder.FromHttpMethod(...)` maps an HTTP verb to MCP 2025-06-18 `ToolAnnotations`.
- `CapabilityToolRegistration.ToTool` now populates `Annotations` on every emitted `Tool`.
- Hint semantics follow RFC 9110:
  - `ReadOnlyHint` — true for GET
  - `DestructiveHint` — true for DELETE
  - `IdempotentHint` — true for GET / PUT / DELETE
  - `OpenWorldHint` — always false (Yumney tools touch only our own modules)

## Why
Phase 2 of the MCP epic (#716). Claude Desktop (post-MCP-auth-spec) uses these hints to skip confirmation for read-only calls and always confirm destructive ones — a meaningful UX improvement that costs us nothing because the data already exists on `CapabilityDescriptor`.

## Test plan
- [x] `ToolAnnotationsBuilderTests` — 5 theory groups (GET / DELETE / PUT / POST+PATCH / OpenWorld-always-false), 14 cases incl. case-insensitivity
- [x] `CapabilityToolRegistrationTests.BuildTools_PopulatesAnnotationsBasedOnHttpMethod` — end-to-end check that the annotations land on the emitted `Tool` for GET / DELETE / POST
- [x] Full `Yumney.Mcp.Server.Tests` suite passes (68/68)
- [x] Strict build clean, `dotnet format --verify-no-changes` clean

## Out of scope
- Optional `Title` annotation: `CapabilityDescriptor` has no separate human-readable name field; MCP clients fall back to `Name` per the spec. Adding `DisplayName` is a follow-up if we want richer client UX.

Closes #719