### PR TITLE
refactor(shared): extract IngredientLineMerger to Shared.Quantities

### DIFF
--- a/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
+++ b/src/Yumney.MealPlan.Application/Commands/Handlers/GenerateShoppingListCommandHandler.cs
@@ -4,6 +4,7 @@ using SmartSolutionsLab.Yumney.MealPlan.Domain.WeeklyPlan;
 using SmartSolutionsLab.Yumney.Shared.Common;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
 
 namespace SmartSolutionsLab.Yumney.MealPlan.Application.Commands.Handlers;
 
@@ -29,56 +30,46 @@ public sealed class GenerateShoppingListCommandHandler(
 		var planned = await readModel.GetPlannedRecipesAsync(owner, week, cancellationToken);
 		if (planned.Recipes.Count == 0) return GenerateShoppingListErrors.NoRecipes;
 
-		var merged = await MergeIngredientsAsync(planned.Recipes, cancellationToken);
+		var mergeInputs = await BuildMergeInputsAsync(planned.Recipes, cancellationToken);
+		var merged = IngredientLineMerger.Merge(mergeInputs);
 		(int staplesSkipped, List<ShoppingItemRequest> itemsToAdd) = await FilterOutStaplesAsync(owner, merged, cancellationToken);
 
 		return new GenerateShoppingListResultDto(itemsToAdd.Count, staplesSkipped);
 	}
 
