### PR TITLE
test(frontend): cover cook-mode voice cleanup + lang + step-read effect (US-362)

### DIFF
--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.spec.ts
@@ -314,4 +314,64 @@ describe('CookModeComponent', () => {
 
     expect(component.ingredientsPanelOpen()).toBe(true);
   }));
+
+  it('stops listening and stops speaking on destroy — back to push-to-talk on exit (TC-362-05)', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    fixture.destroy();
+
+    expect(voiceMock.stopListening).toHaveBeenCalledTimes(1);
+    expect(voiceMock.stopSpeaking).toHaveBeenCalledTimes(1);
+    expect(timersMock.cancelAll).toHaveBeenCalledTimes(1);
+  }));
+
+  it('configures voice recognition language from Transloco on entry (US-362)', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    fixture.detectChanges();
+    tick();
+
+    // setupTranslocoTesting defaults to 'en'; the entry path forwards that
+    // active lang to the speech recognition service so cook-mode commands
+    // are matched against the user's UI language.
+    expect(voiceMock.setLanguage).toHaveBeenCalledWith('en');
+  }));
+
+  it('speaks the current step automatically when voiceAutoReadInCookMode preference is on', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    preferencesMock.voiceAutoReadInCookMode.set(true);
+    fixture.detectChanges();
+    tick();
+
+    expect(voiceMock.speak).toHaveBeenCalledWith('First step');
+
+    voiceMock.speak.mockClear();
+    component.next();
+    fixture.detectChanges();
+    tick();
+
+    expect(voiceMock.speak).toHaveBeenCalledWith('Second step');
+  }));
+
+  it('does not auto-speak the current step when voiceAutoReadInCookMode preference is off', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    preferencesMock.voiceAutoReadInCookMode.set(false);
+    fixture.detectChanges();
+    tick();
+
+    expect(voiceMock.speak).not.toHaveBeenCalled();
+  }));
+
+  it('repeat command re-speaks the current step regardless of auto-read preference (US-240 carry-over)', fakeAsync(() => {
+    setupTestBed(vi.fn().mockReturnValue(of(mockRecipe)));
+    preferencesMock.voiceAutoReadInCookMode.set(false);
+    fixture.detectChanges();
+    tick();
+    voiceMock.speak.mockClear();
+
+    component.repeat();
+
+    expect(voiceMock.speak).toHaveBeenCalledWith('First step');
+  }));
 });


### PR DESCRIPTION
US-362 was implemented before this PR:

- ✅ `CookModeComponent.ngOnInit` auto-activates `startListeningWithFallback` (continuous listening)
- ✅ `handleTranscript` routes unrecognized utterances through `chatApi.send` so "add butter to shopping list" / "mark this meal as cooked" work while cooking
- ✅ `VoiceService.parseCommand` gives cook-mode patterns precedence — "timer 5 minutes" matches the cook timer pattern, not a chat round-trip (TC-362-03 already tested in `voice.service.spec.ts`)
- ✅ Existing tests cover the fallback behaviour, chat round-trip, and auto-start on entry

Missing explicit coverage filled here:

- **TC-362-05** (exit cook mode → back to push-to-talk): on `fixture.destroy()`, verifies `stopListening` + `stopSpeaking` + `timers.cancelAll` all fire so the chat-panel mic returns to push-to-talk mode.
- **Language from Transloco on entry**: asserts `voice.setLanguage('en')` is called with the active Transloco lang on cook-mode entry (was a hard-coded path concern).
- **Auto-read step effect**: when `voiceAutoReadInCookMode` preference is on, the current step is spoken on load and on `next()`; when off, it stays silent.
- **`repeat` command carry-over** (US-240): re-speaks the current step even when the auto-read preference is off.

Refs #189.