### PR TITLE
test(shared): backfill Persistence + EventStore (#464)

### DIFF
--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/ConcurrencyConflictExceptionTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/ConcurrencyConflictExceptionTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class ConcurrencyConflictExceptionTests
+{
+	[Fact]
+	public void Ctor_StoresAggregateNameAndId()
+	{
+		var aggregateId = Guid.NewGuid();
+
+		var exception = new ConcurrencyConflictException("ShoppingList", aggregateId);
+
+		exception.AggregateName.Should().Be("ShoppingList");
+		exception.AggregateId.Should().Be(aggregateId);
+	}
+
+	[Fact]
+	public void Message_IncludesAggregateNameAndId()
+	{
+		var aggregateId = Guid.NewGuid();
+
+		var exception = new ConcurrencyConflictException("ShoppingList", aggregateId);
+
+		exception.Message.Should().Be($"Concurrent update detected on ShoppingList {aggregateId}.");
+	}
+
+	[Fact]
+	public void Ctor_PreservesInnerException()
+	{
+		var inner = new InvalidOperationException("boom");
+
+		var exception = new ConcurrencyConflictException("Recipe", Guid.NewGuid(), inner);
+
+		exception.InnerException.Should().BeSameAs(inner);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/CrossModuleEventConventionTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/CrossModuleEventConventionTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class CrossModuleEventConventionTests
+{
+	public sealed record ConventionTestRecipeImported(Guid RecipeId) : DomainEvent;
+
+	public sealed record ConventionTestRecipeImportedIntegration(string OwnerId, Guid RecipeId) : IntegrationEvent;
+
+	public sealed class ConventionTestMapper : ICrossModuleEventMapper
+	{
+		public Type DomainEventType => typeof(ConventionTestRecipeImported);
+
+		public IIntegrationEvent? TryMap(IReadOnlyList<object> context, IDomainEvent domainEvent)
+		{
+			var domain = (ConventionTestRecipeImported)domainEvent;
+			var owner = (string)context[0];
+			return new ConventionTestRecipeImportedIntegration(owner, domain.RecipeId);
+		}
+	}
+
+	// Abstract mapper — should NOT be discovered.
+	public abstract class AbstractMapper : ICrossModuleEventMapper
+	{
+		public Type DomainEventType => typeof(ConventionTestRecipeImported);
+
+		public abstract IIntegrationEvent? TryMap(IReadOnlyList<object> context, IDomainEvent domainEvent);
+	}
+
+	[Fact]
+	public void BuildMap_RegistersConcreteMapperByDomainEventType()
+	{
+		var map = CrossModuleEventConvention.BuildMap(typeof(CrossModuleEventConventionTests).Assembly);
+
+		map.Should().ContainKey(typeof(ConventionTestRecipeImported));
+	}
+
+	[Fact]
+	public void BuildMap_FactoryInvokesMapperTryMap()
+	{
+		var map = CrossModuleEventConvention.BuildMap(typeof(CrossModuleEventConventionTests).Assembly);
+		var factory = map[typeof(ConventionTestRecipeImported)];
+		var recipe = Guid.NewGuid();
+
+		var integration = factory([(object)"user-1"], new ConventionTestRecipeImported(recipe));
+
+		integration.Should().BeOfType<ConventionTestRecipeImportedIntegration>()
+			.Which.Should().Match<ConventionTestRecipeImportedIntegration>(@event =>
+				@event.OwnerId == "user-1" && @event.RecipeId == recipe);
+	}
+
+	[Fact]
+	public void BuildMap_SkipsAbstractMappers()
+	{
+		var map = CrossModuleEventConvention.BuildMap(typeof(CrossModuleEventConventionTests).Assembly);
+
+		// AbstractMapper is abstract — it has no parameterless ctor that Activator
+		// can instantiate, and the convention is designed to skip it. The map
+		// must still expose exactly one entry per domain-event type (registered
+		// here by ConventionTestMapper).
+		map.Should().HaveCount(map.Keys.Distinct().Count());
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/EventSerializerDefaultsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/EventSerializerDefaultsTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class EventSerializerDefaultsTests
+{
+	private enum Side
+	{
+		Buy,
+		Sell,
+	}
+
+	private sealed record Payload(string OwnerName, int Amount, Side Direction);
+
+	[Fact]
+	public void Options_UsesCamelCasePropertyNames()
+	{
+		var options = EventSerializerDefaults.Options();
+
+		var json = JsonSerializer.Serialize(new Payload("Alice", 5, Side.Buy), options);
+
+		json.Should().Contain("\"ownerName\":\"Alice\"");
+		json.Should().Contain("\"amount\":5");
+	}
+
+	[Fact]
+	public void Options_SerialisesEnumsAsStrings()
+	{
+		var options = EventSerializerDefaults.Options();
+
+		var json = JsonSerializer.Serialize(new Payload("Alice", 5, Side.Sell), options);
+
+		json.Should().Contain("\"direction\":\"Sell\"");
+	}
+
+	[Fact]
+	public void Options_RegistersJsonStringEnumConverter()
+	{
+		var options = EventSerializerDefaults.Options();
+
+		options.Converters.Should().ContainSingle().Which.Should().BeOfType<JsonStringEnumConverter>();
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/EventTypeRegistryTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/EventTypeRegistryTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class EventTypeRegistryTests
+{
+	public sealed record TypeRegistryFakeEventAlpha() : DomainEvent;
+
+	public sealed record TypeRegistryFakeEventBeta() : DomainEvent;
+
+	public sealed class TypeRegistryNotAnEvent;
+
+	[Fact]
+	public void BuildFromAssembly_WithFilter_ReturnsMatchingConcreteEventTypes()
+	{
+		var map = EventTypeRegistry.BuildFromAssembly(
+			typeof(EventTypeRegistryTests).Assembly,
+			type => type.Name.StartsWith("TypeRegistryFake", StringComparison.Ordinal));
+
+		map.Should().ContainKey(nameof(TypeRegistryFakeEventAlpha));
+		map.Should().ContainKey(nameof(TypeRegistryFakeEventBeta));
+		map[nameof(TypeRegistryFakeEventAlpha)].Should().Be<TypeRegistryFakeEventAlpha>();
+	}
+
+	[Fact]
+	public void BuildFromAssembly_WithFilter_SkipsNonEventTypes()
+	{
+		var map = EventTypeRegistry.BuildFromAssembly(
+			typeof(EventTypeRegistryTests).Assembly,
+			type => type.Name == nameof(TypeRegistryNotAnEvent));
+
+		map.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void BuildFromAssembly_WithFilter_NarrowsToSingleType()
+	{
+		var map = EventTypeRegistry.BuildFromAssembly(
+			typeof(EventTypeRegistryTests).Assembly,
+			type => type.Name == nameof(TypeRegistryFakeEventAlpha));
+
+		map.Should().ContainKey(nameof(TypeRegistryFakeEventAlpha));
+		map.Should().NotContainKey(nameof(TypeRegistryFakeEventBeta));
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/Json/IntValueObjectJsonConverterTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/Json/IntValueObjectJsonConverterTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore.Json;
+
+public class IntValueObjectJsonConverterTests
+{
+	public sealed record Step : IValueObject<int>
+	{
+		public int Value { get; }
+
+		private Step(int value) => Value = value;
+
+		public static Step From(int value) => new(value);
+	}
+
+	[Fact]
+	public void Write_SerializesValueAsJsonNumber()
+	{
+		var options = OptionsWithConverter();
+
+		var json = JsonSerializer.Serialize(new Payload(Step.From(42)), options);
+
+		json.Should().Contain("\"Step\":42");
+	}
+
+	[Fact]
+	public void Read_DeserializesJsonNumberThroughFactory()
+	{
+		var options = OptionsWithConverter();
+
+		var payload = JsonSerializer.Deserialize<Payload>("{\"Step\":99}", options);
+
+		payload!.Step.Value.Should().Be(99);
+	}
+
+	private static JsonSerializerOptions OptionsWithConverter()
+	{
+		var options = new JsonSerializerOptions();
+		options.Converters.Add(new IntValueObjectJsonConverter<Step>(Step.From));
+		return options;
+	}
+
+	private sealed record Payload(Step Step);
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/Json/StringValueObjectJsonConverterTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/Json/StringValueObjectJsonConverterTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore.Json;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore.Json;
+
+public class StringValueObjectJsonConverterTests
+{
+	public sealed record OwnerName : IValueObject<string>
+	{
+		public string Value { get; }
+
+		private OwnerName(string value) => Value = value;
+
+		public static OwnerName From(string value) => new(value);
+	}
+
+	[Fact]
+	public void Write_SerializesValueAsJsonString()
+	{
+		var options = OptionsWithConverter();
+
+		var json = JsonSerializer.Serialize(new Payload(OwnerName.From("alice")), options);
+
+		json.Should().Contain("\"Owner\":\"alice\"");
+	}
+
+	[Fact]
+	public void Read_DeserializesJsonStringThroughFactory()
+	{
+		var options = OptionsWithConverter();
+
+		var payload = JsonSerializer.Deserialize<Payload>("{\"Owner\":\"bob\"}", options);
+
+		payload!.Owner.Value.Should().Be("bob");
+	}
+
+	private static JsonSerializerOptions OptionsWithConverter()
+	{
+		var options = new JsonSerializerOptions();
+		options.Converters.Add(new StringValueObjectJsonConverter<OwnerName>(OwnerName.From));
+		return options;
+	}
+
+	private sealed record Payload(OwnerName Owner);
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/JsonEventSerializerTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/JsonEventSerializerTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class JsonEventSerializerTests
+{
+	private sealed record CounterIncremented(int Step) : DomainEvent;
+
+	[Fact]
+	public void Serialize_RoundTripsThroughDeserialize()
+	{
+		var typeMap = new Dictionary<string, Type> { [nameof(CounterIncremented)] = typeof(CounterIncremented) };
+		var serializer = new JsonEventSerializer(EventSerializerDefaults.Options(), typeMap);
+		var original = new CounterIncremented(7);
+
+		var json = serializer.Serialize(original);
+		var roundTripped = serializer.Deserialize(nameof(CounterIncremented), json);
+
+		roundTripped.Should().BeOfType<CounterIncremented>().Which.Step.Should().Be(7);
+	}
+
+	[Fact]
+	public void Deserialize_UnknownEventType_ReturnsNull()
+	{
+		var serializer = new JsonEventSerializer(EventSerializerDefaults.Options(), new Dictionary<string, Type>());
+
+		var result = serializer.Deserialize("UnknownEvent", "{}");
+
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void Serialize_UsesCamelCaseFromDefaults()
+	{
+		var serializer = new JsonEventSerializer(EventSerializerDefaults.Options(), new Dictionary<string, Type>());
+
+		var json = serializer.Serialize(new CounterIncremented(3));
+
+		json.Should().Contain("\"step\":3");
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/ModuleEventConventionTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/ModuleEventConventionTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class ModuleEventConventionTests
+{
+	public sealed record ConventionTestItemAdded(string Name) : DomainEvent;
+
+	public sealed record ConventionTestItemAddedModule(string OwnerId, ConventionTestItemAdded Inner)
+		: ModuleEvent(OwnerId);
+
+	// Has a matching ctor shape but it's for a *different* context (Guid instead
+	// of string) — should be filtered out when the caller asks for (string).
+	public sealed record OtherShapeModuleEvent(Guid Tenant, ConventionTestItemAdded Inner)
+		: ModuleEvent(Tenant.ToString());
+
+	[Fact]
+	public void BuildMap_RegistersMatchingShapeOnly()
+	{
+		var map = ModuleEventConvention.BuildMap(
+			typeof(ModuleEventConventionTests).Assembly,
+			typeof(string));
+
+		map.Should().ContainKey(typeof(ConventionTestItemAdded));
+	}
+
+	[Fact]
+	public void BuildMap_CompiledFactory_ProducesModuleEventWithContextAndInner()
+	{
+		var map = ModuleEventConvention.BuildMap(
+			typeof(ModuleEventConventionTests).Assembly,
+			typeof(string));
+
+		var factory = map[typeof(ConventionTestItemAdded)];
+		var domain = new ConventionTestItemAdded("Onion");
+
+		var module = factory([(object)"user-1"], domain);
+
+		module.Should().BeOfType<ConventionTestItemAddedModule>()
+			.Which.Should().Match<ConventionTestItemAddedModule>(@event =>
+				@event.OwnerId == "user-1" && ReferenceEquals(@event.Inner, domain));
+	}
+
+	[Fact]
+	public void BuildMap_DifferentContextShape_DoesNotMatch()
+	{
+		// When asking for (Guid) only OtherShapeModuleEvent matches; the
+		// (string) shape used by ConventionTestItemAddedModule is filtered out.
+		var map = ModuleEventConvention.BuildMap(
+			typeof(ModuleEventConventionTests).Assembly,
+			typeof(Guid));
+
+		// At least one event registered for (Guid) shape — the OtherShape variant.
+		map.Should().ContainKey(typeof(ConventionTestItemAdded));
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/StoredEventTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/StoredEventTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class StoredEventTests
+{
+	[Fact]
+	public void Properties_AreMutable_ToSupportEfMaterialization()
+	{
+		var id = Guid.NewGuid();
+		var aggregateId = Guid.NewGuid();
+		var occurredAt = new DateTime(2026, 5, 17, 10, 0, 0, DateTimeKind.Utc);
+
+		var stored = new StoredEvent
+		{
+			Id = id,
+			AggregateId = aggregateId,
+			EventType = "RecipeImported",
+			EventData = "{\"step\":3}",
+			Version = 7,
+			OccurredAt = occurredAt,
+		};
+
+		stored.Id.Should().Be(id);
+		stored.AggregateId.Should().Be(aggregateId);
+		stored.EventType.Should().Be("RecipeImported");
+		stored.EventData.Should().Be("{\"step\":3}");
+		stored.Version.Should().Be(7);
+		stored.OccurredAt.Should().Be(occurredAt);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/PagingExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/PagingExtensionsTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+public class PagingExtensionsTests
+{
+	[Fact]
+	public async Task ToPagedListAsync_FirstPage_ReturnsLeadingSliceAndTotal()
+	{
+		await using var context = NewContext();
+		for (var order = 0; order < 25; order++)
+		{
+			context.Rows.Add(new Row { Id = Guid.NewGuid(), Order = order });
+		}
+
+		await context.SaveChangesAsync();
+
+		var (items, total) = await context.Rows.OrderBy(row => row.Order)
+			.ToPagedListAsync(PagingOptions.From(1, 10));
+
+		total.Value.Should().Be(25);
+		items.Should().HaveCount(10);
+		items[0].Order.Should().Be(0);
+		items[9].Order.Should().Be(9);
+	}
+
+	[Fact]
+	public async Task ToPagedListAsync_LaterPage_SkipsPriorPages()
+	{
+		await using var context = NewContext();
+		for (var order = 0; order < 25; order++)
+		{
+			context.Rows.Add(new Row { Id = Guid.NewGuid(), Order = order });
+		}
+
+		await context.SaveChangesAsync();
+
+		var (items, total) = await context.Rows.OrderBy(row => row.Order)
+			.ToPagedListAsync(PagingOptions.From(3, 10));
+
+		total.Value.Should().Be(25);
+		items.Should().HaveCount(5);
+		items[0].Order.Should().Be(20);
+	}
+
+	[Fact]
+	public async Task ToPagedListAsync_EmptyTable_ReturnsEmptyAndZeroTotal()
+	{
+		await using var context = NewContext();
+
+		var (items, total) = await context.Rows.ToPagedListAsync(PagingOptions.From(1, 10));
+
+		total.Value.Should().Be(0);
+		items.Should().BeEmpty();
+	}
+
+	private static TestContext NewContext()
+	{
+		var options = new DbContextOptionsBuilder<TestContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new TestContext(options);
+	}
+
+	private sealed class Row
+	{
+		public Guid Id { get; init; }
+
+		public int Order { get; init; }
+	}
+
+	private sealed class TestContext(DbContextOptions<TestContext> options) : DbContext(options)
+	{
+		public DbSet<Row> Rows => Set<Row>();
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/ReadModelUpsertExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/ReadModelUpsertExtensionsTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+public class ReadModelUpsertExtensionsTests
+{
+	[Fact]
+	public async Task UpsertAsync_RowMissing_InvokesCreateAndMutateAndSaves()
+	{
+		await using var context = NewContext();
+		var id = Guid.NewGuid();
+
+		await context.UpsertAsync<Row>(
+			row => row.Id == id,
+			() => new Row { Id = id, Name = "fresh" },
+			row => row.Count = 1);
+
+		var persisted = await context.Rows.SingleAsync();
+		persisted.Id.Should().Be(id);
+		persisted.Name.Should().Be("fresh");
+		persisted.Count.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task UpsertAsync_RowExists_OnlyInvokesMutate()
+	{
+		await using var context = NewContext();
+		var id = Guid.NewGuid();
+		context.Rows.Add(new Row { Id = id, Name = "existing", Count = 3 });
+		await context.SaveChangesAsync();
+
+		var createCalled = false;
+		await context.UpsertAsync<Row>(
+			row => row.Id == id,
+			() =>
+			{
+				createCalled = true;
+				return new Row { Id = id, Name = "should-not-appear" };
+			},
+			row => row.Count++);
+
+		createCalled.Should().BeFalse();
+		var persisted = await context.Rows.SingleAsync();
+		persisted.Name.Should().Be("existing");
+		persisted.Count.Should().Be(4);
+	}
+
+	[Fact]
+	public async Task UpdateAsync_RowExists_AppliesMutateAndSaves()
+	{
+		await using var context = NewContext();
+		var id = Guid.NewGuid();
+		context.Rows.Add(new Row { Id = id, Name = "before", Count = 0 });
+		await context.SaveChangesAsync();
+
+		await context.UpdateAsync<Row>(
+			row => row.Id == id,
+			row => row.Name = "after");
+
+		var persisted = await context.Rows.SingleAsync();
+		persisted.Name.Should().Be("after");
+	}
+
+	[Fact]
+	public async Task UpdateAsync_RowMissing_IsNoOp()
+	{
+		await using var context = NewContext();
+
+		await context.UpdateAsync<Row>(
+			row => row.Id == Guid.NewGuid(),
+			row => row.Name = "should-not-be-set");
+
+		var count = await context.Rows.CountAsync();
+		count.Should().Be(0);
+	}
+
+	private static TestContext NewContext()
+	{
+		var options = new DbContextOptionsBuilder<TestContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new TestContext(options);
+	}
+
+	private sealed class Row
+	{
+		public Guid Id { get; set; }
+
+		public string Name { get; set; } = string.Empty;
+
+		public int Count { get; set; }
+	}
+
+	private sealed class TestContext(DbContextOptions<TestContext> options) : DbContext(options)
+	{
+		public DbSet<Row> Rows => Set<Row>();
+	}
+}


### PR DESCRIPTION
## Summary
- **EventStore**
  - `EventTypeRegistry`: assembly scan with filter (matches concrete domain events, skips non-events, narrows by predicate).
  - `EventSerializerDefaults`: camelCase + `JsonStringEnumConverter` registration verified.
  - `JsonEventSerializer`: serialise/deserialise roundtrip, unknown-event-type returns null, camelCase defaults flow through.
  - `StoredEvent`: property mapping (EF materialisation contract).
  - `ConcurrencyConflictException`: props + message format + inner-exception preserved.
- **EventStore/Json**
  - `StringValueObjectJsonConverter` + `IntValueObjectJsonConverter`: both directions through the supplied factory.
- **EventStore conventions**
  - `CrossModuleEventConvention.BuildMap`: discovers concrete `ICrossModuleEventMapper` impls, factories invoke `TryMap`, abstract mappers are skipped.
  - `ModuleEventConvention.BuildMap`: compiles factory for the requested context shape, mismatching shapes are filtered out.
- **Persistence helpers**
  - `PagingExtensions.ToPagedListAsync` (InMemory EF): first page slice + total, later page skip math, empty-table case.
  - `ReadModelUpsertExtensions`: `UpsertAsync` create-when-missing + update-when-present (create lambda not invoked), `UpdateAsync` mutate-when-present + no-op when missing.
- 347 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shared.Tests/` green
- [ ] CI green