### PR TITLE
test(users): UsersDiagnostics SourceName + ActivitySource (#464)

### DIFF
--- a/tests/Yumney.Users.Infrastructure.Tests/UsersDiagnosticsTests.cs
+++ b/tests/Yumney.Users.Infrastructure.Tests/UsersDiagnosticsTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Users.Infrastructure;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Users.Infrastructure.Tests;
+
+public class UsersDiagnosticsTests
+{
+	[Fact]
+	public void SourceName_IsTheCanonicalYumneyUsersConstant()
+	{
+		UsersDiagnostics.SourceName.Should().Be("Yumney.Users");
+	}
+
+	[Fact]
+	public void ActivitySource_NameMatchesSourceName()
+	{
+		UsersDiagnostics.ActivitySource.Name.Should().Be(UsersDiagnostics.SourceName);
+	}
+}


### PR DESCRIPTION
Companion to #762 (CQRS Diagnostics) and #766 (RecipesDiagnostics). Mirrors the same tiny pattern: SourceName constant + ActivitySource.Name parity. Refs #464.