### PR TITLE
test(shared): backfill Hosting + Outcomes coverage (Phase 1 of #464)

### DIFF
--- a/tests/Yumney.Shared.Tests/Common/ApiErrorTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/ApiErrorTests.cs
@@ -33,4 +33,66 @@ public class ApiErrorTests
 
 		error1.Should().NotBe(error2);
 	}
+
+	[Fact]
+	public void Equality_DifferentMessage_AreNotEqual()
+	{
+		var error1 = new ApiError("NOT_FOUND", "Resource not found", 404);
+		var error2 = new ApiError("NOT_FOUND", "Different message", 404);
+
+		error1.Should().NotBe(error2);
+	}
+
+	[Fact]
+	public void Equality_DifferentHttpStatusCode_AreNotEqual()
+	{
+		var error1 = new ApiError("NOT_FOUND", "Resource not found", 404);
+		var error2 = new ApiError("NOT_FOUND", "Resource not found", 410);
+
+		error1.Should().NotBe(error2);
+	}
+
+	[Fact]
+	public void GetHashCode_SameValues_AreEqual()
+	{
+		var error1 = new ApiError("NOT_FOUND", "Resource not found", 404);
+		var error2 = new ApiError("NOT_FOUND", "Resource not found", 404);
+
+		error1.GetHashCode().Should().Be(error2.GetHashCode());
+	}
+
+	[Fact]
+	public void ToString_ReturnsPropertyValues()
+	{
+		var error = new ApiError("NOT_FOUND", "Resource not found", 404);
+
+		var text = error.ToString();
+
+		text.Should().Contain("NOT_FOUND").And.Contain("Resource not found").And.Contain("404");
+	}
+
+	[Fact]
+	public void With_Expression_CreatesNewInstanceWithModifiedProperty()
+	{
+		var original = new ApiError("NOT_FOUND", "Resource not found", 404);
+
+		var modified = original with { Message = "Different message" };
+
+		modified.Code.Should().Be("NOT_FOUND");
+		modified.Message.Should().Be("Different message");
+		modified.HttpStatusCode.Should().Be(404);
+		original.Message.Should().Be("Resource not found");
+	}
+
+	[Fact]
+	public void Deconstruct_YieldsAllProperties()
+	{
+		var error = new ApiError("NOT_FOUND", "Resource not found", 404);
+
+		var (code, message, httpStatusCode) = error;
+
+		code.Should().Be("NOT_FOUND");
+		message.Should().Be("Resource not found");
+		httpStatusCode.Should().Be(404);
+	}
 }

--- a/tests/Yumney.Shared.Tests/Common/ResultTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/ResultTests.cs
@@ -64,4 +64,70 @@ public class ResultTests
 
 		act.Should().Throw<InvalidOperationException>();
 	}
+
+	[Fact]
+	public void BaseSuccessOfT_CreatesSuccessfulResultWithValue()
+	{
+		// Result.Success<T>(value) is the static factory on the base class —
+		// equivalent to Result<T>.Success(value) but reachable without the
+		// generic at the call site.
+		var result = Result.Success("hello");
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().Be("hello");
+	}
+
+	[Fact]
+	public void BaseSuccessOfT_WithNullValue_ThrowsArgumentNullException()
+	{
+		var act = () => Result.Success<string>(null!);
+
+		act.Should().Throw<ArgumentNullException>();
+	}
+
+	[Fact]
+	public void GenericSuccess_WithNullValue_ThrowsArgumentNullException()
+	{
+		var act = () => Result<string>.Success(null!);
+
+		act.Should().Throw<ArgumentNullException>();
+	}
+
+	[Fact]
+	public void BaseFailureOfT_CreatesFailedTypedResult()
+	{
+		// Result.Failure<T>(error) — typed failure factory on the base class.
+		var result = Result.Failure<int>(TestError);
+
+		result.IsSuccess.Should().BeFalse();
+		result.Error.Should().Be(TestError);
+	}
+
+	[Fact]
+	public void ImplicitOperator_FromValue_ProducesSuccess()
+	{
+		Result<int> result = 42;
+
+		result.IsSuccess.Should().BeTrue();
+		result.Value.Should().Be(42);
+	}
+
+	[Fact]
+	public void ImplicitOperator_FromApiError_ProducesFailure()
+	{
+		Result<int> result = TestError;
+
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(TestError);
+	}
+
+	[Fact]
+	public void GenericFailure_WithNullError_ThrowsInvalidOperationException()
+	{
+		// Reaches the "failed result must have an error" guard inside the
+		// shared protected ctor via the typed Failure helper.
+		var act = () => Result.Failure<int>(null!);
+
+		act.Should().Throw<InvalidOperationException>();
+	}
 }

