### PR TITLE
chore(infra): bump Ollama to GA, document remaining prerelease pins (#463)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,13 @@
   <ItemGroup>
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <!-- Aspire.Hosting.Browsers / .Keycloak / Aspire.Keycloak.Authentication
+         have no GA on NuGet — every published version is a -preview.1.X.Y.
+         Stay on the matched 13.3.0 preview revision that the rest of the
+         Aspire 13.3.0 GA packages were built against to avoid version skew. -->
     <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.3.0-preview.1.26256.5" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.3.0-preview.1.26256.5" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.1.1" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.3.0" />
@@ -64,6 +68,10 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <!-- Analyzers -->
+    <!-- Pinned on 1.2.0-beta.556: 1.1.118 (latest stable) predates C# 9 records,
+         collection expressions, and primary constructors — downgrading produces
+         33+ false-positive SA1313/SA1010/SA1009 errors across the codebase.
+         Track GA: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Testing -->
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />


### PR DESCRIPTION
## Summary

Partial fix for #463 — bumps the only prerelease package that has a GA counterpart, and adds inline `<!-- … -->` comments to the others explaining why they must stay on preview/beta.

| Package | Was | Now | Status |
|---|---|---|---|
| `CommunityToolkit.Aspire.Hosting.Ollama` | 13.1.1 (GA) | 13.3.0 (GA) | Bumped to current GA — same minor cadence as the rest of the Aspire 13.3.0 stack |
| `Aspire.Hosting.Keycloak` | 13.3.0-preview | unchanged | NO GA on NuGet; every published version is `-preview.1.X.Y` |
| `Aspire.Keycloak.Authentication` | 13.3.0-preview | unchanged | Same |
| `Aspire.Hosting.Browsers` | 13.3.0-preview | unchanged | Same |
| `StyleCop.Analyzers` | 1.2.0-beta.556 | unchanged | Latest stable (1.1.118) predates C# 9 records, collection expressions, and primary constructors — verified locally that downgrading produces 33+ SA1313 / SA1010 / SA1009 false positives across the codebase |

## Why the strict acceptance criterion can't be fully met

The ticket asks for "no `-preview`, `-beta`, `-rc` versions". For the four packages above, no stable version exists on NuGet today. Pinning to the matched 13.3.0 preview revision (for Aspire) keeps the lockfile consistent with the GA Aspire 13.3.0 core packages. Pinning StyleCop on 1.2.0-beta.556 is the only version that understands modern C# syntax.

When upstream ships GA for any of these, a follow-up bump is straightforward; the inline comments call out exactly what to track.

## Test plan

- [x] `dotnet build Yumney.slnx -p:TreatWarningsAsErrors=true` clean
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression from the Ollama bump

Refs #463