### PR TITLE
feat(mcp): versioned tool schemas + capability evolution policy (US-729)

### DIFF
--- a/docs/runbooks/mcp-versioning.md
+++ b/docs/runbooks/mcp-versioning.md
@@ -1,0 +1,72 @@
+# MCP Tool Versioning Policy
+
+External MCP clients (Claude.ai connectors, Claude Desktop, ChatGPT custom GPTs, Cursor, …) cache the tool list on first connect and call by name forever after. Changing a tool's name, removing a required field, or shifting its semantics is a public breaking change for every installed client. This doc is the contract for evolving the surface without breaking users.
+
+## When to bump the version
+
+| Change | Bump version? |
+|---|---|
+| Add an optional request field | No |
+| Add a new response field | No |
+| Loosen a validation rule (e.g. raise max length) | No |
+| Add a new tool | No (it's a new tool with its own v1) |
+| Rename a tool | **Yes** |
+| Remove a required request field, or make one required that wasn't | **Yes** |
+| Change a field's type / shape | **Yes** |
+| Change semantics ("returns top 10" → "returns top 20") | **Yes** if downstream behaviour relies on it |
+| Tighten a validation rule | **Yes** |
+
+When in doubt, bump — the cost of a stale-name suffix is much smaller than a silent breakage of installed connectors.
+
+## How to bump
+
+1. Keep the original endpoint + capability registration in place. Do **not** edit the existing `WithCapability(name: …)` call.
+2. Add a new endpoint with the new shape. Register it with the same `name:` but `version: 2` (or higher):
+   ```csharp
+   group.MapPost("/v2/recipes", SaveRecipeV2)
+       .WithName("SaveRecipeV2")
+       .WithTags("Recipes")
+       .WithCapability(
+           name: "save_recipe",
+           description: "Import a recipe with the new ingredient-quantity grammar — replaces save_recipe v1. …",
+           surfaces: CapabilitySurface.Chat | CapabilitySurface.Mcp,
+           version: 2);
+   ```
+3. The MCP server projects this onto the wire as `save_recipe__v2`. v1 continues to be advertised as `save_recipe`. Both tools appear in `tools/list`; old clients keep calling `save_recipe`, new clients pick `save_recipe__v2`.
+4. Update the v1 endpoint's `description` to call out the deprecation:
+   ```csharp
+   description: "DEPRECATED — superseded by save_recipe__v2 on 2026-08-01. … (original text)"
+   ```
+   The deprecation note shows up in `tools/list` and tells the LLM to prefer the new version when both are visible.
+
+## Removal policy
+
+A deprecated tool version stays available for **at least 90 days** after its replacement ships. The clock starts when the replacement endpoint is merged to `develop`. Document the deprecation date in the source comment above the old `WithCapability` call so any future contributor can see when removal becomes safe:
+
+```csharp
+// Deprecated 2026-08-01 in favour of v2 — earliest removal 2026-10-30.
+group.MapPost("/recipes", SaveRecipeV1)
+    .WithCapability(name: "save_recipe", …);
+```
+
+Removing before the 90-day window means breaking any client config that hasn't been touched in three months. Don't.
+
+## What the wire looks like
+
+| Version | Tool name on wire | Notes |
+|---|---|---|
+| 1 (default) | `{name}` | Unchanged — installed configs keep working |
+| 2 | `{name}__v2` | New connections discover via `tools/list` |
+| ≥ 3 | `{name}__v{Version}` | Same pattern as v2 |
+
+The `__v{n}` suffix is parsed by `CapabilityToolRegistration.WireName(...)` and is the only place the version leaks into the protocol shape. Routes, OpenAPI paths, and module endpoint URLs are independent — pick whatever URL scheme the module module owner prefers (e.g. `/api/v2/recipes`).
+
+## What is NOT versioned
+
+- **Surface flags** (`CapabilitySurface.Chat | CapabilitySurface.Mcp`). Changing whether a tool shows up on MCP isn't a name-versioning concern — it's either visible or not.
+- **Tool annotations** (`ReadOnlyHint`, `DestructiveHint`, …). These are hints; flipping them is not a breaking change.
+- **Internal route changes** that don't affect the wire name or shape. Refactor freely.
+
+## Architecture-test guard (planned)
+
+A future architecture test will assert that no tool version has been removed within 90 days of its replacement going live. The mechanism: the deprecation date lives in a code comment above the old `WithCapability` call; the test grep-parses these comments and compares against `DateTime.UtcNow`. This isn't implemented today because there are no deprecated versions yet — wire it in when the first one ships.

--- a/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
+++ b/src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs
@@ -59,9 +59,19 @@ public static class CapabilityToolRegistration
 		return ValueTask.FromResult(BuildStubInvocationResult(name));
 	}
 
