### PR TITLE
test(shared): backfill EF configurations + Npgsql registration (#464)

### DIFF
--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/StoredEventConfigurationBaseTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/StoredEventConfigurationBaseTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class StoredEventConfigurationBaseTests
+{
+	[Fact]
+	public void Configure_MapsToTheSuppliedTableName()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+
+		entityType.GetTableName().Should().Be("TestEvents");
+	}
+
+	[Fact]
+	public void Configure_PrimaryKey_IsId()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+		var primaryKey = entityType.FindPrimaryKey()!;
+
+		primaryKey.Properties.Should().ContainSingle()
+			.Which.Name.Should().Be(nameof(StoredEvent.Id));
+	}
+
+	[Fact]
+	public void Configure_EventType_HasMaxLength100AndIsRequired()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+		var property = entityType.FindProperty(nameof(StoredEvent.EventType))!;
+
+		property.GetMaxLength().Should().Be(100);
+		property.IsNullable.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Configure_RequiredProperties_AreNotNullable()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+
+		entityType.FindProperty(nameof(StoredEvent.AggregateId))!.IsNullable.Should().BeFalse();
+		entityType.FindProperty(nameof(StoredEvent.EventData))!.IsNullable.Should().BeFalse();
+		entityType.FindProperty(nameof(StoredEvent.Version))!.IsNullable.Should().BeFalse();
+		entityType.FindProperty(nameof(StoredEvent.OccurredAt))!.IsNullable.Should().BeFalse();
+	}
+
+	[Fact]
+	public void Configure_UniqueIndex_OverAggregateIdAndVersion()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+
+		entityType.GetIndexes().Should().Contain(index =>
+			index.IsUnique
+			&& index.Properties.Count == 2
+			&& index.Properties[0].Name == nameof(StoredEvent.AggregateId)
+			&& index.Properties[1].Name == nameof(StoredEvent.Version));
+	}
+
+	[Fact]
+	public void Configure_NonUniqueIndex_OverOccurredAt()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(StoredEvent))!;
+
+		entityType.GetIndexes().Should().Contain(index =>
+			!index.IsUnique
+			&& index.Properties.Count == 1
+			&& index.Properties[0].Name == nameof(StoredEvent.OccurredAt));
+	}
+
+	private static TestContext NewContext()
+	{
+		var options = new DbContextOptionsBuilder<TestContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new TestContext(options);
+	}
+
+	private sealed class TestStoredEventConfiguration : StoredEventConfigurationBase<StoredEvent>
+	{
+		public TestStoredEventConfiguration()
+			: base("TestEvents")
+		{
+		}
+	}
+
+	private sealed class TestContext(DbContextOptions<TestContext> options) : DbContext(options)
+	{
+		public DbSet<StoredEvent> Events => Set<StoredEvent>();
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			modelBuilder.ApplyConfiguration(new TestStoredEventConfiguration());
+		}
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/InboxMessageConfigurationTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/InboxMessageConfigurationTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+public class InboxMessageConfigurationTests
+{
+	[Fact]
+	public void Configure_RegistersCompositePrimaryKey_OverMessageIdAndConsumerName()
+	{
+		using var context = NewContext();
+
+		var entityType = context.Model.FindEntityType(typeof(InboxMessage))!;
+		var primaryKey = entityType.FindPrimaryKey()!;
+
+		primaryKey.Properties.Select(property => property.Name)
+			.Should().Equal(nameof(InboxMessage.MessageId), nameof(InboxMessage.ConsumerName));
+	}
+
+	[Fact]
+	public void Configure_MapsToInboxMessagesTable()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(InboxMessage))!;
+
+		entityType.GetTableName().Should().Be("InboxMessages");
+	}
+
+	[Fact]
+	public void Configure_ConsumerName_HasMaxLength256AndIsRequired()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(InboxMessage))!;
+		var consumerName = entityType.FindProperty(nameof(InboxMessage.ConsumerName))!;
+
+		consumerName.IsNullable.Should().BeFalse();
+		consumerName.GetMaxLength().Should().Be(256);
+	}
+
+	[Fact]
+	public void Configure_ProcessedAt_IsRequired()
+	{
+		using var context = NewContext();
+		var entityType = context.Model.FindEntityType(typeof(InboxMessage))!;
+		var processedAt = entityType.FindProperty(nameof(InboxMessage.ProcessedAt))!;
+
+		processedAt.IsNullable.Should().BeFalse();
+	}
+
+	private static TestContext NewContext()
+	{
+		var options = new DbContextOptionsBuilder<TestContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new TestContext(options);
+	}
+
+	private sealed class TestContext(DbContextOptions<TestContext> options) : DbContext(options)
+	{
+		public DbSet<InboxMessage> InboxMessages => Set<InboxMessage>();
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			modelBuilder.ApplyConfiguration(new InboxMessageConfiguration());
+		}
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/NpgsqlDbContextRegistrationTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/NpgsqlDbContextRegistrationTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+public class NpgsqlDbContextRegistrationTests
+{
+	[Fact]
+	public void AddYumneyNpgsqlDbContext_RegistersDbContextOfRequestedType()
+	{
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["ConnectionStrings:test"] = "Host=localhost;Database=test;Username=test;Password=test",
+			})
+			.Build();
+
+		services.AddYumneyNpgsqlDbContext<FakeContext>(
+			configuration,
+			connectionName: "test",
+			migrationsHistoryTable: "__Migrations");
+
+		services.Should().Contain(descriptor => descriptor.ServiceType == typeof(FakeContext));
+	}
+
+	[Fact]
+	public void AddYumneyNpgsqlDbContext_ReturnsServiceCollection_ForChaining()
+	{
+		var services = new ServiceCollection();
+		var configuration = new ConfigurationBuilder().Build();
+
+		var returned = services.AddYumneyNpgsqlDbContext<FakeContext>(
+			configuration,
+			connectionName: "test",
+			migrationsHistoryTable: "__Migrations");
+
+		returned.Should().BeSameAs(services);
+	}
+
+	private sealed class FakeContext(DbContextOptions<FakeContext> options) : DbContext(options);
+}


### PR DESCRIPTION
## Summary
- **NpgsqlDbContextRegistration**: registers DbContext descriptor, returns service collection for chaining (lambda is not invoked so Npgsql is not actually needed at runtime — the registration shape is what matters).
- **InboxMessageConfiguration**: composite PK `(MessageId, ConsumerName)`, mapped to `InboxMessages`, `ConsumerName` max length 256 + required, `ProcessedAt` required.
- **StoredEventConfigurationBase**: table name flows through, PK on `Id`, `EventType` max length 100 + required, all required props non-nullable, unique `(AggregateId, Version)` index for concurrency check, non-unique `OccurredAt` index for ordering reads.
- 329 tests pass locally; build + format clean.

Notes:
- `InboxStore`, `EventStoreBase`, and `EventSourcedAggregateDraining` are already covered by `Yumney.Integration.Tests/Shared/InboxStoreTests.cs`, the module-specific `ShoppingEventStoreTests`, and the `AccountDeletionCascadeTests` flow. Those rely on the Aspire fixture (real Postgres) which InMemory EF cannot stand in for.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shared.Tests/` green
- [ ] CI green