### PR TITLE
test(users): backfill Domain — AppUserProfile mutators + VoiceSpeed + ActivityLimit + StaplesList owner (#464)

### DIFF
--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/AppUserProfileTests.cs
@@ -131,4 +131,76 @@ public class AppUserProfileTests
 		profile.DietaryProfile.BalanceGoals.MinVeggieMeals.Should().Be(3);
 		profile.DietaryProfile.CookingEffort.Should().Be(CookingEffortPreference.QuickWeekdays);
 	}
+
+	[Fact]
+	public void Create_ValidParameters_SetsDefaultThemeToSystem()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+
+		profile.Theme.Should().Be(Theme.System);
+	}
+
+	[Fact]
+	public void SwitchThemeTo_NewTheme_UpdatesTheme()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+
+		profile.SwitchThemeTo(Theme.Dark);
+
+		profile.Theme.Should().Be(Theme.Dark);
+	}
+
+	[Fact]
+	public void Create_ValidParameters_SetsDefaultVoiceSettings()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+
+		profile.VoiceSettings.Should().Be(VoiceSettings.Default);
+	}
+
+	[Fact]
+	public void UpdateVoiceSettings_NewSettings_UpdatesVoiceSettings()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+		var custom = new VoiceSettings(Enabled: false, VoiceSpeed.Fast, AutoReadInCookMode: true);
+
+		profile.UpdateVoiceSettings(custom);
+
+		profile.VoiceSettings.Should().Be(custom);
+	}
+
+	[Fact]
+	public void Create_ValidParameters_SetsDefaultNotificationPreferences()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+
+		profile.NotificationPreferences.Should().Be(NotificationPreferences.Default);
+	}
+
+	[Fact]
+	public void UpdateNotificationPreferences_NewPrefs_UpdatesNotificationPreferences()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+		var custom = new NotificationPreferences(TimerHapticFeedback: false, TimerSoundAlerts: false);
+
+		profile.UpdateNotificationPreferences(custom);
+
+		profile.NotificationPreferences.Should().Be(custom);
+	}
+
+	[Fact]
+	public void MutatorMethods_ReturnSelf_ForFluentChaining()
+	{
+		var profile = AppUserProfileBuilder.A().Build();
+
+		var result = profile
+			.RenameAs(DisplayName.From("Chained"))
+			.SwitchLanguageTo(PreferredLanguage.From("de"))
+			.SwitchThemeTo(Theme.Light);
+
+		result.Should().BeSameAs(profile);
+		profile.DisplayName.Value.Should().Be("Chained");
+		profile.PreferredLanguage.Value.Should().Be("de");
+		profile.Theme.Should().Be(Theme.Light);
+	}
 }