--- a/tests/Yumney.Shared.Tests/Hosting/EndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Hosting/EndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SmartSolutionsLab.Yumney.Shared.Hosting;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Hosting;
+
+public class EndpointRouteBuilderExtensionsTests
+{
+	[Fact]
+	public void MapApiV1_GroupRequiresAuthorization()
+	{
+		var app = WebApplication.CreateBuilder().Build();
+
+		var group = app.MapApiV1();
+		group.MapGet("/probe", () => "ok");
+
+		var endpoint = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(source => source.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Single(route => route.RoutePattern.RawText == "/api/v1/probe");
+
+		endpoint.Metadata.GetMetadata<IAuthorizeData>().Should().NotBeNull("MapApiV1 wires .RequireAuthorization() on the group");
+	}
+
+	[Fact]
+	public void MapApiV1_GroupHasApiV1Prefix()
+	{
+		var app = WebApplication.CreateBuilder().Build();
+
+		var group = app.MapApiV1();
+		group.MapGet("/recipes", () => "ok");
+
+		var endpoint = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(source => source.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Single();
+
+		endpoint.RoutePattern.RawText.Should().Be("/api/v1/recipes");
+	}
+}

--- a/tests/Yumney.Shared.Tests/Hosting/ModuleRegistrationExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Hosting/ModuleRegistrationExtensionsTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Hosting;
+using SmartSolutionsLab.Yumney.Shared.Modules;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Hosting;
+
+public class ModuleRegistrationExtensionsTests
+{
+	[Fact]
+	public void RegisterServices_WithMultipleModules_CallsEachOnceInOrder()
+	{
+		var builder = WebApplication.CreateBuilder();
+		var moduleA = Substitute.For<IModule>();
+		var moduleB = Substitute.For<IModule>();
+		moduleA.RegisterServices(builder).Returns(builder);
+		moduleB.RegisterServices(builder).Returns(builder);
+
+		var result = builder.RegisterServices(moduleA, moduleB);
+
+		result.Should().BeSameAs(builder);
+		Received.InOrder(() =>
+		{
+			moduleA.RegisterServices(builder);
+			moduleB.RegisterServices(builder);
+		});
+	}
+
+	[Fact]
+	public void RegisterServices_NoModules_ReturnsBuilderUnchanged()
+	{
+		var builder = WebApplication.CreateBuilder();
+
+		var result = builder.RegisterServices();
+
+		result.Should().BeSameAs(builder);
+	}
+
+	[Fact]
+	public void RegisterEndpoints_FiltersToIEndpointModuleOnly()
+	{
+		var builder = WebApplication.CreateBuilder();
+		var app = builder.Build();
+		var plainModule = Substitute.For<IModule>();
+		var endpointModule = Substitute.For<IEndpointModule>();
+		endpointModule.RegisterEndpoints(app).Returns(app);
+
+		var result = app.RegisterEndpoints(plainModule, endpointModule);
+
+		result.Should().BeSameAs(app);
+		endpointModule.Received(1).RegisterEndpoints(app);
+		plainModule.DidNotReceiveWithAnyArgs().RegisterServices(default!);
+	}
+
+	[Fact]
+	public void RegisterEndpoints_OnlyEndpointModules_CallsEachOnce()
+	{
+		var builder = WebApplication.CreateBuilder();
+		var app = builder.Build();
+		var moduleA = Substitute.For<IEndpointModule>();
+		var moduleB = Substitute.For<IEndpointModule>();
+		moduleA.RegisterEndpoints(app).Returns(app);
+		moduleB.RegisterEndpoints(app).Returns(app);
+
+		app.RegisterEndpoints(moduleA, moduleB);
+
+		moduleA.Received(1).RegisterEndpoints(app);
+		moduleB.Received(1).RegisterEndpoints(app);
+	}
+
+	[Fact]
+	public void RegisterEndpoints_NoModules_ReturnsAppUnchanged()
+	{
+		var builder = WebApplication.CreateBuilder();
+		var app = builder.Build();
+
+		var result = app.RegisterEndpoints();
+
+		result.Should().BeSameAs(app);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Yumney.Shared.Tests.csproj
+++ b/tests/Yumney.Shared.Tests/Yumney.Shared.Tests.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\..\src\Yumney.Shared\Yumney.Shared.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Abstractions\Yumney.Shared.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.CQRS\Yumney.Shared.CQRS.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Hosting\Yumney.Shared.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Modules\Yumney.Shared.Modules.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Paging\Yumney.Shared.Paging.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Quantities\Yumney.Shared.Quantities.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Outcomes\Yumney.Shared.Outcomes.csproj" />


### PR DESCRIPTION
## Summary

Phase 1 of the Shared.* coverage backfill called out by #744's CI run (every Domain/Application/Shared assembly under 36% real coverage):

- **Yumney.Shared.Hosting**: 0% → 90%+ via 7 new tests in `tests/Yumney.Shared.Tests/Hosting/` covering:
  - `ModuleRegistrationExtensions.RegisterServices / RegisterEndpoints` — multi-module ordering, `IEndpointModule` filter, empty cases
  - `EndpointRouteBuilderExtensions.MapApiV1` — auth requirement, `/api/v1` route prefix
- **Yumney.Shared.Outcomes**: ~34% → 90%+ via:
  - 7 additional `ResultTests` — base `Success<T>/Failure<T>` factories, implicit operators (`T → Result<T>`, `ApiError → Result<T>`), `ArgumentNullException` guards
  - 6 additional `ApiErrorTests` — per-property inequality, `GetHashCode`, `ToString`, `with` expression, deconstruction

Adds the `Shared.Hosting` + `Shared.Modules` `ProjectReference`s the `Shared.Tests.csproj` was missing for the new Hosting tests to compile.

## What's left

Still failing the (PR #744) gate, each needing its own focused backfill PR:
- `Yumney.Shared.Events` (10%)
- `Yumney.Shared.Events.Contracts` (11%)
- `Yumney.Shared.CQRS` (0%)
- `Yumney.Shared.Abstractions` (12%)
- `Yumney.Shared.Paging` (14%)
- `Yumney.Shared.Quantities` (13%, 5832 lines — biggest)
- `Yumney.Shared.Persistence` (1.8%, 5220 lines — biggest, infrastructure)

Mixing them all into one PR would be too much surface for a single review.

## Test plan

- [x] All 317 Shared.Tests still pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Coverage gate (once #744 lands) reports Hosting + Outcomes above threshold

Refs #464, #744