### PR TITLE
test(recipes): backfill Application coverage (#464)

### DIFF
--- a/tests/Yumney.Recipes.Application.Tests/Commands/TrackRecipeCookedCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/TrackRecipeCookedCommandHandlerTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands;
+using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Commands;
+
+public class TrackRecipeCookedCommandHandlerTests
+{
+	private readonly IRecipeRepository recipes = Substitute.For<IRecipeRepository>();
+	private readonly IRecipesUnitOfWork unitOfWork = Substitute.For<IRecipesUnitOfWork>();
+	private readonly ICurrentUser currentUser = Substitute.For<ICurrentUser>();
+	private readonly IEventBus eventBus = Substitute.For<IEventBus>();
+	private readonly TrackRecipeCookedCommandHandler handler;
+
+	public TrackRecipeCookedCommandHandlerTests()
+	{
+		currentUser.UserId.Returns("user-123");
+		unitOfWork.Recipes.Returns(recipes);
+		handler = new TrackRecipeCookedCommandHandler(unitOfWork, currentUser, eventBus);
+	}
+
+	[Fact]
+	public async Task HandleAsync_OwnerMatches_PublishesEventAndSaves()
+	{
+		var recipe = RecipeTestData.CreateRecipe();
+		recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+		var result = await handler.HandleAsync(new TrackRecipeCookedCommand(recipe.Id));
+
+		result.IsSuccess.Should().BeTrue();
+		await eventBus.Received(1).PublishAsync(
+			Arg.Is<RecipeCookedIntegrationEvent>(@event =>
+				@event.OwnerId == "user-123"
+				&& @event.RecipeIdentifier == recipe.Id.Value
+				&& @event.RecipeTitle == recipe.Title.Value),
+			Arg.Any<CancellationToken>());
+		await unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_DifferentOwner_ReturnsAccessDenied()
+	{
+		var recipe = RecipeTestData.CreateRecipe(ownerId: "other-user");
+		recipes.GetByIdAsync(recipe.Id, Arg.Any<CancellationToken>()).Returns(recipe);
+
+		var result = await handler.HandleAsync(new TrackRecipeCookedCommand(recipe.Id));
+
+		result.IsSuccess.Should().BeFalse();
+		result.Error.Should().Be(TrackRecipeCookedErrors.AccessDenied);
+		await eventBus.DidNotReceiveWithAnyArgs().PublishAsync<RecipeCookedIntegrationEvent>(default!, default);
+		await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/Yumney.Recipes.Application.Tests/Common/LlmResponseParserTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Common/LlmResponseParserTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Application.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.Common;
+
+public class LlmResponseParserTests
+{
+	[Fact]
+	public void ExtractJson_NoFence_ReturnsTrimmedInput()
+	{
+		var result = LlmResponseParser.ExtractJson("  {\"a\":1}  ");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_JsonFence_StripsPrefixAndSuffix()
+	{
+		var result = LlmResponseParser.ExtractJson("```json\n{\"a\":1}\n```");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_JsonFence_CaseInsensitivePrefix()
+	{
+		var result = LlmResponseParser.ExtractJson("```JSON\n{\"a\":1}\n```");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_PlainFence_StripsPrefixAndSuffix()
+	{
+		var result = LlmResponseParser.ExtractJson("```\n{\"a\":1}\n```");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_OnlyOpenFence_StripsPrefixAndReturnsRemainder()
+	{
+		var result = LlmResponseParser.ExtractJson("```json\n{\"a\":1}");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_OnlyClosingFence_StripsSuffix()
+	{
+		var result = LlmResponseParser.ExtractJson("{\"a\":1}\n```");
+
+		result.Should().Be("{\"a\":1}");
+	}
+
+	[Fact]
+	public void ExtractJson_NoFenceJustWhitespace_ReturnsEmpty()
+	{
+		var result = LlmResponseParser.ExtractJson("   \n   ");
+
+		result.Should().BeEmpty();
+	}
+}

--- a/tests/Yumney.Recipes.Application.Tests/CurrentUserExtensionsTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/CurrentUserExtensionsTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Common;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests;
+
+public class CurrentUserExtensionsTests
+{
+	[Fact]
+	public void AsOwner_ProjectsUserIdIntoOwnerIdentifier()
+	{
+		var currentUser = Substitute.For<ICurrentUser>();
+		currentUser.UserId.Returns("kc-user-1");
+
+		var owner = currentUser.AsOwner();
+
+		owner.Should().Be(OwnerIdentifier.From("kc-user-1"));
+	}
+}

--- a/tests/Yumney.Recipes.Application.Tests/DTOs/FavoriteStateMappingExtensionsTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/DTOs/FavoriteStateMappingExtensionsTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.DTOs;
+
+public class FavoriteStateMappingExtensionsTests
+{
+	[Fact]
+	public void ToFavoriteStateDto_True_ProjectsIdentifierAndFlag()
+	{
+		var recipe = RecipeIdentifier.New();
+
+		var dto = recipe.ToFavoriteStateDto(isFavorite: true);
+
+		dto.RecipeIdentifier.Should().Be(recipe.Value);
+		dto.IsFavorite.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ToFavoriteStateDto_False_ProjectsIdentifierAndFlag()
+	{
+		var recipe = RecipeIdentifier.New();
+
+		var dto = recipe.ToFavoriteStateDto(isFavorite: false);
+
+		dto.RecipeIdentifier.Should().Be(recipe.Value);
+		dto.IsFavorite.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Application.Tests/DTOs/RecipeMappingExtensionsTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/DTOs/RecipeMappingExtensionsTests.cs
@@ -1,0 +1,209 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.TestBuilders.Recipes;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.DTOs;
+
+public class RecipeMappingExtensionsTests
+{
+	[Fact]
+	public void ToDetailDto_FullRecipe_ProjectsEveryField()
+	{
+		var recipe = RecipeBuilder.A()
+			.WithTitle("Carbonara")
+			.WithDescription("Roman classic")
+			.WithServings(4)
+			.WithTiming(prepMinutes: 10, cookMinutes: 20)
+			.WithDifficulty("easy")
+			.WithImageUrl("https://example.com/image.jpg")
+			.WithLanguage("en")
+			.WithSourceUrl("https://example.com/recipe")
+			.WithTag("italian")
+			.Build();
+		recipe.RateAs(Rating.From(5));
+		recipe.UpdateNotes(Notes.From("Use guanciale"));
+
+		var dto = recipe.ToDetailDto(isFavorite: true);
+
+		dto.Identifier.Should().Be(recipe.Id.Value);
+		dto.Title.Should().Be("Carbonara");
+		dto.Description.Should().Be("Roman classic");
+		dto.Servings.Should().Be(4);
+		dto.PrepTimeMinutes.Should().Be(10);
+		dto.CookTimeMinutes.Should().Be(20);
+		dto.Difficulty.Should().Be("easy");
+		dto.ImageUrl.Should().Be("https://example.com/image.jpg");
+		dto.Language.Should().Be("en");
+		dto.SourceUrl.Should().Be("https://example.com/recipe");
+		dto.Tags.Should().ContainSingle().Which.Should().Be("italian");
+		dto.IsFavorite.Should().BeTrue();
+		dto.Rating.Should().Be(5);
+		dto.Notes.Should().Be("Use guanciale");
+		dto.Ingredients.Should().NotBeEmpty();
+		dto.Steps.Should().NotBeEmpty();
+	}
+
+	[Fact]
+	public void ToDetailDto_MinimalRecipe_LeavesOptionalFieldsNull()
+	{
+		var recipe = RecipeBuilder.A().WithTitle("Bare").Build();
+
+		var dto = recipe.ToDetailDto();
+
+		dto.Description.Should().BeNull();
+		dto.Servings.Should().BeNull();
+		dto.PrepTimeMinutes.Should().BeNull();
+		dto.CookTimeMinutes.Should().BeNull();
+		dto.Difficulty.Should().BeNull();
+		dto.ImageUrl.Should().BeNull();
+		dto.Language.Should().BeNull();
+		dto.SourceUrl.Should().BeNull();
+		dto.Rating.Should().BeNull();
+		dto.Notes.Should().BeNull();
+		dto.Tags.Should().BeEmpty();
+		dto.IsFavorite.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ToListItemDto_RecipeWithNotes_HasNotesIsTrue()
+	{
+		var recipe = RecipeBuilder.A().WithTitle("Stew").Build();
+		recipe.UpdateNotes(Notes.From("Reduce salt"));
+
+		var dto = recipe.ToListItemDto(isFavorite: true);
+
+		dto.HasNotes.Should().BeTrue();
+		dto.IsFavorite.Should().BeTrue();
+		dto.Title.Should().Be("Stew");
+	}
+
+	[Fact]
+	public void ToListItemDto_RecipeWithoutNotes_HasNotesIsFalse()
+	{
+		var recipe = RecipeBuilder.A().Build();
+
+		var dto = recipe.ToListItemDto();
+
+		dto.HasNotes.Should().BeFalse();
+		dto.IsFavorite.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ToSavedDto_ProjectsIdentifierTitleAndCreatedAt()
+	{
+		var recipe = RecipeBuilder.A().WithTitle("Risotto").Build();
+
+		var dto = recipe.ToSavedDto();
+
+		dto.Identifier.Should().Be(recipe.Id.Value);
+		dto.Title.Should().Be("Risotto");
+		dto.CreatedAt.Should().Be(recipe.CreatedAt);
+	}
+
+	[Fact]
+	public void ToCookableDto_FullMatch_HasEmptyMissingList()
+	{
+		var recipe = RecipeBuilder.A()
+			.WithTitle("Soup")
+			.WithServings(2)
+			.WithTiming(prepMinutes: 5, cookMinutes: 30)
+			.WithDifficulty("medium")
+			.WithImageUrl("https://example.com/soup.jpg")
+			.Build();
+
+		var dto = recipe.ToCookableDto(CookableRecipeMatchTier.Full, missingIngredients: []);
+
+		dto.RecipeIdentifier.Should().Be(recipe.Id.Value);
+		dto.Title.Should().Be("Soup");
+		dto.ImageUrl.Should().Be("https://example.com/soup.jpg");
+		dto.Servings.Should().Be(2);
+		dto.PrepTimeMinutes.Should().Be(5);
+		dto.CookTimeMinutes.Should().Be(30);
+		dto.Difficulty.Should().Be("medium");
+		dto.IngredientCount.Should().Be(recipe.Ingredients.Count);
+		dto.Tier.Should().Be(CookableRecipeMatchTier.Full);
+		dto.MissingIngredients.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ToCookableDto_NearMatch_PreservesMissingList()
+	{
+		var recipe = RecipeBuilder.A().WithTitle("Stir-fry").Build();
+
+		var dto = recipe.ToCookableDto(
+			CookableRecipeMatchTier.Near,
+			missingIngredients: ["soy sauce", "ginger"]);
+
+		dto.Tier.Should().Be(CookableRecipeMatchTier.Near);
+		dto.MissingIngredients.Should().Equal("soy sauce", "ginger");
+	}
+
+	[Fact]
+	public void IngredientToDto_WithQuantity_ProjectsAmountAndUnit()
+	{
+		Ingredient ingredient = IngredientBuilder.A().Named("Flour").WithQuantity(500m, Unit.Gram);
+
+		var dto = ingredient.ToDto();
+
+		dto.Name.Should().Be("Flour");
+		dto.Amount.Should().Be(500m);
+		dto.Unit.Should().Be(Unit.Gram.Value);
+	}
+
+	[Fact]
+	public void IngredientToDto_WithoutQuantity_LeavesAmountAndUnitNull()
+	{
+		Ingredient ingredient = IngredientBuilder.A().Named("Salt");
+
+		var dto = ingredient.ToDto();
+
+		dto.Name.Should().Be("Salt");
+		dto.Amount.Should().BeNull();
+		dto.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void IngredientsToDtos_MapsEveryIngredient()
+	{
+		Ingredient[] ingredients =
+		[
+			IngredientBuilder.A().Named("Flour").WithQuantity(500m, Unit.Gram),
+			IngredientBuilder.A().Named("Eggs"),
+		];
+
+		var dtos = ingredients.ToDtos();
+
+		dtos.Should().HaveCount(2);
+		dtos[0].Name.Should().Be("Flour");
+		dtos[1].Name.Should().Be("Eggs");
+	}
+
+	[Fact]
+	public void StepToDto_ProjectsNumberAndDescription()
+	{
+		Step step = StepBuilder.A().Numbered(2).WithDescription("Mix");
+
+		var dto = step.ToDto();
+
+		dto.Number.Should().Be(2);
+		dto.Description.Should().Be("Mix");
+	}
+
+	[Fact]
+	public void StepsToDtos_MapsEveryStep()
+	{
+		Step[] steps =
+		[
+			StepBuilder.A().Numbered(1).WithDescription("Chop"),
+			StepBuilder.A().Numbered(2).WithDescription("Saute"),
+		];
+
+		var dtos = steps.ToDtos();
+
+		dtos.Should().HaveCount(2);
+		dtos[0].Number.Should().Be(1);
+		dtos[1].Description.Should().Be("Saute");
+	}
+}

--- a/tests/Yumney.Recipes.Application.Tests/IntegrationEventHandlers/UserAccountDeletedHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/IntegrationEventHandlers/UserAccountDeletedHandlerTests.cs
@@ -1,0 +1,40 @@
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.IntegrationEventHandlers;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Application.Tests.IntegrationEventHandlers;
+
+public class UserAccountDeletedHandlerTests
+{
+	private readonly IRecipesUserDataPurger purger = Substitute.For<IRecipesUserDataPurger>();
+	private readonly UserAccountDeletedHandler handler;
+
+	public UserAccountDeletedHandlerTests()
+	{
+		handler = new UserAccountDeletedHandler(purger);
+	}
+
+	[Fact]
+	public async Task HandleAsync_DelegatesToPurger_WithOwnerProjectedFromKeycloakId()
+	{
+		var @event = new UserAccountDeletedIntegrationEvent("kc-user-1");
+
+		await handler.HandleAsync(@event);
+
+		await purger.Received(1).PurgeAsync(OwnerIdentifier.From("kc-user-1"), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ForwardsCancellationToken()
+	{
+		var @event = new UserAccountDeletedIntegrationEvent("kc-user-1");
+		using var cts = new CancellationTokenSource();
+
+		await handler.HandleAsync(@event, cts.Token);
+
+		await purger.Received(1).PurgeAsync(Arg.Any<OwnerIdentifier>(), cts.Token);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds tests for previously uncovered Recipes.Application surface:
  - `TrackRecipeCookedCommandHandler` — happy path + access-denied
  - `IntegrationEventHandlers/UserAccountDeletedHandler` — owner projection + cancellation token forwarding
  - `CurrentUserExtensions.AsOwner`
  - `DTOs/RecipeMappingExtensions` — detail/list/saved/cookable + ingredient + step projections
  - `DTOs/FavoriteStateMappingExtensions`
  - `Common/LlmResponseParser` — markdown-fence stripping variants
- 210 tests pass locally; `dotnet build -p:TreatWarningsAsErrors=true` clean; `dotnet format --verify-no-changes` clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Recipes.Application.Tests/` green
- [ ] CI green