### PR TITLE
feat(mcp): per-tool-call telemetry (counter, histogram, trace span) (US-724)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,7 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci', 'auth', 'e2e', 'frontend', 'test', 'domain', 'application', 'mealplan'],
+      ['recipes', 'shopping', 'users', 'account', 'shared', 'api', 'shell', 'infra', 'ui', 'scaffold', 'ci', 'auth', 'e2e', 'frontend', 'test', 'domain', 'application', 'mealplan', 'mcp'],
     ],
     'header-max-length': [2, 'always', 120],
     'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],

--- a/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
+++ b/src/Yumney.Mcp.Server/Mcp/RestProxyService.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Protocol;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.Telemetry;
 
 namespace SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
 
@@ -28,20 +30,39 @@ public sealed partial class RestProxyService(
 	/// <returns>Upstream response as a tool result, or an error result on failure.</returns>
 	public async Task<CallToolResult> InvokeAsync(string toolName, IDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
 	{
+		using var activity = McpToolTelemetry.ActivitySource.StartActivity($"mcp.tool/{toolName}", ActivityKind.Client);
+		activity?.SetTag("mcp.tool.name", toolName);
+		var stopwatch = Stopwatch.StartNew();
+
 		var descriptor = registry.DescriptorForTool(toolName);
-		if (descriptor is null) return Error($"Unknown tool '{toolName}'.");
+		if (descriptor is null)
+		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.UnknownTool, stopwatch.Elapsed.TotalMilliseconds);
+			return Error($"Unknown tool '{toolName}'.");
+		}
 
 		var serviceName = registry.ServiceNameForTool(toolName);
-		if (serviceName is null) return Error($"Tool '{toolName}' is not bound to a discovered service.");
+		if (serviceName is null)
+		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.UnknownTool, stopwatch.Elapsed.TotalMilliseconds);
+			return Error($"Tool '{toolName}' is not bound to a discovered service.");
+		}
+
+		activity?.SetTag("mcp.tool.service", serviceName);
 
 		var built = RouteUrlBuilder.Build(descriptor.HttpMethod, descriptor.RoutePattern, arguments);
 		if (built.MissingPlaceholders.Count > 0)
 		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.MissingArguments, stopwatch.Elapsed.TotalMilliseconds);
 			return Error($"Tool '{toolName}' is missing required argument(s): {string.Join(", ", built.MissingPlaceholders)}.");
 		}
 
 		var bearer = ExtractBearer();
-		if (bearer is null) return Error("No bearer token forwarded with the MCP request — caller must authenticate.");
+		if (bearer is null)
+		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.Unauthenticated, stopwatch.Elapsed.TotalMilliseconds);
+			return Error("No bearer token forwarded with the MCP request — caller must authenticate.");
+		}
 
 		var client = httpClientFactory.CreateClient(serviceName);
 		using var request = new HttpRequestMessage(new HttpMethod(descriptor.HttpMethod), built.Url);
