### PR TITLE
test(shopping): backfill Application — integration handlers + CurrentUserExtensions (#464)

### DIFF
--- a/tests/Yumney.Shopping.Application.Tests/CurrentUserExtensionsTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/CurrentUserExtensionsTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests;
+
+public class CurrentUserExtensionsTests
+{
+	[Fact]
+	public void AsOwner_ProjectsUserIdIntoOwnerIdentifier()
+	{
+		var currentUser = Substitute.For<ICurrentUser>();
+		currentUser.UserId.Returns("kc-user-1");
+
+		var owner = currentUser.AsOwner();
+
+		owner.Should().Be(OwnerIdentifier.From("kc-user-1"));
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/MealConfirmedHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/MealConfirmedHandlerTests.cs
@@ -1,0 +1,73 @@
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.IntegrationEventHandlers;
+
+public class MealConfirmedHandlerTests
+{
+	private readonly IShoppingEventStore eventStore = Substitute.For<IShoppingEventStore>();
+	private readonly MealConfirmedHandler handler;
+
+	public MealConfirmedHandlerTests()
+	{
+		handler = new MealConfirmedHandler(eventStore);
+	}
+
+	[Fact]
+	public async Task HandleAsync_NoIngredients_DoesNothing()
+	{
+		var @event = new MealConfirmedIntegrationEvent("user-123", Guid.NewGuid(), Servings: 2, Ingredients: []);
+
+		await handler.HandleAsync(@event);
+
+		await eventStore.DidNotReceiveWithAnyArgs().FindAsync(default!, default);
+		await eventStore.DidNotReceiveWithAnyArgs().SaveAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_LedgerMissing_DoesNothing()
+	{
+		var @event = new MealConfirmedIntegrationEvent(
+			"user-123",
+			Guid.NewGuid(),
+			Servings: 2,
+			Ingredients: [new MealConfirmedIngredient("Onion", 1m, null)]);
+		eventStore.FindAsync(OwnerIdentifier.From("user-123"), Arg.Any<CancellationToken>())
+			.Returns((ShoppingLedger?)null);
+
+		await handler.HandleAsync(@event);
+
+		await eventStore.DidNotReceiveWithAnyArgs().SaveAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_LedgerExists_MarksEachIngredientConsumedAndSaves()
+	{
+		var ledger = ShoppingLedger.Create(OwnerIdentifier.From("user-123"));
+
+		// Seed the ledger so the consumed quantities have something to clamp against.
+		ledger.AddItem(ItemName.From("Onion"), Quantity.Of(Amount.From(3m), Unit.FromNullable(null)), ItemSource.From("manual"));
+		ledger.AddItem(ItemName.From("Stock"), Quantity.Of(Amount.From(1000m), Unit.From("ml")), ItemSource.From("manual"));
+		eventStore.FindAsync(OwnerIdentifier.From("user-123"), Arg.Any<CancellationToken>())
+			.Returns(ledger);
+
+		var @event = new MealConfirmedIntegrationEvent(
+			"user-123",
+			Guid.NewGuid(),
+			Servings: 4,
+			Ingredients:
+			[
+				new MealConfirmedIngredient("Onion", 1m, null),
+				new MealConfirmedIngredient("Stock", 500m, "ml"),
+			]);
+
+		await handler.HandleAsync(@event);
+
+		await eventStore.Received(1).SaveAsync(ledger, Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/RecipeDeletedHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/RecipeDeletedHandlerTests.cs
@@ -1,0 +1,71 @@
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.TestBuilders.Shopping;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.IntegrationEventHandlers;
+
+public class RecipeDeletedHandlerTests
+{
+	private readonly IShoppingListProjectionRepository projection = Substitute.For<IShoppingListProjectionRepository>();
+	private readonly IShoppingListEventStore eventStore = Substitute.For<IShoppingListEventStore>();
+	private readonly RecipeDeletedHandler handler;
+
+	public RecipeDeletedHandlerTests()
+	{
+		handler = new RecipeDeletedHandler(projection, eventStore);
+	}
+
+	[Fact]
+	public async Task HandleAsync_NoListsReferenceRecipe_DoesNothing()
+	{
+		var @event = new RecipeDeletedIntegrationEvent("user-123", Guid.NewGuid());
+		projection.FindIdsByRecipeAsync(Arg.Any<OwnerIdentifier>(), Arg.Any<RecipeReference>(), Arg.Any<CancellationToken>())
+			.Returns([]);
+
+		await handler.HandleAsync(@event);
+
+		await eventStore.DidNotReceiveWithAnyArgs().FindAsync(default!, default);
+		await eventStore.DidNotReceiveWithAnyArgs().SaveAsync(default!, default);
+	}
+
+	[Fact]
+	public async Task HandleAsync_OneMatchingList_ClearsAndSaves()
+	{
+		var recipeId = Guid.NewGuid();
+		var list = ShoppingListBuilder.A().OwnedBy("user-123").FromRecipe(recipeId).Build();
+		projection.FindIdsByRecipeAsync(
+				OwnerIdentifier.From("user-123"),
+				RecipeReference.From(recipeId),
+				Arg.Any<CancellationToken>())
+			.Returns([list.Identifier]);
+		eventStore.FindAsync(list.Identifier, Arg.Any<CancellationToken>()).Returns(list);
+
+		await handler.HandleAsync(new RecipeDeletedIntegrationEvent("user-123", recipeId));
+
+		await eventStore.Received(1).SaveAsync(list, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ListVanishedBetweenProjectionAndStore_SkipsItContinues()
+	{
+		var recipeId = Guid.NewGuid();
+		var existing = ShoppingListBuilder.A().OwnedBy("user-123").FromRecipe(recipeId).Build();
+		var vanishedId = ShoppingListIdentifier.From(Guid.NewGuid());
+		projection.FindIdsByRecipeAsync(
+				Arg.Any<OwnerIdentifier>(),
+				Arg.Any<RecipeReference>(),
+				Arg.Any<CancellationToken>())
+			.Returns([vanishedId, existing.Identifier]);
+		eventStore.FindAsync(vanishedId, Arg.Any<CancellationToken>()).Returns((ShoppingList?)null);
+		eventStore.FindAsync(existing.Identifier, Arg.Any<CancellationToken>()).Returns(existing);
+
+		await handler.HandleAsync(new RecipeDeletedIntegrationEvent("user-123", recipeId));
+
+		await eventStore.Received(1).SaveAsync(existing, Arg.Any<CancellationToken>());
+		await eventStore.DidNotReceive().SaveAsync(Arg.Is<ShoppingList>(list => list != existing), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/UserAccountDeletedHandlerTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/IntegrationEventHandlers/UserAccountDeletedHandlerTests.cs
@@ -1,0 +1,40 @@
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using SmartSolutionsLab.Yumney.Shopping.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Shopping.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.IntegrationEventHandlers;
+
+public class UserAccountDeletedHandlerTests
+{
+	private readonly IShoppingUserDataPurger purger = Substitute.For<IShoppingUserDataPurger>();
+	private readonly UserAccountDeletedHandler handler;
+
+	public UserAccountDeletedHandlerTests()
+	{
+		handler = new UserAccountDeletedHandler(purger);
+	}
+
+	[Fact]
+	public async Task HandleAsync_DelegatesToPurger_WithOwnerProjectedFromKeycloakId()
+	{
+		var @event = new UserAccountDeletedIntegrationEvent("kc-user-1");
+
+		await handler.HandleAsync(@event);
+
+		await purger.Received(1).PurgeAsync(OwnerIdentifier.From("kc-user-1"), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCancellationToken()
+	{
+		var @event = new UserAccountDeletedIntegrationEvent("kc-user-1");
+		using var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await purger.Received(1).PurgeAsync(Arg.Any<OwnerIdentifier>(), cts.Token);
+	}
+}


### PR DESCRIPTION
## Summary

Application backfill, slice 3 (after Users in #755, MealPlan in #756). Targets the gaps in `Shopping.Application`:

| File | Coverage focus |
|---|---|
| `IntegrationEventHandlers/UserAccountDeletedHandlerTests.cs` | GDPR Art. 17 reaction (US-101) — delegates to `IShoppingUserDataPurger`, forwards `CancellationToken` |
| `IntegrationEventHandlers/MealConfirmedHandlerTests.cs` | Empty-ingredient short-circuit, missing-ledger short-circuit, populated path with `MarkConsumed` + `SaveAsync` |
| `IntegrationEventHandlers/RecipeDeletedHandlerTests.cs` | No-match early return, single-match `ClearRecipeReference` + `SaveAsync`, vanished-list race tolerance (projection said the list referenced the recipe, but the event store now returns null — handler skips and continues) |
| `CurrentUserExtensionsTests.cs` | `AsOwner` projection |

## What's left

One Application project still below the 80% target: **Yumney.Recipes.Application** (19.7%).

## Test plan

- [x] All 156 Shopping.Application.Tests pass (9 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green confirms no regression

Refs #464