### PR TITLE
test(shopping): backfill Domain events + Servings + ShoppingListSummary (#464)

### DIFF
--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/Events/ShoppingLedgerEventsTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingLedger/Events/ShoppingLedgerEventsTests.cs
@@ -1,0 +1,135 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingLedger.Events;
+
+/// <summary>
+/// Construction + field-stamping tests for every ShoppingLedger domain event.
+/// EventSerializationTests covers JSON round-trips; this file pins the
+/// positional constructors so a field rename or reorder shows up here.
+/// </summary>
+public class ShoppingLedgerEventsTests
+{
+	private static readonly ItemName Milk = ItemName.From("Milk");
+	private static readonly Quantity Litre = Quantity.Of(Amount.From(1m), Unit.From("l"));
+
+	[Fact]
+	public void ShoppingItemAdded_StampsAllFields()
+	{
+		var @event = new ShoppingItemAdded(Milk, Litre, ItemSource.Manual);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+		@event.Source.Should().Be(ItemSource.Manual);
+	}
+
+	[Fact]
+	public void ShoppingItemAddedAsAtHome_StampsItemAndQuantity()
+	{
+		var @event = new ShoppingItemAddedAsAtHome(Milk, Litre);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+	}
+
+	[Fact]
+	public void ShoppingItemBought_StampsItemAndQuantity()
+	{
+		var @event = new ShoppingItemBought(Milk, Litre);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+	}
+
+	[Fact]
+	public void ShoppingItemConsumed_StampsAllFields()
+	{
+		var @event = new ShoppingItemConsumed(Milk, Litre, ItemSource.MealPlan);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+		@event.Source.Should().Be(ItemSource.MealPlan);
+	}
+
+	[Fact]
+	public void ShoppingItemMarkedAsFrozen_StampsItemAndUnit()
+	{
+		var unit = Unit.From("kg");
+
+		var @event = new ShoppingItemMarkedAsFrozen(Milk, unit);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Unit.Should().Be(unit);
+	}
+
+	[Fact]
+	public void ShoppingItemMarkedAsFrozen_NullUnit_IsAllowed()
+	{
+		var @event = new ShoppingItemMarkedAsFrozen(Milk, Unit: null);
+
+		@event.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void ShoppingItemQuantityAdjusted_StampsItemAndNewQuantity()
+	{
+		var newQty = Quantity.Of(Amount.From(2m), Unit.From("l"));
+
+		var @event = new ShoppingItemQuantityAdjusted(Milk, newQty);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.NewQuantity.Should().Be(newQty);
+	}
+
+	[Fact]
+	public void ShoppingItemRemoved_WithReason_StampsAllFields()
+	{
+		var reason = RemovalReason.From("out of stock");
+
+		var @event = new ShoppingItemRemoved(Milk, Litre, reason);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+		@event.Reason.Should().Be(reason);
+	}
+
+	[Fact]
+	public void ShoppingItemRemoved_NullReason_IsAllowed()
+	{
+		var @event = new ShoppingItemRemoved(Milk, Litre, Reason: null);
+
+		@event.Reason.Should().BeNull();
+	}
+
+	[Fact]
+	public void ShoppingItemUndoBought_StampsItemAndQuantity()
+	{
+		var @event = new ShoppingItemUndoBought(Milk, Litre);
+
+		@event.ItemName.Should().Be(Milk);
+		@event.Quantity.Should().Be(Litre);
+	}
+
+	[Fact]
+	public void ShoppingModeStarted_StampsSnapshotTimestamp()
+	{
+		var snapshotAt = new DateTime(2026, 5, 15, 9, 30, 0, DateTimeKind.Utc);
+
+		var @event = new ShoppingModeStarted(snapshotAt);
+
+		@event.SnapshotTakenAt.Should().Be(snapshotAt);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void ShoppingModeEnded_StampsAcceptedPendingChanges(bool accepted)
+	{
+		var @event = new ShoppingModeEnded(accepted);
+
+		@event.AcceptedPendingChanges.Should().Be(accepted);
+	}
+}

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/Events/ShoppingListEventsTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/Events/ShoppingListEventsTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList.Events;
+
+/// <summary>
+/// Construction + field-stamping tests for every ShoppingList domain event.
+/// Records get free Equals / GetHashCode from the compiler; DomainEvent's
+/// OccurredOn timestamp makes deep equality non-deterministic, so tests
+/// assert per-property values instead.
+/// </summary>
+public class ShoppingListEventsTests
+{
+	private static readonly ShoppingListItemIdentifier ItemId = ShoppingListItemIdentifier.From(Guid.NewGuid());
+
+	[Fact]
+	public void ShoppingListCreated_PositionalCtor_StampsAllFields()
+	{
+		var listId = ShoppingListIdentifier.From(Guid.NewGuid());
+		var title = ShoppingListTitle.From("Weekly groceries");
+		var owner = OwnerIdentifier.From("kc-user-1");
+		var recipeRef = RecipeReference.From(Guid.NewGuid());
+		var createdAt = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc);
+
+		var @event = new ShoppingListCreated(listId, title, owner, recipeRef, createdAt);
+
+		@event.Identifier.Should().Be(listId);
+		@event.Title.Should().Be(title);
+		@event.Owner.Should().Be(owner);
+		@event.RecipeReference.Should().Be(recipeRef);
+		@event.CreatedAt.Should().Be(createdAt);
+	}
+
+	[Fact]
+	public void ShoppingListCreated_NullRecipeReference_IsAllowed()
+	{
+		var @event = new ShoppingListCreated(
+			ShoppingListIdentifier.From(Guid.NewGuid()),
+			ShoppingListTitle.From("Manual list"),
+			OwnerIdentifier.From("kc-user-1"),
+			RecipeReference: null,
+			DateTime.UtcNow);
+
+		@event.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public void ListItemAdded_AllFields_StampsThrough()
+	{
+		var name = ItemName.From("Milk");
+		var quantity = Quantity.Of(Amount.From(1m), Unit.From("l"));
+		var category = IngredientCategory.Dairy;
+
+		var @event = new ListItemAdded(ItemId, name, quantity, category);
+
+		@event.ItemId.Should().Be(ItemId);
+		@event.Name.Should().Be(name);
+		@event.Quantity.Should().Be(quantity);
+		@event.Category.Should().Be(category);
+	}
+
+	[Fact]
+	public void ListItemAdded_NullQuantity_IsAllowed()
+	{
+		var @event = new ListItemAdded(ItemId, ItemName.From("Bread"), Quantity: null);
+
+		@event.Quantity.Should().BeNull();
+		@event.Category.Should().BeNull();
+	}
+
+	[Fact]
+	public void ListItemChecked_StampsItemId()
+	{
+		var @event = new ListItemChecked(ItemId);
+
+		@event.ItemId.Should().Be(ItemId);
+	}
+
+	[Fact]
+	public void ListItemUnchecked_StampsItemId()
+	{
+		var @event = new ListItemUnchecked(ItemId);
+
+		@event.ItemId.Should().Be(ItemId);
+	}
+
+	[Fact]
+	public void ListItemCategoryChanged_StampsItemAndCategory()
+	{
+		var @event = new ListItemCategoryChanged(ItemId, IngredientCategory.Produce);
+
+		@event.ItemId.Should().Be(ItemId);
+		@event.Category.Should().Be(IngredientCategory.Produce);
+	}
+
+	[Fact]
+	public void AllItemsChecked_ParameterlessCtor_Works()
+	{
+		var @event = new AllItemsChecked();
+
+		@event.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void AllItemsUnchecked_ParameterlessCtor_Works()
+	{
+		var @event = new AllItemsUnchecked();
+
+		@event.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void RecipeReferenceCleared_ParameterlessCtor_Works()
+	{
+		var @event = new RecipeReferenceCleared();
+
+		@event.Should().NotBeNull();
+	}
+}

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ServingsTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ServingsTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
+
+public class ServingsTests
+{
+	[Theory]
+	[InlineData(1)]
+	[InlineData(4)]
+	[InlineData(100)]
+	public void From_PositiveValue_IsAccepted(int value)
+	{
+		var servings = Servings.From(value);
+
+		servings.Value.Should().Be(value);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void From_NonPositive_Throws(int value)
+	{
+		var act = () => Servings.From(value);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void FromNullable_Null_ReturnsNull()
+	{
+		Servings.FromNullable(null).Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_PositiveValue_ReturnsServings()
+	{
+		var servings = Servings.FromNullable(2);
+
+		servings.Should().NotBeNull();
+		servings!.Value.Should().Be(2);
+	}
+
+	[Fact]
+	public void FromNullable_ZeroValue_Throws()
+	{
+		// HasValue is true for 0 — the guard then rejects the non-positive
+		// payload. FromNullable is "null-coalescing", not "zero-coalescing".
+		var act = () => Servings.FromNullable(0);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversion_ToInt_YieldsValue()
+	{
+		var servings = Servings.From(3);
+		int raw = servings;
+
+		raw.Should().Be(3);
+	}
+
+	[Fact]
+	public void ToString_ReturnsInvariantNumericString()
+	{
+		var servings = Servings.From(4);
+
+		servings.ToString().Should().Be("4");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var a = Servings.From(2);
+		var b = Servings.From(2);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListSummaryTests.cs
+++ b/tests/Yumney.Shopping.Domain.Tests/ShoppingList/ShoppingListSummaryTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Domain.Tests.ShoppingList;
+
+public class ShoppingListSummaryTests
+{
+	[Fact]
+	public void PositionalCtor_StampsAllFields()
+	{
+		var identifier = ShoppingListIdentifier.From(Guid.NewGuid());
+		var title = ShoppingListTitle.From("Weekly groceries");
+		var itemCount = ItemCount.From(7);
+		var createdAt = new DateTime(2026, 5, 17, 8, 30, 0, DateTimeKind.Utc);
+
+		var summary = new ShoppingListSummary(identifier, title, itemCount, createdAt);
+
+		summary.Identifier.Should().Be(identifier);
+		summary.Title.Should().Be(title);
+		summary.ItemCount.Should().Be(itemCount);
+		summary.CreatedAt.Should().Be(createdAt);
+	}
+
+	[Fact]
+	public void Equality_SameFields_AreEqual()
+	{
+		var identifier = ShoppingListIdentifier.From(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+		var createdAt = new DateTime(2026, 5, 17, 8, 30, 0, DateTimeKind.Utc);
+
+		var a = new ShoppingListSummary(identifier, ShoppingListTitle.From("A"), ItemCount.From(3), createdAt);
+		var b = new ShoppingListSummary(identifier, ShoppingListTitle.From("A"), ItemCount.From(3), createdAt);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+
+	[Fact]
+	public void WithExpression_ChangesOnlyTargetField()
+	{
+		var original = new ShoppingListSummary(
+			ShoppingListIdentifier.From(Guid.NewGuid()),
+			ShoppingListTitle.From("Original"),
+			ItemCount.From(2),
+			DateTime.UtcNow);
+
+		var renamed = original with { Title = ShoppingListTitle.From("Renamed") };
+
+		renamed.Title.Value.Should().Be("Renamed");
+		renamed.Identifier.Should().Be(original.Identifier);
+		renamed.ItemCount.Should().Be(original.ItemCount);
+		renamed.CreatedAt.Should().Be(original.CreatedAt);
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Domain coverage backfill (after MealPlan.Domain in #751). Targets the untested portions of `Shopping.Domain`:

| File | Coverage focus |
|---|---|
| `ShoppingList/Events/ShoppingListEventsTests.cs` | All 7 ShoppingList event records — `ShoppingListCreated`, `ListItemAdded`/`Checked`/`Unchecked`, `ListItemCategoryChanged`, `AllItems(Un)Checked`, `RecipeReferenceCleared` |
| `ShoppingLedger/Events/ShoppingLedgerEventsTests.cs` | All 10 ShoppingLedger event records — per-event positional ctor tests beyond what `EventSerializationTests` already covers via JSON round-trips |
| `ShoppingList/ServingsTests.cs` | Positive guard, `FromNullable` null vs zero handling, implicit-to-int, invariant `ToString` |
| `ShoppingList/ShoppingListSummaryTests.cs` | Construction, equality, with-expression |

Aggregates (`ShoppingList`, `ShoppingLedger`) are already well-covered by their existing test files; this PR fills the per-event + per-VO gap that drives most of the uncovered-lines count on the #744 coverage report.

## What's still open

Remaining Domain projects below the CLAUDE.md 90% target:
- `Yumney.Recipes.Domain` (16.4%)
- `Yumney.Users.Domain` (15.6%)

Each is its own focused PR per the sequencing in #749 and #751.

## Test plan

- [x] All 219 Shopping.Domain.Tests pass (33 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression

Refs #464