### PR TITLE
test(recipes): backfill Infrastructure ExternalServices (#464)

### DIFF
--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealSlotClearerTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealSlotClearerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealSlotClearerTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task ClearAsync_MapsConsumerRequestToClientBody()
+	{
+		ClearSlotBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.ClearSlotAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ClearSlotBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<ClearSlotBody>(2);
+				return true;
+			});
+
+		var clearer = new HttpMealSlotClearer(client);
+		await clearer.ClearAsync(new ClearMealSlotRequest(2026, 19, "Wednesday", "Dinner"));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(19);
+		captured.Should().NotBeNull();
+		captured!.Day.Should().Be("Wednesday");
+		captured.MealType.Should().Be("Dinner");
+	}
+
+	[Fact]
+	public async Task ClearAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.ClearSlotAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ClearSlotBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var clearer = new HttpMealSlotClearer(client);
+		var result = await clearer.ClearAsync(new ClearMealSlotRequest(2026, 19, "Friday", "Lunch"));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealSlotSwapperTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpMealSlotSwapperTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Client;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpMealSlotSwapperTests
+{
+	private readonly IMealPlanClient client = Substitute.For<IMealPlanClient>();
+
+	[Fact]
+	public async Task SwapAsync_MapsConsumerRequestToClientBody()
+	{
+		SwapSlotsBody? captured = null;
+		var capturedYear = 0;
+		var capturedWeek = 0;
+		client.SwapSlotsAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<SwapSlotsBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				capturedYear = callInfo.ArgAt<int>(0);
+				capturedWeek = callInfo.ArgAt<int>(1);
+				captured = callInfo.ArgAt<SwapSlotsBody>(2);
+				return true;
+			});
+
+		var swapper = new HttpMealSlotSwapper(client);
+		await swapper.SwapAsync(new SwapMealSlotsRequest(2026, 20, "Monday", "Friday", "Dinner"));
+
+		capturedYear.Should().Be(2026);
+		capturedWeek.Should().Be(20);
+		captured.Should().NotBeNull();
+		captured!.SourceDay.Should().Be("Monday");
+		captured.TargetDay.Should().Be("Friday");
+		captured.MealType.Should().Be("Dinner");
+	}
+
+	[Fact]
+	public async Task SwapAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.SwapSlotsAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<SwapSlotsBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var swapper = new HttpMealSlotSwapper(client);
+		var result = await swapper.SwapAsync(new SwapMealSlotsRequest(2026, 19, "Tuesday", "Thursday", "Lunch"));
+
+		result.Should().BeFalse();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListItemAdderTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListItemAdderTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using Xunit;
+using ShoppingClient = SmartSolutionsLab.Yumney.Shopping.Client;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListItemAdderTests
+{
+	private readonly ShoppingClient.IShoppingClient client = Substitute.For<ShoppingClient.IShoppingClient>();
+
+	[Fact]
+	public async Task AddAsync_MapsConsumerRequestToClientBody_AndStampsChatSource()
+	{
+		ShoppingClient.AddShoppingItemRequest? captured = null;
+		await client.AddItemAsync(
+			Arg.Do<ShoppingClient.AddShoppingItemRequest>(body => captured = body),
+			Arg.Any<CancellationToken>());
+
+		var adder = new HttpShoppingListItemAdder(client);
+		var ok = await adder.AddAsync(new AddShoppingItemRequest("Onion", 2m, "kg"));
+
+		ok.Should().BeTrue();
+		captured.Should().NotBeNull();
+		captured!.Name.Should().Be("Onion");
+		captured.Quantity.Should().Be(2m);
+		captured.Unit.Should().Be("kg");
+		captured.Source.Should().Be("chat");
+	}
+
+	[Fact]
+	public async Task AddAsync_QuantityNull_DefaultsToOne()
+	{
+		ShoppingClient.AddShoppingItemRequest? captured = null;
+		await client.AddItemAsync(
+			Arg.Do<ShoppingClient.AddShoppingItemRequest>(body => captured = body),
+			Arg.Any<CancellationToken>());
+
+		var adder = new HttpShoppingListItemAdder(client);
+		await adder.AddAsync(new AddShoppingItemRequest("Salt", Quantity: null, Unit: null));
+
+		captured!.Quantity.Should().Be(1m);
+	}
+
+	[Fact]
+	public async Task AddAsync_ClientThrows_ReturnsFalse()
+	{
+		client.AddItemAsync(Arg.Any<ShoppingClient.AddShoppingItemRequest>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("boom"));
+
+		var adder = new HttpShoppingListItemAdder(client);
+		var ok = await adder.AddAsync(new AddShoppingItemRequest("Sugar", 1m, null));
+
+		ok.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task AddAsync_ClientThrowsOperationCanceled_Rethrows()
+	{
+		client.AddItemAsync(Arg.Any<ShoppingClient.AddShoppingItemRequest>(), Arg.Any<CancellationToken>())
+			.Throws(new OperationCanceledException());
+
+		var adder = new HttpShoppingListItemAdder(client);
+		var act = async () => await adder.AddAsync(new AddShoppingItemRequest("Sugar", 1m, null));
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+}

--- a/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListItemRemoverTests.cs
+++ b/tests/Yumney.Recipes.Infrastructure.Tests/ExternalServices/HttpShoppingListItemRemoverTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Shopping.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Recipes.Infrastructure.Tests.ExternalServices;
+
+public class HttpShoppingListItemRemoverTests
+{
+	private readonly IShoppingClient client = Substitute.For<IShoppingClient>();
+
+	[Fact]
+	public async Task RemoveAsync_MapsConsumerRequestToClientBody()
+	{
+		RemoveShoppingItemBody? captured = null;
+		client.RemoveItemAsync(Arg.Any<RemoveShoppingItemBody>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo =>
+			{
+				captured = callInfo.ArgAt<RemoveShoppingItemBody>(0);
+				return true;
+			});
+
+		var remover = new HttpShoppingListItemRemover(client);
+		var ok = await remover.RemoveAsync(new RemoveShoppingItemRequest("Onion", 1m, "kg", "out of stock"));
+
+		ok.Should().BeTrue();
+		captured.Should().NotBeNull();
+		captured!.Name.Should().Be("Onion");
+		captured.Quantity.Should().Be(1m);
+		captured.Unit.Should().Be("kg");
+		captured.Reason.Should().Be("out of stock");
+	}
+
+	[Fact]
+	public async Task RemoveAsync_ClientReturnsFalse_PropagatesFalse()
+	{
+		client.RemoveItemAsync(Arg.Any<RemoveShoppingItemBody>(), Arg.Any<CancellationToken>())
+			.Returns(false);
+
+		var remover = new HttpShoppingListItemRemover(client);
+		var ok = await remover.RemoveAsync(new RemoveShoppingItemRequest("Salt", null, null, null));
+
+		ok.Should().BeFalse();
+	}
+}


### PR DESCRIPTION
## Summary
Backfills the four previously-untested cross-module HTTP adapters in `Recipes.Infrastructure`:

- **HttpMealSlotClearer**: `ClearMealSlotRequest → IMealPlanClient.ClearSlotAsync(year, week, ClearSlotBody)`; bool propagates.
- **HttpMealSlotSwapper**: `SwapMealSlotsRequest → IMealPlanClient.SwapSlotsAsync(year, week, SwapSlotsBody)`; bool propagates.
- **HttpShoppingListItemAdder**: maps to `Shopping.Client.AddShoppingItemRequest` with the literal `"chat"` source label, defaults a missing `Quantity` to `1m`, swallows non-cancellation exceptions as `false`, and *re-throws* `OperationCanceledException` so caller cancellation isn't masked.
- **HttpShoppingListItemRemover**: `RemoveShoppingItemRequest → RemoveShoppingItemBody`; bool propagates.

175 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Recipes.Infrastructure.Tests/` green
- [ ] CI green