### PR TITLE
test(shared): backfill Paging, Quantities, Abstractions (#464)

### DIFF
--- a/tests/Yumney.Shared.Tests/Common/AggregateVersionTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/AggregateVersionTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class AggregateVersionTests
+{
+	[Fact]
+	public void Zero_ReturnsVersionWithValueZero()
+	{
+		AggregateVersion.Zero().Value.Should().Be(0);
+	}
+
+	[Fact]
+	public void From_PositiveValue_StoresValue()
+	{
+		AggregateVersion.From(7).Value.Should().Be(7);
+	}
+
+	[Fact]
+	public void From_NegativeValue_Throws()
+	{
+		var act = () => AggregateVersion.From(-1);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void Increment_ReturnsNewVersion_LeavesOriginalUnchanged()
+	{
+		var original = AggregateVersion.From(3);
+
+		var next = original.Increment();
+
+		next.Value.Should().Be(4);
+		original.Value.Should().Be(3);
+	}
+
+	[Fact]
+	public void ImplicitConversionToInt_YieldsValue()
+	{
+		var version = AggregateVersion.From(12);
+
+		int raw = version;
+
+		raw.Should().Be(12);
+	}
+
+	[Fact]
+	public void ToString_UsesInvariantCulture()
+	{
+		AggregateVersion.From(1234).ToString().Should().Be("1234");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		AggregateVersion.From(5).Should().Be(AggregateVersion.From(5));
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/ConvertedAmountTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/ConvertedAmountTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class ConvertedAmountTests
+{
+	[Fact]
+	public void Ctor_StampsAmountAndUnit()
+	{
+		var converted = new ConvertedAmount(8m, "oz");
+
+		converted.Amount.Should().Be(8m);
+		converted.Unit.Should().Be("oz");
+	}
+
+	[Fact]
+	public void Equality_SameValues_AreEqual()
+	{
+		var first = new ConvertedAmount(250m, "ml");
+		var second = new ConvertedAmount(250m, "ml");
+
+		first.Should().Be(second);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/EntityNotFoundExceptionTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/EntityNotFoundExceptionTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class EntityNotFoundExceptionTests
+{
+	[Fact]
+	public void Ctor_StoresEntityNameAndIdentifier()
+	{
+		var identifier = Guid.NewGuid();
+
+		var exception = new EntityNotFoundException("Recipe", identifier);
+
+		exception.EntityName.Should().Be("Recipe");
+		exception.Identifier.Should().Be(identifier);
+	}
+
+	[Fact]
+	public void Message_IncludesEntityNameAndIdentifier()
+	{
+		var exception = new EntityNotFoundException("Recipe", "abc-123");
+
+		exception.Message.Should().Be("Recipe with identifier 'abc-123' was not found.");
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/EventSourcedAggregateTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/EventSourcedAggregateTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class EventSourcedAggregateTests
+{
+	private sealed record CounterIncremented(int Step) : DomainEvent;
+
+	private sealed record CounterReset() : DomainEvent;
+
+	private sealed class Counter : EventSourcedAggregate<Guid>
+	{
+		public int Total { get; private set; }
+
+		public int Resets { get; private set; }
+
+		public Counter(Guid id)
+		{
+			Identifier = id;
+			On<CounterIncremented>(@event => Total += @event.Step);
+			On<CounterReset>(_ =>
+			{
+				Total = 0;
+				Resets++;
+			});
+		}
+
+		public void Increment(int step) => RaiseEvent(new CounterIncremented(step));
+
+		public void Reset() => RaiseEvent(new CounterReset());
+
+		public void Replay(IEnumerable<IDomainEvent> history, AggregateVersion? startVersion = null) =>
+			LoadFromHistory(history, startVersion);
+	}
+
+	[Fact]
+	public void NewAggregate_HasZeroVersionAndNoUncommitted()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Version.Value.Should().Be(0);
+		counter.UncommittedEvents.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void RaiseEvent_AppliesHandlerAndBuffersEvent()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Increment(5);
+
+		counter.Total.Should().Be(5);
+		counter.Version.Value.Should().Be(1);
+		counter.UncommittedEvents.Should().ContainSingle();
+	}
+
+	[Fact]
+	public void RaiseEvent_TwoEvents_AdvancesVersionTwice()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Increment(3);
+		counter.Increment(2);
+
+		counter.Total.Should().Be(5);
+		counter.Version.Value.Should().Be(2);
+		counter.UncommittedEvents.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public void MarkCommitted_ClearsUncommittedBuffer_PreservesVersion()
+	{
+		var counter = new Counter(Guid.NewGuid());
+		counter.Increment(1);
+
+		counter.MarkCommitted();
+
+		counter.UncommittedEvents.Should().BeEmpty();
+		counter.Version.Value.Should().Be(1);
+	}
+
+	[Fact]
+	public void LoadFromHistory_ReplaysWithoutBuffering()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Replay([new CounterIncremented(2), new CounterIncremented(3)]);
+
+		counter.Total.Should().Be(5);
+		counter.Version.Value.Should().Be(2);
+		counter.UncommittedEvents.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void LoadFromHistory_HonoursStartVersion()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Replay([new CounterReset()], startVersion: AggregateVersion.From(7));
+
+		counter.Resets.Should().Be(1);
+		counter.Version.Value.Should().Be(8);
+	}
+
+	[Fact]
+	public void EventWithoutHandler_IsIgnored()
+	{
+		var counter = new Counter(Guid.NewGuid());
+
+		counter.Replay([new UnhandledEvent()]);
+
+		counter.Total.Should().Be(0);
+		counter.Version.Value.Should().Be(1);
+	}
+
+	private sealed record UnhandledEvent() : DomainEvent;
+}

--- a/tests/Yumney.Shared.Tests/Common/FreshnessExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/FreshnessExtensionsTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class FreshnessExtensionsTests
+{
+	[Theory]
+	[InlineData(Freshness.NotTracked, 0)]
+	[InlineData(Freshness.Fresh, 1)]
+	[InlineData(Freshness.UseSoon, 2)]
+	[InlineData(Freshness.CheckIt, 3)]
+	public void Urgency_ReturnsExpectedRank(Freshness freshness, int expected)
+	{
+		freshness.Urgency().Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(Freshness.NotTracked, false)]
+	[InlineData(Freshness.Fresh, false)]
+	[InlineData(Freshness.UseSoon, true)]
+	[InlineData(Freshness.CheckIt, true)]
+	public void IsUrgent_TrueForUseSoonAndCheckIt(Freshness freshness, bool expected)
+	{
+		freshness.IsUrgent().Should().Be(expected);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/ItemCountTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/ItemCountTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Guards;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class ItemCountTests
+{
+	[Fact]
+	public void From_Zero_IsAccepted()
+	{
+		var count = ItemCount.From(0);
+
+		count.Value.Should().Be(0);
+	}
+
+	[Fact]
+	public void From_PositiveValue_StoresValue()
+	{
+		var count = ItemCount.From(42);
+
+		count.Value.Should().Be(42);
+	}
+
+	[Fact]
+	public void From_NegativeValue_Throws()
+	{
+		var act = () => ItemCount.From(-1);
+
+		act.Should().Throw<GuardException>();
+	}
+
+	[Fact]
+	public void ImplicitConversionToInt_YieldsValue()
+	{
+		var count = ItemCount.From(7);
+
+		int raw = count;
+
+		raw.Should().Be(7);
+	}
+
+	[Fact]
+	public void ToString_UsesInvariantCulture()
+	{
+		var count = ItemCount.From(1000);
+
+		count.ToString().Should().Be("1000");
+	}
+
+	[Fact]
+	public void Equality_SameValue_AreEqual()
+	{
+		var first = ItemCount.From(5);
+		var second = ItemCount.From(5);
+
+		first.Should().Be(second);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/PagedResultExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/PagedResultExtensionsTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class PagedResultExtensionsTests
+{
+	[Fact]
+	public void AsPagedResult_ProjectsItemsAndPaging()
+	{
+		IReadOnlyList<string> items = ["a", "b", "c"];
+		var paging = PagingOptions.Of(Page.From(2), PageSize.From(10));
+
+		var result = items.AsPagedResult(ItemCount.From(42), paging);
+
+		result.Items.Should().Equal("a", "b", "c");
+		result.TotalCount.Should().Be(42);
+		result.Page.Should().Be(2);
+		result.PageSize.Should().Be(10);
+	}
+
+	[Fact]
+	public void AsPagedResult_EmptyItems_PreservesTotalCount()
+	{
+		IReadOnlyList<string> items = [];
+		var paging = PagingOptions.Of(Page.From(1), PageSize.From(20));
+
+		var result = items.AsPagedResult(ItemCount.From(0), paging);
+
+		result.Items.Should().BeEmpty();
+		result.TotalCount.Should().Be(0);
+	}
+
+	[Fact]
+	public void Map_AppliesSelectorToItems_PreservesPaging()
+	{
+		var source = new PagedResult<int>([1, 2, 3], TotalCount: 99, Page: 3, PageSize: 5);
+
+		var mapped = source.Map(value => value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+		mapped.Items.Should().Equal("1", "2", "3");
+		mapped.TotalCount.Should().Be(99);
+		mapped.Page.Should().Be(3);
+		mapped.PageSize.Should().Be(5);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/RoundedQuantityTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/RoundedQuantityTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class RoundedQuantityTests
+{
+	[Fact]
+	public void WasRounded_DifferentValues_IsTrue()
+	{
+		var quantity = new RoundedQuantity(DisplayQuantity: 2m, ExactQuantity: 1.78m);
+
+		quantity.WasRounded.Should().BeTrue();
+	}
+
+	[Fact]
+	public void WasRounded_EqualValues_IsFalse()
+	{
+		var quantity = new RoundedQuantity(DisplayQuantity: 3m, ExactQuantity: 3m);
+
+		quantity.WasRounded.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Ctor_StoresBothQuantities()
+	{
+		var quantity = new RoundedQuantity(DisplayQuantity: 1.5m, ExactQuantity: 1.42m);
+
+		quantity.DisplayQuantity.Should().Be(1.5m);
+		quantity.ExactQuantity.Should().Be(1.42m);
+	}
+}


### PR DESCRIPTION
## Summary
- **Paging**: `ItemCount` (negative-guard + implicit int + invariant ToString), `PagedResultExtensions.AsPagedResult` + `Map` (projection preserves total/page/pageSize).
- **Quantities**: `FreshnessExtensions.Urgency` + `IsUrgent` (parameterised), `RoundedQuantity.WasRounded`, `ConvertedAmount` construction + equality.
- **Abstractions**: `AggregateVersion` (Zero/From/Increment/implicit int), `EntityNotFoundException` (props + message format), `EventSourcedAggregate` (RaiseEvent applies handler + buffers + bumps version, MarkCommitted clears buffer, LoadFromHistory replays without buffering and honours startVersion, no-handler events are silently ignored).
- 355 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shared.Tests/` green
- [ ] CI green