### PR TITLE
fix(test): filter metric instruments by Meter reference, not by name

### DIFF
--- a/tests/Yumney.Shared.Events.Tests/EventMetricsTests.cs
+++ b/tests/Yumney.Shared.Events.Tests/EventMetricsTests.cs
@@ -7,32 +7,13 @@ namespace SmartSolutionsLab.Yumney.Shared.Events.Tests;
 
 public class EventMetricsTests
 {
-	private sealed class FakeMeterFactory : IMeterFactory
-	{
-		public Meter Create(MeterOptions options) => new(options);
-
-		public void Dispose()
-		{
-		}
-	}
-
 	[Fact]
 	public void RecordCompletion_Success_EmitsCounterWithSuccessTag()
 	{
-		using var listener = new MeterListener();
-		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = [];
-		listener.InstrumentPublished = (instrument, l) =>
-		{
-			if (instrument.Meter.Name == EventMetrics.MeterName)
-			{
-				l.EnableMeasurementEvents(instrument);
-			}
-		};
-		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-			samples.Add((measurement, tags.ToArray())));
-		listener.Start();
+		var (factory, getMeter) = CreateFactory();
+		var metrics = new EventMetrics(factory);
 
-		var metrics = new EventMetrics(new FakeMeterFactory());
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = ListenForCounter(getMeter());
 		metrics.RecordCompletion("domain", "RecipeImported", "ShoppingListProjectionHandler", succeeded: true);
 
 		samples.Should().ContainSingle();
@@ -46,29 +27,66 @@ public class EventMetricsTests
 	[Fact]
 	public void RecordCompletion_Failure_EmitsCounterWithFailureTag()
 	{
-		using var listener = new MeterListener();
-		List<KeyValuePair<string, object?>[]> samples = [];
-		listener.InstrumentPublished = (instrument, l) =>
-		{
-			if (instrument.Meter.Name == EventMetrics.MeterName)
-			{
-				l.EnableMeasurementEvents(instrument);
-			}
-		};
-		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-			samples.Add(tags.ToArray()));
-		listener.Start();
+		var (factory, getMeter) = CreateFactory();
+		var metrics = new EventMetrics(factory);
 
-		var metrics = new EventMetrics(new FakeMeterFactory());
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = ListenForCounter(getMeter());
 		metrics.RecordCompletion("integration", "RecipeDeleted", "ShoppingCleanupHandler", succeeded: false);
 
 		samples.Should().ContainSingle();
-		samples[0].Should().Contain(tag => tag.Key == "result" && (string)tag.Value! == "failure");
+		samples[0].Tags.Should().Contain(tag => tag.Key == "result" && (string)tag.Value! == "failure");
 	}
 
 	[Fact]
 	public void MeterName_IsTheCanonicalYumneyEventsConstant()
 	{
 		EventMetrics.MeterName.Should().Be("Yumney.Events");
+	}
+
+	// Filter by Meter REFERENCE (not by name): MeterListener is process-wide
+	// and InstrumentPublished fires for every pre-existing matching instrument
+	// at Start(). Other tests in this assembly create their own EventMetrics
+	// → multiple counters share the "Yumney.Events" meter name → a name-based
+	// filter enables every instrument and one Add(1) produces multiple
+	// samples in xUnit's parallel runner. The reference filter scopes us to
+	// the meter we just created.
+	private static List<(long Value, KeyValuePair<string, object?>[] Tags)> ListenForCounter(Meter meter)
+	{
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = [];
+		var listener = new MeterListener
+		{
+			InstrumentPublished = (instrument, l) =>
+			{
+				if (ReferenceEquals(instrument.Meter, meter))
+				{
+					l.EnableMeasurementEvents(instrument);
+				}
+			},
+		};
+		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+			samples.Add((measurement, tags.ToArray())));
+		listener.Start();
+		return samples;
+	}
+
+	private static (CapturingMeterFactory Factory, Func<Meter> GetMeter) CreateFactory()
+	{
+		var factory = new CapturingMeterFactory();
+		return (factory, () => factory.LastCreated ?? throw new InvalidOperationException("Meter not yet created."));
+	}
+
+	private sealed class CapturingMeterFactory : IMeterFactory
+	{
+		public Meter? LastCreated { get; private set; }
+
+		public Meter Create(MeterOptions options)
+		{
+			LastCreated = new Meter(options);
+			return LastCreated;
+		}
+
+		public void Dispose()
+		{
+		}
 	}
 }

--- a/tests/Yumney.Shared.Tests/CQRS/ApplicationMetricsTests.cs
+++ b/tests/Yumney.Shared.Tests/CQRS/ApplicationMetricsTests.cs
@@ -10,21 +10,11 @@ public class ApplicationMetricsTests
 	[Fact]
 	public void RecordExecution_IncrementsExecutedCounterWithTags()
 	{
-		using var listener = new MeterListener();
-		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = [];
-		listener.InstrumentPublished = (instrument, l) =>
-		{
-			if (instrument.Meter.Name == ApplicationMetrics.MeterName
-				&& instrument.Name == "yumney.handlers.executed")
-			{
-				l.EnableMeasurementEvents(instrument);
-			}
-		};
-		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-			samples.Add((measurement, tags.ToArray())));
-		listener.Start();
+		var (factory, getMeter) = CreateFactory();
+		var metrics = new ApplicationMetrics(factory);
+		var meter = getMeter();
 
