### PR TITLE
test(shared): Eventually.UntilAsync + migrate ad-hoc Task.Delay polls (#606)

### DIFF
--- a/tests/Yumney.Integration.Tests/CrossModule/AccountDeletionCascadeTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/AccountDeletionCascadeTests.cs
@@ -42,14 +42,14 @@ public class AccountDeletionCascadeTests(AspireFixture fixture)
 		await CreateShoppingListAsync(shopping, recipeId);
 		await AssignMealSlotAsync(mealplan, recipeId);
 
-		await WaitForAsync(
+		await Eventually.UntilAsync(
 			async () => await CountAcrossAllModulesAsync(userId) > 0,
 			because: "seeding must land before the delete fires");
 
 		var delete = await users.DeleteAsync("/api/v1/users/me");
 		delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-		await WaitForAsync(
+		await Eventually.UntilAsync(
 			async () => await CountAcrossAllModulesAsync(userId) == 0,
 			because: "every subscribing module must purge the owner's rows after UserAccountDeletedIntegrationEvent");
 	}
@@ -146,16 +146,5 @@ public class AccountDeletionCascadeTests(AspireFixture fixture)
 		response.EnsureSuccessStatusCode();
 	}
 
-	private static async Task WaitForAsync(Func<Task<bool>> predicate, string because, int timeoutSeconds = 15)
-	{
-		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
-		while (DateTime.UtcNow < deadline)
-		{
-			if (await predicate()) return;
-			await Task.Delay(250);
-		}
-
-		throw new TimeoutException($"Condition not met within {timeoutSeconds}s — {because}");
-	}
 #pragma warning restore SA1204
 }

--- a/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
+++ b/tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs
@@ -37,7 +37,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		// deleting. RecipeDeletedHandler queries the projection to find lists,
 		// so the projection MUST have the row indexed before the delete event
 		// arrives or the handler will return zero matches and bail out.
