### PR TITLE
test(users): backfill Application — integration handlers + mapping extensions + CurrentUserExtensions (#464)

### DIFF
--- a/tests/Yumney.Users.Application.Tests/CurrentUserExtensionsTests.cs
+++ b/tests/Yumney.Users.Application.Tests/CurrentUserExtensionsTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Users.Application;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests;
+
+public class CurrentUserExtensionsTests
+{
+	[Fact]
+	public void AsOwner_ProjectsUserIdIntoOwnerIdentifier()
+	{
+		var currentUser = Substitute.For<ICurrentUser>();
+		currentUser.UserId.Returns("kc-user-1");
+
+		var owner = currentUser.AsOwner();
+
+		owner.Should().Be(OwnerIdentifier.From("kc-user-1"));
+	}
+
+	[Fact]
+	public void AsOwner_TwoCallsForSameUser_AreEqual()
+	{
+		var currentUser = Substitute.For<ICurrentUser>();
+		currentUser.UserId.Returns("kc-user-1");
+
+		currentUser.AsOwner().Should().Be(currentUser.AsOwner());
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/DTOs/UserActivityMappingExtensionsTests.cs
+++ b/tests/Yumney.Users.Application.Tests/DTOs/UserActivityMappingExtensionsTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.TestBuilders.Users;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.DTOs;
+
+public class UserActivityMappingExtensionsTests
+{
+	[Fact]
+	public void ToDto_FullActivity_MapsAllFields()
+	{
+		var recipeId = Guid.NewGuid();
+		var activity = UserActivity.Record(
+			OwnerIdentifier.From("kc-user-1"),
+			ActivityType.RecipeViewed,
+			RecipeIdentifierSnapshot.From(recipeId),
+			RecipeTitleSnapshot.From("Pasta"));
+
+		var dto = activity.ToDto();
+
+		dto.Type.Should().Be("recipe_viewed");
+		dto.RecipeIdentifier.Should().Be(recipeId);
+		dto.RecipeTitle.Should().Be("Pasta");
+		dto.OccurredAt.Should().Be(activity.OccurredAt);
+	}
+
+	[Fact]
+	public void ToDto_DeletedRecipeActivity_MapsNullTitle()
+	{
+		var recipeId = Guid.NewGuid();
+		var activity = UserActivity.Record(
+			OwnerIdentifier.From("kc-user-1"),
+			ActivityType.RecipeDeleted,
+			RecipeIdentifierSnapshot.From(recipeId));
+
+		var dto = activity.ToDto();
+
+		dto.RecipeIdentifier.Should().Be(recipeId);
+		dto.RecipeTitle.Should().BeNull();
+	}
+
+	[Fact]
+	public void ToDtos_Collection_ReturnsListPreservingOrder()
+	{
+		var a = UserActivity.Record(
+			OwnerIdentifier.From("kc-user-1"),
+			ActivityType.RecipeImported,
+			RecipeIdentifierSnapshot.From(Guid.NewGuid()),
+			RecipeTitleSnapshot.From("A"));
+		var b = UserActivity.Record(
+			OwnerIdentifier.From("kc-user-1"),
+			ActivityType.RecipeCooked,
+			RecipeIdentifierSnapshot.From(Guid.NewGuid()),
+			RecipeTitleSnapshot.From("B"));
+
+		var dtos = new[] { a, b }.ToDtos();
+
+		dtos.Should().HaveCount(2);
+		dtos[0].RecipeTitle.Should().Be("A");
+		dtos[1].RecipeTitle.Should().Be("B");
+	}
+
+	[Fact]
+	public void ToDtos_EmptyCollection_ReturnsEmptyList()
+	{
+		Array.Empty<UserActivity>().ToDtos().Should().BeEmpty();
+	}
+
+	[Fact]
+	public void RecipeActivityStats_ToDto_MapsAllFields()
+	{
+		var lastCookedAt = new DateTime(2026, 4, 15, 19, 30, 0, DateTimeKind.Utc);
+		var stats = new RecipeActivityStats(CookCount: 3, LastCookedAt: lastCookedAt, ViewCount: 7);
+
+		var dto = stats.ToDto();
+
+		dto.CookCount.Should().Be(3);
+		dto.LastCookedAt.Should().Be(lastCookedAt);
+		dto.ViewCount.Should().Be(7);
+	}
+
+	[Fact]
+	public void RecipeActivityStats_ToDto_NeverCooked_PreservesNullLastCookedAt()
+	{
+		var stats = new RecipeActivityStats(CookCount: 0, LastCookedAt: null, ViewCount: 5);
+
+		var dto = stats.ToDto();
+
+		dto.CookCount.Should().Be(0);
+		dto.LastCookedAt.Should().BeNull();
+		dto.ViewCount.Should().Be(5);
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/DTOs/UserProfileMappingExtensionsTests.cs
+++ b/tests/Yumney.Users.Application.Tests/DTOs/UserProfileMappingExtensionsTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.TestBuilders.Users;
+using SmartSolutionsLab.Yumney.Users.Application.DTOs;
+using SmartSolutionsLab.Yumney.Users.Domain.AppUserProfile;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.DTOs;
+
+public class UserProfileMappingExtensionsTests
+{
+	[Fact]
+	public void Profile_ToDto_MapsAllFields()
+	{
+		var profile = AppUserProfileBuilder.A()
+			.WithKeycloakUserId("kc-user-1")
+			.Named("Alice")
+			.Build();
+		profile.SwitchLanguageTo(PreferredLanguage.From("de"));
+		profile.SwitchUnitSystemTo(PreferredUnitSystem.From("imperial"));
+		profile.AdjustDefaultServingsTo(DefaultServings.From(6));
+		profile.SwitchThemeTo(Theme.Dark);
+
+		var dto = profile.ToDto("alice@example.com");
+
+		dto.DisplayName.Should().Be("Alice");
+		dto.Email.Should().Be("alice@example.com");
+		dto.PreferredLanguage.Should().Be("de");
+		dto.PreferredUnitSystem.Should().Be("imperial");
+		dto.DefaultServings.Should().Be(6);
+		dto.Theme.Should().Be("dark");
+		dto.VoiceSettings.Should().NotBeNull();
+		dto.NotificationPreferences.Should().NotBeNull();
+		dto.DietaryProfile.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void VoiceSettings_ToDto_MapsAllFields()
+	{
+		var settings = new VoiceSettings(Enabled: false, VoiceSpeed.Fast, AutoReadInCookMode: true);
+
+		var dto = settings.ToDto();
+
+		dto.Enabled.Should().BeFalse();
+		dto.Speed.Should().Be("fast");
+		dto.AutoReadInCookMode.Should().BeTrue();
+	}
+
+	[Fact]
+	public void NotificationPreferences_ToDto_MapsAllFields()
+	{
+		var prefs = new NotificationPreferences(TimerHapticFeedback: true, TimerSoundAlerts: false);
+
+		var dto = prefs.ToDto();
+
+		dto.TimerHapticFeedback.Should().BeTrue();
+		dto.TimerSoundAlerts.Should().BeFalse();
+	}
+
+	[Fact]
+	public void DietaryProfile_ToDto_EmptyProfile_MapsNullsAndEmpties()
+	{
+		var dto = DietaryProfile.Empty.ToDto();
+
+		dto.DietaryType.Should().BeNull();
+		dto.Restrictions.Should().BeEmpty();
+		dto.CookingEffort.Should().BeNull();
+	}
+
+	[Fact]
+	public void DietaryProfile_ToDto_PopulatedProfile_MapsAllFields()
+	{
+		var dietary = DietaryProfile.From(
+			DietaryType.Vegan,
+			[DietaryRestriction.GlutenFree, DietaryRestriction.NutAllergy],
+			WeeklyBalanceGoals.From(5, 0),
+			CookingEffortPreference.QuickWeekdays);
+
+		var dto = dietary.ToDto();
+
+		dto.DietaryType.Should().Be("vegan");
+		dto.Restrictions.Should().BeEquivalentTo(["gluten-free", "nut-allergy"]);
+		dto.MinVeggieMeals.Should().Be(5);
+		dto.MaxRedMeatMeals.Should().Be(0);
+		dto.CookingEffort.Should().Be("quick-weekdays");
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeDeletedActivityHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeDeletedActivityHandlerTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.IntegrationEventHandlers;
+
+public class RecipeDeletedActivityHandlerTests
+{
+	private readonly IUserActivityRepository activities = Substitute.For<IUserActivityRepository>();
+	private readonly RecipeDeletedActivityHandler handler;
+
+	public RecipeDeletedActivityHandlerTests()
+	{
+		handler = new RecipeDeletedActivityHandler(activities);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PersistsRecipeDeletedActivityWithoutTitle()
+	{
+		var recipeId = Guid.NewGuid();
+		var @event = new RecipeDeletedIntegrationEvent("user-123", recipeId);
+
+		UserActivity? captured = null;
+		await activities.AddAsync(
+			Arg.Do<UserActivity>(activity => captured = activity),
+			Arg.Any<CancellationToken>());
+
+		await handler.HandleAsync(@event);
+
+		captured.Should().NotBeNull();
+		captured!.Type.Should().Be(ActivityType.RecipeDeleted);
+		captured.Owner.Value.Should().Be("user-123");
+		captured.RecipeIdentifier!.Value.Should().Be(recipeId);
+
+		// RecipeDeletedIntegrationEvent doesn't carry the title (it's gone by
+		// the time the event fires) — handler intentionally records null.
+		captured.RecipeTitle.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task HandleAsync_PassesCancellationTokenThrough()
+	{
+		var @event = new RecipeDeletedIntegrationEvent("user-123", Guid.NewGuid());
+		using var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await activities.Received(1).AddAsync(Arg.Any<UserActivity>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeImportedActivityHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeImportedActivityHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.IntegrationEventHandlers;
+
+public class RecipeImportedActivityHandlerTests
+{
+	private readonly IUserActivityRepository activities = Substitute.For<IUserActivityRepository>();
+	private readonly RecipeImportedActivityHandler handler;
+
+	public RecipeImportedActivityHandlerTests()
+	{
+		handler = new RecipeImportedActivityHandler(activities);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PersistsRecipeImportedActivity()
+	{
+		var recipeId = Guid.NewGuid();
+		var @event = new RecipeImportedIntegrationEvent("user-123", recipeId, "Imported Recipe");
+
+		UserActivity? captured = null;
+		await activities.AddAsync(
+			Arg.Do<UserActivity>(activity => captured = activity),
+			Arg.Any<CancellationToken>());
+
+		await handler.HandleAsync(@event);
+
+		captured.Should().NotBeNull();
+		captured!.Type.Should().Be(ActivityType.RecipeImported);
+		captured.Owner.Value.Should().Be("user-123");
+		captured.RecipeIdentifier!.Value.Should().Be(recipeId);
+		captured.RecipeTitle!.Value.Should().Be("Imported Recipe");
+	}
+
+	[Fact]
+	public async Task HandleAsync_PassesCancellationTokenThrough()
+	{
+		var @event = new RecipeImportedIntegrationEvent("user-123", Guid.NewGuid(), "Stew");
+		using var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await activities.Received(1).AddAsync(Arg.Any<UserActivity>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeViewedActivityHandlerTests.cs
+++ b/tests/Yumney.Users.Application.Tests/IntegrationEventHandlers/RecipeViewedActivityHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Users.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Users.Domain.UserActivity;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Application.Tests.IntegrationEventHandlers;
+
+public class RecipeViewedActivityHandlerTests
+{
+	private readonly IUserActivityRepository activities = Substitute.For<IUserActivityRepository>();
+	private readonly RecipeViewedActivityHandler handler;
+
+	public RecipeViewedActivityHandlerTests()
+	{
+		handler = new RecipeViewedActivityHandler(activities);
+	}
+
+	[Fact]
+	public async Task HandleAsync_PersistsRecipeViewedActivity()
+	{
+		var recipeId = Guid.NewGuid();
+		var @event = new RecipeViewedIntegrationEvent("user-123", recipeId, "Pad Thai");
+
+		UserActivity? captured = null;
+		await activities.AddAsync(
+			Arg.Do<UserActivity>(activity => captured = activity),
+			Arg.Any<CancellationToken>());
+
+		await handler.HandleAsync(@event);
+
+		captured.Should().NotBeNull();
+		captured!.Type.Should().Be(ActivityType.RecipeViewed);
+		captured.Owner.Value.Should().Be("user-123");
+		captured.RecipeIdentifier!.Value.Should().Be(recipeId);
+		captured.RecipeTitle!.Value.Should().Be("Pad Thai");
+	}
+
+	[Fact]
+	public async Task HandleAsync_PassesCancellationTokenThrough()
+	{
+		var @event = new RecipeViewedIntegrationEvent("user-123", Guid.NewGuid(), "Soup");
+		using var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await activities.Received(1).AddAsync(Arg.Any<UserActivity>(), cts.Token);
+	}
+}

--- a/tests/Yumney.Users.Application.Tests/Yumney.Users.Application.Tests.csproj
+++ b/tests/Yumney.Users.Application.Tests/Yumney.Users.Application.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Users.Application\Yumney.Users.Application.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
+    <ProjectReference Include="..\Yumney.TestBuilders\Yumney.TestBuilders.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Starts the **Application** coverage backfill (Domain phase finished across all four modules in #751–#754). Targets the gaps in `Users.Application`:

| File | Coverage focus |
|---|---|
| `IntegrationEventHandlers/RecipeViewedActivityHandlerTests.cs` | Persists `RecipeViewed` activity, forwards `CancellationToken` |
| `IntegrationEventHandlers/RecipeDeletedActivityHandlerTests.cs` | Persists `RecipeDeleted` with **null** title (event doesn't carry one — handler's intentional null) |
| `IntegrationEventHandlers/RecipeImportedActivityHandlerTests.cs` | Persists `RecipeImported` with title |
| `CurrentUserExtensionsTests.cs` | `ICurrentUser.AsOwner()` projects `UserId` → `OwnerIdentifier` |
| `DTOs/UserActivityMappingExtensionsTests.cs` | `ToDto` (full + null-title), `ToDtos` (collection + empty), `RecipeActivityStats ToDto` (cooked + never-cooked) |
| `DTOs/UserProfileMappingExtensionsTests.cs` | `Profile ToDto`, `VoiceSettings ToDto`, `NotificationPreferences ToDto`, `DietaryProfile ToDto` (empty + populated) |

Pulls in the existing `Yumney.TestBuilders` `ProjectReference` (`AppUserProfileBuilder`) which wasn't on the test csproj before — same builder Domain.Tests uses.

## What's left

Other Application projects still below the 80% target (per #744's coverage run):
- `Yumney.Recipes.Application` (19.7%)
- `Yumney.Shopping.Application` (18.9%)
- `Yumney.MealPlan.Application` (24.6%)

Each is its own focused PR.

## Test plan

- [x] All 78 Users.Application.Tests pass (16 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression

Refs #464