### PR TITLE
feat(mcp): expose OpenAPI 3.1 spec for ChatGPT Custom GPT Action (US-726)

### DIFF
--- a/docs/mcp/chatgpt-setup.md
+++ b/docs/mcp/chatgpt-setup.md
@@ -1,0 +1,59 @@
+# Connecting Yumney to ChatGPT
+
+ChatGPT offers two integration paths today:
+
+| Path | Spec | Status |
+|---|---|---|
+| GPT Action (OpenAPI) | OpenAPI 3.1 spec + OAuth2 | Generally available |
+| Native MCP | Same `.well-known` discovery as Claude | Rolling out |
+
+Path A (GPT Action) reaches the much larger ChatGPT user base today; Path B piggybacks on Phase 1 work and is essentially free once it ships broadly.
+
+## Path A — Custom GPT with an OpenAPI Action
+
+1. Go to https://chatgpt.com/gpts/editor and click **Create**.
+2. On the **Configure** tab fill in:
+   - **Name:** Yumney
+   - **Description:** Recipe import, meal planning, shopping list management.
+   - **Instructions:** _"You help the user manage their recipe collection, plan meals for the week, and assemble shopping lists. Always confirm before deleting recipes or finalising a meal plan."_
+   - **Conversation starters:** see the sample prompts in [claude-setup.md](claude-setup.md).
+3. Scroll to **Actions** → **Create new action**.
+4. **Authentication:** OAuth.
+   - **Client ID:** `yumney-chatgpt` (or `yumney-web` if you don't want to provision a dedicated client)
+   - **Client Secret:** the one from Keycloak → Clients → yumney-chatgpt → Credentials
+   - **Authorization URL:** `https://yumney-keycloak.<env>.azurecontainerapps.io/realms/yumney/protocol/openid-connect/auth`
+   - **Token URL:** `https://yumney-keycloak.<env>.azurecontainerapps.io/realms/yumney/protocol/openid-connect/token`
+   - **Scope:** `openid profile yumney-api`
+   - **Token Exchange Method:** Default (POST request)
+5. **Schema:** click **Import from URL** and paste:
+   `https://yumney-gateway.<env>.azurecontainerapps.io/openapi/v1.json`
+   This URL is served by `Yumney.Mcp.Server` and returns an OpenAPI 3.1 spec covering exactly the MCP-surface capabilities (filtered from the per-module manifests; same set `RestProxyService` invokes).
+6. The OpenAI builder displays the parsed operations and a callback URL like `https://chat.openai.com/aip/<action-id>/oauth/callback`. Copy that callback URL and add it to the Keycloak client's **Valid redirect URIs** list.
+7. Save the GPT. On first call, ChatGPT triggers the OAuth dance; sign in with your Yumney credentials, click **Allow** on the consent screen, and the action is live.
+
+### Sample first call
+
+In a new chat with the GPT, ask: _"What's on my Yumney shopping list?"_ — the GPT calls `get_merged_shopping_list` and returns the parsed list.
+
+## Path B — Native MCP (when it lands more broadly)
+
+Same flow as [Claude.ai](claude-setup.md#path-a--claudeai-webproteam): paste the `/mcp` URL, let ChatGPT discover via `/.well-known/oauth-protected-resource`, complete the OAuth handshake. We don't have a UI walkthrough for this path yet because OpenAI's native-MCP UI is still in flux.
+
+## OpenAPI schema limits
+
+The spec served at `/openapi/v1.json` is a minimal-but-valid OpenAPI 3.1 document:
+
+- Operations cover every MCP-surface capability discovered by the MCP server.
+- Path parameters are extracted from the route templates (`{identifier:guid}` → `{identifier}`, `{year:int}` → `{year}`).
+- Request bodies on POST/PUT/PATCH are `application/json` with `additionalProperties: true` — ChatGPT will pass through whatever fields the LLM thinks the tool expects. The tool description text is the authoritative source for field shapes.
+- OAuth2 security points at the configured Keycloak realm.
+
+What's missing (planned follow-up): per-operation request/response **schemas**. Today they're not aggregated from the per-module OpenAPI specs; the model relies on description text. For tools with non-obvious payloads (`save_recipe`, `create_shopping_list_from_recipes`), expect the model to occasionally guess the field names. When that happens, paste the curl example into the GPT's instructions as a hint.
+
+## Submitting to the GPT Store
+
+Once the GPT works end-to-end against staging, repeat the setup against production and submit it via **Share** → **Publish to the GPT Store**. OpenAI reviews can take a few days; in the meantime use the private share link to onboard early users.
+
+## Troubleshooting
+
+Same as the Claude doc — token expiry symptoms, 401/403 causes, 429 rate-limit body, where to find logs. See [claude-setup.md → Troubleshooting](claude-setup.md#troubleshooting).

--- a/src/Yumney.Mcp.Server/OpenApi/OpenApiCapabilityBuilder.cs
+++ b/src/Yumney.Mcp.Server/OpenApi/OpenApiCapabilityBuilder.cs
@@ -1,0 +1,151 @@
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.OpenApi;
+
+/// <summary>
+/// Builds an OpenAPI 3.1 spec covering the MCP-exposed capability surface —
+/// the same operations <c>RestProxyService</c> can invoke. ChatGPT Custom GPT
+/// Actions ingest this URL; the resulting GPT calls Yumney through the same
+/// gateway + OAuth path as Claude.ai's MCP custom connector.
+/// </summary>
+/// <remarks>
+/// First cut emits a minimal-but-valid spec: paths, methods, path parameters
+/// extracted from route templates, OAuth2 security pointing at Keycloak, and
+/// permissive request bodies on non-GET operations. Schema enrichment per
+/// operation (request/response shapes) is a follow-up; this gives ChatGPT
+/// enough surface to make calls, with the LLM relying on the description
+/// text for argument shapes.
+/// </remarks>
+public static partial class OpenApiCapabilityBuilder
+{
+	/// <summary>Build the spec document for the discovered MCP-surface capabilities.</summary>
+	/// <param name="registry">Registry populated by <see cref="CapabilityDiscoveryService"/>.</param>
+	/// <param name="serverUrl">Public URL of the Yumney gateway (e.g. <c>https://yumney-gateway.example.com</c>).</param>
+	/// <param name="authorizationUrl">Keycloak authorization endpoint.</param>
+	/// <param name="tokenUrl">Keycloak token endpoint.</param>
+	/// <returns>OpenAPI 3.1 document as a JSON node tree.</returns>
+	public static JsonObject Build(AggregatedCapabilityRegistry registry, string serverUrl, string authorizationUrl, string tokenUrl)
+	{
+		var paths = new JsonObject();
+		foreach (var capability in registry.AllCapabilities().Where(capability => capability.Surfaces.HasFlag(CapabilitySurface.Mcp)))
+		{
+			AddOperation(paths, capability);
+		}
+
+		return new JsonObject
+		{
+			["openapi"] = "3.1.0",
+			["info"] = new JsonObject
+			{
+				["title"] = "Yumney MCP Capability Surface",
+				["description"] = "OpenAPI mirror of the MCP-exposed tools — usable as a ChatGPT Custom GPT Action.",
+				["version"] = "1.0.0",
+			},
+			["servers"] = new JsonArray { new JsonObject { ["url"] = serverUrl } },
+			["paths"] = paths,
+			["components"] = new JsonObject
+			{
+				["securitySchemes"] = new JsonObject
+				{
+					["keycloak"] = new JsonObject
+					{
+						["type"] = "oauth2",
+						["flows"] = new JsonObject
+						{
+							["authorizationCode"] = new JsonObject
+							{
+								["authorizationUrl"] = authorizationUrl,
+								["tokenUrl"] = tokenUrl,
+								["scopes"] = new JsonObject
+								{
+									["openid"] = "OpenID Connect",
+									["profile"] = "User profile",
+									["yumney-api"] = "Yumney API access",
+								},
+							},
+						},
+					},
+				},
+			},
+			["security"] = new JsonArray
+			{
+				new JsonObject { ["keycloak"] = new JsonArray { "openid", "profile", "yumney-api" } },
+			},
+		};
+	}
+
+	private static void AddOperation(JsonObject paths, CapabilityDescriptor capability)
+	{
+		var openApiPath = NormalisePath(capability.RoutePattern);
+		var pathItem = paths[openApiPath] as JsonObject ?? new JsonObject();
+		paths[openApiPath] = pathItem;
+
+		var operation = new JsonObject
+		{
+			["operationId"] = capability.Name,
+			["summary"] = capability.Name,
+			["description"] = capability.Description,
+			["parameters"] = BuildPathParameters(capability.RoutePattern),
+			["responses"] = new JsonObject
+			{
+				["200"] = new JsonObject { ["description"] = "Successful response." },
+				["401"] = new JsonObject { ["description"] = "Bearer token missing or invalid." },
+				["403"] = new JsonObject { ["description"] = "Bearer token lacks the yumney-api scope." },
+			},
+		};
+
+		if (RequiresBody(capability.HttpMethod))
+		{
+			operation["requestBody"] = new JsonObject
+			{
+				["required"] = true,
+				["content"] = new JsonObject
+				{
+					["application/json"] = new JsonObject
+					{
+						["schema"] = new JsonObject
+						{
+							["type"] = "object",
+							["additionalProperties"] = true,
+							["description"] = "See the tool description for the expected fields.",
+						},
+					},
+				},
+			};
+		}
+
+		pathItem[capability.HttpMethod.ToLowerInvariant()] = operation;
+	}
+
+	private static JsonArray BuildPathParameters(string routePattern)
+	{
+		var parameters = new JsonArray();
+		foreach (Match match in PlaceholderPattern().Matches(routePattern))
+		{
+			var name = match.Groups["name"].Value;
+			parameters.Add(new JsonObject
+			{
+				["name"] = name,
+				["in"] = "path",
+				["required"] = true,
+				["schema"] = new JsonObject { ["type"] = "string" },
+			});
+		}
+
+		return parameters;
+	}
+
+	private static string NormalisePath(string routePattern) =>
+		PlaceholderPattern().Replace(routePattern, "{${name}}");
+
+	private static bool RequiresBody(string httpMethod) =>
+		httpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase)
+			|| httpMethod.Equals("PUT", StringComparison.OrdinalIgnoreCase)
+			|| httpMethod.Equals("PATCH", StringComparison.OrdinalIgnoreCase);
+
+	[GeneratedRegex(@"\{(?<name>[a-zA-Z_][a-zA-Z0-9_]*)(:[^}]+)?\}")]
+	private static partial Regex PlaceholderPattern();
+}

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using SmartSolutionsLab.Yumney.Mcp.Server.Auth;
 using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
 using SmartSolutionsLab.Yumney.Mcp.Server.Mcp;
+using SmartSolutionsLab.Yumney.Mcp.Server.OpenApi;
 using SmartSolutionsLab.Yumney.Mcp.Server.RateLimit;
 using SmartSolutionsLab.Yumney.ServiceDefaults;
 
@@ -73,6 +74,17 @@ app.MapGet("/discovered-capabilities", (AggregatedCapabilityRegistry registry) =
 // required in deployments where the request reaches the server through a
 // gateway (the Host header is the internal container name, not the public URL).
 app.MapOAuthProtectedResourceEndpoint(builder.Configuration.GetValue<string>("McpServer:PublicUrl"));
+
+// OpenAPI 3.1 mirror of the MCP-exposed capability surface. Targets the
+// ChatGPT Custom GPT Action path; the discovered capabilities here are the
+// same set RestProxyService can invoke.
+app.MapGet("/openapi/v1.json", (AggregatedCapabilityRegistry registry, IConfiguration configuration) =>
+{
+	var serverUrl = configuration.GetValue<string>("McpServer:GatewayUrl") ?? "http://localhost:5100";
+	var authorizationUrl = configuration.GetValue<string>("McpServer:KeycloakAuthorizationUrl") ?? $"{KeycloakAuthExtensions.ResolveRealmUrl(configuration)}/protocol/openid-connect/auth";
+	var tokenUrl = configuration.GetValue<string>("McpServer:KeycloakTokenUrl") ?? $"{KeycloakAuthExtensions.ResolveRealmUrl(configuration)}/protocol/openid-connect/token";
+	return Results.Json(OpenApiCapabilityBuilder.Build(registry, serverUrl, authorizationUrl, tokenUrl));
+}).AllowAnonymous();
 
 // MCP HTTP/SSE transport at /mcp. External clients (Claude Desktop, custom GPTs)
 // authenticate via the standard Authorization: Bearer header — the bearer is

--- a/tests/Yumney.Mcp.Server.Tests/OpenApi/OpenApiCapabilityBuilderTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/OpenApi/OpenApiCapabilityBuilderTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Mcp.Server.Discovery;
+using SmartSolutionsLab.Yumney.Mcp.Server.OpenApi;
+using SmartSolutionsLab.Yumney.Mcp.Server.Tests.OpenApi.TestSupport;
+using SmartSolutionsLab.Yumney.Shared.Capabilities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.OpenApi;
+
+public class OpenApiCapabilityBuilderTests
+{
+	[Fact]
+	public void Build_OnlyIncludesMcpSurfaceCapabilities()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+				new CapabilityDescriptor("mcp_tool", "MCP", CapabilitySurface.Mcp, "GET", "/api/v1/recipes/"),
+				new CapabilityDescriptor("chat_only_tool", "chat", CapabilitySurface.Chat, "GET", "/api/v1/chat-only/"),
+			]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://gateway.example.com", "https://kc/auth", "https://kc/token");
+
+		var paths = spec["paths"]!.AsObject().AsDictionary();
+		paths.Should().HaveCount(1);
+		paths.Should().ContainKey("/api/v1/recipes/");
+	}
+
+	[Fact]
+	public void Build_StripsRouteConstraintsFromPath()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+				new CapabilityDescriptor("get_recipe", "Get recipe by id", CapabilitySurface.Mcp, "GET", "/api/v1/recipes/{identifier:guid}"),
+			]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://gateway.example.com", "https://kc/auth", "https://kc/token");
+
+		spec["paths"]!.AsObject().AsDictionary().Should().ContainKey("/api/v1/recipes/{identifier}");
+	}
+
+	[Fact]
+	public void Build_GetOperation_HasNoRequestBody()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[new CapabilityDescriptor("search_recipes", "Search", CapabilitySurface.Mcp, "GET", "/api/v1/recipes/")]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://g", "https://kc/auth", "https://kc/token");
+
+		var op = spec["paths"]!["/api/v1/recipes/"]!["get"]!.AsObject();
+		op.AsDictionary().Should().NotContainKey("requestBody");
+	}
+
+	[Theory]
+	[InlineData("POST")]
+	[InlineData("PUT")]
+	[InlineData("PATCH")]
+	public void Build_NonGetOperation_HasPermissiveRequestBody(string httpMethod)
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[new CapabilityDescriptor("write_tool", "Write something", CapabilitySurface.Mcp, httpMethod, "/api/v1/recipes/")]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://g", "https://kc/auth", "https://kc/token");
+
+		var op = spec["paths"]!["/api/v1/recipes/"]![httpMethod.ToLowerInvariant()]!.AsObject();
+		op.AsDictionary().Should().ContainKey("requestBody");
+		op["requestBody"]!["content"]!["application/json"]!["schema"]!["additionalProperties"]!.GetValue<bool>().Should().BeTrue();
+	}
+
+	[Fact]
+	public void Build_PathParameters_AreEmittedForEachPlaceholder()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("meal-plan-api", new CapabilityManifest(
+			"meal-plan-api",
+			[new CapabilityDescriptor("confirm_meal_cooked", "Confirm cooked", CapabilitySurface.Mcp, "POST", "/api/v1/meal-plans/{year:int}/{week:int}/meals/{day}/{mealType}")]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://g", "https://kc/auth", "https://kc/token");
+
+		var path = spec["paths"]!["/api/v1/meal-plans/{year}/{week}/meals/{day}/{mealType}"]!.AsObject();
+		var parameters = path["post"]!["parameters"]!.AsArray();
+		parameters.Should().HaveCount(4);
+		parameters.Select(parameter => parameter!["name"]!.GetValue<string>())
+			.Should().BeEquivalentTo(["year", "week", "day", "mealType"]);
+	}
+
+	[Fact]
+	public void Build_SecuritySchemeIsOauth2WithKeycloakUrls()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://g", "https://kc.example.com/realms/yumney/protocol/openid-connect/auth", "https://kc.example.com/realms/yumney/protocol/openid-connect/token");
+
+		var scheme = spec["components"]!["securitySchemes"]!["keycloak"]!.AsObject();
+		scheme["type"]!.GetValue<string>().Should().Be("oauth2");
+		var flow = scheme["flows"]!["authorizationCode"]!.AsObject();
+		flow["authorizationUrl"]!.GetValue<string>().Should().Be("https://kc.example.com/realms/yumney/protocol/openid-connect/auth");
+		flow["tokenUrl"]!.GetValue<string>().Should().Be("https://kc.example.com/realms/yumney/protocol/openid-connect/token");
+		flow["scopes"]!.AsObject().AsDictionary().Should().ContainKey("yumney-api");
+	}
+
+	[Fact]
+	public void Build_DeclaresOpenApi310()
+	{
+		var spec = OpenApiCapabilityBuilder.Build(new AggregatedCapabilityRegistry(), "https://g", "https://kc/auth", "https://kc/token");
+
+		spec["openapi"]!.GetValue<string>().Should().Be("3.1.0");
+	}
+
+	[Fact]
+	public void Build_TopLevelSecurityListsAllRequiredScopes()
+	{
+		var spec = OpenApiCapabilityBuilder.Build(new AggregatedCapabilityRegistry(), "https://g", "https://kc/auth", "https://kc/token");
+
+		var security = spec["security"]!.AsArray();
+		security.Should().HaveCount(1);
+		var scopes = security[0]!["keycloak"]!.AsArray();
+		scopes.Select(node => node!.GetValue<string>()).Should().Contain("yumney-api");
+	}
+
+	[Fact]
+	public void Build_MultipleMcpCapabilitiesOnSamePath_ShareThePathItem()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+				new CapabilityDescriptor("search_recipes", "search", CapabilitySurface.Mcp, "GET", "/api/v1/recipes/"),
+				new CapabilityDescriptor("save_recipe", "save", CapabilitySurface.Mcp, "POST", "/api/v1/recipes/"),
+			]));
+
+		var spec = OpenApiCapabilityBuilder.Build(registry, "https://g", "https://kc/auth", "https://kc/token");
+
+		var pathItem = spec["paths"]!["/api/v1/recipes/"]!.AsObject();
+		pathItem.AsDictionary().Should().ContainKey("get");
+		pathItem.AsDictionary().Should().ContainKey("post");
+	}
+}

