### PR TITLE
feat(shell): public /docs/mcp landing page with one-click connect buttons (US-728)

### DIFF
--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -443,5 +443,41 @@
       "networkUnavailable": "Der Server ist nicht erreichbar. Bitte prüfe deine Verbindung und versuche es erneut.",
       "serviceUnavailable": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es gleich erneut."
     }
+  },
+  "docsMcp": {
+    "hero": {
+      "title": "Nutze Yumney in Claude, ChatGPT und jedem MCP-fähigen Tool",
+      "subtitle": "Eine Verbindung — deine Rezeptsammlung, Wochenplan und Einkaufslisten direkt aus deiner Lieblings-KI."
+    },
+    "connect": {
+      "title": "In 30 Sekunden verbinden",
+      "claudeAi": {
+        "title": "Zu Claude.ai hinzufügen",
+        "description": "Custom Connector mit OAuth — funktioniert in Claude Pro und Team.",
+        "cta": "Zu Claude hinzufügen"
+      },
+      "claudeDesktop": {
+        "title": "Claude Desktop",
+        "description": "Snippet in claude_desktop_config.json einfügen und neu starten.",
+        "cta": "Config kopieren",
+        "copied": "Kopiert!"
+      },
+      "chatgpt": {
+        "title": "ChatGPT",
+        "description": "Nutze das offizielle Yumney Custom GPT (oder baue dein eigenes mit der OpenAPI-Spec).",
+        "cta": "In ChatGPT öffnen"
+      }
+    },
+    "tools": {
+      "title": "Was du bekommst",
+      "loading": "Verfügbare Tools werden geladen…",
+      "empty": "Aktuell sind keine Tools verfügbar — schau später nochmal vorbei."
+    },
+    "limits": {
+      "title": "Limits & Zugriff",
+      "rateLimit": "60 Tool-Aufrufe pro Minute pro Nutzer — beim Überschreiten gibts ein 429 mit Retry-Hinweis.",
+      "scope": "Jeder Aufruf braucht den yumney-api Scope; automatisch beim OAuth-Flow gesetzt.",
+      "auth": "Authentifizierung über Keycloak OAuth2 (Authorization Code mit PKCE)."
+    }
   }
 }

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -443,5 +443,41 @@
       "networkUnavailable": "We can't reach the server. Check your connection and try again.",
       "serviceUnavailable": "The service is temporarily unavailable. Please try again in a moment."
     }
+  },
+  "docsMcp": {
+    "hero": {
+      "title": "Use Yumney inside Claude, ChatGPT, and any MCP-aware tool",
+      "subtitle": "One connection — your whole recipe collection, meal planner, and shopping lists, callable from your favourite AI."
+    },
+    "connect": {
+      "title": "Connect in 30 seconds",
+      "claudeAi": {
+        "title": "Add to Claude.ai",
+        "description": "Custom connector with OAuth — works in Claude Pro and Team.",
+        "cta": "Add to Claude"
+      },
+      "claudeDesktop": {
+        "title": "Claude Desktop",
+        "description": "Paste this snippet into claude_desktop_config.json and restart.",
+        "cta": "Copy config",
+        "copied": "Copied!"
+      },
+      "chatgpt": {
+        "title": "ChatGPT",
+        "description": "Use the official Yumney custom GPT (or wire your own with the OpenAPI spec).",
+        "cta": "Open in ChatGPT"
+      }
+    },
+    "tools": {
+      "title": "What you get",
+      "loading": "Loading available tools…",
+      "empty": "No tools are exposed right now — check back shortly."
+    },
+    "limits": {
+      "title": "Limits & access",
+      "rateLimit": "60 tool calls per minute per user — bursting past returns a 429 with retry hint.",
+      "scope": "Each call needs the yumney-api scope; granted automatically during the OAuth dance.",
+      "auth": "Authentication uses Keycloak OAuth2 (authorization code with PKCE)."
+    }
   }
 }

