### PR TITLE
test(shopping): backfill Application DTO mappings (#464)

### DIFF
--- a/tests/Yumney.Shopping.Application.Tests/DTOs/IngredientBalanceMappingExtensionsTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/DTOs/IngredientBalanceMappingExtensionsTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.DTOs;
+
+public class IngredientBalanceMappingExtensionsTests
+{
+	[Fact]
+	public void ToStapleBalanceItem_ProjectsCategoryAndNameWithStapleSource()
+	{
+		var category = IngredientCategory.From("pantry");
+
+		var item = category.ToStapleBalanceItem("Flour");
+
+		item.ItemName.Should().Be("Flour");
+		item.Category.Should().Be("pantry");
+		item.Source.Should().Be(IngredientBalanceSource.Staple);
+		item.Quantity.Should().BeNull();
+		item.Unit.Should().BeNull();
+		item.Freshness.Should().Be(Freshness.NotTracked);
+	}
+
+	[Fact]
+	public void ToBalanceDto_WrapsItemListInBalanceDto()
+	{
+		IReadOnlyList<IngredientBalanceItemDto> items =
+		[
+			IngredientCategory.From("pantry").ToStapleBalanceItem("Flour"),
+			IngredientCategory.From("spices").ToStapleBalanceItem("Salt"),
+		];
+
+		var dto = items.ToBalanceDto();
+
+		dto.Items.Should().BeSameAs(items);
+	}
+
+	[Fact]
+	public void ToBalanceDto_EmptyItems_YieldsDtoWithEmptyItems()
+	{
+		IReadOnlyList<IngredientBalanceItemDto> items = [];
+
+		var dto = items.ToBalanceDto();
+
+		dto.Items.Should().BeEmpty();
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/DTOs/ShoppingLedgerMappingExtensionsTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/DTOs/ShoppingLedgerMappingExtensionsTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingLedger;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.DTOs;
+
+public class ShoppingLedgerMappingExtensionsTests
+{
+	[Fact]
+	public void ToAddedItemDto_ProjectsEveryField()
+	{
+		var ledger = ShoppingLedger.Create(OwnerIdentifier.From("user-1"));
+		var quantity = Quantity.Of(Amount.From(2m), Unit.From("kg"));
+
+		var dto = ledger.ToAddedItemDto(
+			ItemName.From("Onion"),
+			quantity,
+			IngredientCategory.From("produce"),
+			ItemSource.From("manual"));
+
+		dto.ItemName.Should().Be("Onion");
+		dto.Quantity.Should().Be(2m);
+		dto.Unit.Should().Be("kg");
+		dto.Category.Should().Be("produce");
+		dto.Source.Should().Be("manual");
+		dto.LedgerIdentifier.Should().Be(ledger.Identifier);
+	}
+
+	[Fact]
+	public void ToAddedItemDto_NullUnit_StaysNull()
+	{
+		var ledger = ShoppingLedger.Create(OwnerIdentifier.From("user-1"));
+		var quantity = Quantity.Of(Amount.From(3m), Unit.FromNullable(null));
+
+		var dto = ledger.ToAddedItemDto(
+			ItemName.From("Eggs"),
+			quantity,
+			IngredientCategory.From("dairy"),
+			ItemSource.From("manual"));
+
+		dto.Unit.Should().BeNull();
+	}
+}

--- a/tests/Yumney.Shopping.Application.Tests/DTOs/ShoppingListMappingExtensionsTests.cs
+++ b/tests/Yumney.Shopping.Application.Tests/DTOs/ShoppingListMappingExtensionsTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Application.Tests.DTOs;
+
+public class ShoppingListMappingExtensionsTests
+{
+	[Fact]
+	public void ToDetailDto_ProjectsTopLevelFieldsAndItems()
+	{
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Weekly"),
+			OwnerIdentifier.From("user-1"),
+			[ShoppingListItem.Create(ItemName.From("Onion"), Quantity.Of(Amount.From(2m), Unit.From("kg")))],
+			RecipeReference.From(Guid.NewGuid()));
+
+		var dto = list.ToDetailDto();
+
+		dto.Identifier.Should().Be(list.Identifier.Value);
+		dto.Title.Should().Be("Weekly");
+		dto.RecipeReference.Should().Be(list.RecipeReference!.Value);
+		dto.CreatedAt.Should().Be(list.CreatedAt);
+		dto.Items.Should().ContainSingle().Which.Name.Should().Be("Onion");
+	}
+
+	[Fact]
+	public void ToDetailDto_NullRecipeReference_StaysNull()
+	{
+		var list = ShoppingList.Create(
+			ShoppingListTitle.From("Plain"),
+			OwnerIdentifier.From("user-1"),
+			[ShoppingListItem.Create(ItemName.From("Salt"), quantity: null)],
+			recipeReference: null);
+
+		var dto = list.ToDetailDto();
+
+		dto.RecipeReference.Should().BeNull();
+	}
+
+	[Fact]
+	public void ToSummaryDto_ProjectsAllFields()
+	{
+		var identifier = ShoppingListIdentifier.From(Guid.NewGuid());
+		var createdAt = new DateTime(2026, 5, 17, 10, 0, 0, DateTimeKind.Utc);
+		var summary = new ShoppingListSummary(
+			identifier,
+			ShoppingListTitle.From("Weekly"),
+			ItemCount.From(7),
+			createdAt);
+
+		var dto = summary.ToSummaryDto();
+
+		dto.Identifier.Should().Be(identifier.Value);
+		dto.Title.Should().Be("Weekly");
+		dto.ItemCount.Should().Be(7);
+		dto.CreatedAt.Should().Be(createdAt);
+	}
+
+	[Fact]
+	public void ToSummaryDtos_MapsEverySummary()
+	{
+		ShoppingListSummary[] summaries =
+		[
+			new(ShoppingListIdentifier.From(Guid.NewGuid()), ShoppingListTitle.From("A"), ItemCount.From(1), DateTime.UtcNow),
+			new(ShoppingListIdentifier.From(Guid.NewGuid()), ShoppingListTitle.From("B"), ItemCount.From(2), DateTime.UtcNow),
+		];
+
+		var dtos = summaries.ToSummaryDtos();
+
+		dtos.Should().HaveCount(2);
+		dtos[0].Title.Should().Be("A");
+		dtos[1].Title.Should().Be("B");
+	}
+
+	[Fact]
+	public void ItemToDto_WithQuantity_ProjectsAmountAndUnit()
+	{
+		var item = ShoppingListItem.Create(
+			ItemName.From("Flour"),
+			Quantity.Of(Amount.From(500m), Unit.From("g")),
+			IngredientCategory.From("pantry"));
+
+		var dto = item.ToDto();
+
+		dto.Name.Should().Be("Flour");
+		dto.Amount.Should().Be(500m);
+		dto.Unit.Should().Be("g");
+		dto.Category.Should().Be("pantry");
+		dto.IsChecked.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ItemToDto_WithoutQuantity_LeavesAmountAndUnitNull()
+	{
+		var item = ShoppingListItem.Create(ItemName.From("Salt"), quantity: null);
+
+		var dto = item.ToDto();
+
+		dto.Amount.Should().BeNull();
+		dto.Unit.Should().BeNull();
+	}
+
+	[Fact]
+	public void ItemsToDtos_MapsEveryItem()
+	{
+		ShoppingListItem[] items =
+		[
+			ShoppingListItem.Create(ItemName.From("Onion"), quantity: null),
+			ShoppingListItem.Create(ItemName.From("Garlic"), quantity: null),
+		];
+
+		var dtos = items.ToDtos();
+
+		dtos.Should().HaveCount(2);
+		dtos[0].Name.Should().Be("Onion");
+		dtos[1].Name.Should().Be("Garlic");
+	}
+}


### PR DESCRIPTION
## Summary
- **ShoppingListMappingExtensions**: `ToDetailDto` projects top-level fields + items + nullable recipe reference, `ToSummaryDto` / `ToSummaryDtos`, `ItemToDto` with/without quantity, `ItemsToDtos`.
- **ShoppingLedgerMappingExtensions**: `ToAddedItemDto` projects every field, null unit stays null.
- **IngredientBalanceMappingExtensions**: `ToStapleBalanceItem` fills name/category with `Staple` source (quantity/unit null, freshness NotTracked); `ToBalanceDto` wraps the supplied list (same instance); empty list yields empty DTO.

12 new tests; build + format clean.

Refs #464.

## Test plan
- [x] `dotnet test tests/Yumney.Shopping.Application.Tests/` green
- [ ] CI green