--- a/tests/Yumney.Mcp.Server.Tests/OpenApi/TestSupport/JsonObjectExtensions.cs
+++ b/tests/Yumney.Mcp.Server.Tests/OpenApi/TestSupport/JsonObjectExtensions.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace SmartSolutionsLab.Yumney.Mcp.Server.Tests.OpenApi.TestSupport;
+
+internal static class JsonObjectExtensions
+{
+	// FluentAssertions doesn't ship JsonObject-shaped dictionary assertions;
+	// JsonObject implements IDictionary<string, JsonNode?>, so a cast unlocks
+	// the regular dictionary assertions (ContainKey / HaveCount / etc).
+	public static IDictionary<string, JsonNode?> AsDictionary(this JsonObject obj) => obj;
+}


### PR DESCRIPTION
## Summary

Adds `GET /openapi/v1.json` on `mcp-server`. The spec mirrors the MCP-exposed capability surface (the same set `RestProxyService` invokes) derived directly from the discovered `CapabilityDescriptor`s:

- One operation per capability filtered to `CapabilitySurface.Mcp`
- Path parameters extracted from route templates, constraints stripped (`/{id:guid}` → `/{id}`)
- OAuth2 authorization-code flow scheme pointing at the configured Keycloak realm
- Permissive request body on POST/PUT/PATCH (`application/json` with `additionalProperties: true`)
- OpenAPI **3.1.0** declared at the top