-		await WaitForAsync(async () =>
+		await Eventually.UntilAsync(async () =>
 		{
 			await using var ctx = await fixture.CreateShoppingReadDbContextAsync();
 			var summary = await ctx.ShoppingListSummaryReadItems
@@ -48,7 +48,7 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		var delete = await recipesClient.DeleteAsync($"/api/v1/recipes/{recipeId}");
 		delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-		await WaitForAsync(async () =>
+		await Eventually.UntilAsync(async () =>
 		{
 			await using var ctx = await fixture.CreateShoppingReadDbContextAsync();
 			var summary = await ctx.ShoppingListSummaryReadItems
@@ -101,18 +101,6 @@ public class RecipeDeletedPropagationTests(AspireFixture fixture) : IAsyncLifeti
 		response.EnsureSuccessStatusCode();
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 		return body.GetProperty("identifier").GetGuid();
-	}
-
-	private static async Task WaitForAsync(Func<Task<bool>> predicate, int timeoutSeconds = 15)
-	{
-		var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
-		while (DateTime.UtcNow < deadline)
-		{
-			if (await predicate()) return;
-			await Task.Delay(250);
-		}
-
-		throw new TimeoutException($"Condition not met within {timeoutSeconds}s");
 	}
 
 	private async Task CleanupAsync()

--- a/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/Eventually.cs
@@ -95,6 +95,36 @@ public static class Eventually
 			lastError);
 	}
 
+	/// <summary>
+	/// Predicate variant of <see cref="AssertAsync"/>. Polls until the predicate
+	/// returns true. Use when the wait condition is a boolean (e.g. "row exists",
+	/// "count > 0") rather than a FluentAssertion expression. Same timeout +
+	/// jitter machinery so CI parity stays consistent across both call shapes.
+	/// </summary>
+	/// <param name="predicate">Returns true when the wait condition is met.</param>
+	/// <param name="because">Human-readable label included in the timeout message.</param>
+	/// <param name="timeout">Override the default 30s (local) / 90s (CI) timeout.</param>
+	/// <param name="pollInterval">Override the default 100ms poll interval.</param>
+	/// <returns>A task that completes when the predicate first returns true.</returns>
+	public static async Task UntilAsync(
+		Func<Task<bool>> predicate,
+		string because = "",
+		TimeSpan? timeout = null,
+		TimeSpan? pollInterval = null)
+	{
+		await AssertAsync(
+			async () =>
+			{
+				if (!await predicate())
+				{
+					throw new InvalidOperationException(
+						string.IsNullOrEmpty(because) ? "predicate not yet true" : because);
+				}
+			},
+			timeout,
+			pollInterval);
+	}
+
 	private static bool IsRunningOnCi()
 	{
 		// Both GitHub Actions and most other runners set CI=true. Treat any

--- a/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
+++ b/tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs
@@ -95,10 +95,10 @@ public class MealPlanFlowTests(AspireFixture fixture)
 
 		await client.PostAsJsonAsync($"{WeekPath}/slots", request);
 
-		// MealPlan read-model projection is driven async by Wolverine; poll.
-		var deadline = DateTime.UtcNow.AddSeconds(15);
+		// MealPlan read-model projection is driven async by Wolverine; Eventually
+		// applies the shared CI-aware timeout + jitter (#606 mitigation).
 		JsonElement wednesdayDinner = default;
-		while (DateTime.UtcNow < deadline)
+		await Eventually.AssertAsync(async () =>
 		{
 			var response = await client.GetAsync(WeekPath);
 			var plan = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
@@ -108,9 +108,8 @@ public class MealPlanFlowTests(AspireFixture fixture)
 					slot.GetProperty("day").GetString() == "Wednesday" &&
 					slot.GetProperty("mealType").GetString() == "Dinner" &&
 					!slot.GetProperty("isEmpty").GetBoolean());
-			if (wednesdayDinner.ValueKind != JsonValueKind.Undefined) break;
-			await Task.Delay(250);
-		}
+			wednesdayDinner.ValueKind.Should().NotBe(JsonValueKind.Undefined);
+		});
 
 		wednesdayDinner.GetProperty("recipeTitle").GetString().Should().Be("Wednesday Dinner");
 		wednesdayDinner.GetProperty("servings").GetInt32().Should().Be(2);

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs
@@ -45,21 +45,25 @@ public class ExportShoppingListContractTests(AspireFixture fixture) : IAsyncLife
 
 		// The shopping read-model projection is driven async by Wolverine, so
 		// the export may not see the new item immediately after the POST returns.
-		var deadline = DateTime.UtcNow.AddSeconds(15);
+		// Eventually applies CI-aware timeout + jitter; the bare 15s loop here
+		// flaked on cold runners (#606).
 		string body = string.Empty;
 		HttpResponseMessage? response = null;
-		while (DateTime.UtcNow < deadline)
+		try
+		{
+			await Eventually.AssertAsync(async () =>
+			{
+				response?.Dispose();
+				response = await client.GetAsync(Endpoint);
+				body = await response.Content.ReadAsStringAsync();
+				response.StatusCode.Should().Be(HttpStatusCode.OK);
+				body.Should().Contain("Strawberries");
+			});
+		}
+		finally
 		{
 			response?.Dispose();
-			response = await client.GetAsync(Endpoint);
-			body = await response.Content.ReadAsStringAsync();
-			if (body.Contains("Strawberries", StringComparison.Ordinal)) break;
-			await Task.Delay(250);
 		}
-
-		response!.StatusCode.Should().Be(HttpStatusCode.OK);
-		body.Should().Contain("Strawberries");
-		response.Dispose();
 	}
 
 	[Fact]

--- a/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs
@@ -47,24 +47,29 @@ public class GetMergedShoppingListContractTests(AspireFixture fixture) : IAsyncL
 		using var client = await fixture.CreateAuthenticatedClientAsync("shopping-api");
 		await client.PostAsJsonAsync("/api/v1/shopping-lists/items", new { name = "Oranges", quantity = 4m });
 
-		// Shopping read-model projection is driven async by Wolverine; poll.
-		var deadline = DateTime.UtcNow.AddSeconds(15);
+		// Shopping read-model projection is driven async by Wolverine; the bare
+		// 15s loop here flaked on cold runners (#606). Eventually applies the
+		// shared CI-aware timeout + jitter.
 		JsonElement body = default;
 		HttpResponseMessage? response = null;
-		while (DateTime.UtcNow < deadline)
+		try
+		{
+			await Eventually.AssertAsync(async () =>
+			{
+				response?.Dispose();
+				response = await client.GetAsync(Endpoint);
+				body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+				response.StatusCode.Should().Be(HttpStatusCode.OK);
+				body.GetProperty("items").GetArrayLength().Should().Be(1);
+			});
+		}
+		finally
 		{
 			response?.Dispose();
-			response = await client.GetAsync(Endpoint);
-			body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
-			if (body.GetProperty("items").GetArrayLength() > 0) break;
-			await Task.Delay(250);
 		}
 
-		response!.StatusCode.Should().Be(HttpStatusCode.OK);
 		var items = body.GetProperty("items");
-		items.GetArrayLength().Should().Be(1);
 		items[0].GetProperty("itemName").GetString().Should().Be("Oranges");
-		response.Dispose();
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Five integration-test files were rolling their own poll loops with fixed-millisecond `Task.Delay` calls — none of them applied the CI-aware timeout, jitter, or first-failure diagnostics that `Eventually.AssertAsync` got in #743. On a cold runner they were latent #606 flakes waiting to happen.

## Changes

- **New helper:** `Eventually.UntilAsync(predicate, because)` — predicate-shaped variant that shares the same timeout + jitter machinery as `AssertAsync`. Use when the wait condition is boolean (row exists, count > 0) rather than a FluentAssertion.
- **Migrated** the ad-hoc `WaitForAsync` private helpers in `AccountDeletionCascadeTests` + `RecipeDeletedPropagationTests` to `Eventually.UntilAsync` — duplicate helpers deleted.
- **Migrated** the bare poll loops in `ExportShoppingListContractTests`, `GetMergedShoppingListContractTests`, and `MealPlanFlowTests` to `Eventually.AssertAsync`. Same wait semantics, longer CI timeout, diagnostic info on failure.

## Files

- `tests/Yumney.Integration.Tests/Fixtures/Eventually.cs` — `UntilAsync` added
- `tests/Yumney.Integration.Tests/CrossModule/AccountDeletionCascadeTests.cs` — call sites + duplicate helper removed
- `tests/Yumney.Integration.Tests/CrossModule/RecipeDeletedPropagationTests.cs` — call sites + duplicate helper removed
- `tests/Yumney.Integration.Tests/Shopping/Contract/ExportShoppingListContractTests.cs` — bare poll migrated
- `tests/Yumney.Integration.Tests/Shopping/Contract/GetMergedShoppingListContractTests.cs` — bare poll migrated
- `tests/Yumney.Integration.Tests/MealPlan/MealPlanFlowTests.cs` — bare poll migrated

## What's still bare Task.Delay

Two call sites in `HistorySurvivesRecipeDeletionTests` and `RecipeDeletedPropagationTests` use `Task.Delay` to assert that a delete does **not** propagate (i.e., that a state remains intact after the bus has had time to deliver). Replacing those with polling would invert the test's semantic. Left as-is.

## Phase B (separate PR)

The structural fix called out in `Eventually.cs`'s type-level summary — per-event readiness signal at the Shopping API level (`?waitForEventAfter=<utc>` query param) — needs a schema change + endpoint contract change and is distinct risk from these test-only changes. Will land as a focused successor.

## Test plan
- [x] `dotnet build tests/Yumney.Integration.Tests -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI run on this PR validates the migrated polls behave identically

Refs #606