-		var metrics = new ApplicationMetrics(new TestMeterFactory());
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = ListenForLongInstrument(meter, "yumney.handlers.executed");
 		metrics.RecordExecution("ImportHandler", "ImportRecipeCommand", "success", durationMs: 12.5);
 
 		samples.Should().ContainSingle();
@@ -37,21 +27,11 @@ public class ApplicationMetricsTests
 	[Fact]
 	public void RecordExecution_RecordsHistogramWithDurationAndTags()
 	{
-		using var listener = new MeterListener();
-		List<(double Value, KeyValuePair<string, object?>[] Tags)> samples = [];
-		listener.InstrumentPublished = (instrument, l) =>
-		{
-			if (instrument.Meter.Name == ApplicationMetrics.MeterName
-				&& instrument.Name == "yumney.handlers.duration")
-			{
-				l.EnableMeasurementEvents(instrument);
-			}
-		};
-		listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
-			samples.Add((measurement, tags.ToArray())));
-		listener.Start();
+		var (factory, getMeter) = CreateFactory();
+		var metrics = new ApplicationMetrics(factory);
+		var meter = getMeter();
 
-		var metrics = new ApplicationMetrics(new TestMeterFactory());
+		List<(double Value, KeyValuePair<string, object?>[] Tags)> samples = ListenForDoubleInstrument(meter, "yumney.handlers.duration");
 		metrics.RecordExecution("RateHandler", "RateRecipeCommand", "failure", durationMs: 42.3);
 
 		samples.Should().ContainSingle();
@@ -63,5 +43,71 @@ public class ApplicationMetricsTests
 	public void MeterName_IsTheCanonicalYumneyApplicationConstant()
 	{
 		ApplicationMetrics.MeterName.Should().Be("Yumney.Application");
+	}
+
+	// Filter by Meter REFERENCE (not by name): MeterListener is process-wide
+	// and InstrumentPublished fires for every pre-existing matching instrument
+	// at Start(). Other tests in this assembly create their own ApplicationMetrics
+	// → multiple counters share the "Yumney.Application" meter name → a name-based
+	// filter enables every instrument and one Add(1) produces multiple
+	// samples in xUnit's parallel runner. The reference filter scopes us to
+	// the meter we just created.
+	private static List<(long Value, KeyValuePair<string, object?>[] Tags)> ListenForLongInstrument(Meter meter, string instrumentName)
+	{
+		List<(long Value, KeyValuePair<string, object?>[] Tags)> samples = [];
+		var listener = new MeterListener
+		{
+			InstrumentPublished = (instrument, l) =>
+			{
+				if (ReferenceEquals(instrument.Meter, meter) && instrument.Name == instrumentName)
+				{
+					l.EnableMeasurementEvents(instrument);
+				}
+			},
+		};
+		listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+			samples.Add((measurement, tags.ToArray())));
+		listener.Start();
+		return samples;
+	}
+
+	private static List<(double Value, KeyValuePair<string, object?>[] Tags)> ListenForDoubleInstrument(Meter meter, string instrumentName)
+	{
+		List<(double Value, KeyValuePair<string, object?>[] Tags)> samples = [];
+		var listener = new MeterListener
+		{
+			InstrumentPublished = (instrument, l) =>
+			{
+				if (ReferenceEquals(instrument.Meter, meter) && instrument.Name == instrumentName)
+				{
+					l.EnableMeasurementEvents(instrument);
+				}
+			},
+		};
+		listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+			samples.Add((measurement, tags.ToArray())));
+		listener.Start();
+		return samples;
+	}
+
+	private static (CapturingMeterFactory Factory, Func<Meter> GetMeter) CreateFactory()
+	{
+		var factory = new CapturingMeterFactory();
+		return (factory, () => factory.LastCreated ?? throw new InvalidOperationException("Meter not yet created."));
+	}
+
+	private sealed class CapturingMeterFactory : IMeterFactory
+	{
+		public Meter? LastCreated { get; private set; }
+
+		public Meter Create(MeterOptions options)
+		{
+			LastCreated = new Meter(options);
+			return LastCreated;
+		}
+
+		public void Dispose()
+		{
+		}
 	}
 }


### PR DESCRIPTION
Both EventMetricsTests and ApplicationMetricsTests filter MeterListener instrument-published events by meter-NAME. That's racey under xUnit parallel: MeterListener.Start() iterates every pre-existing Counter/Histogram in the process, so prior tests' (still GC-rooted) metric instances with the same meter name each get EnableMeasurementEvents wired into the new test's listener. One RecordExecution call then surfaces as multiple measurement events → `ContainSingle()` flaked with 'Sequence contains more than one element' (hit on PR #776).

Switches both tests to a CapturingMeterFactory that exposes the last-created Meter, and the listener filters by `ReferenceEquals(instrument.Meter, meter)` — scoped to just the test's own meter instances.