+	/// <summary>
+	/// Tool name as advertised on the MCP wire. v1 keeps the bare name so the
+	/// migration to versioned tools doesn't break installed client configs;
+	/// v ≥ 2 suffixes with <c>__v{Version}</c> per <c>docs/runbooks/mcp-versioning.md</c>.
+	/// </summary>
+	/// <param name="capability">Descriptor whose name + version to project.</param>
+	/// <returns>Wire-shape tool name.</returns>
+	public static string WireName(CapabilityDescriptor capability) =>
+		capability.Version <= 1 ? capability.Name : $"{capability.Name}__v{capability.Version}";
+
 	private static Tool ToTool(CapabilityDescriptor capability) => new()
 	{
-		Name = capability.Name,
+		Name = WireName(capability),
 		Description = $"{capability.Description} (proxies {capability.HttpMethod} {capability.RoutePattern})",
 		Annotations = ToolAnnotationsBuilder.FromHttpMethod(capability.HttpMethod),
 	};

--- a/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs
@@ -14,7 +14,17 @@ public sealed record CapabilityDescriptor(
 	string Description,
 	CapabilitySurface Surfaces,
 	string HttpMethod,
-	string RoutePattern);
+	string RoutePattern)
+{
+	/// <summary>
+	/// Gets the tool version. Defaults to 1; bumped per the rules in
+	/// <c>docs/runbooks/mcp-versioning.md</c> when a breaking change ships
+	/// (rename, removed required field, semantic shift). Wire name on MCP is
+	/// <c>{Name}</c> for v1 and <c>{Name}__v{Version}</c> for v ≥ 2 so old
+	/// client configs keep working.
+	/// </summary>
+	public int Version { get; init; } = 1;
+}
 
 /// <summary>Wire shape of one host's capability manifest, returned by <c>/.well-known/yumney-capabilities</c>.</summary>
 /// <param name="ServiceName">Aspire service name (e.g. <c>recipes-api</c>).</param>

--- a/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
+++ b/src/Yumney.Shared.Capabilities/CapabilityMetadata.cs
@@ -8,4 +8,13 @@ namespace SmartSolutionsLab.Yumney.Shared.Capabilities;
 /// <param name="Name">Stable LLM-facing tool name (snake_case). Treat as a public contract — renaming breaks installed clients.</param>
 /// <param name="Description">One-paragraph description used by the LLM to decide when to call this capability.</param>
 /// <param name="Surfaces">Bitfield of surfaces this capability is exposed on.</param>
-public sealed record CapabilityMetadata(string Name, string Description, CapabilitySurface Surfaces);
+public sealed record CapabilityMetadata(string Name, string Description, CapabilitySurface Surfaces)
+{
+	/// <summary>
+	/// Gets the tool version. Defaults to 1; bumped per the rules in
+	/// <c>docs/runbooks/mcp-versioning.md</c> when a breaking change ships.
+	/// Wire name on MCP is <c>{Name}</c> for v1 and <c>{Name}__v{Version}</c>
+	/// for v ≥ 2 so old client configs keep working.
+	/// </summary>
+	public int Version { get; init; } = 1;
+}

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs
@@ -52,6 +52,6 @@ public static class CapabilityManifestEndpoint
 		var httpMethod = methods is { Count: > 0 } ? methods[0] : "GET";
 		var routePattern = endpoint.RoutePattern.RawText ?? string.Empty;
 
-		return new CapabilityDescriptor(meta.Name, meta.Description, meta.Surfaces, httpMethod, routePattern);
+		return new CapabilityDescriptor(meta.Name, meta.Description, meta.Surfaces, httpMethod, routePattern) { Version = meta.Version };
 	}
 }

--- a/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs
@@ -14,12 +14,14 @@ public static class CapabilityRouteBuilderExtensions
 	/// <param name="name">Stable LLM-facing tool name (snake_case).</param>
 	/// <param name="description">One-paragraph description used by the LLM.</param>
 	/// <param name="surfaces">Surfaces this capability is exposed on. Defaults to Chat | Mcp.</param>
+	/// <param name="version">Tool version. Default 1; bump per <c>docs/runbooks/mcp-versioning.md</c> on a breaking change.</param>
 	/// <returns>The same builder, for fluent chaining.</returns>
 	public static TBuilder WithCapability<TBuilder>(
 		this TBuilder builder,
 		string name,
 		string description,
-		CapabilitySurface surfaces = CapabilitySurface.Chat | CapabilitySurface.Mcp)
+		CapabilitySurface surfaces = CapabilitySurface.Chat | CapabilitySurface.Mcp,
+		int version = 1)
 		where TBuilder : IEndpointConventionBuilder =>
-		builder.WithMetadata(new CapabilityMetadata(name, description, surfaces));
+		builder.WithMetadata(new CapabilityMetadata(name, description, surfaces) { Version = version });
 }

--- a/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
+++ b/tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs
@@ -139,6 +139,49 @@ public class CapabilityToolRegistrationTests
 		tools.Select(tool => tool.Name).Should().BeEquivalentTo(["search_recipes", "get_merged_shopping_list"]);
 	}
 
