### PR TITLE
test(shared): backfill Events.InProcess (#464)

### DIFF
--- a/tests/Yumney.Shared.Events.Tests/EventMetricsTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/EventMetricsTests.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class EventMetricsTests
+{
+	private sealed class FakeMeterFactory : IMeterFactory
+	{
+		public Meter Create(MeterOptions options) => new(options);
+
+		public void Dispose()
+		{
+		}
+	}
+
+	[Fact]
+	public void RecordCompletion_Success_EmitsCounterWithSuccessTag()
+	{
+		using var listener = new MeterListener();
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = [];
+		listener.InstrumentPublished = (instrument, l) =>
+		{
+			if (instrument.Meter.Name == EventMetrics.MeterName)
+			{
+				l.EnableMeasurementEvents(instrument);
+			}
+		};
+		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+			samples.Add((measurement, tags.ToArray())));
+		listener.Start();
+
+		var metrics = new EventMetrics(new FakeMeterFactory());
+		metrics.RecordCompletion("domain", "RecipeImported", "ShoppingListProjectionHandler", succeeded: true);
+
+		samples.Should().ContainSingle();
+		samples[0].Value.Should().Be(1);
+		samples[0].Tags.Should().Contain(tag => tag.Key == "result" && (string)tag.Value! == "success");
+		samples[0].Tags.Should().Contain(tag => tag.Key == "event.category" && (string)tag.Value! == "domain");
+		samples[0].Tags.Should().Contain(tag => tag.Key == "event.type" && (string)tag.Value! == "RecipeImported");
+		samples[0].Tags.Should().Contain(tag => tag.Key == "handler.type" && (string)tag.Value! == "ShoppingListProjectionHandler");
+	}
+
+	[Fact]
+	public void RecordCompletion_Failure_EmitsCounterWithFailureTag()
+	{
+		using var listener = new MeterListener();
+		List<KeyValuePair<string, object?>[]> samples = [];
+		listener.InstrumentPublished = (instrument, l) =>
+		{
+			if (instrument.Meter.Name == EventMetrics.MeterName)
+			{
+				l.EnableMeasurementEvents(instrument);
+			}
+		};
+		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+			samples.Add(tags.ToArray()));
+		listener.Start();
+
+		var metrics = new EventMetrics(new FakeMeterFactory());
+		metrics.RecordCompletion("integration", "RecipeDeleted", "ShoppingCleanupHandler", succeeded: false);
+
+		samples.Should().ContainSingle();
+		samples[0].Should().Contain(tag => tag.Key == "result" && (string)tag.Value! == "failure");
+	}
+
+	[Fact]
+	public void MeterName_IsTheCanonicalYumneyEventsConstant()
+	{
+		EventMetrics.MeterName.Should().Be("Yumney.Events");
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/EventingServiceCollectionExtensionsTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/EventingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class EventingServiceCollectionExtensionsTests
+{
+	[Fact]
+	public void AddInProcessDomainEventDispatcher_RegistersDispatcherAsScoped()
+	{
+		var services = new ServiceCollection();
+
+		services.AddInProcessDomainEventDispatcher();
+
+		var descriptor = services.Single(service => service.ServiceType == typeof(IDomainEventDispatcher));
+		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+		descriptor.ImplementationType.Should().Be<InProcessDomainEventDispatcher>();
+	}
+
+	[Fact]
+	public void AddInProcessDomainEventDispatcher_RegistersEventMetricsAsSingleton()
+	{
+		var services = new ServiceCollection();
+
+		services.AddInProcessDomainEventDispatcher();
+
+		var descriptor = services.Single(service => service.ServiceType == typeof(EventMetrics));
+		descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
+	}
+
+	[Fact]
+	public void AddInProcessDomainEventDispatcher_ReturnsServiceCollectionForChaining()
+	{
+		var services = new ServiceCollection();
+
+		var returned = services.AddInProcessDomainEventDispatcher();
+
+		returned.Should().BeSameAs(services);
+	}
+
+	[Fact]
+	public void AddInProcessEventBus_RegistersBusAsScoped()
+	{
+		var services = new ServiceCollection();
+
+		services.AddInProcessEventBus();
+
+		var descriptor = services.Single(service => service.ServiceType == typeof(IEventBus));
+		descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+		descriptor.ImplementationType.Should().Be<InProcessEventBus>();
+	}
+
+	[Fact]
+	public void AddInProcessEventBus_RegistersEventMetricsAsSingletonOnce()
+	{
+		var services = new ServiceCollection();
+
+		services.AddInProcessEventBus();
+		services.AddInProcessEventBus();
+
+		services.Count(service => service.ServiceType == typeof(EventMetrics)).Should().Be(1);
+	}
+
+	[Fact]
+	public void AddInProcessEventBus_ReturnsServiceCollectionForChaining()
+	{
+		var services = new ServiceCollection();
+
+		var returned = services.AddInProcessEventBus();
+
+		returned.Should().BeSameAs(services);
+	}
+}

--- a/tests/Yumney.Shared.Events.Tests/EventsDiagnosticsTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/EventsDiagnosticsTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Events;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
+
+public class EventsDiagnosticsTests
+{
+	[Fact]
+	public void SourceName_IsTheCanonicalYumneyEventsConstant()
+	{
+		EventsDiagnostics.SourceName.Should().Be("Yumney.Events");
+	}
+
+	[Fact]
+	public void ActivitySource_NameMatchesSourceName()
+	{
+		EventsDiagnostics.ActivitySource.Name.Should().Be(EventsDiagnostics.SourceName);
+	}
+}


### PR DESCRIPTION
Pushes Yumney.Shared.Events.InProcess from 76.9% toward 90%.

- DI registration for IDomainEventDispatcher + IEventBus + EventMetrics
- EventsDiagnostics SourceName + ActivitySource
- EventMetrics counter emits with success/failure tag

55 tests pass locally; build + format clean. Refs #464.