--- a/tests/Yumney.Users.Domain.Tests/AppUserProfile/VoiceSpeedTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/AppUserProfile/VoiceSpeedTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.AppUserProfile;
+
+public class VoiceSpeedTests
+{
+	[Fact]
+	public void Slow_StaticAccessor_HasSlowValue()
+	{
+		VoiceSpeed.Slow.Value.Should().Be("slow");
+	}
+
+	[Fact]
+	public void Normal_StaticAccessor_HasNormalValue()
+	{
+		VoiceSpeed.Normal.Value.Should().Be("normal");
+	}
+
+	[Fact]
+	public void Fast_StaticAccessor_HasFastValue()
+	{
+		VoiceSpeed.Fast.Value.Should().Be("fast");
+	}
+
+	[Theory]
+	[InlineData("slow")]
+	[InlineData("normal")]
+	[InlineData("fast")]
+	public void From_AllowedValue_IsAccepted(string raw)
+	{
+		var speed = VoiceSpeed.From(raw);
+
+		speed.Value.Should().Be(raw);
+	}
+
+	[Theory]
+	[InlineData("turbo")]
+	[InlineData("medium")]
+	[InlineData("SLOW")]
+	public void From_DisallowedValue_Throws(string raw)
+	{
+		var act = () => VoiceSpeed.From(raw);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Empty_Throws()
+	{
+		var act = () => VoiceSpeed.From(string.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversion_ToString_YieldsValue()
+	{
+		string raw = VoiceSpeed.Normal;
+
+		raw.Should().Be("normal");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var a = VoiceSpeed.From("fast");
+		var b = VoiceSpeed.From("fast");
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/StaplesList/OwnerIdentifierTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/StaplesList/OwnerIdentifierTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.StaplesList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.StaplesList;
+
+public class OwnerIdentifierTests
+{
+	[Fact]
+	public void From_TrimsSurroundingWhitespace()
+	{
+		var owner = OwnerIdentifier.From("  kc-user-1  ");
+
+		owner.Value.Should().Be("kc-user-1");
+	}
+
+	[Fact]
+	public void From_AtMaxLength_IsAccepted()
+	{
+		var owner = OwnerIdentifier.From(new string('x', OwnerIdentifier.MaxLength));
+
+		owner.Value.Length.Should().Be(OwnerIdentifier.MaxLength);
+	}
+
+	[Fact]
+	public void From_BeyondMaxLength_Throws()
+	{
+		var act = () => OwnerIdentifier.From(new string('x', OwnerIdentifier.MaxLength + 1));
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Empty_Throws()
+	{
+		var act = () => OwnerIdentifier.From(string.Empty);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void From_Whitespace_Throws()
+	{
+		var act = () => OwnerIdentifier.From("   ");
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversion_ToString_YieldsValue()
+	{
+		var owner = OwnerIdentifier.From("kc-user-1");
+		string raw = owner;
+
+		raw.Should().Be("kc-user-1");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var a = OwnerIdentifier.From("kc-user-1");
+		var b = OwnerIdentifier.From("kc-user-1");
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}

--- a/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityLimitTests.cs
+++ b/tests/Yumney.Users.Domain.Tests/UserActivity/ActivityLimitTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Domain.Tests.UserActivity;
+
+public class ActivityLimitTests
+{
+	[Theory]
+	[InlineData(1)]
+	[InlineData(5)]
+	[InlineData(100)]
+	public void From_PositiveValue_IsAccepted(int value)
+	{
+		var limit = ActivityLimit.From(value);
+
+		limit.Value.Should().Be(value);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void From_NonPositive_Throws(int value)
+	{
+		var act = () => ActivityLimit.From(value);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Default_HasDefaultValueOfFive()
+	{
+		ActivityLimit.Default().Value.Should().Be(ActivityLimit.DefaultValue);
+		ActivityLimit.DefaultValue.Should().Be(5);
+	}
+
+	[Fact]
+	public void ToString_ReturnsInvariantNumericString()
+	{
+		var limit = ActivityLimit.From(42);
+
+		limit.ToString().Should().Be("42");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var a = ActivityLimit.From(3);
+		var b = ActivityLimit.From(3);
+
+		a.Should().Be(b);
+		a.GetHashCode().Should().Be(b.GetHashCode());
+	}
+}


### PR DESCRIPTION
## Summary

Final Domain backfill phase (after MealPlan #751, Shopping #752, Recipes #753). Targets the gaps in `Users.Domain`:

| File | Coverage focus |
|---|---|
| `AppUserProfile/AppUserProfileTests.cs` (existing, extended) | `SwitchThemeTo`, `UpdateVoiceSettings`, `UpdateNotificationPreferences`, default values for `Theme`/`VoiceSettings`/`NotificationPreferences`, fluent-chain return-self check |
| `AppUserProfile/VoiceSpeedTests.cs` | `Slow`/`Normal`/`Fast` statics, `IsOneOf` validation (case-sensitive — capitals rejected), implicit-to-string, equality |
| `StaplesList/OwnerIdentifierTests.cs` | Trim, max-length boundary, empty/whitespace rejection, implicit-to-string. Distinct from `UserActivity.OwnerIdentifier` (per-aggregate identifier convention) — the latter already had tests |
| `UserActivity/ActivityLimitTests.cs` | Positive guard, `Default()` factory, `ToString` |

## What this closes out

All four Domain projects now have their event-record / VO / aggregate-mutator gaps filled. The remaining backfill work for #744's gate is:

- Shared.* phases 2–N (7 more projects)
- All Application projects (~20% coverage each)
- Infrastructure / Api advisory thresholds (warn-only per CLAUDE.md)

Each is its own focused PR.

## Test plan

- [x] All 277 Users.Domain.Tests pass (26 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression

Refs #464