### PR TITLE
test(recipes): backfill Domain — events + RecipeFavorite + chat + TimingInfo + filter (#464)

### DIFF
--- a/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
+++ b/tests/Yumney.MealPlan.Domain.Tests/WeeklyPlan/SlotRecipeReferenceTests.cs
@@ -9,7 +9,7 @@ public class SlotRecipeReferenceTests
 	[Fact]
 	public void From_ValueObjects_CreatesInstance()
 	{
-		var recipe = SlotRecipeIdentifier.From(Guid.NewGuid());
+		var recipe = SlotRecipeIdentifier.New();
 		var title = SlotRecipeTitle.From("Pad Thai");
 
 		var reference = SlotRecipeReference.From(recipe, title);

--- a/tests/Yumney.Recipes.Domain.Tests/Chat/ChatHistoryEntryTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Chat/ChatHistoryEntryTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Chat;
+
+public class ChatHistoryEntryTests
+{
+	[Fact]
+	public void PositionalCtor_StampsRoleAndContent()
+	{
+		var content = ChatMessageContent.From("Hello");
+
+		var entry = new ChatHistoryEntry(ChatRole.User, content);
+
+		entry.Role.Should().Be(ChatRole.User);
+		entry.Content.Should().Be(content);
+	}
+
+	[Fact]
+	public void Equality_SameRoleAndContent_AreEqual()
+	{
+		var content = ChatMessageContent.From("Hello");
+
+		var a = new ChatHistoryEntry(ChatRole.Assistant, content);
+		var b = new ChatHistoryEntry(ChatRole.Assistant, content);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Chat/ChatMessageContentTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Chat/ChatMessageContentTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Chat;
+
+public class ChatMessageContentTests
+{
+	[Fact]
+	public void From_TrimsSurroundingWhitespace()
+	{
+		var content = ChatMessageContent.From("  hello  ");
+
+		content.Value.Should().Be("hello");
+	}
+
+	[Fact]
+	public void From_AtMaxLength_IsAccepted()
+	{
+		var content = ChatMessageContent.From(new string('x', ChatMessageContent.MaxLength));
+
+		content.Value.Length.Should().Be(ChatMessageContent.MaxLength);
+	}
+
+	[Fact]
+	public void From_BeyondMaxLength_Throws()
+	{
+		var act = () => ChatMessageContent.From(new string('x', ChatMessageContent.MaxLength + 1));
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Empty_Throws()
+	{
+		var act = () => ChatMessageContent.From(string.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Whitespace_Throws()
+	{
+		var act = () => ChatMessageContent.From("   ");
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversion_ToString_YieldsValue()
+	{
+		var content = ChatMessageContent.From("hi");
+		string raw = content;
+
+		raw.Should().Be("hi");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var a = ChatMessageContent.From("hi");
+		var b = ChatMessageContent.From("hi");
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Chat/ChatRoleTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Chat/ChatRoleTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Chat;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Chat;
+
+public class ChatRoleTests
+{
+	[Fact]
+	public void User_StaticAccessor_HasUserValue()
+	{
+		ChatRole.User.Value.Should().Be("user");
+	}
+
+	[Fact]
+	public void Assistant_StaticAccessor_HasAssistantValue()
+	{
+		ChatRole.Assistant.Value.Should().Be("assistant");
+	}
+
+	[Theory]
+	[InlineData("user")]
+	[InlineData("assistant")]
+	[InlineData("USER")]
+	[InlineData("Assistant")]
+	public void From_KnownRole_ProducesLowercaseValue(string raw)
+	{
+		var role = ChatRole.From(raw);
+
+		role.Value.Should().Be(raw.ToLowerInvariant());
+	}
+
+	[Theory]
+	[InlineData("system")]
+	[InlineData("bot")]
+	[InlineData("nonsense")]
+	public void From_UnknownRole_Throws(string raw)
+	{
+		var act = () => ChatRole.From(raw);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Empty_Throws()
+	{
+		var act = () => ChatRole.From(string.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversion_ToString_YieldsValue()
+	{
+		string raw = ChatRole.User;
+
+		raw.Should().Be("user");
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/Events/RecipeEventsTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/Events/RecipeEventsTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe.Events;
+
+/// <summary>
+/// Construction + field-stamping tests for every Recipe domain event.
+/// Records get free Equals / GetHashCode from the compiler; DomainEvent's
+/// OccurredOn timestamp makes deep equality non-deterministic, so tests
+/// assert per-property values instead.
+/// </summary>
+public class RecipeEventsTests
+{
+	private static readonly RecipeIdentifier RecipeId = RecipeIdentifier.From(Guid.NewGuid());
+	private static readonly RecipeTitle Title = RecipeTitle.From("Carbonara");
+	private static readonly OwnerIdentifier Owner = OwnerIdentifier.From("kc-user-1");
+
+	[Fact]
+	public void RecipeSavedEvent_PositionalCtor_StampsAllFields()
+	{
+		var @event = new RecipeSavedEvent(RecipeId, Title);
+
+		@event.Recipe.Should().Be(RecipeId);
+		@event.Title.Should().Be(Title);
+	}
+
+	[Fact]
+	public void RecipeUpdatedEvent_PositionalCtor_StampsAllFields()
+	{
+		var @event = new RecipeUpdatedEvent(RecipeId, Title);
+
+		@event.Recipe.Should().Be(RecipeId);
+		@event.Title.Should().Be(Title);
+	}
+
+	[Fact]
+	public void RecipeDeletedEvent_PositionalCtor_StampsAllFields()
+	{
+		var @event = new RecipeDeletedEvent(RecipeId, Title, Owner);
+
+		@event.Recipe.Should().Be(RecipeId);
+		@event.Title.Should().Be(Title);
+		@event.Owner.Should().Be(Owner);
+	}
+
+	[Fact]
+	public void RecipeRatedEvent_PositionalCtor_StampsAllFields()
+	{
+		var rating = Rating.From(4);
+
+		var @event = new RecipeRatedEvent(RecipeId, rating);
+
+		@event.Recipe.Should().Be(RecipeId);
+		@event.Rating.Should().Be(rating);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void RecipeNotesUpdatedEvent_PositionalCtor_StampsAllFields(bool hasNotes)
+	{
+		var @event = new RecipeNotesUpdatedEvent(RecipeId, hasNotes);
+
+		@event.Recipe.Should().Be(RecipeId);
+		@event.HasNotes.Should().Be(hasNotes);
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/Events/RecipeEventsTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/Events/RecipeEventsTests.cs
@@ -13,7 +13,7 @@ namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe.Events;
 /// </summary>
 public class RecipeEventsTests
 {
-	private static readonly RecipeIdentifier RecipeId = RecipeIdentifier.From(Guid.NewGuid());
+	private static readonly RecipeIdentifier RecipeId = RecipeIdentifier.New();
 	private static readonly RecipeTitle Title = RecipeTitle.From("Carbonara");
 	private static readonly OwnerIdentifier Owner = OwnerIdentifier.From("kc-user-1");
 

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeFilterTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/RecipeFilterTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe;
+
+public class RecipeFilterTests
+{
+	[Fact]
+	public void DefaultCtor_AllNullsOrFalseEquivalents_IsEmpty()
+	{
+		var filter = new RecipeFilter();
+
+		filter.IsEmpty.Should().BeTrue();
+	}
+
+	[Fact]
+	public void EmptyTagsList_CountsAsEmpty()
+	{
+		var filter = new RecipeFilter(Tags: []);
+
+		filter.IsEmpty.Should().BeTrue();
+	}
+
+	[Fact]
+	public void WithTags_IsNotEmpty()
+	{
+		var filter = new RecipeFilter(Tags: [RecipeTag.From("italian")]);
+
+		filter.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WithDifficulty_IsNotEmpty()
+	{
+		var filter = new RecipeFilter(Difficulty: Difficulty.From("easy"));
+
+		filter.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WithMaxPrepTime_IsNotEmpty()
+	{
+		var filter = new RecipeFilter(MaxPrepTime: PreparationTime.From(15));
+
+		filter.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WithMaxCookTime_IsNotEmpty()
+	{
+		var filter = new RecipeFilter(MaxCookTime: CookingTime.From(30));
+
+		filter.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WithFavoritesOnlyTrue_IsNotEmpty()
+	{
+		var filter = new RecipeFilter(FavoritesOnly: true);
+
+		filter.IsEmpty.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WithFavoritesOnlyFalse_IsStillEmpty()
+	{
+		// FavoritesOnly = false means "don't filter by favorites" — semantically
+		// equivalent to null, so IsEmpty stays true. Only `true` activates the
+		// filter.
+		var filter = new RecipeFilter(FavoritesOnly: false);
+
+		filter.IsEmpty.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Equality_SameFields_AreEqual()
+	{
+		var a = new RecipeFilter(Difficulty: Difficulty.From("medium"), MaxPrepTime: PreparationTime.From(20));
+		var b = new RecipeFilter(Difficulty: Difficulty.From("medium"), MaxPrepTime: PreparationTime.From(20));
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/Recipe/TimingInfoTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/Recipe/TimingInfoTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.Recipe;
+
+public class TimingInfoTests
+{
+	[Fact]
+	public void Of_BothComponents_StampsBoth()
+	{
+		var prep = PreparationTime.From(10);
+		var cook = CookingTime.From(20);
+
+		var timing = TimingInfo.Of(prep, cook);
+
+		timing.Preparation.Should().Be(prep);
+		timing.Cooking.Should().Be(cook);
+		timing.TotalMinutes.Should().Be(30);
+	}
+
+	[Fact]
+	public void Of_PreparationOnly_LeavesCookingNull()
+	{
+		var prep = PreparationTime.From(15);
+
+		var timing = TimingInfo.Of(prep, cooking: null);
+
+		timing.Preparation.Should().Be(prep);
+		timing.Cooking.Should().BeNull();
+		timing.TotalMinutes.Should().Be(15);
+	}
+
+	[Fact]
+	public void Of_CookingOnly_LeavesPreparationNull()
+	{
+		var cook = CookingTime.From(25);
+
+		var timing = TimingInfo.Of(preparation: null, cook);
+
+		timing.Preparation.Should().BeNull();
+		timing.Cooking.Should().Be(cook);
+		timing.TotalMinutes.Should().Be(25);
+	}
+
+	[Fact]
+	public void Of_BothNull_StampsNullAndTotalMinutesIsNull()
+	{
+		var timing = TimingInfo.Of(preparation: null, cooking: null);
+
+		timing.Preparation.Should().BeNull();
+		timing.Cooking.Should().BeNull();
+		timing.TotalMinutes.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_BothNull_ReturnsNull()
+	{
+		// FromNullable collapses the all-null case to null so the caller
+		// doesn't need to special-case it. Distinguishes from Of (above),
+		// which produces a TimingInfo with both null fields and null total.
+		TimingInfo.FromNullable(preparation: null, cooking: null).Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_PreparationOnly_ReturnsTimingInfo()
+	{
+		var prep = PreparationTime.From(10);
+
+		var timing = TimingInfo.FromNullable(prep, cooking: null);
+
+		timing.Should().NotBeNull();
+		timing!.Preparation.Should().Be(prep);
+		timing.Cooking.Should().BeNull();
+	}
+
+	[Fact]
+	public void FromNullable_CookingOnly_ReturnsTimingInfo()
+	{
+		var cook = CookingTime.From(20);
+
+		var timing = TimingInfo.FromNullable(preparation: null, cook);
+
+		timing.Should().NotBeNull();
+		timing!.Cooking.Should().Be(cook);
+	}
+
+	[Fact]
+	public void Equality_SameComponents_AreEqual()
+	{
+		var prep = PreparationTime.From(10);
+		var cook = CookingTime.From(20);
+
+		var a = TimingInfo.Of(prep, cook);
+		var b = TimingInfo.Of(prep, cook);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteIdentifierTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteIdentifierTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.RecipeFavorite;
+
+public class RecipeFavoriteIdentifierTests
+{
+	[Fact]
+	public void New_ProducesNonEmptyGuid()
+	{
+		var id = RecipeFavoriteIdentifier.New();
+
+		id.Value.Should().NotBe(Guid.Empty);
+	}
+
+	[Fact]
+	public void New_TwoCalls_ProduceDistinctIdentifiers()
+	{
+		var first = RecipeFavoriteIdentifier.New();
+		var second = RecipeFavoriteIdentifier.New();
+
+		first.Should().NotBe(second);
+	}
+
+	[Fact]
+	public void From_NonEmptyGuid_RoundTrips()
+	{
+		var guid = Guid.NewGuid();
+
+		var id = RecipeFavoriteIdentifier.From(guid);
+
+		id.Value.Should().Be(guid);
+	}
+
+	[Fact]
+	public void From_EmptyGuid_Throws()
+	{
+		var act = () => RecipeFavoriteIdentifier.From(Guid.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ToString_ReturnsGuidString()
+	{
+		var guid = Guid.NewGuid();
+		var id = RecipeFavoriteIdentifier.From(guid);
+
+		id.ToString().Should().Be(guid.ToString());
+	}
+
+	[Fact]
+	public void Equality_SameUnderlyingGuid_AreEqual()
+	{
+		var guid = Guid.NewGuid();
+
+		var a = RecipeFavoriteIdentifier.From(guid);
+		var b = RecipeFavoriteIdentifier.From(guid);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteTests.cs
@@ -11,7 +11,7 @@ public class RecipeFavoriteTests
 	[Fact]
 	public void Create_StampsRecipeOwnerAndFavoritedAt()
 	{
-		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+		var recipe = RecipeIdentifier.New();
 		var owner = OwnerIdentifier.From("kc-user-1");
 		var before = DateTime.UtcNow;
 
@@ -36,7 +36,7 @@ public class RecipeFavoriteTests
 	[Fact]
 	public void Create_NullOwner_Throws()
 	{
-		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+		var recipe = RecipeIdentifier.New();
 
 		var act = () => global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, null!);
 
@@ -46,7 +46,7 @@ public class RecipeFavoriteTests
 	[Fact]
 	public void Create_TwoCalls_ProduceDistinctIdentifiers()
 	{
-		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+		var recipe = RecipeIdentifier.New();
 		var owner = OwnerIdentifier.From("kc-user-1");
 
 		var first = global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, owner);

--- a/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteTests.cs
+++ b/tests/Yumney.Recipes.Domain.Tests/RecipeFavorite/RecipeFavoriteTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Domain.Tests.RecipeFavorite;
+
+public class RecipeFavoriteTests
+{
+	[Fact]
+	public void Create_StampsRecipeOwnerAndFavoritedAt()
+	{
+		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+		var owner = OwnerIdentifier.From("kc-user-1");
+		var before = DateTime.UtcNow;
+
+		var favorite = global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, owner);
+
+		favorite.Recipe.Should().Be(recipe);
+		favorite.Owner.Should().Be(owner);
+		favorite.FavoritedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(DateTime.UtcNow);
+		favorite.Id.Should().NotBe(default(RecipeFavoriteIdentifier));
+	}
+
+	[Fact]
+	public void Create_NullRecipe_Throws()
+	{
+		var owner = OwnerIdentifier.From("kc-user-1");
+
+		var act = () => global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(null!, owner);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Create_NullOwner_Throws()
+	{
+		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+
+		var act = () => global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, null!);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Create_TwoCalls_ProduceDistinctIdentifiers()
+	{
+		var recipe = RecipeIdentifier.From(Guid.NewGuid());
+		var owner = OwnerIdentifier.From("kc-user-1");
+
+		var first = global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, owner);
+		var second = global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create(recipe, owner);
+
+		first.Id.Should().NotBe(second.Id);
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the Domain coverage backfill (after MealPlan in #751 and Shopping in #752). Targets the untested portions of `Recipes.Domain`:

| File | Coverage focus |
|---|---|
| `Recipe/Events/RecipeEventsTests.cs` | All 5 events — `RecipeSaved`, `RecipeUpdated`, `RecipeDeleted`, `RecipeRated`, `RecipeNotesUpdated`. Per-event positional ctor tests |
| `RecipeFavorite/RecipeFavoriteTests.cs` | `Create` stamps recipe + owner + `FavoritedAt`, null guards on both args, distinct identifiers per call |
| `RecipeFavorite/RecipeFavoriteIdentifierTests.cs` | `New` produces non-empty, `From` round-trips, empty-Guid guard, `ToString` |
| `Recipe/TimingInfoTests.cs` | All four (both / prep-only / cook-only / null) paths through `Of` + `FromNullable` + `TotalMinutes`, incl. the null collapse in `FromNullable` |
| `Recipe/RecipeFilterTests.cs` | `IsEmpty` across every axis (Tags, Difficulty, MaxPrep, MaxCook, FavoritesOnly) plus the semantic that `FavoritesOnly = false` doesn't activate the filter |
| `Chat/ChatRoleTests.cs` | `User`/`Assistant` statics, case folding, unknown-role rejection, implicit-to-string |
| `Chat/ChatMessageContentTests.cs` | Trim, max-length boundary, empty/whitespace rejection, implicit-to-string |
| `Chat/ChatHistoryEntryTests.cs` | Construction + equality |

`RecipeFavoriteTests` qualifies `global::SmartSolutionsLab.Yumney.Recipes.Domain.RecipeFavorite.RecipeFavorite.Create` because the test class's containing namespace ends in `RecipeFavorite` and C# would otherwise resolve the bare identifier as a namespace lookup, not a type.

## What's left

Only one Domain project still below the CLAUDE.md 90% target: **Yumney.Users.Domain** (15.6%).

## Test plan

- [x] All 327 Recipes.Domain.Tests pass (37 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression

Refs #464