### PR TITLE
test(shared): reduce Eventually.AssertAsync flake rate on CI (#606)

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -9,6 +9,15 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 /// test that does write → immediate read can race the handler. Wrapping the
 /// read+assert block in <see cref="AssertAsync"/> makes the test honest about
 /// the async boundary without changing production code.
+///
+/// The proper structural fix is a per-event readiness signal (something like
+/// <c>GET /api/v1/shopping-lists/{id}?waitForEvent={eventId}</c> that blocks
+/// until the projection has consumed that event). That would eliminate
+/// polling entirely. Until that lands, this helper minimises flake rate via:
+/// (a) a generous CI timeout, (b) jitter on the poll interval so parallel
+/// tests don't thundering-herd the API at the same instants, and
+/// (c) diagnostic info on timeout that lets us tell "projection is slow but
+/// converging" from "assertion never starts passing" in the CI logs.
 /// </summary>
 public static class Eventually
 {
@@ -17,12 +26,18 @@ public static class Eventually
 	//
 	// On CI the same suite shares a runner with the full backend test matrix
 	// plus a cold AppHost boot, so the first writes can serialise behind
-	// Wolverine + RabbitMQ start-up. We double to 60s there to keep the
-	// recurrence trail under issue #606 from flaking PRs that are otherwise
-	// green. A genuinely broken handler still surfaces inside the window
-	// because polling probes every 100 ms.
+	// Wolverine + RabbitMQ start-up. Set to 90s there — past attempts at 60s
+	// still caught flakes on a cold runner (issue #606), and polling
+	// short-circuits on success so a healthy projection still completes in
+	// well under a second.
+	// Random 0..MaxJitterMs added on top of every poll interval so parallel
+	// tests under [Collection(AspireCollection.Name)] don't all hit the API
+	// at the same 100ms boundary. Removes a small but real source of
+	// contention on a single CI runner.
+	private const int MaxJitterMs = 50;
+
 	private static readonly TimeSpan LocalTimeout = TimeSpan.FromSeconds(30);
-	private static readonly TimeSpan CiTimeout = TimeSpan.FromSeconds(60);
+	private static readonly TimeSpan CiTimeout = TimeSpan.FromSeconds(90);
 	private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
 
 	private static readonly bool IsCi = IsRunningOnCi();
@@ -39,7 +54,9 @@ public static class Eventually
 		var deadline = start + effectiveTimeout;
 		var interval = pollInterval ?? DefaultPollInterval;
 		Exception? lastError = null;
+		DateTime? firstFailureAt = null;
 		var attempts = 0;
+		var jitter = new Random();
 
 		while (true)
 		{
@@ -52,7 +69,9 @@ public static class Eventually
 			catch (Exception ex) when (DateTime.UtcNow < deadline)
 			{
 				lastError = ex;
-				await Task.Delay(interval);
+				firstFailureAt ??= DateTime.UtcNow;
+				var jitterMs = jitter.Next(MaxJitterMs);
+				await Task.Delay(interval + TimeSpan.FromMilliseconds(jitterMs));
 			}
 			catch (Exception ex)
 			{
@@ -62,10 +81,17 @@ public static class Eventually
 		}
 
 		var elapsed = DateTime.UtcNow - start;
+
+		// Time-to-first-failure helps triage: near-zero means the projection
+		// never converged in the window; near `elapsed` means the assertion
+		// flipped from passing to failing partway through (race with concurrent
+		// state mutation — usually a test-design bug, not projection lag).
+		var firstFailureElapsed = firstFailureAt is null ? "n/a" : $"{(firstFailureAt.Value - start).TotalSeconds:F2}s";
 		throw new TimeoutException(
 			$"Eventually.AssertAsync timed out after {elapsed.TotalSeconds:F1}s "
 			+ $"and {attempts} attempts (configured timeout {effectiveTimeout.TotalSeconds:F0}s, "
-			+ $"CI={IsCi}). Last assertion error: {lastError?.Message}",
+			+ $"CI={IsCi}, time-to-first-failure={firstFailureElapsed}). "
+			+ $"Last assertion error: {lastError?.Message}",
 			lastError);
 	}
 


### PR DESCRIPTION
## Summary

Three changes to `tests/Yumney.Integration.Tests/Fixtures/Eventually.cs` targeting the Shopping check-off flakes documented in #606:

| Change | Why |
|---|---|
| `CiTimeout` 60s → 90s | Past 60s attempts still flaked on cold CI runners; polling short-circuits on success so healthy projections still pass in well under a second. |
| 0..50 ms jitter per poll | Parallel tests under `[Collection(AspireCollection.Name)]` were synchronising their polls to the same 100 ms boundaries and contending on the single shopping-api instance. |
| Time-to-first-failure in the timeout message | Lets us read "projection is slow but converging" (firstFailureAt near elapsed) vs "assertion never starts passing" (firstFailureAt near zero) straight from the CI log without re-running. |

## Why not the structural fix

The issue's preferred fix #1 — a deterministic bus drain — is the right long-term answer. The type-level summary in `Eventually.cs` calls out the concrete shape: a per-event readiness signal at the API layer (e.g. `GET /api/v1/shopping-lists/{id}?waitForEvent={eventId}` that blocks until the projection has consumed that event). That eliminates polling entirely. But it needs a coordinated API + handler change across every event-sourced read endpoint, which is a much bigger PR than #606 warrants on its own.

This PR delivers the mechanical mitigations the issue itself lists as alternatives (#2 timeout, plus jitter as an addition the issue doesn't mention but is cheap and pure-test-only).

## Test plan
- [x] Strict build clean (`-p:TreatWarningsAsErrors=true`)
- [x] `dotnet format --verify-no-changes` clean
- [ ] **Acceptance signal (post-merge)**: three consecutive green runs of `Integration Tests` on develop with no re-runs needed. Will close #606 once we have that.

Refs #606