--- a/client/apps/shell/src/app/app.routes.ts
+++ b/client/apps/shell/src/app/app.routes.ts
@@ -50,6 +50,11 @@ export const appRoutes: Route[] = [
     loadChildren: () => loadRemoteModule('account', './routes').then((m) => m.accountRoutes),
   },
   {
+    path: 'docs/mcp',
+    title: 'Connect Yumney to Claude / ChatGPT — Yumney',
+    loadComponent: () => import('./docs-mcp').then((m) => m.DocsMcpComponent),
+  },
+  {
     path: '',
     redirectTo: 'dashboard',
     pathMatch: 'full',

--- a/client/apps/shell/src/app/docs-mcp/discovered-capabilities.service.ts
+++ b/client/apps/shell/src/app/docs-mcp/discovered-capabilities.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { DiscoveredCapabilitiesResponse, DiscoveredCapability } from './discovered-capability';
+
+@Injectable({ providedIn: 'root' })
+export class DiscoveredCapabilitiesService {
+  private readonly http = inject(HttpClient);
+
+  // The MCP server's /discovered-capabilities endpoint is anonymous (no bearer
+  // required) so the marketing page works for visitors without a Yumney login.
+  // Filters to MCP-surface capabilities client-side — the LLM landing page
+  // shouldn't advertise tools that aren't reachable from an MCP client.
+  fetchMcpTools(): Observable<DiscoveredCapability[]> {
+    return this.http.get<DiscoveredCapabilitiesResponse>('/discovered-capabilities').pipe(
+      map((response) => response.capabilities.filter((capability) => capability.surfaces.includes('Mcp'))),
+      catchError(() => of([] as DiscoveredCapability[])),
+    );
+  }
+}

--- a/client/apps/shell/src/app/docs-mcp/discovered-capability.ts
+++ b/client/apps/shell/src/app/docs-mcp/discovered-capability.ts
@@ -1,0 +1,15 @@
+export interface DiscoveredCapability {
+  readonly name: string;
+  readonly description: string;
+  readonly httpMethod: string;
+  readonly routePattern: string;
+  readonly surfaces: string;
+}
+
+export interface DiscoveredCapabilitiesResponse {
+  readonly serviceCount: number;
+  readonly capabilityCount: number;
+  readonly mcpToolCount: number;
+  readonly services: string[];
+  readonly capabilities: DiscoveredCapability[];
+}

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.html
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.html
@@ -2,7 +2,9 @@
   <section class="hero">
     <h1>{{ 'docsMcp.hero.title' | transloco }}</h1>
     <p class="hero__subtitle">{{ 'docsMcp.hero.subtitle' | transloco }}</p>
-    <p class="hero__url"><code>{{ mcpUrl }}</code></p>
+    <p class="hero__url">
+      <code>{{ mcpUrl }}</code>
+    </p>
   </section>
 
   <section class="connect">
@@ -45,9 +47,13 @@
       <ul class="tools__list">
         @for (tool of tools(); track tool.name) {
           <li class="tools__item">
-            <h3 class="tools__name"><code>{{ tool.name }}</code></h3>
+            <h3 class="tools__name">
+              <code>{{ tool.name }}</code>
+            </h3>
             <p class="tools__description">{{ tool.description }}</p>
-            <p class="tools__route"><small>{{ tool.httpMethod }} {{ tool.routePattern }}</small></p>
+            <p class="tools__route">
+              <small>{{ tool.httpMethod }} {{ tool.routePattern }}</small>
+            </p>
           </li>
         }
       </ul>

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.html
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.html
@@ -1,0 +1,65 @@
+<div class="docs-mcp">
+  <section class="hero">
+    <h1>{{ 'docsMcp.hero.title' | transloco }}</h1>
+    <p class="hero__subtitle">{{ 'docsMcp.hero.subtitle' | transloco }}</p>
+    <p class="hero__url"><code>{{ mcpUrl }}</code></p>
+  </section>
+
+  <section class="connect">
+    <h2>{{ 'docsMcp.connect.title' | transloco }}</h2>
+    <div class="connect__grid">
+      <a class="connect__card" [href]="claudeAiAddUrl" target="_blank" rel="noopener">
+        <h3>{{ 'docsMcp.connect.claudeAi.title' | transloco }}</h3>
+        <p>{{ 'docsMcp.connect.claudeAi.description' | transloco }}</p>
+        <span class="connect__cta">{{ 'docsMcp.connect.claudeAi.cta' | transloco }}</span>
+      </a>
+
+      <div class="connect__card">
+        <h3>{{ 'docsMcp.connect.claudeDesktop.title' | transloco }}</h3>
+        <p>{{ 'docsMcp.connect.claudeDesktop.description' | transloco }}</p>
+        <pre class="connect__snippet"><code>{{ desktopConfig }}</code></pre>
+        <button type="button" class="connect__cta" (click)="copyDesktopConfig()">
+          @if (copied()) {
+            {{ 'docsMcp.connect.claudeDesktop.copied' | transloco }}
+          } @else {
+            {{ 'docsMcp.connect.claudeDesktop.cta' | transloco }}
+          }
+        </button>
+      </div>
+
+      <a class="connect__card" [href]="chatGptGptUrl" target="_blank" rel="noopener">
+        <h3>{{ 'docsMcp.connect.chatgpt.title' | transloco }}</h3>
+        <p>{{ 'docsMcp.connect.chatgpt.description' | transloco }}</p>
+        <span class="connect__cta">{{ 'docsMcp.connect.chatgpt.cta' | transloco }}</span>
+      </a>
+    </div>
+  </section>
+
+  <section class="tools">
+    <h2>{{ 'docsMcp.tools.title' | transloco }}</h2>
+    @if (toolsLoading()) {
+      <p class="tools__loading">{{ 'docsMcp.tools.loading' | transloco }}</p>
+    } @else if (tools()!.length === 0) {
+      <p class="tools__empty">{{ 'docsMcp.tools.empty' | transloco }}</p>
+    } @else {
+      <ul class="tools__list">
+        @for (tool of tools(); track tool.name) {
+          <li class="tools__item">
+            <h3 class="tools__name"><code>{{ tool.name }}</code></h3>
+            <p class="tools__description">{{ tool.description }}</p>
+            <p class="tools__route"><small>{{ tool.httpMethod }} {{ tool.routePattern }}</small></p>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+
+  <section class="limits">
+    <h2>{{ 'docsMcp.limits.title' | transloco }}</h2>
+    <ul>
+      <li>{{ 'docsMcp.limits.rateLimit' | transloco }}</li>
+      <li>{{ 'docsMcp.limits.scope' | transloco }}</li>
+      <li>{{ 'docsMcp.limits.auth' | transloco }}</li>
+    </ul>
+  </section>
+</div>

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.scss
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.scss
@@ -1,0 +1,142 @@
+.docs-mcp {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+
+  h1,
+  h2 {
+    margin-bottom: 0.75rem;
+  }
+
+  h2 {
+    margin-top: 2.5rem;
+    font-size: 1.5rem;
+  }
+}
+
+.hero {
+  text-align: center;
+  padding: 2.5rem 0 1.5rem;
+
+  &__subtitle {
+    font-size: 1.125rem;
+    color: var(--yn-muted, #6b7280);
+    margin-bottom: 1rem;
+  }
+
+  &__url code {
+    background: var(--yn-surface-2, #f3f4f6);
+    padding: 0.4rem 0.75rem;
+    border-radius: 0.4rem;
+    font-size: 0.95rem;
+    word-break: break-all;
+  }
+}
+
+.connect {
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: 1rem;
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.5rem;
+    border: 1px solid var(--yn-border, #e5e7eb);
+    border-radius: 0.75rem;
+    background: var(--yn-surface, #ffffff);
+    color: inherit;
+    text-decoration: none;
+    transition: border-color 120ms ease-out, transform 120ms ease-out;
+
+    &:hover {
+      border-color: var(--yn-accent, #6366f1);
+      transform: translateY(-2px);
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    p {
+      margin: 0;
+      color: var(--yn-muted, #6b7280);
+      font-size: 0.95rem;
+    }
+  }
+
+  &__snippet {
+    background: var(--yn-surface-2, #0f172a);
+    color: #e2e8f0;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    margin: 0;
+  }
+
+  &__cta {
+    align-self: flex-start;
+    background: var(--yn-accent, #6366f1);
+    color: #ffffff;
+    padding: 0.5rem 1rem;
+    border-radius: 0.4rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+    border: none;
+    cursor: pointer;
+  }
+}
+
+.tools {
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  &__item {
+    padding: 1rem;
+    border: 1px solid var(--yn-border, #e5e7eb);
+    border-radius: 0.6rem;
+    background: var(--yn-surface, #ffffff);
+  }
+
+  &__name {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+  }
+
+  &__description {
+    margin: 0 0 0.4rem;
+    color: var(--yn-muted, #6b7280);
+    font-size: 0.9rem;
+  }
+
+  &__route small {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: var(--yn-muted-strong, #94a3b8);
+  }
+
+  &__loading,
+  &__empty {
+    color: var(--yn-muted, #6b7280);
+    font-style: italic;
+  }
+}
+
+.limits ul {
+  padding-left: 1.5rem;
+
+  li {
+    margin-bottom: 0.4rem;
+    color: var(--yn-muted, #6b7280);
+  }
+}

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.scss
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.scss
@@ -50,7 +50,9 @@
     background: var(--yn-surface, #ffffff);
     color: inherit;
     text-decoration: none;
-    transition: border-color 120ms ease-out, transform 120ms ease-out;
+    transition:
+      border-color 120ms ease-out,
+      transform 120ms ease-out;
 
     &:hover {
       border-color: var(--yn-accent, #6366f1);

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.spec.ts
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideTransloco, TranslocoConfig } from '@jsverse/transloco';
+import { DocsMcpComponent } from './docs-mcp.component';
+import { DiscoveredCapabilitiesResponse } from './discovered-capability';
+
+class StubTranslocoLoader {
+  getTranslation = (lang: string): Promise<Record<string, string>> => Promise.resolve({ lang });
+}
+
+const transloco: Partial<TranslocoConfig> = {
+  availableLangs: ['en'],
+  defaultLang: 'en',
+  reRenderOnLangChange: false,
+  prodMode: true,
+};
+
+describe('DocsMcpComponent', () => {
+  let fixture: ComponentFixture<DocsMcpComponent>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DocsMcpComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTransloco({ config: transloco, loader: StubTranslocoLoader }),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocsMcpComponent);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('renders the MCP server URL in the hero', () => {
+    fixture.detectChanges();
+    http.expectOne('/discovered-capabilities').flush(emptyResponse());
+
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.textContent).toContain('yumney-gateway');
+    expect(html.textContent).toContain('/mcp');
+  });
+
+  it('filters discovered capabilities to the MCP surface', () => {
+    fixture.detectChanges();
+    http.expectOne('/discovered-capabilities').flush({
+      serviceCount: 1,
+      capabilityCount: 2,
+      mcpToolCount: 1,
+      services: ['recipes-api'],
+      capabilities: [
+        { name: 'search_recipes', description: 'Search', httpMethod: 'GET', routePattern: '/r', surfaces: 'Chat, Mcp' },
+        { name: 'chat_only', description: 'Chat only', httpMethod: 'POST', routePattern: '/c', surfaces: 'Chat' },
+      ],
+    });
+    fixture.detectChanges();
+
+    const html = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(html).toContain('search_recipes');
+    expect(html).not.toContain('chat_only');
+  });
+
+  it('falls back to an empty list when discovery fails', () => {
+    fixture.detectChanges();
+    http.expectOne('/discovered-capabilities').error(new ProgressEvent('Network error'));
+    fixture.detectChanges();
+
+    // Stub Transloco loader leaves keys untranslated, so assert against the
+    // structural marker (the empty-state paragraph) instead of the message text.
+    const emptyMarker = (fixture.nativeElement as HTMLElement).querySelector('.tools__empty');
+    expect(emptyMarker).not.toBeNull();
+  });
+
+  it('serialises the Claude Desktop config snippet with the mcp-remote args', () => {
+    fixture.detectChanges();
+    http.expectOne('/discovered-capabilities').flush(emptyResponse());
+    fixture.detectChanges();
+
+    const html = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(html).toContain('mcp-remote@latest');
+    expect(html).toContain('"yumney"');
+  });
+});
+
+function emptyResponse(): DiscoveredCapabilitiesResponse {
+  return { serviceCount: 0, capabilityCount: 0, mcpToolCount: 0, services: [], capabilities: [] };
+}

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.spec.ts
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.spec.ts
@@ -23,11 +23,7 @@ describe('DocsMcpComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DocsMcpComponent],
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        provideTransloco({ config: transloco, loader: StubTranslocoLoader }),
-      ],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideTransloco({ config: transloco, loader: StubTranslocoLoader })],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DocsMcpComponent);

--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.ts
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.ts
@@ -1,0 +1,57 @@
+import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { DiscoveredCapabilitiesService } from './discovered-capabilities.service';
+import { DiscoveredCapability } from './discovered-capability';
+
+const MCP_PUBLIC_URL = 'https://yumney-gateway.calmsky-ae1ea5be.canadacentral.azurecontainerapps.io/mcp';
+const CLAUDE_AI_ADD_URL = `https://claude.ai/settings/connectors/add?url=${encodeURIComponent(MCP_PUBLIC_URL)}`;
+const CHATGPT_GPT_URL = 'https://chatgpt.com/g/yumney';
+
+@Component({
+  selector: 'yn-docs-mcp',
+  imports: [TranslocoModule],
+  templateUrl: './docs-mcp.component.html',
+  styleUrl: './docs-mcp.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocsMcpComponent implements OnInit {
+  protected readonly mcpUrl = MCP_PUBLIC_URL;
+  protected readonly claudeAiAddUrl = CLAUDE_AI_ADD_URL;
+  protected readonly chatGptGptUrl = CHATGPT_GPT_URL;
+
+  protected readonly desktopConfig = JSON.stringify(
+    {
+      mcpServers: {
+        yumney: {
+          command: 'npx',
+          args: ['-y', 'mcp-remote@latest', MCP_PUBLIC_URL],
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  protected readonly tools = signal<DiscoveredCapability[] | null>(null);
+  protected readonly copied = signal(false);
+  protected readonly toolsLoading = computed(() => this.tools() === null);
+
+  private readonly capabilitiesService = inject(DiscoveredCapabilitiesService);
+
+  ngOnInit(): void {
+    this.capabilitiesService.fetchMcpTools().subscribe((tools) => this.tools.set(tools));
+  }
+
+  copyDesktopConfig(): void {
+    navigator.clipboard
+      .writeText(this.desktopConfig)
+      .then(() => {
+        this.copied.set(true);
+        setTimeout(() => this.copied.set(false), 2000);
+      })
+      .catch(() => {
+        // Clipboard write can fail on insecure contexts or older browsers — the
+        // textarea below is selectable as a fallback, so swallow silently.
+      });
+  }
+}

--- a/client/apps/shell/src/app/docs-mcp/index.ts
+++ b/client/apps/shell/src/app/docs-mcp/index.ts
@@ -1,0 +1,1 @@
+export { DocsMcpComponent } from './docs-mcp.component';

--- a/client/libs/shared/models/src/lib/route-paths.ts
+++ b/client/libs/shared/models/src/lib/route-paths.ts
@@ -19,4 +19,7 @@ export const ROUTES = {
     detail: (identifier: string) => `/shopping/lists/${identifier}`,
     create: (recipeId: string) => `/shopping/create/${recipeId}`,
   },
+  docs: {
+    mcp: '/docs/mcp',
+  },
 } as const;


### PR DESCRIPTION
## Summary

Adds a public Angular route at `/docs/mcp` (no auth guard) so non-logged-in visitors landing from external marketing / blog posts can connect Yumney to their favourite MCP client in 30 seconds.

**Sections rendered:**
- Hero with the canonical MCP URL
- **3 Connect cards**:
  - **Add to Claude.ai** — deep link to Claude's custom connector add flow with the MCP URL prefilled (`claude.ai/settings/connectors/add?url=…`)
  - **Claude Desktop** — pre-formatted `claude_desktop_config.json` snippet with one-click clipboard copy
  - **ChatGPT** — external link to the official Yumney custom GPT
- **Tool catalog** — live list fetched from `/discovered-capabilities` (anonymous endpoint), filtered to capabilities whose `surfaces` includes `Mcp`. Each tool shows name + description + HTTP method + route pattern.
- **Limits & access** — rate-limit (60/min), required scope (`yumney-api`), auth mechanism (Keycloak OAuth2 PKCE)

EN + DE strings under `docsMcp.*` via the existing Transloco setup.

## Files

- `client/apps/shell/src/app/docs-mcp/` — new module (component, service, types, spec, barrel)
- `client/apps/shell/src/app/app.routes.ts` — `/docs/mcp` route, no `canActivate`
- `client/libs/shared/models/src/lib/route-paths.ts` — `ROUTES.docs.mcp`
- `client/apps/shell/public/assets/i18n/{en,de}.json` — `docsMcp.*` keys

## Out of scope (called out in the ticket)

- **Animated GIFs / screenshots** — image assets; design + capture is a separate task.
- **In-app header navigation link** — the dashboard nav is for authenticated users; this page is the marketing landing for unauthenticated visitors. The marketing site / blog will link here directly.

## Test plan

- [x] 4 spec cases (`docs-mcp.component.spec.ts`): MCP URL renders, surface filter works, empty/error fallback, desktop config snippet contains `mcp-remote@latest` + `"yumney"`
- [x] `yarn nx test shell` passes (268/268)
- [x] `yarn nx build shell` clean
- [x] `yarn nx lint shell` clean (1 pre-existing unrelated warning in meal-planner spec)

Closes #728