### PR TITLE
chore(api): curate MCP tool descriptions + guard non-empty descriptions (US-720)

### DIFF
--- a/src/Yumney.MealPlan.Api/MealPlanAnalyticsEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanAnalyticsEndpoints.cs
@@ -19,7 +19,7 @@ public static class MealPlanAnalyticsEndpoints
 			.WithTags("MealPlan")
 			.WithCapability(
 				name: "get_meal_analytics",
-				description: "Cooking analytics for a calendar period. Pass year only for the whole year, or year + month (1-12) for a single month. Returns totals, top recipes, frequency, discovery rate, and category distribution.",
+				description: "Cooking analytics for a calendar period — pass year only for the whole year, or year + month (1-12) for a single month. Returns totals, top recipes, frequency, discovery rate, and category distribution. Use for 'how many recipes did I cook in 2025?' / 'top recipes last month' / 'was hab ich im März gekocht?'.",
 				surfaces: CapabilitySurface.Mcp)
 			.Produces<MealAnalyticsDto>();
 

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -138,7 +138,7 @@ public static partial class RecipesEndpoints
 			.WithValidation<Requests.ImportRecipe>()
 			.WithCapability(
 				name: "import_recipe_from_url",
-				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the parsed recipe (title, ingredients, steps).",
+				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the parsed recipe (title, ingredients, steps). Use for 'save this recipe' / 'add this to my collection' / 'speicher das Rezept'.",
 				surfaces: CapabilitySurface.Mcp | CapabilitySurface.Voice)
 			.Produces<ExtractedRecipeDto>()
 			.ProducesValidationProblem()

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.cs
@@ -35,7 +35,7 @@ public static partial class RecipesEndpoints
 			.WithTags("Recipes")
 			.WithCapability(
 				name: "search_recipes",
-				description: "Search the user's recipe collection by free text query and optional filters (tags, difficulty, max prep/cook time, favorites). Returns paged recipe summaries.",
+				description: "Search the user's recipe collection by free text query and optional filters (tags, difficulty, max prep/cook time, favorites). Returns paged recipe summaries. Use for 'find pasta recipes' / 'easy 30-minute dinners' / 'zeig mir vegetarische Rezepte'.",
 				surfaces: CapabilitySurface.All)
 			.Produces<PagedResult<RecipeListItemDto>>();
 
@@ -68,7 +68,7 @@ public static partial class RecipesEndpoints
 			.WithTags("Recipes")
 			.WithCapability(
 				name: "get_recipe",
-				description: "Fetch full details (ingredients, steps, timings, servings) of one recipe by its identifier.",
+				description: "Fetch full details (ingredients, steps, timings, servings) of one recipe by its identifier. Use for 'show me the carbonara recipe' / 'what's in the risotto?' (call search_recipes first to get the identifier).",
 				surfaces: CapabilitySurface.All)
 			.Produces<RecipeDetailDto>()
 			.ProducesProblem(StatusCodes.Status404NotFound);

--- a/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
+++ b/tests/Yumney.Architecture.Tests/CapabilityTaggingTests.cs
@@ -49,8 +49,29 @@ public partial class CapabilityTaggingTests
 			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation.Name} at {violation.Location}")));
 	}
 
+	[Fact]
+	public void EveryWithCapabilityCall_HasNonEmptyDescription()
+	{
+		var srcRoot = SolutionRoot.Src;
+		var pattern = WithCapabilityFullPattern();
+
+		var violations = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+			.Where(IsTrackedSourceFile)
+			.SelectMany(path => FullMatchesIn(path, pattern))
+			.Where(match => string.IsNullOrWhiteSpace(match.Description))
+			.ToList();
+
+		violations.Should().BeEmpty(
+			"Every WithCapability call must carry a non-empty description — the description is what the LLM reads to decide whether to call the tool. Offenders:{0}{1}",
+			Environment.NewLine,
+			string.Join(Environment.NewLine, violations.Select(violation => $"  {violation.Name} at {violation.Location}")));
+	}
+
 	[GeneratedRegex(@"WithCapability\s*\(\s*name:\s*""(?<name>[^""]+)""", RegexOptions.Singleline)]
 	private static partial Regex WithCapabilityNamePattern();
