### PR TITLE
feat(frontend): no-speech hint + E2E coverage for command-bar mic (US-360)

### DIFF
--- a/client/apps/shell-e2e/src/recipes/command-bar-mic.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/command-bar-mic.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { ChatPage } from '../pages/chat.page';
+import { TIMEOUTS } from '../helpers/timeouts';
+
+// US-360: Push-to-Talk Voice Input on the Command Bar.
+// The mic button lives inside the chat panel's input area (mounted globally
+// via yn-app-layout and toggled by the persistent command FAB).
+// Browsers Playwright runs against don't expose a real SpeechRecognition,
+// so each test injects a mock constructor via addInitScript that records
+// start() / stop() and exposes the captured event handlers on window so the
+// test can drive onresult / onerror / onend deterministically.
+test.describe('Command bar mic (US-360)', () => {
+  const installMockRecognition = async (page: import('@playwright/test').Page): Promise<void> => {
+    await page.addInitScript(() => {
+      type RecogHandlers = {
+        onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+        onerror: ((event: { error: string }) => void) | null;
+        onend: (() => void) | null;
+      };
+      const created: Array<RecogHandlers & { lang: string; continuous: boolean; interimResults: boolean; started: boolean }> = [];
+      class MockRecognition {
+        lang = '';
+        continuous = false;
+        interimResults = false;
+        started = false;
+        onresult: RecogHandlers['onresult'] = null;
+        onerror: RecogHandlers['onerror'] = null;
+        onend: RecogHandlers['onend'] = null;
+        constructor() {
+          created.push(this as unknown as RecogHandlers & {
+            lang: string;
+            continuous: boolean;
+            interimResults: boolean;
+            started: boolean;
+          });
+        }
+        start(): void {
+          this.started = true;
+        }
+        stop(): void {
+          this.onend?.();
+        }
+      }
+      (window as unknown as { SpeechRecognition: typeof MockRecognition }).SpeechRecognition = MockRecognition;
+      (window as unknown as { __mockRecognitions: typeof created }).__mockRecognitions = created;
+    });
+  };
+
+  test('mic button is rendered when speech recognition is supported', async ({ authenticatedPage }) => {
+    await installMockRecognition(authenticatedPage);
+    await authenticatedPage.reload();
+
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
+
+    const mic = authenticatedPage.locator('[data-testid="chat-mic"]');
+    await expect(mic).toBeVisible();
+  });
+
+  test('clicking the mic populates the input with the spoken transcript', async ({ authenticatedPage }) => {
+    await installMockRecognition(authenticatedPage);
+    await authenticatedPage.reload();
+
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
+
+    const mic = authenticatedPage.locator('[data-testid="chat-mic"]');
+    await mic.click();
+
+    // Drive the recognition session — fire onresult with the transcript,
+    // then onend so isListening flips back to false.
+    await authenticatedPage.evaluate(() => {
+      const created = (window as unknown as { __mockRecognitions: Array<{
+        onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+        onend: (() => void) | null;
+      }> }).__mockRecognitions;
+      const recognition = created[created.length - 1];
+      recognition.onresult?.({ results: [[{ transcript: 'add milk to my shopping list' }]] });
+      recognition.onend?.();
+    });
+
+    await expect(chat.input).toHaveValue('add milk to my shopping list');
+  });
+
+  test('mic button shows the listening visual state while recognition is active', async ({ authenticatedPage }) => {
+    await installMockRecognition(authenticatedPage);
+    await authenticatedPage.reload();
+
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
+
+    const mic = authenticatedPage.locator('[data-testid="chat-mic"]');
+    await mic.click();
+
+    await expect(mic).toHaveClass(/listening/);
+    await expect(mic).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('shows the no-speech hint when recognition ends without a transcript (TC-360-05)', async ({ authenticatedPage }) => {
+    await installMockRecognition(authenticatedPage);
+    await authenticatedPage.reload();
+
+    const chat = new ChatPage(authenticatedPage);
+    await chat.open();
+    await expect(chat.panel).toBeVisible({ timeout: TIMEOUTS.short });
+
+    await authenticatedPage.locator('[data-testid="chat-mic"]').click();
+
+    // Browser's silence-timeout path: onerror with 'no-speech' then onend.
+    await authenticatedPage.evaluate(() => {
+      const created = (window as unknown as { __mockRecognitions: Array<{
+        onerror: ((event: { error: string }) => void) | null;
+        onend: (() => void) | null;
+      }> }).__mockRecognitions;
+      const recognition = created[created.length - 1];
+      recognition.onerror?.({ error: 'no-speech' });
+      recognition.onend?.();
+    });
+
+    const errorBanner = authenticatedPage.locator('.chat-error[role="alert"]');
+    await expect(errorBanner).toBeVisible();
+  });
+});

--- a/client/apps/shell-e2e/src/recipes/command-bar-mic.spec.ts
+++ b/client/apps/shell-e2e/src/recipes/command-bar-mic.spec.ts
@@ -27,12 +27,14 @@ test.describe('Command bar mic (US-360)', () => {
         onerror: RecogHandlers['onerror'] = null;
         onend: RecogHandlers['onend'] = null;
         constructor() {
-          created.push(this as unknown as RecogHandlers & {
-            lang: string;
-            continuous: boolean;
-            interimResults: boolean;
-            started: boolean;
-          });
+          created.push(
+            this as unknown as RecogHandlers & {
+              lang: string;
+              continuous: boolean;
+              interimResults: boolean;
+              started: boolean;
+            },
+          );
         }
         start(): void {
           this.started = true;
@@ -72,10 +74,14 @@ test.describe('Command bar mic (US-360)', () => {
     // Drive the recognition session — fire onresult with the transcript,
     // then onend so isListening flips back to false.
     await authenticatedPage.evaluate(() => {
-      const created = (window as unknown as { __mockRecognitions: Array<{
-        onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
-        onend: (() => void) | null;
-      }> }).__mockRecognitions;
+      const created = (
+        window as unknown as {
+          __mockRecognitions: Array<{
+            onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+            onend: (() => void) | null;
+          }>;
+        }
+      ).__mockRecognitions;
       const recognition = created[created.length - 1];
       recognition.onresult?.({ results: [[{ transcript: 'add milk to my shopping list' }]] });
       recognition.onend?.();
@@ -111,10 +117,14 @@ test.describe('Command bar mic (US-360)', () => {
 
     // Browser's silence-timeout path: onerror with 'no-speech' then onend.
     await authenticatedPage.evaluate(() => {
-      const created = (window as unknown as { __mockRecognitions: Array<{
-        onerror: ((event: { error: string }) => void) | null;
-        onend: (() => void) | null;
-      }> }).__mockRecognitions;
+      const created = (
+        window as unknown as {
+          __mockRecognitions: Array<{
+            onerror: ((event: { error: string }) => void) | null;
+            onend: (() => void) | null;
+          }>;
+        }
+      ).__mockRecognitions;
       const recognition = created[created.length - 1];
       recognition.onerror?.({ error: 'no-speech' });
       recognition.onend?.();

--- a/client/apps/shell/public/assets/i18n/de.json
+++ b/client/apps/shell/public/assets/i18n/de.json
@@ -318,7 +318,8 @@
     "clearHistory": "Verlauf löschen",
     "errors": {
       "offline": "Chat benötigt eine Internetverbindung.",
-      "failed": "Chat-Dienst nicht erreichbar. Bitte erneut versuchen."
+      "failed": "Chat-Dienst nicht erreichbar. Bitte erneut versuchen.",
+      "noSpeech": "Habe nichts gehört. Erneut probieren?"
     },
     "actions": {
       "navigate": "Öffnen",

--- a/client/apps/shell/public/assets/i18n/en.json
+++ b/client/apps/shell/public/assets/i18n/en.json
@@ -318,7 +318,8 @@
     "clearHistory": "Clear conversation history",
     "errors": {
       "offline": "Chat requires an internet connection.",
-      "failed": "Could not reach the chat service. Please try again."
+      "failed": "Could not reach the chat service. Please try again.",
+      "noSpeech": "Didn't catch that. Try again?"
     },
     "actions": {
       "navigate": "Open",

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -291,6 +291,51 @@ describe('VoiceService.startListeningForTranscript (US-360)', () => {
 
     expect(first.start).not.toHaveBeenCalled();
   });
+
+  it('fires onNoSpeech when the browser signals no-speech with no prior transcript', () => {
+    const transcript = vi.fn();
+    const noSpeech = vi.fn();
+    service.startListeningForTranscript(transcript, noSpeech);
+
+    getRecognition().onerror?.({ error: 'no-speech' });
+
+    expect(transcript).not.toHaveBeenCalled();
+    expect(noSpeech).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onNoSpeech when the session ends without ever capturing a transcript', () => {
+    const transcript = vi.fn();
+    const noSpeech = vi.fn();
+    service.startListeningForTranscript(transcript, noSpeech);
+
+    getRecognition().onend?.();
+
+    expect(transcript).not.toHaveBeenCalled();
+    expect(noSpeech).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onNoSpeech when a transcript was captured', () => {
+    const transcript = vi.fn();
+    const noSpeech = vi.fn();
+    service.startListeningForTranscript(transcript, noSpeech);
+
+    const recognition = getRecognition();
+    recognition.onresult?.({ results: [[{ transcript: 'add milk' }]] });
+    recognition.onend?.();
+
+    expect(transcript).toHaveBeenCalledWith('add milk');
+    expect(noSpeech).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onNoSpeech for non-silence errors (e.g. not-allowed)', () => {
+    const transcript = vi.fn();
+    const noSpeech = vi.fn();
+    service.startListeningForTranscript(transcript, noSpeech);
+
+    getRecognition().onerror?.({ error: 'not-allowed' });
+
+    expect(noSpeech).not.toHaveBeenCalled();
+  });
 });
 
 describe('VoiceService.startListeningWithFallback (US-362)', () => {

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -199,14 +199,21 @@ export class VoiceService {
    * The browser auto-ends the recognition session once the user finishes
    * speaking (continuous=false), so the caller doesn't need to call
    * `stopListening` unless cancelling mid-utterance.
+   *
+   * <paramref name="onNoSpeech" /> fires when the recognition session ends
+   * without ever capturing a transcript (browsers signal this either by
+   * firing `onerror` with `error="no-speech"`, or by firing `onend` after
+   * the silence-timeout without any `onresult`). Callers use it to surface
+   * a "didn't catch that" hint to the user — AC TC-360-05.
    */
-  startListeningForTranscript(onTranscript: (transcript: string) => void): void {
+  startListeningForTranscript(onTranscript: (transcript: string) => void, onNoSpeech?: () => void): void {
     if (!this.sttSupported() || this.isListening()) {
       return;
     }
     const recognition = this.createRecognition();
     if (!recognition) return;
 
+    let gotTranscript = false;
     recognition.lang = this.currentLang;
     recognition.continuous = false;
     recognition.interimResults = false;
@@ -214,14 +221,29 @@ export class VoiceService {
       const last = event.results[event.results.length - 1];
       const transcript = last[0]?.transcript?.trim() ?? '';
       if (transcript !== '') {
+        gotTranscript = true;
         onTranscript(transcript);
       }
     };
-    recognition.onerror = () => {
+    recognition.onerror = (event) => {
       this.isListening.set(false);
+      // 'no-speech' is the browser's "silence timeout" signal; surface it
+      // to the caller so the UI can prompt "didn't catch that".
+      // Other errors (aborted, audio-capture, not-allowed, network) are
+      // not no-speech — leave them to the silent failure path the chat
+      // panel already handles via lastInputWasVoice reset.
+      if (event.error === 'no-speech' && !gotTranscript) {
+        onNoSpeech?.();
+      }
     };
     recognition.onend = () => {
       this.isListening.set(false);
+      // Some browsers (Chromium on Android) fire onend without an explicit
+      // 'no-speech' onerror when the silence timeout elapses. Cover that
+      // path too.
+      if (!gotTranscript) {
+        onNoSpeech?.();
+      }
     };
 
     this.recognition = recognition;

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -546,6 +546,47 @@ describe('ChatPanelComponent', () => {
       const button = fixture.nativeElement.querySelector('[data-testid="chat-mic"]');
       expect(button.classList.contains('listening')).toBe(true);
     });
+
+    it('surfaces the noSpeech hint when recognition ends with nothing captured (TC-360-05)', () => {
+      chatState.open();
+      fixture.detectChanges();
+      fixture.componentInstance['onToggleMic']();
+      const onNoSpeech = voiceMock.startListeningForTranscript.mock.calls[0][1] as () => void;
+
+      onNoSpeech();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance['error']()).toBe('chat.errors.noSpeech');
+    });
+
+    it('clears the prior noSpeech hint when a new transcript is captured', () => {
+      chatState.open();
+      fixture.detectChanges();
+      // First mic press — silence.
+      fixture.componentInstance['onToggleMic']();
+      const firstNoSpeech = voiceMock.startListeningForTranscript.mock.calls[0][1] as () => void;
+      firstNoSpeech();
+      fixture.detectChanges();
+      expect(fixture.componentInstance['error']()).toBe('chat.errors.noSpeech');
+
+      // Second mic press — user speaks. The transcript path clears the prior hint.
+      voiceMock.isListening.set(false);
+      fixture.componentInstance['onToggleMic']();
+      const secondTranscript = voiceMock.startListeningForTranscript.mock.calls[1][0] as (text: string) => void;
+      secondTranscript('add milk');
+
+      expect(fixture.componentInstance['error']()).toBeNull();
+    });
+
+    it('clears any prior error when starting a fresh mic session', () => {
+      chatState.open();
+      fixture.detectChanges();
+      fixture.componentInstance['error'].set('chat.errors.offline');
+
+      fixture.componentInstance['onToggleMic']();
+
+      expect(fixture.componentInstance['error']()).toBeNull();
+    });
   });
 
   describe('tts (US-361)', () => {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -84,11 +84,23 @@ export class ChatPanelComponent implements AfterViewInit {
       return;
     }
     this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
-    this.voice.startListeningForTranscript((transcript) => {
-      const current = this.input();
-      this.input.set(current ? `${current} ${transcript}`.trim() : transcript);
-      this.lastInputWasVoice.set(true);
-    });
+    this.error.set(null);
+    this.voice.startListeningForTranscript(
+      (transcript) => {
+        const current = this.input();
+        this.input.set(current ? `${current} ${transcript}`.trim() : transcript);
+        this.lastInputWasVoice.set(true);
+        // A successful transcript clears any prior "didn't catch that" hint
+        // from an earlier attempt.
+        this.error.set(null);
+      },
+      () => {
+        // TC-360-05: the browser auto-stopped on silence without ever
+        // capturing speech. Surface a hint so the user knows the mic
+        // closed and isn't waiting for an invisible recognition session.
+        this.error.set('chat.errors.noSpeech');
+      },
+    );
   }
 
   protected onToggleMute(): void {


### PR DESCRIPTION
## Summary
Closes the remaining gaps in US-360. The mic button on the command bar (chat panel input) was already wired — `VoiceService.startListeningForTranscript`, `sttSupported()` feature detection, `yn-mic-pulse` keyframes, mounted globally via `yn-app-layout`. What was missing for the AC:

- **TC-360-05** (no speech detected → prompt user). Until now, if the browser auto-stopped on silence without ever firing `onresult`, the mic icon just flipped back to idle with no signal to the user. Adds an optional `onNoSpeech` callback to `VoiceService.startListeningForTranscript` that fires on `onerror.error === 'no-speech'` OR on `onend` without a prior `onresult` (Chromium on Android takes the second path). `chat-panel` surfaces the hint via the existing `error` signal.
- **i18n** keys `chat.errors.noSpeech` (de + en).
- Mic press now clears any prior error banner so a fresh attempt doesn't carry over a stale offline / no-speech message.

## Test plan
- [x] `yarn nx test shared-models` (4 new tests on `startListeningForTranscript` no-speech behaviour)
- [x] `yarn nx test ui` (3 new tests on chat-panel error wiring)
- [ ] `yarn nx e2e shell-e2e --testNamePattern="Command bar mic"` — new spec mocks `SpeechRecognition` via `addInitScript`, covers TC-360-01 (transcript populates input), TC-360-03 (listening visual + aria-pressed), TC-360-04 (render gated by feature detection — implied), TC-360-05 (no-speech hint).
- [ ] CI green

Refs #187.