### PR TITLE
test(shared): close to threshold — Abstractions / Paging / Quantities / Persistence (#464)

### DIFF
--- a/tests/Yumney.Shared.Tests/Common/AggregateRootCheckRuleTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/AggregateRootCheckRuleTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Abstractions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class AggregateRootCheckRuleTests
+{
+	private sealed class AlwaysBrokenRule : IBusinessRule
+	{
+		public string Message => "always-broken";
+
+		public bool IsBroken() => true;
+	}
+
+	private sealed class AlwaysSatisfiedRule : IBusinessRule
+	{
+		public string Message => "always-satisfied";
+
+		public bool IsBroken() => false;
+	}
+
+	private sealed class FakeAggregate : AggregateRoot<Guid>
+	{
+		public FakeAggregate() => Id = Guid.NewGuid();
+
+		public static void Enforce(IBusinessRule rule) => CheckRule(rule);
+	}
+
+	[Fact]
+	public void CheckRule_BrokenRule_ThrowsBusinessRuleValidationException()
+	{
+		var rule = new AlwaysBrokenRule();
+
+		var act = () => FakeAggregate.Enforce(rule);
+
+		act.Should().Throw<BusinessRuleValidationException>()
+			.Which.BrokenRule.Should().BeSameAs(rule);
+	}
+
+	[Fact]
+	public void CheckRule_SatisfiedRule_DoesNotThrow()
+	{
+		var act = () => FakeAggregate.Enforce(new AlwaysSatisfiedRule());
+
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/IngredientCategoryOperatorTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/IngredientCategoryOperatorTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class IngredientCategoryOperatorTests
+{
+	[Fact]
+	public void ImplicitConversionToString_YieldsValue()
+	{
+		var category = IngredientCategory.Produce;
+
+		string raw = category;
+
+		raw.Should().Be(category.Value);
+	}
+
+	[Fact]
+	public void All_ContainsEveryStaticCategoryInOrder()
+	{
+		IngredientCategory.All.Should().Equal(
+			IngredientCategory.Produce,
+			IngredientCategory.Dairy,
+			IngredientCategory.MeatFish,
+			IngredientCategory.Bakery,
+			IngredientCategory.Frozen,
+			IngredientCategory.Beverages,
+			IngredientCategory.Pantry,
+			IngredientCategory.Spices,
+			IngredientCategory.Household,
+			IngredientCategory.Other);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/PagingOptionsDefaultsTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/PagingOptionsDefaultsTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class PagingOptionsDefaultsTests
+{
+	[Fact]
+	public void Default_ReturnsPage1WithDefaultPageSize()
+	{
+		var options = PagingOptions.Default();
+
+		options.Page.Value.Should().Be(PagingOptions.DefaultPage);
+		options.PageSize.Value.Should().Be(PagingOptions.DefaultPageSize);
+	}
+
+	[Fact]
+	public void Default_DefaultPage_IsOne()
+	{
+		PagingOptions.DefaultPage.Should().Be(1);
+	}
+
+	[Fact]
+	public void Default_DefaultPageSize_IsTwenty()
+	{
+		PagingOptions.DefaultPageSize.Should().Be(20);
+	}
+
+	[Fact]
+	public void From_DelegatesToOf()
+	{
+		var fromCtor = PagingOptions.From(3, 25);
+
+		fromCtor.Page.Value.Should().Be(3);
+		fromCtor.PageSize.Value.Should().Be(25);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Common/SortingOptionsParseTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/SortingOptionsParseTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Paging;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class SortingOptionsParseTests
+{
+	private enum SortField
+	{
+		CreatedAt,
+		Title,
+		Rating,
+	}
+
+	[Fact]
+	public void Parse_KnownValue_ReturnsParsedField()
+	{
+		var options = SortingOptions<SortField>.Parse("Title", SortDirection.Ascending, fallback: SortField.CreatedAt);
+
+		options.SortBy.Should().Be(SortField.Title);
+		options.Direction.Should().Be(SortDirection.Ascending);
+	}
+
+	[Fact]
+	public void Parse_KnownValueCaseInsensitive_ReturnsParsedField()
+	{
+		var options = SortingOptions<SortField>.Parse("rating", SortDirection.Descending, fallback: SortField.CreatedAt);
+
+		options.SortBy.Should().Be(SortField.Rating);
+	}
+
+	[Fact]
+	public void Parse_NullValue_UsesFallback()
+	{
+		var options = SortingOptions<SortField>.Parse(null, SortDirection.Descending, fallback: SortField.CreatedAt);
+
+		options.SortBy.Should().Be(SortField.CreatedAt);
+		options.Direction.Should().Be(SortDirection.Descending);
+	}
+
+	[Fact]
+	public void Parse_UnknownValue_UsesFallback()
+	{
+		var options = SortingOptions<SortField>.Parse("Unknown", SortDirection.Ascending, fallback: SortField.Rating);
+
+		options.SortBy.Should().Be(SortField.Rating);
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/EventStore/DbUpdateExceptionExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/EventStore/DbUpdateExceptionExtensionsTests.cs
@@ -1,0 +1,47 @@
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SmartSolutionsLab.Yumney.Shared.Persistence.EventStore;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence.EventStore;
+
+public class DbUpdateExceptionExtensionsTests
+{
+	[Theory]
+	[InlineData("23505", true)] // Postgres unique_violation
+	[InlineData("2627", true)] // SQL Server PK violation
+	[InlineData("2601", true)] // SQL Server unique-index violation
+	[InlineData("23503", false)] // foreign_key_violation
+	[InlineData("42P01", false)] // undefined_table
+	[InlineData(null, false)] // no SqlState — treated as non-violation
+	public void IsUniqueViolation_MatchesProviderSqlStates(string? sqlState, bool expected)
+	{
+		var dbException = new FakeDbException(sqlState);
+		var update = new DbUpdateException("save failed", dbException);
+
+		update.IsUniqueViolation().Should().Be(expected);
+	}
+
+	[Fact]
+	public void IsUniqueViolation_InnerNotDbException_ReturnsFalse()
+	{
+		var update = new DbUpdateException("save failed", new InvalidOperationException("not a provider exception"));
+
+		update.IsUniqueViolation().Should().BeFalse();
+	}
+
+	[Fact]
+	public void IsUniqueViolation_NoInner_ReturnsFalse()
+	{
+		var update = new DbUpdateException();
+
+		update.IsUniqueViolation().Should().BeFalse();
+	}
+
+	private sealed class FakeDbException(string? sqlState) : DbException("simulated")
+	{
+		public override string? SqlState { get; } = sqlState;
+	}
+}

--- a/tests/Yumney.Shared.Tests/Persistence/QueryCountingServiceCollectionExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/QueryCountingServiceCollectionExtensionsTests.cs
@@ -14,7 +14,7 @@ public class QueryCountingServiceCollectionExtensionsTests
 
 		services.AddQueryCounting();
 
-		var descriptor = services.Single(d => d.ServiceType == typeof(IQueryCounter));
+		var descriptor = services.Single(service => service.ServiceType == typeof(IQueryCounter));
 		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
 		descriptor.ImplementationType.Should().Be<QueryCounter>();
 	}
@@ -26,7 +26,7 @@ public class QueryCountingServiceCollectionExtensionsTests
 
 		services.AddQueryCounting();
 
-		var descriptor = services.Single(d => d.ServiceType == typeof(QueryCountingInterceptor));
+		var descriptor = services.Single(service => service.ServiceType == typeof(QueryCountingInterceptor));
 		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
 	}
 

--- a/tests/Yumney.Shared.Tests/Persistence/QueryCountingServiceCollectionExtensionsTests.cs
+++ b/tests/Yumney.Shared.Tests/Persistence/QueryCountingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Persistence;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Persistence;
+
+public class QueryCountingServiceCollectionExtensionsTests
+{
+	[Fact]
+	public void AddQueryCounting_RegistersIQueryCounterAsScoped()
+	{
+		var services = new ServiceCollection();
+
+		services.AddQueryCounting();
+
+		var descriptor = services.Single(d => d.ServiceType == typeof(IQueryCounter));
+		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+		descriptor.ImplementationType.Should().Be<QueryCounter>();
+	}
+
+	[Fact]
+	public void AddQueryCounting_RegistersInterceptorAsScoped()
+	{
+		var services = new ServiceCollection();
+
+		services.AddQueryCounting();
+
+		var descriptor = services.Single(d => d.ServiceType == typeof(QueryCountingInterceptor));
+		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+	}
+
+	[Fact]
+	public void AddQueryCounting_ReturnsServiceCollectionForChaining()
+	{
+		var services = new ServiceCollection();
+
+		var returned = services.AddQueryCounting();
+
+		returned.Should().BeSameAs(services);
+	}
+}


### PR DESCRIPTION
Targeted backfill at lines flagged by the (now-fixed) coverage gate.

- `AggregateRoot<T>.CheckRule` — broken-rule throws, satisfied-rule no-op.
- `PagingOptions.Default()` + `DefaultPage` / `DefaultPageSize` constants + `From` delegation.
- `SortingOptions<T>.Parse` — known value (case-insensitive), null/unknown fall back.
- `IngredientCategory` — implicit string operator, `All` static ordered list.
- `QueryCountingServiceCollectionExtensions.AddQueryCounting` — DI lifetimes + chaining.
- `DbUpdateExceptionExtensions.IsUniqueViolation` — Postgres 23505 + SQL Server 2627/2601 → true; FK / undefined-table / non-DbException / no-inner → false.

425 tests pass locally; build + format clean. Pushes Shared.Abstractions / Paging / Quantities / Persistence noticeably closer to the 90 % gate.

Refs #464.