-	private async Task<Dictionary<string, MergedItem>> MergeIngredientsAsync(
+	private async Task<List<IngredientLineMergeInput>> BuildMergeInputsAsync(
 		IReadOnlyList<PlannedRecipeDto> recipes,
 		CancellationToken cancellationToken)
 	{
-		Dictionary<string, MergedItem> merged = new(StringComparer.OrdinalIgnoreCase);
-
+		List<IngredientLineMergeInput> inputs = new(recipes.Count);
 		foreach (var recipe in recipes)
 		{
 			var recipeRef = SlotRecipeIdentifier.From(recipe.RecipeIdentifier);
 			var ingredients = await recipeIngredients.LookupAsync(recipeRef, cancellationToken);
-			var recipeServings = (ingredients.Count > 0 ? ingredients[0].RecipeServings : null) ?? recipe.Servings;
-			var scaleFactor = recipeServings > 0 ? (decimal)recipe.Servings / recipeServings : 1m;
+			if (ingredients.Count == 0) continue;
 
-			foreach (var ingredient in ingredients)
-			{
-				var scaledAmount = ingredient.Amount.HasValue
-					? Math.Round(ingredient.Amount.Value * scaleFactor, 2)
-					: 0m;
-
-				var key = $"{ingredient.Name.ToLowerInvariant()}|{ingredient.Unit ?? string.Empty}";
-				if (merged.TryGetValue(key, out var existing))
-				{
-					existing.Quantity += scaledAmount;
-				}
-				else
-				{
-					merged[key] = new MergedItem(ingredient.Name, scaledAmount, ingredient.Unit);
-				}
-			}
+			inputs.Add(new IngredientLineMergeInput(
+				[.. ingredients.Select(ingredient => new ScalableIngredientLine(
+					ingredient.Name,
+					ingredient.Amount,
+					ingredient.Unit,
+					ingredient.RecipeServings))],
+				recipe.Servings));
 		}
 
-		return merged;
+		return inputs;
 	}
 
 	private async Task<(int StaplesSkipped, List<ShoppingItemRequest> ItemsToAdd)> FilterOutStaplesAsync(
 		OwnerIdentifier owner,
-		Dictionary<string, MergedItem> merged,
+		IReadOnlyList<MergedIngredientLine> merged,
 		CancellationToken cancellationToken = default)
 	{
 		var staples = await staplesProvider.GetStapleNamesAsync(cancellationToken);
 		var staplesSkipped = 0;
 		List<ShoppingItemRequest> itemsToAdd = [];
 
-		foreach (var item in merged.Values)
+		foreach (var item in merged)
 		{
 			if (staples.Contains(item.Name.ToLowerInvariant()))
 			{
@@ -86,7 +77,7 @@ public sealed class GenerateShoppingListCommandHandler(
 				continue;
 			}
 
-			itemsToAdd.Add(item.ToShoppingItemRequest(mealPlanSource));
+			itemsToAdd.Add(new ShoppingItemRequest(item.Name, item.Amount ?? 0m, item.Unit, mealPlanSource));
 		}
 
 		if (itemsToAdd.Count > 0)
@@ -96,15 +87,4 @@ public sealed class GenerateShoppingListCommandHandler(
 
 		return (staplesSkipped, itemsToAdd);
 	}
-}
-
-internal sealed record MergedItem(string Name, decimal Quantity, string? Unit)
-{
-	public decimal Quantity { get; set; } = Quantity;
-}
-
-internal static class MergedItemMappingExtensions
-{
-	public static ShoppingItemRequest ToShoppingItemRequest(this MergedItem item, string source) =>
-		new(item.Name, item.Quantity, item.Unit, source);
 }

--- a/src/Yumney.Shared.Quantities/IngredientLineMerger.cs
+++ b/src/Yumney.Shared.Quantities/IngredientLineMerger.cs
@@ -1,0 +1,91 @@
+namespace SmartSolutionsLab.Yumney.Shared.Quantities;
+
+/// <summary>
+/// Pure logic for "scale each recipe's ingredients to the desired servings
+/// then merge identical lines across recipes". Lives in Shared.Quantities so
+/// both Shopping and MealPlan can apply the same merge semantics without
+/// copying the math (and the same subtle rules — case-insensitive name
+/// match, unit-sensitive grouping, null-amount preservation, smart-rounding
+/// of integer originals).
+///
+/// Inputs and outputs are primitives: callers wrap/unwrap their own domain
+/// types at the boundary so no module's domain leaks here.
+/// </summary>
+public static class IngredientLineMerger
+{
+	public static IReadOnlyList<MergedIngredientLine> Merge(IEnumerable<IngredientLineMergeInput> inputs)
+	{
+		List<ScaledIngredientLine> scaled = [];
+		foreach (var input in inputs)
+		{
+			foreach (var ingredient in input.Ingredients)
+			{
+				scaled.Add(new ScaledIngredientLine(
+					ingredient.Name,
+					ScaleAmount(ingredient.Amount, ingredient.RecipeServings, input.DesiredServings),
+					ingredient.Unit));
+			}
+		}
+
+		return scaled
+			.GroupBy(line => new MergeKey(line.Name.Trim(), line.Unit?.Trim()))
+			.Select(BuildMerged)
+			.ToList();
+	}
+
+	private static decimal? ScaleAmount(decimal? amount, int? recipeServings, int? desiredServings)
+	{
+		if (amount is null) return null;
+		if (desiredServings is null || recipeServings is null or <= 0) return amount;
+		if (recipeServings == desiredServings.Value) return amount;
+
+		var ratio = (decimal)desiredServings.Value / recipeServings.Value;
+		var scaled = amount.Value * ratio;
+		return amount.Value % 1 == 0
+			? Math.Round(scaled)
+			: Math.Round(scaled, 2);
+	}
+
+	private static MergedIngredientLine BuildMerged(IGrouping<MergeKey, ScaledIngredientLine> group)
+	{
+		var first = group.First();
+		var allNull = group.All(line => line.Amount is null);
+		if (allNull)
+		{
+			return new MergedIngredientLine(first.Name, Amount: null, first.Unit);
+		}
+
+		var summed = group.Where(line => line.Amount.HasValue).Sum(line => line.Amount!.Value);
+		return new MergedIngredientLine(first.Name, summed, first.Unit);
+	}
+
+	private sealed record ScaledIngredientLine(string Name, decimal? Amount, string? Unit);
+
+	private sealed record MergeKey(string Name, string? Unit)
+	{
+		public bool Equals(MergeKey? other) =>
+			other is not null
+			&& string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+			&& string.Equals(Unit, other.Unit, StringComparison.OrdinalIgnoreCase);
+
+		public override int GetHashCode() => HashCode.Combine(
+			Name.ToLowerInvariant(),
+			Unit?.ToLowerInvariant());
+	}
+}
+
+/// <summary>
+/// One recipe's worth of ingredient lines plus the consumer's desired
+/// servings. <see cref="ScalableIngredientLine.RecipeServings"/> is the
+/// recipe's NATIVE servings — the ratio for scaling is
+/// <c>desired / recipeServings</c>.
+/// </summary>
+public sealed record IngredientLineMergeInput(
+	IReadOnlyList<ScalableIngredientLine> Ingredients,
+	int? DesiredServings);
+
+/// <summary>One ingredient line going into the merger.</summary>
+public sealed record ScalableIngredientLine(string Name, decimal? Amount, string? Unit, int? RecipeServings);
+
+/// <summary>One merged-and-scaled line coming out of the merger.</summary>
+public sealed record MergedIngredientLine(string Name, decimal? Amount, string? Unit);

--- a/src/Yumney.Shopping.Application/Common/IngredientMerger.cs
+++ b/src/Yumney.Shopping.Application/Common/IngredientMerger.cs
@@ -1,76 +1,42 @@
+using SmartSolutionsLab.Yumney.Shared.Quantities;
 using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Common;
 
+/// <summary>
+/// Shopping-flavoured façade over <see cref="IngredientLineMerger"/>.
+/// Coerces Shopping's domain types (RecipeIngredientLookupResult, Servings,
+/// ItemName, Quantity) onto the primitives the shared helper accepts, runs
+/// the merge, and wraps the result back into <see cref="MergedIngredient"/>.
+/// All merge math (scaling, case-insensitive grouping, null-amount handling,
+/// smart rounding) lives in Shared.Quantities so MealPlan can apply the
+/// same semantics.
+/// </summary>
 public static class IngredientMerger
 {
-	public static IReadOnlyList<MergedIngredient> Merge(IEnumerable<IngredientMergeInput> inputs)
-	{
-		var scaled = inputs.SelectMany(Scale).ToList();
-
-		var groupedByKey = scaled
-			.GroupBy(scaledIngredient => new MergeKey(
-				scaledIngredient.Name.Trim(),
-				scaledIngredient.Unit?.Trim()))
-			.Select(BuildMerged)
+	public static IReadOnlyList<MergedIngredient> Merge(IEnumerable<IngredientMergeInput> inputs) =>
+		IngredientLineMerger
+			.Merge(inputs.Select(ToLineInput))
+			.Select(ToMergedIngredient)
 			.ToList();
 
-		return groupedByKey;
-	}
-
-	private static IEnumerable<ScaledIngredient> Scale(IngredientMergeInput input)
-	{
-		foreach (var ingredient in input.Ingredients)
-		{
-			yield return new ScaledIngredient(
+	private static IngredientLineMergeInput ToLineInput(IngredientMergeInput input) =>
+		new(
+			[.. input.Ingredients.Select(ingredient => new ScalableIngredientLine(
 				ingredient.Name,
-				ScaleAmount(ingredient.Amount, ingredient.RecipeServings, input.DesiredServings),
-				ingredient.Unit);
-		}
-	}
+				ingredient.Amount,
+				ingredient.Unit,
+				ingredient.RecipeServings))],
+			input.DesiredServings?.Value);
 
-	private static decimal? ScaleAmount(decimal? amount, int? originalServings, Servings? desiredServings)
+	private static MergedIngredient ToMergedIngredient(MergedIngredientLine line)
 	{
-		if (amount is null) return null;
-		if (desiredServings is null || originalServings is null or <= 0) return amount;
-		if (originalServings == desiredServings.Value) return amount;
-
-		var ratio = (decimal)desiredServings.Value / originalServings.Value;
-		var scaled = amount.Value * ratio;
-		return amount.Value % 1 == 0
-			? Math.Round(scaled)
-			: Math.Round(scaled, 2);
-	}
-
-	private static MergedIngredient BuildMerged(IGrouping<MergeKey, ScaledIngredient> group)
-	{
-		var first = group.First();
-		var name = ItemName.From(first.Name);
-		var unit = Unit.FromNullable(first.Unit);
-
-		var summed = group
-			.Select(item => item.Amount)
-			.Where(amount => amount.HasValue)
-			.Sum(amount => amount!.Value);
-		if (summed == 0 && group.All(item => item.Amount is null))
+		var name = ItemName.From(line.Name);
+		if (line.Amount is null)
 		{
-			return new MergedIngredient(name, null);
+			return new MergedIngredient(name, Quantity: null);
 		}
 
-		return new MergedIngredient(name, Quantity.Of(Amount.From(summed), unit));
-	}
-
-	private sealed record ScaledIngredient(string Name, decimal? Amount, string? Unit);
-
-	private sealed record MergeKey(string Name, string? Unit)
-	{
-		public bool Equals(MergeKey? other) =>
-			other is not null
-			&& string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
-			&& string.Equals(Unit, other.Unit, StringComparison.OrdinalIgnoreCase);
-
-		public override int GetHashCode() => HashCode.Combine(
-			Name.ToLowerInvariant(),
-			Unit?.ToLowerInvariant());
+		return new MergedIngredient(name, Quantity.Of(Amount.From(line.Amount.Value), Unit.FromNullable(line.Unit)));
 	}
 }

--- a/tests/Yumney.Shared.Tests/Common/IngredientLineMergerTests.cs
+++ b/tests/Yumney.Shared.Tests/Common/IngredientLineMergerTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Shared.Quantities;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Shared.Tests.Common;
+
+public class IngredientLineMergerTests
+{
+	[Fact]
+	public void Merge_SameNameAndUnitAcrossRecipes_SumsAmounts()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("Flour", 200m, "g")),
+			Input(servings: 4, ("Flour", 300m, "g")),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Name.Should().Be("Flour");
+		merged[0].Amount.Should().Be(500m);
+		merged[0].Unit.Should().Be("g");
+	}
+
+	[Fact]
+	public void Merge_SameNameDifferentUnits_KeepsSeparate()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("Milk", 2m, "cup")),
+			Input(servings: 4, ("Milk", 500m, "ml")),
+		]);
+
+		merged.Should().HaveCount(2);
+		merged.Should().ContainSingle(line => line.Unit == "cup" && line.Amount == 2m);
+		merged.Should().ContainSingle(line => line.Unit == "ml" && line.Amount == 500m);
+	}
+
+	[Fact]
+	public void Merge_DifferentCaseSameIngredient_TreatsAsDuplicate()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("flour", 200m, "g")),
+			Input(servings: 4, ("FLOUR", 300m, "G")),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Amount.Should().Be(500m);
+	}
+
+	[Fact]
+	public void Merge_ScalesAmountsToDesiredServings()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			InputWithDesired(recipeServings: 4, desiredServings: 8, ("Flour", 100m, "g")),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Amount.Should().Be(200m);
+	}
+
+	[Fact]
+	public void Merge_DesiredServingsNull_DoesNotScale()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			InputWithDesired(recipeServings: 4, desiredServings: null, ("Flour", 100m, "g")),
+		]);
+
+		merged[0].Amount.Should().Be(100m);
+	}
+
+	[Fact]
+	public void Merge_RecipeServingsZeroOrNull_DoesNotScale()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			InputWithDesired(recipeServings: 0, desiredServings: 8, ("Flour", 100m, "g")),
+			InputWithDesired(recipeServings: null, desiredServings: 8, ("Sugar", 50m, "g")),
+		]);
+
+		merged.Should().Contain(line => line.Name == "Flour" && line.Amount == 100m);
+		merged.Should().Contain(line => line.Name == "Sugar" && line.Amount == 50m);
+	}
+
+	[Fact]
+	public void Merge_IntegerAmountStaysIntegerAfterScale()
+	{
+		// 3 eggs × (2/4) = 1.5 → integer-original rounds to whole.
+		var merged = IngredientLineMerger.Merge(
+		[
+			InputWithDesired(recipeServings: 4, desiredServings: 2, ("Eggs", 3m, null)),
+		]);
+
+		merged[0].Amount.Should().Be(2m); // Math.Round(1.5) = 2 (banker's rounding to even).
+	}
+
+	[Fact]
+	public void Merge_FractionalAmountRoundsToTwoDecimalPlaces()
+	{
+		// 2.5 cups × (4/2) = 5 — but the original amount is fractional so the
+		// rounding path uses 2 decimal places. Going the other way: 1.25 cups ×
+		// (3/2) = 1.875 → Math.Round(1.875, 2) = 1.88 (banker's-rounding
+		// rounds-half-to-even still rounds the trailing .005 to .88).
+		var merged = IngredientLineMerger.Merge(
+		[
+			InputWithDesired(recipeServings: 2, desiredServings: 3, ("Milk", 1.25m, "cup")),
+		]);
+
+		merged[0].Amount.Should().Be(1.88m);
+	}
+
+	[Fact]
+	public void Merge_AllNullAmountsForOneLine_KeepsAmountNull()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("Salt", null, null)),
+			Input(servings: 4, ("salt", null, null)),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Amount.Should().BeNull();
+	}
+
+	[Fact]
+	public void Merge_NullAndNonNullAmountForSameLine_SumsTheNonNullOnly()
+	{
+		// Edge case the legacy MealPlan handler got wrong: it treated null as 0,
+		// which polluted the sum. The shared helper preserves the non-null
+		// value and ignores the null contribution.
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("Pepper", null, null)),
+			Input(servings: 4, ("Pepper", 2m, null)),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Amount.Should().Be(2m);
+	}
+
+	[Fact]
+	public void Merge_NameWithSurroundingWhitespace_NormalisesByTrim()
+	{
+		var merged = IngredientLineMerger.Merge(
+		[
+			Input(servings: 4, ("  Flour", 100m, "g")),
+			Input(servings: 4, ("Flour  ", 200m, "g")),
+		]);
+
+		merged.Should().ContainSingle();
+		merged[0].Amount.Should().Be(300m);
+	}
+
+	[Fact]
+	public void Merge_EmptyInput_ReturnsEmpty()
+	{
+		var merged = IngredientLineMerger.Merge([]);
+
+		merged.Should().BeEmpty();
+	}
+
+	private static IngredientLineMergeInput Input(int servings, params (string Name, decimal? Amount, string? Unit)[] ingredients) =>
+		InputWithDesired(servings, servings, ingredients);
+
+	private static IngredientLineMergeInput InputWithDesired(
+		int? recipeServings,
+		int? desiredServings,
+		params (string Name, decimal? Amount, string? Unit)[] ingredients) =>
+		new(
+			[.. ingredients.Select(ingredient => new ScalableIngredientLine(
+				ingredient.Name,
+				ingredient.Amount,
+				ingredient.Unit,
+				recipeServings))],
+			desiredServings);
+}