OpenAI's GPT Action builder ingests this URL; the resulting Custom GPT calls Yumney through the same gateway + OAuth path as Claude.ai's MCP connector.

`docs/mcp/chatgpt-setup.md` walks the OpenAI-side setup end-to-end (OAuth client config, redirect-URI registration in Keycloak, sample first call) and flags the deliberate schema-richness gap.

## Files

- `src/Yumney.Mcp.Server/OpenApi/OpenApiCapabilityBuilder.cs` — pure spec builder
- `src/Yumney.Mcp.Server/Program.cs` — wires the endpoint with `McpServer:GatewayUrl` + Keycloak URL overrides
- `tests/Yumney.Mcp.Server.Tests/OpenApi/OpenApiCapabilityBuilderTests.cs` — 11 unit cases
- `tests/Yumney.Mcp.Server.Tests/OpenApi/TestSupport/JsonObjectExtensions.cs` — small `AsDictionary()` helper so FluentAssertions' dictionary asserts compose with `System.Text.Json.Nodes.JsonObject`
- `docs/mcp/chatgpt-setup.md` — setup runbook

## What's deliberately out of scope

- **Per-operation request/response schemas** aggregated from the per-module OpenAPI specs. Today the spec carries operation paths/methods/descriptions; the model relies on the description text for argument shapes. Aggregation is the natural follow-up — non-trivial schema-merge work that doesn't gate the GPT submission.
- **Custom GPT creation + GPT Store submission** — those happen in OpenAI's UI; the doc walks the user through it.
- **`yumney-chatgpt` static Keycloak client** — the runbook offers `yumney-web` as a fallback; the dedicated client is a small `yumney-realm.json` follow-up if we want it isolated.

## Test plan

- [x] 11 unit tests cover the MCP-surface filter, constraint stripping, GET vs POST/PUT/PATCH body, path parameter extraction (incl. typed constraints), security scheme + scopes, multi-method same-path sharing, OpenAPI version
- [x] Full `Yumney.Mcp.Server.Tests` suite passes
- [x] Strict build clean, format clean
- [ ] **Staging smoke (post-merge)**: hit `/openapi/v1.json`, import into a throwaway GPT, confirm OAuth round-trips and a sample `get_merged_shopping_list` call succeeds

Closes #726