### PR TITLE
test(shopping): backfill EventStore JSON serializer roundtrips (#464)

### DIFF
--- a/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
+++ b/src/Yumney.Shopping.Infrastructure/Yumney.Shopping.Infrastructure.csproj
@@ -5,6 +5,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Yumney.Shopping.Infrastructure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Yumney.Shopping.Application\Yumney.Shopping.Application.csproj" />
     <ProjectReference Include="..\Yumney.Shopping.Domain\Yumney.Shopping.Domain.csproj" />
     <ProjectReference Include="..\Yumney.Shared.Persistence\Yumney.Shared.Persistence.csproj" />

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/EventStore/ShoppingLedgerEventSerializerTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/EventStore/ShoppingLedgerEventSerializerTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger.Events;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Persistence.EventStore;
+
+/// <summary>
+/// Round-trips the value-object converters registered on the ShoppingLedger
+/// serializer. Internal serializer surfaced to tests via InternalsVisibleTo.
+/// </summary>
+public class ShoppingLedgerEventSerializerTests
+{
+	[Fact]
+	public void Options_RegistersConverters()
+	{
+		ShoppingLedgerEventSerializer.Options.Converters.Should().HaveCountGreaterThan(0);
+	}
+
+	[Fact]
+	public void Roundtrip_ShoppingItemAdded_PreservesNameQuantityAndSource()
+	{
+		var name = ItemName.From("Onion");
+		var quantity = Quantity.Of(Amount.From(3m), Unit.From("kg"));
+		var source = ItemSource.From("manual");
+		var @event = new ShoppingItemAdded(name, quantity, source);
+
+		var json = JsonSerializer.Serialize(@event, ShoppingLedgerEventSerializer.Options);
+		var rehydrated = (ShoppingItemAdded)ShoppingLedgerEventSerializer.Instance.Deserialize(
+			nameof(ShoppingItemAdded), json)!;
+
+		rehydrated.ItemName.Should().Be(name);
+		rehydrated.Quantity.Amount.Value.Should().Be(3m);
+		rehydrated.Quantity.Unit!.Value.Should().Be("kg");
+		rehydrated.Source.Value.Should().Be("manual");
+	}
+
+	[Fact]
+	public void Roundtrip_ShoppingItemRemoved_PreservesReason()
+	{
+		var @event = new ShoppingItemRemoved(
+			ItemName.From("Bread"),
+			Quantity.Of(Amount.From(1m), Unit.FromNullable(null)),
+			RemovalReason.From("out of stock"));
+
+		var json = JsonSerializer.Serialize(@event, ShoppingLedgerEventSerializer.Options);
+		var rehydrated = (ShoppingItemRemoved)ShoppingLedgerEventSerializer.Instance.Deserialize(
+			nameof(ShoppingItemRemoved), json)!;
+
+		rehydrated.Reason!.Value.Should().Be("out of stock");
+		rehydrated.Quantity.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void Roundtrip_ShoppingItemRemoved_NullReason_StaysNull()
+	{
+		var @event = new ShoppingItemRemoved(
+			ItemName.From("Bread"),
+			Quantity.Of(Amount.From(1m), Unit.From("loaf")),
+			Reason: null);
+
+		var json = JsonSerializer.Serialize(@event, ShoppingLedgerEventSerializer.Options);
+		var rehydrated = (ShoppingItemRemoved)ShoppingLedgerEventSerializer.Instance.Deserialize(
+			nameof(ShoppingItemRemoved), json)!;
+
+		rehydrated.Reason.Should().BeNull();
+	}
+
+	[Fact]
+	public void Deserialize_UnknownEventType_ReturnsNull()
+	{
+		ShoppingLedgerEventSerializer.Instance.Deserialize("NotALedgerEvent", "{}").Should().BeNull();
+	}
+}

--- a/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/EventStore/ShoppingListEventSerializerTests.cs
+++ b/tests/Yumney.Shopping.Infrastructure.Tests/Persistence/EventStore/ShoppingListEventSerializerTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList.Events;
+using SmartSolutionsLab.Yumney.Shopping.Infrastructure.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.Tests.Persistence.EventStore;
+
+/// <summary>
+/// Round-trips every value-object converter registered on the ShoppingList
+/// serializer through serialize → deserialize. The converters are internal —
+/// this exercises them via the public serializer surface.
+/// </summary>
+public class ShoppingListEventSerializerTests
+{
+	[Fact]
+	public void Options_RegistersAllExpectedConverters()
+	{
+		var options = ShoppingListEventSerializer.Options;
+
+		options.Converters.Should().HaveCountGreaterThan(0);
+	}
+
+	[Fact]
+	public void Roundtrip_ShoppingListCreated_PreservesEveryField()
+	{
+		var listId = ShoppingListIdentifier.From(Guid.NewGuid());
+		var owner = OwnerIdentifier.From("user-1");
+		var title = ShoppingListTitle.From("Weekly groceries");
+		var recipeRef = RecipeReference.From(Guid.NewGuid());
+		var createdAt = new DateTime(2026, 5, 17, 10, 0, 0, DateTimeKind.Utc);
+		var @event = new ShoppingListCreated(listId, title, owner, recipeRef, createdAt);
+
+		var json = JsonSerializer.Serialize(@event, ShoppingListEventSerializer.Options);
+		var rehydrated = (ShoppingListCreated)ShoppingListEventSerializer.Deserialize(
+			nameof(ShoppingListCreated), json)!;
+
+		rehydrated.Identifier.Should().Be(listId);
+		rehydrated.Title.Should().Be(title);
+		rehydrated.Owner.Should().Be(owner);
+		rehydrated.RecipeReference.Should().Be(recipeRef);
+		rehydrated.CreatedAt.Should().Be(createdAt);
+	}
+
+	[Fact]
+	public void Roundtrip_ListItemAdded_PreservesQuantityAndCategory()
+	{
+		var itemId = ShoppingListItemIdentifier.From(Guid.NewGuid());
+		var name = ItemName.From("Onion");
+		var quantity = Quantity.Of(Amount.From(2.5m), Unit.From("kg"));
+		var category = IngredientCategory.From("produce");
+		var @event = new ListItemAdded(itemId, name, quantity, category);
+
+		var json = JsonSerializer.Serialize(@event, ShoppingListEventSerializer.Options);
+		var rehydrated = (ListItemAdded)ShoppingListEventSerializer.Deserialize(
+			nameof(ListItemAdded), json)!;
+
+		rehydrated.ItemId.Should().Be(itemId);
+		rehydrated.Name.Should().Be(name);
+		rehydrated.Quantity!.Amount.Value.Should().Be(2.5m);
+		rehydrated.Quantity.Unit!.Value.Should().Be("kg");
+		rehydrated.Category!.Value.Should().Be("produce");
+	}
+
+	[Fact]
+	public void Roundtrip_UnitConverter_NullUnit_StaysNull()
+	{
+		var quantity = Quantity.Of(Amount.From(3m), Unit.FromNullable(null));
+		var @event = new ListItemAdded(
+			ShoppingListItemIdentifier.From(Guid.NewGuid()),
+			ItemName.From("Eggs"),
+			quantity,
+			IngredientCategory.From("dairy"));
+
+		var json = JsonSerializer.Serialize(@event, ShoppingListEventSerializer.Options);
+		var rehydrated = (ListItemAdded)ShoppingListEventSerializer.Deserialize(
+			nameof(ListItemAdded), json)!;
+
+		rehydrated.Quantity!.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void Deserialize_UnknownEventType_ReturnsNull()
+	{
+		ShoppingListEventSerializer.Deserialize("NotAShoppingListEvent", "{}").Should().BeNull();
+	}
+}


### PR DESCRIPTION
## Summary
Backfills the previously-untested ShoppingList + ShoppingLedger event-store JSON serializers. Both classes are `internal static` — a one-line `InternalsVisibleTo` on `Yumney.Shopping.Infrastructure.csproj` exposes them to the test project so the registered value-object converters can be exercised end-to-end.

**ShoppingListEventSerializer:**
- Options has converters registered.
- `ShoppingListCreated` round-trips (identifier, title, owner, recipe reference, createdAt).
- `ListItemAdded` round-trips (itemId, name, quantity with unit, category).
- Nullable `Unit` stays null after roundtrip.
- Unknown event type → null.

**ShoppingLedgerEventSerializer:**
- Options has converters registered.
- `ShoppingItemAdded` round-trips (name, quantity with unit, source).
- `ShoppingItemRemoved` round-trips with `RemovalReason`.
- Null `Reason` stays null after roundtrip.
- Unknown event type → null.

The roundtrips exercise every internal converter: `AmountJsonConverter`, `ItemNameJsonConverter`, `UnitJsonConverter`, `ItemSourceJsonConverter`, `RemovalReasonJsonConverter`, `RecipeReferenceJsonConverter`, `ShoppingListIdentifierJsonConverter`, `ShoppingListItemIdentifierJsonConverter`, `IngredientCategoryJsonConverter`.

38 tests pass locally; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shopping.Infrastructure.Tests/` green
- [ ] CI green