+
+	[GeneratedRegex(@"WithCapability\s*\(\s*name:\s*""(?<name>[^""]+)""\s*,\s*description:\s*""(?<description>[^""]*)""", RegexOptions.Singleline)]
+	private static partial Regex WithCapabilityFullPattern();
 
 	[GeneratedRegex(@"^[a-z][a-z0-9_]*$")]
 	private static partial Regex SnakeCasePattern();
@@ -65,6 +86,19 @@ public partial class CapabilityTaggingTests
 		}
 	}
 
+	private static IEnumerable<CapabilityFullMatch> FullMatchesIn(string path, Regex pattern)
+	{
+		var content = File.ReadAllText(path);
+		var matches = pattern.Matches(content);
+		foreach (Match match in matches)
+		{
+			yield return new CapabilityFullMatch(
+				match.Groups["name"].Value,
+				match.Groups["description"].Value,
+				Path.GetRelativePath(SolutionRoot.Path, path));
+		}
+	}
+
 	private static bool IsTrackedSourceFile(string path)
 	{
 		var normalized = path.Replace('\\', '/');
@@ -73,4 +107,6 @@ public partial class CapabilityTaggingTests
 	}
 
 	private sealed record CapabilityMatch(string Name, string Location);
+
+	private sealed record CapabilityFullMatch(string Name, string Description, string Location);
 }


### PR DESCRIPTION
## Summary

Audit of every `WithCapability(...)` call across the 4 API hosts (11 capabilities total) per the US-720 acceptance criteria:

| ✓ | Capability | Surface | Notes |
|---|------------|---------|-------|
| ✓ | get_meal_analytics | Mcp | description beefed up with example phrasings |
| ✓ | suggest_week_plan | Mcp | already had example phrasings |
| ✓ | get_weekly_plan | All | already had example phrasings |
| ✓ | assign_meal | Chat\|Mcp | already had example phrasings |
| ✓ | confirm_meal_cooked | Chat\|Mcp | already had example phrasings |
| ✓ | import_recipe_from_url | Mcp\|Voice | description beefed up |
| ✓ | search_recipes | All | description beefed up |
| ✓ | get_recipe | All | description beefed up, references search_recipes for the identifier |
| ✓ | get_cookable_recipes | All | already good |
| ✓ | create_shopping_list_from_recipes | Chat\|Mcp | already good |
| ✓ | get_merged_shopping_list | All | already good |

**No internal-only endpoints** (dashboard reset, MigrationRunner) carry `WithCapability` — already filtered out by omission.

**Names** — all snake_case verb-first (`get_*`, `assign_*`, `create_*`, `confirm_*`); enforced by existing `EveryWithCapabilityCall_UsesSnakeCaseName`.

**New architecture test** `EveryWithCapabilityCall_HasNonEmptyDescription` guards future additions so an MCP-exposed tool can't ship with no LLM-facing description.

## Out of scope
- Input JSON schema tightening: the MCP SDK derives schemas from endpoint parameter types automatically; explicit `InputSchema` overrides aren't wired through `WithCapability` yet — separate ticket.
- Title hint on `ToolAnnotations`: `CapabilityDescriptor` has no separate human-readable field (covered in #719's out-of-scope note).

## Test plan
- [x] `EveryWithCapabilityCall_HasNonEmptyDescription` passes against all 11 current capabilities
- [x] `EveryWithCapabilityCall_HasUniqueName` and `EveryWithCapabilityCall_UsesSnakeCaseName` still pass (3/3 in CapabilityTaggingTests)
- [x] Strict build clean (`-p:TreatWarningsAsErrors=true`), `dotnet format --verify-no-changes` clean

Closes #720