### PR TITLE
test(frontend): cover language propagation through TTS path (US-361)

### DIFF
--- a/client/libs/shared/models/src/lib/testing/setup-transloco-testing.ts
+++ b/client/libs/shared/models/src/lib/testing/setup-transloco-testing.ts
@@ -5,16 +5,28 @@ import { TranslocoTestingModule, TranslocoTestingOptions } from '@jsverse/transl
  * given translation map. Replaces the verbose `TranslocoTestingModule.forRoot`
  * boilerplate that 24+ spec files used to repeat.
  *
+ * Pass `extraLangs` to register additional languages (e.g. `de`) for tests
+ * that need to verify lang-switch behaviour. Each extra lang reuses the same
+ * translation map — sufficient because we're asserting the active-lang code
+ * path, not the localised string content.
+ *
  * @example
  * await TestBed.configureTestingModule({
  *   imports: [MyComponent, setupTranslocoTesting({ greeting: 'Hello' })],
  * }).compileComponents();
+ *
+ * @example
+ * imports: [MyComponent, setupTranslocoTesting({ greeting: 'Hello' }, ['de'])]
  */
-export function setupTranslocoTesting(translations: Record<string, unknown> = {}) {
+export function setupTranslocoTesting(translations: Record<string, unknown> = {}, extraLangs: readonly string[] = []) {
+  const langs: Record<string, Record<string, unknown>> = { en: translations };
+  for (const lang of extraLangs) {
+    langs[lang] = translations;
+  }
   const options: TranslocoTestingOptions = {
-    langs: { en: translations },
+    langs,
     translocoConfig: {
-      availableLangs: ['en'],
+      availableLangs: ['en', ...extraLangs],
       defaultLang: 'en',
     },
   };

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -176,6 +176,42 @@ describe('VoiceService.speak', () => {
 
     expect(prefs.ensureLoaded).toHaveBeenCalledTimes(1);
   });
+
+  it('defaults the utterance to en-US when no language is configured (US-361)', () => {
+    const { service, lastUtterance } = configureSpeak(makePrefsStub(true));
+
+    service.speak('hello');
+
+    expect(lastUtterance.value?.lang).toBe('en-US');
+  });
+
+  it('applies de-DE to the utterance after setLanguage("de") (TC-361-05)', () => {
+    const { service, lastUtterance } = configureSpeak(makePrefsStub(true));
+    service.setLanguage('de');
+
+    service.speak('hallo');
+
+    expect(lastUtterance.value?.lang).toBe('de-DE');
+  });
+
+  it('switching from de back to en updates the next utterance.lang', () => {
+    const { service, lastUtterance } = configureSpeak(makePrefsStub(true));
+    service.setLanguage('de');
+    service.speak('hallo');
+    service.setLanguage('en');
+
+    service.speak('hello');
+
+    expect(lastUtterance.value?.lang).toBe('en-US');
+  });
+
+  it('skips speaking when the text is empty / whitespace only', () => {
+    const { service, speak } = configureSpeak(makePrefsStub(true));
+
+    service.speak('   ');
+
+    expect(speak).not.toHaveBeenCalled();
+  });
 });
 
 interface MockRecognition {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -2,6 +2,7 @@ import { provideYumneyIcons } from '../icons/provide-icons';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
+import { TranslocoService } from '@jsverse/transloco';
 import { ChatPanelComponent } from './chat-panel.component';
 import { ChatApiService, RecipeApiService } from '@yumney/shared/api-client';
 import { ChatStateService, setupTranslocoTesting, VoiceService } from '@yumney/shared/models';
@@ -712,6 +713,47 @@ describe('ChatPanelComponent', () => {
 
       const button = fixture.nativeElement.querySelector('[data-testid="chat-replay"]') as HTMLButtonElement;
       expect(button.disabled).toBe(true);
+    });
+
+    it('propagates the active Transloco language to voice.setLanguage before each speak (TC-361-05)', async () => {
+      chatState.open();
+      fixture.detectChanges();
+
+      fixture.componentInstance['onToggleMic']();
+      const onTranscript = voiceMock.startListeningForTranscript.mock.calls[0][0] as (text: string) => void;
+      onTranscript('Was gibt es Dienstag?');
+
+      // The default test Transloco lang is 'en'; assert that the value flowing
+      // into setLanguage is the active lang, not a hard-coded constant. We can
+      // change the active lang at runtime via TranslocoService.setActiveLang
+      // and the next speak path should pick the new value up.
+      const transloco = TestBed.inject(TranslocoService);
+      // setupTranslocoTesting is configured with availableLangs=['en']; expand
+      // here so 'de' is acceptable.
+      transloco.setAvailableLangs(['en', 'de']);
+      transloco.setActiveLang('de');
+
+      chatApiMock.send.mockReturnValue(of({ reply: 'Dienstag ist Spaghetti', suggestions: [] }));
+      await sendMessage('Was gibt es Dienstag?');
+
+      expect(voiceMock.setLanguage).toHaveBeenLastCalledWith('de');
+      expect(voiceMock.speak).toHaveBeenCalledWith('Dienstag ist Spaghetti');
+    });
+
+    it('replay reapplies the active Transloco language to voice before speaking', async () => {
+      chatState.open();
+      chatApiMock.send.mockReturnValue(of({ reply: 'Hallo', suggestions: [] }));
+      await sendMessage('Hi');
+      voiceMock.setLanguage.mockClear();
+
+      const transloco = TestBed.inject(TranslocoService);
+      transloco.setAvailableLangs(['en', 'de']);
+      transloco.setActiveLang('de');
+
+      const button = fixture.nativeElement.querySelector('[data-testid="chat-replay"]') as HTMLButtonElement;
+      button.click();
+
+      expect(voiceMock.setLanguage).toHaveBeenCalledWith('de');
     });
   });
 });


### PR DESCRIPTION
US-361 was largely implemented before this PR:

- ✅ `VoiceService.speak` uses Web Speech API + applies `currentLang` to utterance
- ✅ Chat-panel reads `transloco.getActiveLang()` before each `speak` (voice path) AND before replay
- ✅ TTS only fires when `lastInputWasVoice` is true (typed = silent)
- ✅ Mute toggle + replay button + feature detection
- ✅ Existing tests cover the gate (\`tts (US-361)\` describe block)

What was missing for the AC to be closeable:

**VoiceService.speak** had no test asserting `utterance.lang`:
- Defaults to `en-US` when no language is configured.
- Becomes `de-DE` after `setLanguage('de')` (TC-361-05).
- Switches back when language flips.
- Skips speaking for whitespace-only text.

**chat-panel ↔ Transloco** had no test asserting the active lang flows into `voice.setLanguage`:
- Voice send path: when active lang is `de`, `setLanguage('de')` fires before `speak`.
- Replay path: same behaviour on the replay button.

Bumped `setupTranslocoTesting` to optionally register additional langs so the spec can flip the active lang at runtime via `TranslocoService.setActiveLang('de')` without bypassing the real Transloco service.

Refs #188.