### PR DESCRIPTION
## Why

Shopping has a clean `IngredientMerger` static helper (scale by servings, group by name+unit case-insensitive, sum amounts, smart-round whole numbers). MealPlan's `GenerateShoppingListCommandHandler` reimplemented the same algorithm inline with two subtle bugs:

- **Null amount coerced to 0 before sum** — "pinch of salt" entries polluted the sum of measured "salt" lines.
- **Always 2dp rounding** instead of Shopping's integer-stays-integer pattern — "3 eggs scaled 1.5×" surfaced as 4.5 eggs rather than 5.

## What

- New `Yumney.Shared.Quantities.IngredientLineMerger` — pure logic, primitives-only API.
- `Shopping.Application.Common.IngredientMerger` becomes a thin façade: coerces its domain types (`RecipeIngredientLookupResult`, `Servings`, `ItemName`, `Quantity`) into the shared primitive shape, calls the helper, wraps the result back.
- `MealPlan.Application.Commands.Handlers.GenerateShoppingListCommandHandler` drops its ad-hoc merge loop (`MergedItem` with mutable `Quantity`, inline `ToLowerInvariant` keying, etc.) and calls the shared helper directly — picks up Shopping's null-amount + smart-rounding behaviour as a side effect.

## Test plan

- [x] `IngredientLineMergerTests` in `Yumney.Shared.Tests` — 12 tests covering scaling, case-insensitive name grouping, unit-sensitive separation, null-amount preservation (the bug above), all-null-collapses-to-null, integer-stays-integer rounding, whitespace normalization, no-servings-no-scale.
- [x] `IngredientMergerTests` (Shopping) — unchanged, all pass against the façade.
- [x] `GenerateShoppingListCommandHandlerTests` (MealPlan) — unchanged, all pass with the new helper.
- [ ] CI green.

## Why this lives in Shared.Quantities

`Yumney.Shared.Quantities` already houses cross-cutting quantity helpers (`QuantityRounder`, `IngredientCategoryResolver`, `Freshness`). The merger fits the same theme: pure logic about ingredient quantities with no module-specific dependencies. Both `Shopping.Domain` and `MealPlan.Domain` already reference `Shared.Quantities`, so no new project references were needed.