### PR TITLE
test(mealplan): backfill Infrastructure ExternalServices (#464)

### DIFF
--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpDietaryProfileProviderTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpDietaryProfileProviderTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Application.Interfaces;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Users.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpDietaryProfileProviderTests
+{
+	private readonly IUsersClient users = Substitute.For<IUsersClient>();
+
+	[Fact]
+	public async Task GetAsync_ProfileNull_ReturnsEmpty()
+	{
+		users.GetMyProfileAsync(Arg.Any<CancellationToken>()).Returns((UsersProfileResponse?)null);
+
+		var snapshot = await new HttpDietaryProfileProvider(users).GetAsync();
+
+		snapshot.Should().Be(DietaryProfileSnapshot.Empty);
+	}
+
+	[Fact]
+	public async Task GetAsync_DietaryProfileMissing_ReturnsEmpty()
+	{
+		users.GetMyProfileAsync(Arg.Any<CancellationToken>())
+			.Returns(new UsersProfileResponse(DietaryProfile: null));
+
+		var snapshot = await new HttpDietaryProfileProvider(users).GetAsync();
+
+		snapshot.Should().Be(DietaryProfileSnapshot.Empty);
+	}
+
+	[Fact]
+	public async Task GetAsync_DietaryProfilePresent_ProjectsTypeAndRestrictions()
+	{
+		users.GetMyProfileAsync(Arg.Any<CancellationToken>())
+			.Returns(new UsersProfileResponse(new DietaryProfilePayload("vegan", ["nuts", "gluten"])));
+
+		var snapshot = await new HttpDietaryProfileProvider(users).GetAsync();
+
+		snapshot.DietaryType.Should().Be("vegan");
+		snapshot.Restrictions.Should().Equal("nuts", "gluten");
+	}
+
+	[Fact]
+	public async Task GetAsync_RestrictionsNull_NormalisesToEmptyList()
+	{
+		users.GetMyProfileAsync(Arg.Any<CancellationToken>())
+			.Returns(new UsersProfileResponse(new DietaryProfilePayload("omnivore", Restrictions: null)));
+
+		var snapshot = await new HttpDietaryProfileProvider(users).GetAsync();
+
+		snapshot.DietaryType.Should().Be("omnivore");
+		snapshot.Restrictions.Should().BeEmpty();
+	}
+}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeCatalogProviderTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeCatalogProviderTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Recipes.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpRecipeCatalogProviderTests
+{
+	private readonly IRecipesClient recipes = Substitute.For<IRecipesClient>();
+
+	[Fact]
+	public async Task ListAsync_ForwardsPageSizeToClient()
+	{
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse([]));
+
+		await new HttpRecipeCatalogProvider(recipes).ListAsync(pageSize: 25);
+
+		await recipes.Received(1).ListRecipeCatalogAsync(25, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task ListAsync_EmptyResponse_ReturnsEmpty()
+	{
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse([]));
+
+		var entries = await new HttpRecipeCatalogProvider(recipes).ListAsync(pageSize: 10);
+
+		entries.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ListAsync_MapsEveryFieldFromCatalogItemToEntry()
+	{
+		var identifier = Guid.NewGuid();
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse(
+			[
+				new RecipeCatalogItem(
+					Identifier: identifier,
+					Title: "Carbonara",
+					PrepTimeMinutes: 10,
+					CookTimeMinutes: 15,
+					Difficulty: "easy",
+					Tags: ["italian", "pasta"],
+					IsFavorite: true,
+					Rating: 5),
+			]));
+
+		var entries = await new HttpRecipeCatalogProvider(recipes).ListAsync(pageSize: 10);
+
+		entries.Should().ContainSingle();
+		var entry = entries[0];
+		entry.RecipeIdentifier.Should().Be(identifier);
+		entry.Title.Should().Be("Carbonara");
+		entry.PrepTimeMinutes.Should().Be(10);
+		entry.CookTimeMinutes.Should().Be(15);
+		entry.Difficulty.Should().Be("easy");
+		entry.Tags.Should().Equal("italian", "pasta");
+		entry.IsFavorite.Should().BeTrue();
+		entry.Rating.Should().Be(5);
+	}
+}

--- a/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeTagsLookupTests.cs
+++ b/tests/Yumney.MealPlan.Infrastructure.Tests/Services/HttpRecipeTagsLookupTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NSubstitute;
+using SmartSolutionsLab.Yumney.MealPlan.Infrastructure.ExternalServices;
+using SmartSolutionsLab.Yumney.Recipes.Client;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.MealPlan.Infrastructure.Tests.Services;
+
+public class HttpRecipeTagsLookupTests
+{
+	private readonly IRecipesClient recipes = Substitute.For<IRecipesClient>();
+
+	[Fact]
+	public async Task GetAllAsync_UsesPageSize100ForCatalogScan()
+	{
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse([]));
+
+		await new HttpRecipeTagsLookup(recipes).GetAllAsync();
+
+		await recipes.Received(1).ListRecipeCatalogAsync(100, Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task GetAllAsync_BuildsDictionaryKeyedByRecipeIdentifier()
+	{
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse(
+			[
+				new RecipeCatalogItem(first, "A", null, null, null, ["italian"], false, null),
+				new RecipeCatalogItem(second, "B", null, null, null, ["asian", "spicy"], false, null),
+			]));
+
+		var map = await new HttpRecipeTagsLookup(recipes).GetAllAsync();
+
+		map.Should().HaveCount(2);
+		map[first].Should().Equal("italian");
+		map[second].Should().Equal("asian", "spicy");
+	}
+
+	[Fact]
+	public async Task GetAllAsync_EmptyResponse_ReturnsEmptyMap()
+	{
+		recipes.ListRecipeCatalogAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(new RecipeCatalogResponse([]));
+
+		var map = await new HttpRecipeTagsLookup(recipes).GetAllAsync();
+
+		map.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
## Summary
Backfills the three previously-untested cross-module HTTP adapters in `MealPlan.Infrastructure`:

- **HttpDietaryProfileProvider**: null user profile and null DietaryProfile both yield `DietaryProfileSnapshot.Empty`; populated profile projects `DietaryType` + `Restrictions`; null `Restrictions` normalises to an empty list.
- **HttpRecipeCatalogProvider**: forwards the requested `pageSize` to `IRecipesClient.ListRecipeCatalogAsync`, maps every `RecipeCatalogItem` field onto `RecipeCatalogEntry`, empty response returns empty.
- **HttpRecipeTagsLookup**: pins the catalog scan to page size 100, builds a `IReadOnlyDictionary<Guid, IReadOnlyList<string>>` keyed by recipe identifier, empty response returns empty map.

41 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.MealPlan.Infrastructure.Tests/` green
- [ ] CI green