@@ -55,6 +76,10 @@ public sealed partial class RestProxyService(
 		{
 			using var response = await client.SendAsync(request, cancellationToken);
 			var body = await response.Content.ReadAsStringAsync(cancellationToken);
+			activity?.SetTag("http.response.status_code", (int)response.StatusCode);
+			var outcome = McpToolTelemetry.OutcomeFromHttpStatus((int)response.StatusCode);
+			McpToolTelemetry.Record(toolName, outcome, stopwatch.Elapsed.TotalMilliseconds);
+
 			if (!response.IsSuccessStatusCode)
 			{
 				LogUpstreamFailure(toolName, serviceName, (int)response.StatusCode);
@@ -67,8 +92,14 @@ public sealed partial class RestProxyService(
 				IsError = false,
 			};
 		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.Timeout, stopwatch.Elapsed.TotalMilliseconds);
+			throw;
+		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
+			McpToolTelemetry.Record(toolName, McpToolTelemetry.Outcomes.ProxyError, stopwatch.Elapsed.TotalMilliseconds);
 			LogProxyException(toolName, serviceName, ex.Message);
 			return Error($"Proxy call to {serviceName} failed: {ex.Message}");
 		}

--- a/src/Yumney.Mcp.Server/Telemetry/McpToolTelemetry.cs
+++ b/src/Yumney.Mcp.Server/Telemetry/McpToolTelemetry.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Telemetry;
+
+/// <summary>
+/// OpenTelemetry meter + activity source for MCP tool invocations.
+/// Two signals power the Phase-3 dashboards:
+/// <c>mcp.tool.invocations</c> (counter tagged with tool name + outcome) and
+/// <c>mcp.tool.duration</c> (histogram tagged with tool name).
+/// Each tool call also gets a span named <c>mcp.tool/{toolName}</c> so the
+/// trace links the inbound MCP request to the upstream module HTTP call
+/// (W3C traceparent is forwarded by the HttpClient handler chain).
+/// </summary>
+public static class McpToolTelemetry
+{
+	/// <summary>Meter name registered with OpenTelemetry exporters.</summary>
+	public const string MeterName = "Yumney.Mcp.Server.Tools";
+
+	/// <summary>Activity source name registered with OpenTelemetry exporters.</summary>
+	public const string ActivitySourceName = "Yumney.Mcp.Server.Tools";
+
+	/// <summary>ActivitySource exposed so the proxy can <c>StartActivity</c> per call.</summary>
+	public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+#pragma warning disable SA1303, SA1311
+	private static readonly Meter meter = new(MeterName);
+	private static readonly Counter<long> invocations = meter.CreateCounter<long>(
+		name: "mcp.tool.invocations",
+		unit: "{invocation}",
+		description: "MCP tool invocations, tagged with tool name and outcome.");
+
+	private static readonly Histogram<double> duration = meter.CreateHistogram<double>(
+		name: "mcp.tool.duration",
+		unit: "ms",
+		description: "Wall-clock duration of an MCP tool invocation, tagged with tool name.");
+#pragma warning restore SA1303, SA1311
+
+	/// <summary>Outcome tag values — keep the set small so the cardinality stays useful for alerting.</summary>
+	public static class Outcomes
+	{
+		public const string Success = "success";
+		public const string ClientError = "client_error";
+		public const string ServerError = "server_error";
+		public const string Timeout = "timeout";
+		public const string UnknownTool = "unknown_tool";
+		public const string MissingArguments = "missing_arguments";
+		public const string Unauthenticated = "unauthenticated";
+		public const string ProxyError = "proxy_error";
+	}
+
+	/// <summary>Records the outcome + elapsed time for one invocation.</summary>
+	/// <param name="toolName">Capability name (matches the MCP tool identifier).</param>
+	/// <param name="outcome">One of <see cref="Outcomes"/>.</param>
+	/// <param name="elapsedMilliseconds">Total wall-clock time for the invocation.</param>
+	public static void Record(string toolName, string outcome, double elapsedMilliseconds)
+	{
+		invocations.Add(1, new KeyValuePair<string, object?>("tool", toolName), new KeyValuePair<string, object?>("outcome", outcome));
+		duration.Record(elapsedMilliseconds, new KeyValuePair<string, object?>("tool", toolName));
+	}
+
+	/// <summary>Maps an upstream HTTP status code to one of the metric outcome values.</summary>
+	/// <param name="statusCode">HTTP status code from the upstream module response.</param>
+	/// <returns>Outcome string for the metrics tag.</returns>
+	public static string OutcomeFromHttpStatus(int statusCode) => statusCode switch
+	{
+		>= 200 and < 300 => Outcomes.Success,
+		>= 400 and < 500 => Outcomes.ClientError,
+		_ => Outcomes.ServerError,
+	};
+}

--- a/tests/Yumney.Mcp.Server.Tests/Telemetry/McpToolTelemetryTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Telemetry/McpToolTelemetryTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Telemetry;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.Telemetry;
+
+public class McpToolTelemetryTests
+{
+	[Theory]
+	[InlineData(200)]
+	[InlineData(201)]
+	[InlineData(204)]
+	[InlineData(299)]
+	public void OutcomeFromHttpStatus_2xx_IsSuccess(int statusCode)
+	{
+		McpToolTelemetry.OutcomeFromHttpStatus(statusCode).Should().Be(McpToolTelemetry.Outcomes.Success);
+	}
+
+	[Theory]
+	[InlineData(400)]
+	[InlineData(401)]
+	[InlineData(404)]
+	[InlineData(429)]
+	[InlineData(499)]
+	public void OutcomeFromHttpStatus_4xx_IsClientError(int statusCode)
+	{
+		McpToolTelemetry.OutcomeFromHttpStatus(statusCode).Should().Be(McpToolTelemetry.Outcomes.ClientError);
+	}
+
+	[Theory]
+	[InlineData(500)]
+	[InlineData(502)]
+	[InlineData(503)]
+	[InlineData(504)]
+	[InlineData(599)]
+	public void OutcomeFromHttpStatus_5xx_IsServerError(int statusCode)
+	{
+		McpToolTelemetry.OutcomeFromHttpStatus(statusCode).Should().Be(McpToolTelemetry.Outcomes.ServerError);
+	}
+
+	[Theory]
+	[InlineData(100)]
+	[InlineData(199)]
+	[InlineData(300)]
+	[InlineData(399)]
+	public void OutcomeFromHttpStatus_Non4xx5xxNon2xx_FallsThroughToServerError(int statusCode)
+	{
+		// Anything outside 2xx/4xx is bucketed as server_error — non-2xx redirects
+		// shouldn't reach this code path (HttpClient follows them by default), but
+		// if one does, surfacing it as server_error is louder than success.
+		McpToolTelemetry.OutcomeFromHttpStatus(statusCode).Should().Be(McpToolTelemetry.Outcomes.ServerError);
+	}
+
+	[Fact]
+	public void MeterName_MatchesYumneyWildcard()
+	{
+		// ServiceDefaults registers `AddMeter("Yumney.*")` — our meter MUST live
+		// under that namespace or it's silently dropped from the exporter.
+		McpToolTelemetry.MeterName.Should().StartWith("Yumney.");
+	}
+
+	[Fact]
+	public void ActivitySourceName_MatchesYumneyWildcard()
+	{
+		McpToolTelemetry.ActivitySourceName.Should().StartWith("Yumney.");
+	}
+
+	[Fact]
+	public void Outcomes_AreLowercaseSnakeCase()
+	{
+		// Tag values are lowered to keep cardinality math simple in PromQL /
+		// App Insights KQL — Outcome enum values like "ClientError" would
+		// shadow casing-only dupes.
+		string[] all =
+		[
+			McpToolTelemetry.Outcomes.Success,
+			McpToolTelemetry.Outcomes.ClientError,
+			McpToolTelemetry.Outcomes.ServerError,
+			McpToolTelemetry.Outcomes.Timeout,
+			McpToolTelemetry.Outcomes.UnknownTool,
+			McpToolTelemetry.Outcomes.MissingArguments,
+			McpToolTelemetry.Outcomes.Unauthenticated,
+			McpToolTelemetry.Outcomes.ProxyError,
+		];
+
+		all.Should().OnlyContain(outcome => string.Equals(outcome, outcome.ToLowerInvariant(), StringComparison.Ordinal));
+	}
+}


### PR DESCRIPTION
## Summary

Instruments `RestProxyService.InvokeAsync` with the OTel signals the Phase-3 dashboards need:

| Signal | Type | Tags |
|---|---|---|
| `mcp.tool.invocations` | Counter | `tool`, `outcome` |
| `mcp.tool.duration` | Histogram (ms) | `tool` |
| `mcp.tool/{name}` | Activity span (Client) | `mcp.tool.name`, `mcp.tool.service`, `http.response.status_code` |

**Outcomes** kept to a small fixed set so the cardinality stays useful for alerting:
`success`, `client_error`, `server_error`, `timeout`, `unknown_tool`, `missing_arguments`, `unauthenticated`, `proxy_error`.

**Tracing** — the span is created with `ActivityKind.Client`, before the upstream `HttpClient.SendAsync`. The HTTP handler chain (OTel instrumentation already wired in `ServiceDefaults`) injects the W3C `traceparent` header, so the upstream module's request appears as a child span of the MCP call in the trace tree.

**Wildcard registration** — `Yumney.Mcp.Server.Tools` matches `ServiceDefaults`' `AddMeter("Yumney.*")` and `AddSource("Yumney.*")` patterns, so the new signals flow to whichever exporter the host is configured against (App Insights in publish mode, console / Aspire dashboard in run mode) without any extra wiring.

## Files

- `src/Yumney.Mcp.Server/Telemetry/McpToolTelemetry.cs` — new
- `src/Yumney.Mcp.Server/Mcp/RestProxyService.cs` — instrumented (every early-return + success/error path records an outcome)
- `tests/Yumney.Mcp.Server.Tests/Telemetry/McpToolTelemetryTests.cs` — 21 unit cases

## Test plan
- [x] 21 unit tests cover `OutcomeFromHttpStatus` (2xx/4xx/5xx/edge), meter & source naming against the Yumney wildcard, outcome casing
- [x] Existing 6 `RestProxyServiceTests` still pass — instrumentation is non-invasive
- [x] Strict build clean, format clean

## Out of scope (per the ticket)
- Dashboard JSON (App Insights / Grafana) — infra config, separate change
- The p95 > 5 s for 5+ min alert rule — same; lives in the alerts repo
- LLM-cost telemetry — explicitly out of scope; that's a chat-side dashboard

Closes #724