+	[Fact]
+	public void WireName_DefaultVersion_IsBareName()
+	{
+		var capability = new CapabilityDescriptor("search_recipes", "search", CapabilitySurface.Mcp, "GET", "/r");
+
+		CapabilityToolRegistration.WireName(capability).Should().Be("search_recipes");
+	}
+
+	[Fact]
+	public void WireName_V1Explicit_IsBareName()
+	{
+		var capability = new CapabilityDescriptor("search_recipes", "search", CapabilitySurface.Mcp, "GET", "/r") { Version = 1 };
+
+		CapabilityToolRegistration.WireName(capability).Should().Be("search_recipes");
+	}
+
+	[Theory]
+	[InlineData(2, "search_recipes__v2")]
+	[InlineData(3, "search_recipes__v3")]
+	[InlineData(10, "search_recipes__v10")]
+	public void WireName_V2OrLater_AppendsSuffix(int version, string expected)
+	{
+		var capability = new CapabilityDescriptor("search_recipes", "search", CapabilitySurface.Mcp, "GET", "/r") { Version = version };
+
+		CapabilityToolRegistration.WireName(capability).Should().Be(expected);
+	}
+
+	[Fact]
+	public void BuildTools_VersionedDescriptor_UsesSuffixedWireName()
+	{
+		var registry = new AggregatedCapabilityRegistry();
+		registry.SetManifest("recipes-api", new CapabilityManifest(
+			"recipes-api",
+			[
+				new CapabilityDescriptor("search_recipes", "v1", CapabilitySurface.Mcp, "GET", "/r"),
+				new CapabilityDescriptor("search_recipes", "v2 breaking", CapabilitySurface.Mcp, "GET", "/r/v2") { Version = 2 },
+			]));
+
+		var names = CapabilityToolRegistration.BuildTools(registry).Select(tool => tool.Name).ToList();
+
+		names.Should().BeEquivalentTo(["search_recipes", "search_recipes__v2"]);
+	}
+
 	private static CapabilityDescriptor Descriptor(string name, CapabilitySurface surfaces) =>
 		new(name, $"description for {name}", surfaces, "GET", $"/{name}");
 }


### PR DESCRIPTION
## Summary

Adds explicit versioning to the MCP tool surface so we can ship breaking changes (rename, removed-required-field, semantic shift) without silently breaking installed client configs.

**Schema**: `Version` field on `CapabilityMetadata` and `CapabilityDescriptor`, default 1. New `version: int` parameter on `WithCapability(...)`.

**Wire**: `CapabilityToolRegistration.WireName(descriptor)` is the projection. v1 stays as the bare name (no change to today's wire — no client breakage). v ≥ 2 suffix with `__v{Version}`.

**Policy**: `docs/runbooks/mcp-versioning.md` codifies when to bump (rename, removed required field, semantic shift), how to ship a v2 (keep the old endpoint, register a new one with the same `name:` and `version: 2`), deprecation phrasing in the v1 description, and the 90-day minimum window before removing a deprecated version.

## Files
- `src/Yumney.Shared.Capabilities/CapabilityDescriptor.cs` — `Version` property
- `src/Yumney.Shared.Capabilities/CapabilityMetadata.cs` — `Version` property
- `src/Yumney.Shared.Web/Capabilities/CapabilityRouteBuilderExtensions.cs` — `version` parameter on `WithCapability`
- `src/Yumney.Shared.Web/Capabilities/CapabilityManifestEndpoint.cs` — plumbs `Version` from metadata to descriptor
- `src/Yumney.Mcp.Server/Mcp/CapabilityToolRegistration.cs` — `WireName(...)` + threads it into the emitted `Tool`
- `tests/Yumney.Mcp.Server.Tests/Mcp/CapabilityToolRegistrationTests.cs` — 6 new cases
- `docs/runbooks/mcp-versioning.md` — policy

## Backward compatibility

Zero impact on current behaviour — every existing call site stays on the default `version: 1`, the wire name is unchanged, and installed clients continue calling `search_recipes` / `get_recipe` / etc. exactly as today.

## Test plan

- [x] 6 new tests covering `WireName` (default v1, explicit v1, v ≥ 2 with suffix, integration via `BuildTools`)
- [x] Full `Yumney.Mcp.Server.Tests` suite passes (13/13 in `CapabilityToolRegistrationTests`)
- [x] Strict build + format clean across `Shared.Capabilities`, `Shared.Web`, `Mcp.Server`, `Mcp.Server.Tests`

## Out of scope (called out in the doc)

- **`X-Deprecation` HTTP header / inline deprecation notice** on tool-result responses. The MCP SDK doesn't expose response headers per tool call cleanly; the workable substitute today is a `DEPRECATED — superseded by …` prefix in the v1 tool description (which `tools/list` already returns to the LLM).
- **Architecture-test enforcement of the 90-day window**. Mechanism is in the doc: grep for `// Deprecated YYYY-MM-DD in favour of v2` comments above `WithCapability` calls, compare against `DateTime.UtcNow`. Not implemented today because there are zero deprecated versions to test against — wire in when the first one ships.

Closes #729