### PR TITLE
test(shared): backfill Events + Events.Contracts (#464)

### DIFF
--- a/tests/Yumney.Shared.Events.Tests/Contracts/IntegrationEventContractsTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/Contracts/IntegrationEventContractsTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Events.Contracts;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests.Contracts;
+
+/// <summary>
+/// Construction + base-property smoke tests for every cross-module integration
+/// event contract. The records inherit EventIdentifier + OccurredOn from
+/// <see cref="IntegrationEvent"/>; we assert each ctor stamps every payload
+/// field through and that the base infrastructure auto-populates correctly.
+/// </summary>
+public class IntegrationEventContractsTests
+{
+	[Fact]
+	public void UserAccountDeletedIntegrationEvent_StampsKeycloakUserId()
+	{
+		var @event = new UserAccountDeletedIntegrationEvent("kc-user-1");
+
+		@event.KeycloakUserId.Should().Be("kc-user-1");
+		@event.EventIdentifier.Should().NotBe(Guid.Empty);
+		@event.OccurredOn.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+	}
+
+	[Fact]
+	public void RecipeImportedIntegrationEvent_StampsAllFields()
+	{
+		var recipe = Guid.NewGuid();
+
+		var @event = new RecipeImportedIntegrationEvent("user-1", recipe, "Carbonara");
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.RecipeIdentifier.Should().Be(recipe);
+		@event.RecipeTitle.Should().Be("Carbonara");
+	}
+
+	[Fact]
+	public void RecipeDeletedIntegrationEvent_StampsAllFields()
+	{
+		var recipe = Guid.NewGuid();
+
+		var @event = new RecipeDeletedIntegrationEvent("user-1", recipe);
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.RecipeIdentifier.Should().Be(recipe);
+	}
+
+	[Fact]
+	public void RecipeViewedIntegrationEvent_StampsAllFields()
+	{
+		var recipe = Guid.NewGuid();
+
+		var @event = new RecipeViewedIntegrationEvent("user-1", recipe, "Soup");
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.RecipeIdentifier.Should().Be(recipe);
+		@event.RecipeTitle.Should().Be("Soup");
+	}
+
+	[Fact]
+	public void RecipeCookedIntegrationEvent_StampsAllFields()
+	{
+		var recipe = Guid.NewGuid();
+
+		var @event = new RecipeCookedIntegrationEvent("user-1", recipe, "Risotto");
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.RecipeIdentifier.Should().Be(recipe);
+		@event.RecipeTitle.Should().Be("Risotto");
+	}
+
+	[Fact]
+	public void MealConfirmedIntegrationEvent_StampsAllFields()
+	{
+		var recipe = Guid.NewGuid();
+		IReadOnlyList<MealConfirmedIngredient> ingredients =
+		[
+			new("Onion", 1m, null),
+			new("Stock", 500m, "ml"),
+		];
+
+		var @event = new MealConfirmedIntegrationEvent("user-1", recipe, Servings: 4, ingredients);
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.RecipeIdentifier.Should().Be(recipe);
+		@event.Servings.Should().Be(4);
+		@event.Ingredients.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void MealConfirmedIngredient_NullUnit_IsAllowed()
+	{
+		var ingredient = new MealConfirmedIngredient("Egg", 3m, Unit: null);
+
+		ingredient.Name.Should().Be("Egg");
+		ingredient.Quantity.Should().Be(3m);
+		ingredient.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void IntegrationEvent_OverridingInitProperties_Roundtrips()
+	{
+		// Wolverine rehydrates events through System.Text.Json — the `init`
+		// setters on EventIdentifier + OccurredOn must accept incoming values
+		// or the inbox-dedup key would be regenerated on every redelivery.
+		var fixedId = Guid.NewGuid();
+		var fixedTime = new DateTime(2026, 5, 17, 10, 0, 0, DateTimeKind.Utc);
+
+		var @event = new RecipeDeletedIntegrationEvent("user-1", Guid.NewGuid())
+		{
+			EventIdentifier = fixedId,
+			OccurredOn = fixedTime,
+		};
+
+		@event.EventIdentifier.Should().Be(fixedId);
+		@event.OccurredOn.Should().Be(fixedTime);
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/InboxMessageTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/InboxMessageTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class InboxMessageTests
+{
+	[Fact]
+	public void RequiredProperties_AreStamped()
+	{
+		var messageId = Guid.NewGuid();
+		var message = new InboxMessage
+		{
+			MessageId = messageId,
+			ConsumerName = "ShoppingLedger.RecipeDeleted",
+		};
+
+		message.MessageId.Should().Be(messageId);
+		message.ConsumerName.Should().Be("ShoppingLedger.RecipeDeleted");
+	}
+
+	[Fact]
+	public void ProcessedAt_DefaultsToUtcNow()
+	{
+		var message = new InboxMessage
+		{
+			MessageId = Guid.NewGuid(),
+			ConsumerName = "consumer",
+		};
+
+		message.ProcessedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+	}
+
+	[Fact]
+	public void ProcessedAt_CanBeOverridden()
+	{
+		var when = new DateTime(2026, 5, 17, 10, 0, 0, DateTimeKind.Utc);
+
+		var message = new InboxMessage
+		{
+			MessageId = Guid.NewGuid(),
+			ConsumerName = "consumer",
+			ProcessedAt = when,
+		};
+
+		message.ProcessedAt.Should().Be(when);
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/IntegrationEventBaseTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/IntegrationEventBaseTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class IntegrationEventBaseTests
+{
+	private sealed record FakeIntegrationEvent(string OwnerId) : IntegrationEvent;
+
+	[Fact]
+	public void DefaultCtor_AutoStampsNonEmptyEventIdentifier()
+	{
+		var @event = new FakeIntegrationEvent("user-1");
+
+		@event.EventIdentifier.Should().NotBe(Guid.Empty);
+	}
+
+	[Fact]
+	public void DefaultCtor_AutoStampsOccurredOnFromUtcNow()
+	{
+		var @event = new FakeIntegrationEvent("user-1");
+
+		@event.OccurredOn.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+	}
+
+	[Fact]
+	public void TwoInstances_HaveDifferentEventIdentifiers()
+	{
+		var first = new FakeIntegrationEvent("user-1");
+		var second = new FakeIntegrationEvent("user-1");
+
+		first.EventIdentifier.Should().NotBe(second.EventIdentifier);
+	}
+
+	[Fact]
+	public void InitSetters_AcceptIncomingValues()
+	{
+		var id = Guid.NewGuid();
+		var when = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc);
+
+		var @event = new FakeIntegrationEvent("user-1")
+		{
+			EventIdentifier = id,
+			OccurredOn = when,
+		};
+
+		@event.EventIdentifier.Should().Be(id);
+		@event.OccurredOn.Should().Be(when);
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/ModuleEventBaseTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/ModuleEventBaseTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class ModuleEventBaseTests
+{
+	private sealed record FakeModuleEvent(string OwnerId, string Payload) : ModuleEvent(OwnerId);
+
+	[Fact]
+	public void DefaultCtor_StampsOwnerAndAutoFields()
+	{
+		var @event = new FakeModuleEvent("user-1", "hello");
+
+		@event.OwnerId.Should().Be("user-1");
+		@event.Payload.Should().Be("hello");
+		@event.EventIdentifier.Should().NotBe(Guid.Empty);
+		@event.OccurredOn.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+	}
+
+	[Fact]
+	public void InitSetters_AcceptIncomingValues()
+	{
+		var id = Guid.NewGuid();
+		var when = new DateTime(2026, 5, 17, 8, 0, 0, DateTimeKind.Utc);
+
+		var @event = new FakeModuleEvent("user-1", "p")
+		{
+			EventIdentifier = id,
+			OccurredOn = when,
+		};
+
+		@event.EventIdentifier.Should().Be(id);
+		@event.OccurredOn.Should().Be(when);
+	}
+
+	[Fact]
+	public void TwoInstances_HaveDifferentEventIdentifiers()
+	{
+		var first = new FakeModuleEvent("user-1", "p");
+		var second = new FakeModuleEvent("user-1", "p");
+
+		first.EventIdentifier.Should().NotBe(second.EventIdentifier);
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/NoOpInboxStoreTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/NoOpInboxStoreTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class NoOpInboxStoreTests
+{
+	private readonly NoOpInboxStore store = new();
+
+	[Fact]
+	public async Task TryProcessAsync_InvokesHandlerAndReturnsProcessed()
+	{
+		var invoked = false;
+
+		var outcome = await store.TryProcessAsync(
+			Guid.NewGuid(),
+			"consumer",
+			ct =>
+			{
+				invoked = true;
+				return Task.CompletedTask;
+			});
+
+		invoked.Should().BeTrue();
+		outcome.Should().Be(InboxOutcome.Processed);
+	}
+
+	[Fact]
+	public async Task TryProcessAsync_ForwardsCancellationToken()
+	{
+		using var cts = new CancellationTokenSource();
+		CancellationToken seenToken = default;
+
+		await store.TryProcessAsync(
+			Guid.NewGuid(),
+			"consumer",
+			ct =>
+			{
+				seenToken = ct;
+				return Task.CompletedTask;
+			},
+			cts.Token);
+
+		seenToken.Should().Be(cts.Token);
+	}
+
+	[Fact]
+	public async Task TryProcessAsync_HandlerThrows_PropagatesException()
+	{
+		var act = async () => await store.TryProcessAsync(
+			Guid.NewGuid(),
+			"consumer",
+			ct => throw new InvalidOperationException("boom"));
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/Yumney.Shared.Events.Tests.csproj
+++ b/tests/Yumney.Shared.Events.Tests/Yumney.Shared.Events.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.InProcess\Yumney.Shared.Events.InProcess.csproj" />
     <ProjectReference Include="..\..\src\Yumney.Shared.Events.Wolverine\Yumney.Shared.Events.Wolverine.csproj" />
+    <ProjectReference Include="..\..\src\Yumney.Shared.Events.Contracts\Yumney.Shared.Events.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- `Contracts/IntegrationEventContractsTests`: construction smoke for all 6 cross-module event records + `MealConfirmedIngredient` value record + `init`-setter roundtrip (required for Wolverine rehydration / inbox dedup).
- `IntegrationEventBaseTests` + `ModuleEventBaseTests`: confirm auto-stamped `EventIdentifier` / `OccurredOn` and that `init` setters accept incoming values.
- `InboxMessageTests`: required props + `ProcessedAt` default + override.
- `NoOpInboxStoreTests`: pass-through invocation, cancellation forwarding, exception propagation.
- Added `Yumney.Shared.Events.Contracts` ProjectReference to the test csproj.
- 44 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shared.Events.Tests/` green
- [ ] CI green