### PR TITLE
refactor(shared): style cleanup + Aspire 13.3.3 + NuGet upgrades

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,69 +4,70 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
     <!-- Aspire.Hosting.Browsers / .Keycloak / Aspire.Keycloak.Authentication
          have no GA on NuGet — every published version is a -preview.1.X.Y.
-         Stay on the matched 13.3.0 preview revision that the rest of the
-         Aspire 13.3.0 GA packages were built against to avoid version skew. -->
-    <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.3.0-preview.1.26256.5" />
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.3.0-preview.1.26256.5" />
+         Stay on the matched 13.3.3 preview revision that the rest of the
+         Aspire 13.3.3 GA packages were built against to avoid version skew. -->
+    <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.3.3-preview.1.26264.13" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.3.3-preview.1.26264.13" />
+    <!-- CommunityToolkit pins to 13.3.0; no 13.3.x follow-up published yet. -->
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Ollama" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.3.0-preview.1.26256.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.5.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.3.3-preview.1.26264.13" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.6.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <!-- Persistence -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <!-- LLM & Scraping -->
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.76.0" />
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <!-- Model Context Protocol (used by Yumney.Mcp.Server to expose capabilities to external LLM clients per ADR 0002) -->
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
-    <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.31.1" />
-    <PackageVersion Include="WolverineFx.Postgresql" Version="5.31.1" />
-    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.31.1" />
+    <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.39.2" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.39.2" />
+    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.39.2" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <!-- DI, Configuration & Logging Abstractions -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <!-- Analyzers -->
     <!-- Pinned on 1.2.0-beta.556: 1.1.118 (latest stable) predates C# 9 records,
          collection expressions, and primary constructors — downgrading produces
@@ -74,14 +75,14 @@
          Track GA: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
   </ItemGroup>
 </Project>

--- a/Yumney.slnx
+++ b/Yumney.slnx
@@ -1,11 +1,13 @@
 <Solution>
   <Folder Name="/src/" />
-  <Folder Name="/src/Host/">
-    <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
+  <Folder Name="/src/Common/">
     <Project Path="src/Yumney.Gateway/Yumney.Gateway.csproj" />
     <Project Path="src/Yumney.Mcp.Server/Yumney.Mcp.Server.csproj" />
-    <Project Path="src/Yumney.ServiceDefaults/Yumney.ServiceDefaults.csproj" />
     <Project Path="src/Yumney.MigrationRunner/Yumney.MigrationRunner.csproj" />
+  </Folder>
+  <Folder Name="/src/Host/">
+    <Project Path="src/Yumney.AppHost/Yumney.AppHost.csproj" />
+    <Project Path="src/Yumney.ServiceDefaults/Yumney.ServiceDefaults.csproj" />
   </Folder>
   <Folder Name="/src/Shared/">
     <Project Path="src/Yumney.Shared/Yumney.Shared.csproj" />

--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using Aspire.Hosting.Azure;
+using Azure.Provisioning.AppContainers;
 using SmartSolutionsLab.Yumney.AppHost.Options;
 
 namespace SmartSolutionsLab.Yumney.AppHost;
@@ -27,15 +30,9 @@ internal static class AppHostExtensions
 		return configured;
 	}
 
-	/// <summary>
-	/// Registers the LLM provider's shared resources on the AppHost. Call once
-	/// from <c>Program.cs</c> before any <see cref="WithLlmProvider"/> usage —
-	/// <c>AddParameter</c> / <c>AddOllama</c> throw on duplicate names, so the
-	/// resource has to be created in exactly one place.
-	/// </summary>
-	/// <param name="builder">The AppHost's distributed application builder.</param>
-	/// <param name="options">App host options that decide between OpenAI and Ollama.</param>
-	/// <returns>A handle to the registered resources; empty when E2E tests are on.</returns>
+	// Call once from Program.cs before any WithLlmProvider usage —
+	// AddParameter / AddOllama throw on duplicate names, so the
+	// resource has to be created in exactly one place.
 	public static LlmResources BuildLlmResources(this IDistributedApplicationBuilder builder, AppHostOptions options)
 	{
 		if (options.E2ETests) return new LlmResources(null, null);
@@ -71,4 +68,43 @@ internal static class AppHostExtensions
 
 		return builder;
 	}
+
+	public static IResourceBuilder<ProjectResource> PublishAsScaledContainerApp(
+		this IResourceBuilder<ProjectResource> project,
+		int min,
+		int max,
+		int? concurrentRequests = null) =>
+		project.PublishAsAzureContainerApp(ConfigureScaling(min, max, concurrentRequests));
+
+	public static IResourceBuilder<ContainerResource> PublishAsScaledContainerApp(
+		this IResourceBuilder<ContainerResource> container,
+		int min,
+		int max,
+		int? concurrentRequests = null) =>
+		container.PublishAsAzureContainerApp(ConfigureScaling(min, max, concurrentRequests));
+
+	private static Action<AzureResourceInfrastructure, ContainerApp> ConfigureScaling(int min, int max, int? concurrentRequests) =>
+		(_, app) =>
+		{
+			app.Template.Scale.MinReplicas = min;
+			app.Template.Scale.MaxReplicas = max;
+
+			if (concurrentRequests.HasValue)
+			{
+				app.Template.Scale.Rules.Add(new ContainerAppScaleRule
+				{
+					Name = "http-scaling",
+					Http = new ContainerAppHttpScaleRule
+					{
+						Metadata =
+						{
+							{
+								"concurrentRequests",
+								concurrentRequests.Value.ToString(CultureInfo.InvariantCulture)
+							},
+						},
+					},
+				});
+			}
+		};
 }

--- a/src/Yumney.AppHost/DashboardResetEntries.cs
+++ b/src/Yumney.AppHost/DashboardResetEntries.cs
@@ -9,7 +9,7 @@ namespace SmartSolutionsLab.Yumney.AppHost;
 /// </summary>
 internal static class DashboardResetEntries
 {
-	public static void AddShoppingAndMealPlanResetEntries(
+	public static void AddResetEntries(
 		IDistributedApplicationBuilder builder,
 		IResourceBuilder<IResourceWithConnectionString> recipesDb,
 		IResourceBuilder<IResourceWithConnectionString> shoppingDb,

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -1,7 +1,5 @@
-using System.Globalization;
-using Aspire.Hosting.Azure;
+using Aspire.Hosting.JavaScript;
 using Aspire.Hosting.Yarp;
-using Azure.Provisioning.AppContainers;
 using SmartSolutionsLab.Yumney.AppHost;
 using SmartSolutionsLab.Yumney.AppHost.Options;
 using Yarp.ReverseProxy.Forwarder;
@@ -30,16 +28,7 @@ var yumneyApiClientSecret = isRunMode
 
 IResourceBuilder<IResourceWithConnectionString> recipesDb, shoppingDb, usersDb, mealplanDb, keycloakDb;
 
-if (options.DatabaseOnly)
-{
-	var postgres = builder.AddPostgres("postgres");
-	recipesDb = postgres.AddDatabase("recipesdb");
-	shoppingDb = postgres.AddDatabase("shoppingdb");
-	usersDb = postgres.AddDatabase("usersdb");
-	mealplanDb = postgres.AddDatabase("mealplandb");
-	keycloakDb = postgres.AddDatabase("keycloakdb");
-}
-else
+if (!options.DatabaseOnly)
 {
 	var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
 		.WithPasswordAuthentication(userName: postgresUser, password: postgresPassword)
@@ -59,242 +48,227 @@ else
 	mealplanDb = postgres.AddDatabase("mealplandb");
 	keycloakDb = postgres.AddDatabase("keycloakdb");
 }
-
-if (!options.DatabaseOnly)
+else
 {
-	var migrationRunner = builder
-		.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
-		.WithReference(recipesDb)
-		.WithReference(shoppingDb)
-		.WithReference(usersDb)
-		.WithReference(mealplanDb)
-		.WaitFor(recipesDb)
-		.WaitFor(shoppingDb)
-		.WaitFor(usersDb)
-		.WaitFor(mealplanDb);
+	var postgres = builder.AddPostgres("postgres");
+	recipesDb = postgres.AddDatabase("recipesdb");
+	shoppingDb = postgres.AddDatabase("shoppingdb");
+	usersDb = postgres.AddDatabase("usersdb");
+	mealplanDb = postgres.AddDatabase("mealplandb");
+	keycloakDb = postgres.AddDatabase("keycloakdb");
 
-	// Dashboard-only operational entries (run mode): one resource per maintenance
-	// task. Each sits idle until the dev clicks Start in the dashboard.
-	if (isRunMode)
-	{
-		DashboardResetEntries.AddShoppingAndMealPlanResetEntries(builder, recipesDb, shoppingDb, usersDb, mealplanDb);
-	}
+	builder.Build().Run();
+	return;
+}
 
-	// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)
-	var redis = builder
-		.AddRedis("redis", password: redisPassword)
-		.WithImageTag("alpine");
-	var messaging = builder
-		.AddRabbitMQ("messaging", password: messagingPassword)
-		.WithImageTag("4-management-alpine")
-		.WithManagementPlugin();
-	var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword);
+var migrationRunner = builder
+	.AddProject<Projects.Yumney_MigrationRunner>("yumney-migrations")
+	.WithReference(recipesDb)
+	.WithReference(shoppingDb)
+	.WithReference(usersDb)
+	.WithReference(mealplanDb)
+	.WaitFor(recipesDb)
+	.WaitFor(shoppingDb)
+	.WaitFor(usersDb)
+	.WaitFor(mealplanDb);
 
-	if (isRunMode && !options.E2ETests)
-	{
-		redis.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
-		messaging.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
-		keycloak.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
-	}
+// Dashboard-only operational entries (run mode): one resource per maintenance
+// task. Each sits idle until the dev clicks Start in the dashboard.
+DashboardResetEntries.AddResetEntries(builder, recipesDb, shoppingDb, usersDb, mealplanDb);
 
-	keycloak.WithRealmImport("Realms");
+// ── Infrastructure ── (persistent with data volumes for dev, ephemeral for E2E)
+var redis = builder
+	.AddRedis("redis", password: redisPassword)
+	.WithImageTag("alpine");
+var messaging = builder
+	.AddRabbitMQ("messaging", password: messagingPassword)
+	.WithImageTag("4-management-alpine")
+	.WithManagementPlugin();
+var keycloak = builder.AddKeycloak("keycloak", port: 8080, adminPassword: keycloakPassword);
 
-	if (isRunMode && !options.E2ETests)
-	{
-		builder
-			.AddContainer("mailpit", "axllent/mailpit", "v1.22")
-			.WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
-			.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
-			.WithLifetime(ContainerLifetime.Persistent);
-	}
+if (isRunMode && !options.E2ETests)
+{
+	redis.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
+	messaging.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
+	keycloak.WithLifetime(ContainerLifetime.Persistent).WithDataVolume();
+}
 
-	if (!isRunMode)
-	{
-		var keycloakDbHost = builder.AddParameter("KeycloakDbHost");
-		keycloak
-			.WithEnvironment("KC_DB", "postgres")
-			.WithEnvironment("KC_DB_URL_HOST", keycloakDbHost)
-			.WithEnvironment("KC_DB_URL_DATABASE", "keycloakdb")
-			.WithEnvironment("KC_DB_USERNAME", postgresUser)
-			.WithEnvironment("KC_DB_PASSWORD", postgresPassword)
-			.WithEnvironment("KC_HTTP_ENABLED", "true")
-			.WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
-			.WithEnvironment("KC_HOSTNAME_STRICT", "false")
-			.WithEndpoint("http", endpoint => endpoint.IsExternal = true);
-	}
+keycloak.WithRealmImport("Realms");
 
-	var apiEnvironment = builder.Environment.EnvironmentName;
+if (isRunMode && !options.E2ETests)
+{
+	builder
+		.AddContainer("mailpit", "axllent/mailpit", "v1.22")
+		.WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
+		.WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
+		.WithLifetime(ContainerLifetime.Persistent);
+}
 
-	// SMTP for outbound app email. In dev the mailpit container exposes
-	// 1025 on the host so the users-api process (running on host) reaches
-	// it at `localhost:1025`. In publish mode a Container App secret
-	// supplies real production credentials. The Users module is the only
-	// consumer today (GDPR account-deletion confirmation, US-567).
-	var usersApi = builder
-		.AddProject<Projects.Yumney_Users_Api>("users-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.WithEnvironment("Keycloak__ClientSecret", yumneyApiClientSecret)
-		.WithEnvironment("Smtp__Host", "localhost")
-		.WithEnvironment("Smtp__Port", "1025")
-		.WithEnvironment("Smtp__FromAddress", "noreply@yumney.local")
-		.WithEnvironment("Smtp__FromDisplayName", "Yumney")
-		.AsYumneyApi(options, usersDb, keycloak, redis, messaging, migrationRunner);
-	var shoppingApi = builder
-		.AddProject<Projects.Yumney_Shopping_Api>("shopping-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.AsYumneyApi(options, shoppingDb, keycloak, redis, messaging, migrationRunner)
-		.WithReference(usersApi);
+if (!isRunMode)
+{
+	var keycloakDbHost = builder.AddParameter("KeycloakDbHost");
+	keycloak
+		.WithEnvironment("KC_DB", "postgres")
+		.WithEnvironment("KC_DB_URL_HOST", keycloakDbHost)
+		.WithEnvironment("KC_DB_URL_DATABASE", "keycloakdb")
+		.WithEnvironment("KC_DB_USERNAME", postgresUser)
+		.WithEnvironment("KC_DB_PASSWORD", postgresPassword)
+		.WithEnvironment("KC_HTTP_ENABLED", "true")
+		.WithEnvironment("KC_PROXY_HEADERS", "xforwarded")
+		.WithEnvironment("KC_HOSTNAME_STRICT", "false")
+		.WithEndpoint("http", endpoint => endpoint.IsExternal = true);
+}
 
-	// Shared LLM resources registered once — Aspire's parameter / ollama
-	// collections refuse duplicate names, so each `WithLlmProvider` consumer
-	// gets the same handle here rather than creating its own.
-	var llm = builder.BuildLlmResources(options);
+var apiEnvironment = builder.Environment.EnvironmentName;
 
-	var recipesApi = builder
-		.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.AsYumneyApi(options, recipesDb, keycloak, redis, messaging, migrationRunner)
-		.WithLlmProvider(options, llm)
-		.WithReference(shoppingApi)
-		.WithReference(usersApi);
-	var mealplanApi = builder
-		.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.AsYumneyApi(options, mealplanDb, keycloak, redis, messaging, migrationRunner)
-		.WithLlmProvider(options, llm)
-		.WithReference(recipesApi)
-		.WithReference(shoppingApi)
-		.WithReference(usersApi);
+// SMTP for outbound app email. In dev the mailpit container exposes
+// 1025 on the host so the users-api process (running on host) reaches
+// it at `localhost:1025`. In publish mode a Container App secret
+// supplies real production credentials. The Users module is the only
+// consumer today (GDPR account-deletion confirmation, US-567).
+var usersApi = builder
+	.AddProject<Projects.Yumney_Users_Api>("users-api")
+	.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+	.WithEnvironment("Keycloak__ClientSecret", yumneyApiClientSecret)
+	.WithEnvironment("Smtp__Host", "localhost")
+	.WithEnvironment("Smtp__Port", "1025")
+	.WithEnvironment("Smtp__FromAddress", "noreply@yumney.local")
+	.WithEnvironment("Smtp__FromDisplayName", "Yumney")
+	.AsYumneyApi(options, usersDb, keycloak, redis, messaging, migrationRunner);
+var shoppingApi = builder
+	.AddProject<Projects.Yumney_Shopping_Api>("shopping-api")
+	.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+	.AsYumneyApi(options, shoppingDb, keycloak, redis, messaging, migrationRunner)
+	.WithReference(usersApi);
 
-	// Reverse reference: chat tools in Recipes call mealplan-api for get_weekly_plan
-	// (and future planner tools). Cannot inline above because mealplanApi is
-	// declared after recipesApi.
-	recipesApi.WithReference(mealplanApi);
+// Shared LLM resources registered once — Aspire's parameter / ollama
+// collections refuse duplicate names, so each `WithLlmProvider` consumer
+// gets the same handle here rather than creating its own.
+var llm = builder.BuildLlmResources(options);
 
-	// Reverse reference: shopping-api's CreateShoppingListFromRecipes handler
-	// calls recipes-api over HTTP via HttpRecipeIngredientLookup. Without this
-	// reference Aspire doesn't register service discovery for "recipes-api" in
-	// the shopping host, so cross-module HTTP calls fall through to DNS for
-	// the literal hostname "recipes-api" and hit the 30s Polly timeout. Same
-	// recipesApi-declared-after-shoppingApi inline-impossibility as above.
-	shoppingApi.WithReference(recipesApi);
+var recipesApi = builder
+	.AddProject<Projects.Yumney_Recipes_Api>("recipes-api")
+	.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+	.AsYumneyApi(options, recipesDb, keycloak, redis, messaging, migrationRunner)
+	.WithLlmProvider(options, llm)
+	.WithReference(shoppingApi)
+	.WithReference(usersApi);
+var mealplanApi = builder
+	.AddProject<Projects.Yumney_MealPlan_Api>("mealplan-api")
+	.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+	.AsYumneyApi(options, mealplanDb, keycloak, redis, messaging, migrationRunner)
+	.WithLlmProvider(options, llm)
+	.WithReference(recipesApi)
+	.WithReference(shoppingApi)
+	.WithReference(usersApi);
 
-	// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
-	// ACA pulls them via the environment's managed identity, so no registry credentials
-	// are baked into the container app revisions.
-	void ConfigureContainerApp(AzureResourceInfrastructure infra, ContainerApp app, int minReplicas, int maxReplicas, int? concurrentRequests = null)
-	{
-		app.Template.Scale.MinReplicas = minReplicas;
-		app.Template.Scale.MaxReplicas = maxReplicas;
+// Reverse reference: chat tools in Recipes call mealplan-api for get_weekly_plan
+// (and future planner tools). Cannot inline above because mealplanApi is
+// declared after recipesApi.
+recipesApi.WithReference(mealplanApi);
 
-		if (concurrentRequests.HasValue)
-		{
-			app.Template.Scale.Rules.Add(new ContainerAppScaleRule
-			{
-				Name = "http-scaling",
-				Http = new ContainerAppHttpScaleRule
-				{
-					Metadata =
-				{
-					{
-						"concurrentRequests",
-						concurrentRequests.Value.ToString(CultureInfo.InvariantCulture)
-					},
-				},
-				},
-			});
-		}
-	}
+// Reverse reference: shopping-api's CreateShoppingListFromRecipes handler
+// calls recipes-api over HTTP via HttpRecipeIngredientLookup. Without this
+// reference Aspire doesn't register service discovery for "recipes-api" in
+// the shopping host, so cross-module HTTP calls fall through to DNS for
+// the literal hostname "recipes-api" and hit the 30s Polly timeout. Same
+// recipesApi-declared-after-shoppingApi inline-impossibility as above.
+shoppingApi.WithReference(recipesApi);
 
-	// minReplicas = 1 keeps APIs warm to avoid ACA cold-starts tripping the
-	// 10 s Polly timeout on cross-module calls. Migration runner stays at 0.
-	recipesApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 10, 20));
-	shoppingApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 5, 50));
-	usersApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 3, 50));
-	mealplanApi.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 3, 50));
-	migrationRunner.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 0, 1));
+// minReplicas = 1 keeps APIs warm to avoid ACA cold-starts tripping the
+// 10 s Polly timeout on cross-module calls. Migration runner stays at 0.
+// Images are pushed to the ACR provisioned by AddAzureContainerAppEnvironment("cae");
+// ACA pulls via the environment's managed identity — no registry credentials
+// baked into the revisions.
+recipesApi.PublishAsScaledContainerApp(min: 1, max: 10, concurrentRequests: 20);
+shoppingApi.PublishAsScaledContainerApp(min: 1, max: 5, concurrentRequests: 50);
+usersApi.PublishAsScaledContainerApp(min: 1, max: 3, concurrentRequests: 50);
+mealplanApi.PublishAsScaledContainerApp(min: 1, max: 3, concurrentRequests: 50);
+migrationRunner.PublishAsScaledContainerApp(min: 0, max: 1);
 
-	// MCP server: aggregates capability manifests, exposes /mcp + dashboard link.
-	var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
-		.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
-		.WithReference(keycloak)
-		.WithReference(redis)
-		.WithReference(recipesApi)
-		.WithReference(shoppingApi)
-		.WithReference(mealplanApi)
-		.WithUrl("/mcp", "MCP Endpoint");
+// MCP server: aggregates capability manifests, exposes /mcp + dashboard link.
+var mcpServer = builder.AddProject<Projects.Yumney_Mcp_Server>("mcp-server")
+	.WithEnvironment("ASPNETCORE_ENVIRONMENT", apiEnvironment)
+	.WithReference(keycloak)
+	.WithReference(redis)
+	.WithReference(recipesApi)
+	.WithReference(shoppingApi)
+	.WithReference(mealplanApi)
+	.WithUrl("/mcp", "MCP Endpoint");
 
-	// Same cold-start guard as the APIs, smaller cap (per-user, rarely concurrent).
-	mcpServer.PublishAsAzureContainerApp((infra, app) => ConfigureContainerApp(infra, app, 1, 3));
+// Same cold-start guard as the APIs, smaller cap (per-user, rarely concurrent).
+mcpServer.PublishAsScaledContainerApp(min: 1, max: 3);
 
-	if (isRunMode)
-	{
-		// Run mode (incl. E2E) spawns the MFEs + gateway so the full stack
-		// is reachable on localhost; sidecars are toggled separately above.
-		var addMfe = (string name, string script, int port) =>
+if (isRunMode)
+{
+	// Run mode (incl. E2E) spawns the MFEs + gateway so the full stack
+	// is reachable on localhost; sidecars are toggled separately above.
+	var addMfe = (string name, string script, int port) =>
 #pragma warning disable ASPIREBROWSERLOGS001
-			builder.AddJavaScriptApp(name, "../../client", script)
-				.WithYarn()
-				.WithEnvironment("NX_DAEMON", "false")
-				.WithEnvironment("NX_ISOLATE_PLUGINS", "false")
-				.WithHttpEndpoint(targetPort: port)
-				.WithBrowserLogs();
+		builder.AddJavaScriptApp(name, "../../client", script)
+			.WithYarn()
+			.WithEnvironment("NX_DAEMON", "false")
+			.WithEnvironment("NX_ISOLATE_PLUGINS", "false")
+			.WithHttpEndpoint(targetPort: port)
+			.WithBrowserLogs();
 #pragma warning restore ASPIREBROWSERLOGS001
 
-		// E2E mode runs against a production build (`yarn build:all`
-		// co-locates every MFE in `dist/apps/shell/browser`) so PWA tests
-		// exercise the real shape.
-		var shell = options.E2ETests
-			? addMfe("shell", "serve:shell:dist", 4200)
-			: addMfe("shell", "serve:shell", 4200);
+	// E2E mode runs against a production build (`yarn build:all`
+	// co-locates every MFE in `dist/apps/shell/browser`) so PWA tests
+	// exercise the real shape.
+	IResourceBuilder<JavaScriptAppResource> shell;
 
-		if (!options.E2ETests)
-		{
-			addMfe("recipes-mfe", "serve:recipes", 4201);
-			addMfe("shopping-mfe", "serve:shopping", 4202);
-			addMfe("account-mfe", "serve:account", 4203);
-		}
-
-		builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
-			.WithHttpEndpoint(port: 5100)
-			.WithReference(recipesApi)
-			.WithReference(shoppingApi)
-			.WithReference(usersApi)
-			.WithReference(mealplanApi)
-			.WithReference(mcpServer)
-			.WithReference(shell)
-			.WithReference(keycloak)
-			.WaitFor(keycloak);
-	}
-	else if (!isRunMode)
+	if (!options.E2ETests)
 	{
-		var frontend = builder
-			.AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
-			.WithHttpEndpoint(targetPort: 80);
-
-		builder
-			.AddYarp("yumney-gateway")
-			.WithConfiguration(yarp =>
-			{
-				yarp.AddRoute("/api/v1/recipes/{**catch-all}", recipesApi);
-				yarp.AddRoute("/api/v1/shopping-lists/{**catch-all}", shoppingApi);
-				yarp.AddRoute("/api/v1/auth/{**catch-all}", usersApi);
-				yarp.AddRoute("/api/v1/meal-plans/{**catch-all}", mealplanApi);
-				var mcpCluster = yarp.AddCluster(mcpServer);
-
-				// MCP SSE: extend the 100 s ActivityTimeout so idle sessions survive; buffering pinned off.
-				mcpCluster.WithForwarderRequestConfig(new ForwarderRequestConfig
-				{
-					ActivityTimeout = TimeSpan.FromMinutes(10),
-					AllowResponseBuffering = false,
-				});
-				yarp.AddRoute("/mcp/{**catch-all}", mcpCluster);
-				yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
-			})
-			.WithExternalHttpEndpoints();
-
-		frontend.PublishAsAzureContainerApp((i, a) => ConfigureContainerApp(i, a, 1, 5, 100));
+		shell = addMfe("shell", "serve:shell", 4200);
+		addMfe("recipes-mfe", "serve:recipes", 4201);
+		addMfe("shopping-mfe", "serve:shopping", 4202);
+		addMfe("account-mfe", "serve:account", 4203);
 	}
+	else
+	{
+		shell = addMfe("shell", "serve:shell:dist", 4200);
+	}
+
+	builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
+		.WithHttpEndpoint(port: 5100)
+		.WithReference(recipesApi)
+		.WithReference(shoppingApi)
+		.WithReference(usersApi)
+		.WithReference(mealplanApi)
+		.WithReference(mcpServer)
+		.WithReference(shell)
+		.WithReference(keycloak)
+		.WaitFor(keycloak);
+}
+else
+{
+	var frontend = builder
+		.AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
+		.WithHttpEndpoint(targetPort: 80);
+
+	builder
+		.AddYarp("yumney-gateway")
+		.WithConfiguration(yarp =>
+		{
+			yarp.AddRoute("/api/v1/recipes/{**catch-all}", recipesApi);
+			yarp.AddRoute("/api/v1/shopping-lists/{**catch-all}", shoppingApi);
+			yarp.AddRoute("/api/v1/auth/{**catch-all}", usersApi);
+			yarp.AddRoute("/api/v1/meal-plans/{**catch-all}", mealplanApi);
+			var mcpCluster = yarp.AddCluster(mcpServer);
+
+			// MCP SSE: extend the 100 s ActivityTimeout so idle sessions survive; buffering pinned off.
+			mcpCluster.WithForwarderRequestConfig(new ForwarderRequestConfig
+			{
+				ActivityTimeout = TimeSpan.FromMinutes(10),
+				AllowResponseBuffering = false,
+			});
+			yarp.AddRoute("/mcp/{**catch-all}", mcpCluster);
+			yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
+		})
+		.WithExternalHttpEndpoints();
+
+	frontend.PublishAsScaledContainerApp(min: 1, max: 5, concurrentRequests: 100);
 }
 
 builder.Build().Run();

--- a/src/Yumney.AppHost/Yumney.AppHost.csproj
+++ b/src/Yumney.AppHost/Yumney.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
+++ b/src/Yumney.Mcp.Server/Auth/KeycloakAuthExtensions.cs
@@ -43,6 +43,16 @@ public static class KeycloakAuthExtensions
 					options.TokenValidationParameters.ValidIssuer = RealmUrl(configuration);
 				}
 
+				// Aspire 13.3.3+ may publish Keycloak as HTTPS in dev with a self-signed
+				// cert. OIDC discovery + JWKS fetch over that URL needs to skip TLS validation.
+				if (isDevelopment)
+				{
+					options.BackchannelHttpHandler = new HttpClientHandler
+					{
+						ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+					};
+				}
+
 				options.Events = new JwtBearerEvents
 				{
 					OnChallenge = challenge =>
@@ -77,6 +87,7 @@ public static class KeycloakAuthExtensions
 	private static string GetBaseUrl(IConfiguration configuration) =>
 		configuration.GetConnectionString(keycloakConnectionStringName)
 			?? configuration[$"services:{keycloakConnectionStringName}:http:0"]
+			?? configuration[$"services:{keycloakConnectionStringName}:https:0"]
 			?? defaultUrl;
 
 	private static string GetRealm(IConfiguration configuration) =>

--- a/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
+++ b/src/Yumney.MealPlan.Api/MealPlanEndpoints.cs
@@ -33,9 +33,8 @@ public static class MealPlanEndpoints
 			IQueryHandler<GetWeeklyPlanQuery, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
-			var week = WeekIdentifier.From(year, weekNumber);
-
-			var result = await handler.HandleAsync(new GetWeeklyPlanQuery(week), cancellationToken);
+			var query = new GetWeeklyPlanQuery(WeekIdentifier.From(year, weekNumber));
+			var result = await handler.HandleAsync(query, cancellationToken);
 			return result.ToOk();
 		}
 
@@ -78,8 +77,7 @@ public static class MealPlanEndpoints
 			ICommandHandler<ToggleExtendedModeCommand, Result<WeeklyPlanDto>> handler,
 			CancellationToken cancellationToken)
 		{
-			var week = WeekIdentifier.From(year, weekNumber);
-			var command = new ToggleExtendedModeCommand(week, request.Enable);
+			var command = new ToggleExtendedModeCommand(WeekIdentifier.From(year, weekNumber), request.Enable);
 
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();
@@ -233,8 +231,7 @@ public static class MealPlanEndpoints
 			IQueryHandler<GetPlannedRecipesQuery, Result<WeeklyPlannedRecipesDto>> handler,
 			CancellationToken cancellationToken)
 		{
-			var week = WeekIdentifier.From(year, weekNumber);
-			var result = await handler.HandleAsync(new GetPlannedRecipesQuery(week), cancellationToken);
+			var result = await handler.HandleAsync(new GetPlannedRecipesQuery(WeekIdentifier.From(year, weekNumber)), cancellationToken);
 			return result.ToOk();
 		}
 
@@ -274,8 +271,7 @@ public static class MealPlanEndpoints
 			ICommandHandler<GenerateShoppingListCommand, Result<GenerateShoppingListResultDto>> handler,
 			CancellationToken cancellationToken)
 		{
-			var week = WeekIdentifier.From(year, weekNumber);
-			var command = new GenerateShoppingListCommand(week);
+			var command = new GenerateShoppingListCommand(WeekIdentifier.From(year, weekNumber));
 
 			var result = await handler.HandleAsync(command, cancellationToken);
 			return result.ToOk();

--- a/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.History.cs
@@ -19,10 +19,7 @@ public static partial class RecipesEndpoints
 			.ProducesProblem(StatusCodes.Status404NotFound);
 	}
 
-	private static async Task<IResult> TrackCookedAsync(
-		Guid identifier,
-		ICommandHandler<TrackRecipeCookedCommand, Result> handler,
-		CancellationToken cancellationToken)
+	private static async Task<IResult> TrackCookedAsync(Guid identifier, ICommandHandler<TrackRecipeCookedCommand, Result> handler, CancellationToken cancellationToken)
 	{
 		var command = new TrackRecipeCookedCommand(RecipeIdentifier.From(identifier));
 		var result = await handler.HandleAsync(command, cancellationToken);

--- a/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/DeleteRecipeCommandHandler.cs
@@ -17,10 +17,7 @@ public sealed class DeleteRecipeCommandHandler(IRecipesUnitOfWork unitOfWork, IC
 
 		var recipe = await unitOfWork.Recipes.GetByIdForUpdateAsync(identifier, cancellationToken);
 
-		if (recipe.Owner != owner)
-		{
-			return Result.Failure(DeleteRecipeErrors.AccessDenied);
-		}
+		if (recipe.Owner != owner) return Result.Failure(DeleteRecipeErrors.AccessDenied);
 
 		recipe.MarkAsDeleted();
 
@@ -30,10 +27,7 @@ public sealed class DeleteRecipeCommandHandler(IRecipesUnitOfWork unitOfWork, IC
 		// transaction as the row removal. Subscribers (Shopping clears
 		// recipe references; Users records the deletion) won't observe a
 		// "recipe is gone but no event arrived" half-state.
-		await eventBus.PublishAsync(
-			new RecipeDeletedIntegrationEvent(owner.Value, identifier.Value),
-			cancellationToken);
-
+		await eventBus.PublishAsync(new RecipeDeletedIntegrationEvent(owner.Value, identifier.Value), cancellationToken);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Success();

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeCommandHandler.cs
@@ -14,16 +14,11 @@ public sealed class ImportRecipeCommandHandler(IWebScraper scraper, IRecipeExtra
 
 		var scrapeResult = await scraper.ScrapeAsync(url, cancellationToken);
 
-		if (scrapeResult.IsFailure)
-		{
-			return scrapeResult.Error!;
-		}
+		if (scrapeResult.IsFailure) return scrapeResult.Error!;
 
 		var extractResult = await extraction.ExtractAsync(scrapeResult.Value, cancellationToken);
-		if (extractResult.IsFailure)
-		{
-			return extractResult.Error!;
-		}
+
+		if (extractResult.IsFailure) return extractResult.Error!;
 
 		return extractResult;
 	}

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromTextCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeFromTextCommandHandler.cs
@@ -15,10 +15,7 @@ public sealed class ImportRecipeFromTextCommandHandler(IRecipeExtractionService 
 		var content = new ScrapedContent(text, SourceUrl: null);
 		var extractResult = await extraction.ExtractAsync(content, cancellationToken);
 
-		if (extractResult.IsFailure)
-		{
-			return extractResult.Error!;
-		}
+		if (extractResult.IsFailure) return extractResult.Error!;
 
 		return extractResult;
 	}

--- a/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/SaveRecipeCommandHandler.cs
@@ -46,9 +46,7 @@ public sealed class SaveRecipeCommandHandler(IRecipesUnitOfWork unitOfWork, ICur
 		// transaction as the Recipe row. With the outbox-backed IEventBus
 		// registered for this module, PublishAsync stages the message and
 		// SaveChangesAsync persists both rows atomically.
-		await eventBus.PublishAsync(
-			new RecipeImportedIntegrationEvent(owner.Value, recipe.Id.Value, recipe.Title.Value),
-			cancellationToken);
+		await eventBus.PublishAsync(new RecipeImportedIntegrationEvent(owner.Value, recipe.Id.Value, recipe.Title.Value), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ToggleFavoriteCommandHandler.cs
@@ -19,10 +19,7 @@ public sealed class ToggleFavoriteCommandHandler(IRecipesUnitOfWork unitOfWork, 
 
 		var recipe = await unitOfWork.Recipes.GetByIdAsync(identifier, cancellationToken);
 
-		if (recipe.Owner != owner)
-		{
-			return ToggleFavoriteErrors.AccessDenied;
-		}
+		if (recipe.Owner != owner) return ToggleFavoriteErrors.AccessDenied;
 
 		var alreadyFavorited = await unitOfWork.Favorites.IsFavoritedAsync(owner, identifier, cancellationToken);
 

--- a/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/TrackRecipeCookedCommandHandler.cs
@@ -14,17 +14,12 @@ public sealed class TrackRecipeCookedCommandHandler(IRecipesUnitOfWork unitOfWor
 	{
 		var recipe = await unitOfWork.Recipes.GetByIdAsync(command.Identifier, cancellationToken);
 
-		if (recipe.Owner != currentUser.AsOwner())
-		{
-			return Result.Failure(TrackRecipeCookedErrors.AccessDenied);
-		}
+		if (recipe.Owner != currentUser.AsOwner()) return Result.Failure(TrackRecipeCookedErrors.AccessDenied);
 
 		// PublishAsync stages on the outbox; SaveChangesAsync commits the
 		// staged row even though no entity changes occurred. Without the save,
 		// the outbox row would never persist and the message would be lost.
-		await eventBus.PublishAsync(
-			new RecipeCookedIntegrationEvent(recipe.Owner.Value, recipe.Id.Value, recipe.Title.Value),
-			cancellationToken);
+		await eventBus.PublishAsync(new RecipeCookedIntegrationEvent(recipe.Owner.Value, recipe.Id.Value, recipe.Title.Value), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/UpdateRecipeCommandHandler.cs
@@ -18,10 +18,7 @@ public sealed class UpdateRecipeCommandHandler(IRecipesUnitOfWork unitOfWork, IC
 
 		var recipe = await unitOfWork.Recipes.GetByIdForUpdateAsync(identifier, cancellationToken);
 
-		if (recipe.Owner != owner)
-		{
-			return UpdateRecipeErrors.AccessDenied;
-		}
+		if (recipe.Owner != owner) return UpdateRecipeErrors.AccessDenied;
 
 		var ingredients = ingredientCommands.Select(ingredient => ingredient.ToDomain()).ToList();
 		var steps = stepCommands.Select(step => step.ToDomain()).ToList();

--- a/src/Yumney.Recipes.Application/DTOs/FavoriteStateMappingExtensions.cs
+++ b/src/Yumney.Recipes.Application/DTOs/FavoriteStateMappingExtensions.cs
@@ -4,6 +4,5 @@ namespace SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 
 public static class FavoriteStateMappingExtensions
 {
-	public static FavoriteStateDto ToFavoriteStateDto(this RecipeIdentifier recipe, bool isFavorite) =>
-		new(recipe.Value, isFavorite);
+	public static FavoriteStateDto ToFavoriteStateDto(this RecipeIdentifier recipe, bool isFavorite) => new(recipe.Value, isFavorite);
 }

--- a/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
+++ b/src/Yumney.Recipes.Application/Queries/Handlers/GetRecipeSuggestionsQueryHandler.cs
@@ -25,17 +25,9 @@ public sealed class GetRecipeSuggestionsQueryHandler(
 		await Task.WhenAll(availableTask, dietaryTask);
 
 		var available = await availableTask;
-		if (available.Count == 0)
-		{
-			return RecipeSuggestionErrors.NoIngredients;
-		}
+		if (available.Count == 0) return RecipeSuggestionErrors.NoIngredients;
 
 		var dietary = await dietaryTask;
-		return await suggestionService.SuggestAsync(
-			(IReadOnlyCollection<string>)available.Keys.ToList(),
-			dietary.DietaryType,
-			dietary.Restrictions,
-			count,
-			cancellationToken);
+		return await suggestionService.SuggestAsync(available.Keys.ToList(), dietary.DietaryType, dietary.Restrictions, count, cancellationToken);
 	}
 }

--- a/src/Yumney.Shared.Abstractions/AggregateRoot.cs
+++ b/src/Yumney.Shared.Abstractions/AggregateRoot.cs
@@ -14,10 +14,7 @@ public abstract class AggregateRoot<TId> : Entity<TId>, IHasDomainEvents
 
 	protected static void CheckRule(IBusinessRule rule)
 	{
-		if (rule.IsBroken())
-		{
-			throw new BusinessRuleValidationException(rule);
-		}
+		if (rule.IsBroken()) throw new BusinessRuleValidationException(rule);
 	}
 
 	protected void AddDomainEvent(IDomainEvent domainEvent)

--- a/src/Yumney.Shared.CQRS/CqrsServiceCollectionExtensions.cs
+++ b/src/Yumney.Shared.CQRS/CqrsServiceCollectionExtensions.cs
@@ -7,23 +7,26 @@ namespace SmartSolutionsLab.Yumney.Shared.CQRS;
 
 public static class CqrsServiceCollectionExtensions
 {
-	public static IServiceCollection AddHandlersFromAssemblyContaining<T>(this IServiceCollection services)
+	extension(IServiceCollection services)
 	{
-		var assembly = typeof(T).Assembly;
+		public IServiceCollection AddHandlersFromAssemblyContaining<T>()
+		{
+			var assembly = typeof(T).Assembly;
 
-		RegisterHandlers(services, assembly, typeof(ICommandHandler<,>));
-		RegisterHandlers(services, assembly, typeof(IQueryHandler<,>));
+			RegisterHandlers(services, assembly, typeof(ICommandHandler<,>));
+			RegisterHandlers(services, assembly, typeof(IQueryHandler<,>));
 
-		return services;
-	}
+			return services;
+		}
 
-	public static IServiceCollection AddCqrsLoggingDecorators(this IServiceCollection services)
-	{
-		services.AddSingleton<ApplicationMetrics>();
-		DecorateAll(services, typeof(ICommandHandler<,>), typeof(LoggingCommandHandlerDecorator<,>));
-		DecorateAll(services, typeof(IQueryHandler<,>), typeof(LoggingQueryHandlerDecorator<,>));
+		public IServiceCollection AddCqrsLoggingDecorators()
+		{
+			services.AddSingleton<ApplicationMetrics>();
+			DecorateAll(services, typeof(ICommandHandler<,>), typeof(LoggingCommandHandlerDecorator<,>));
+			DecorateAll(services, typeof(IQueryHandler<,>), typeof(LoggingQueryHandlerDecorator<,>));
 
-		return services;
+			return services;
+		}
 	}
 
 	private static void RegisterHandlers(IServiceCollection services, Assembly assembly, Type openGenericInterface)
@@ -58,10 +61,7 @@ public static class CqrsServiceCollectionExtensions
 			// Re-register the original handler under its concrete type so the decorator can resolve it
 			if (descriptor.ImplementationType is not null)
 			{
-				var serviceDescriptor = new ServiceDescriptor(
-					descriptor.ImplementationType,
-					descriptor.ImplementationType,
-					descriptor.Lifetime);
+				var serviceDescriptor = new ServiceDescriptor(descriptor.ImplementationType, descriptor.ImplementationType, descriptor.Lifetime);
 				services.Add(serviceDescriptor);
 			}
 

--- a/src/Yumney.Shared.CQRS/FluentValidationExtensions.cs
+++ b/src/Yumney.Shared.CQRS/FluentValidationExtensions.cs
@@ -4,8 +4,7 @@ namespace SmartSolutionsLab.Yumney.Shared.CQRS;
 
 public static class FluentValidationExtensions
 {
-	public static IRuleBuilderOptions<T, string> MustBeValidHttpUrl<T>(
-		this IRuleBuilder<T, string> ruleBuilder, int maxLength)
+	public static IRuleBuilderOptions<T, string> MustBeValidHttpUrl<T>(this IRuleBuilder<T, string> ruleBuilder, int maxLength)
 	{
 		return ruleBuilder
 			.MaximumLength(maxLength)

--- a/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
+++ b/src/Yumney.Shared.Events.InProcess/EventingServiceCollectionExtensions.cs
@@ -8,37 +8,39 @@ namespace SmartSolutionsLab.Yumney.Shared.Events;
 /// </summary>
 public static class EventingServiceCollectionExtensions
 {
-	/// <summary>
-	/// Registers the in-process <see cref="IDomainEventDispatcher"/>. Always
-	/// required — domain events are intra-module and never go over the wire,
-	/// even when integration events use a distributed bus.
-	/// </summary>
 	/// <param name="services">The service collection.</param>
-	/// <returns>The service collection for chaining.</returns>
-	public static IServiceCollection AddInProcessDomainEventDispatcher(this IServiceCollection services)
+	extension(IServiceCollection services)
 	{
-		// Counters used by the dispatcher and the in-process bus. Registered
-		// as singleton because Counter<T> instances from a Meter are
-		// thread-safe and meant to be reused across the process lifetime.
-		services.TryAddSingleton<EventMetrics>();
-		services.AddScoped<IDomainEventDispatcher, InProcessDomainEventDispatcher>();
+		/// <summary>
+		/// Registers the in-process <see cref="IDomainEventDispatcher"/>. Always
+		/// required — domain events are intra-module and never go over the wire,
+		/// even when integration events use a distributed bus.
+		/// </summary>
+		/// <returns>The service collection for chaining.</returns>
+		public IServiceCollection AddInProcessDomainEventDispatcher()
+		{
+			// Counters used by the dispatcher and the in-process bus. Registered
+			// as singleton because Counter<T> instances from a Meter are
+			// thread-safe and meant to be reused across the process lifetime.
+			services.TryAddSingleton<EventMetrics>();
+			services.AddScoped<IDomainEventDispatcher, InProcessDomainEventDispatcher>();
 
-		return services;
-	}
+			return services;
+		}
 
-	/// <summary>
-	/// Registers the in-process <see cref="IEventBus"/>. Use this only when
-	/// the host does NOT register a distributed event bus (Wolverine etc.) —
-	/// a later <c>IEventBus</c> registration supersedes this one for
-	/// cross-module integration events.
-	/// </summary>
-	/// <param name="services">The service collection.</param>
-	/// <returns>The service collection for chaining.</returns>
-	public static IServiceCollection AddInProcessEventBus(this IServiceCollection services)
-	{
-		services.TryAddSingleton<EventMetrics>();
-		services.AddScoped<IEventBus, InProcessEventBus>();
+		/// <summary>
+		/// Registers the in-process <see cref="IEventBus"/>. Use this only when
+		/// the host does NOT register a distributed event bus (Wolverine etc.) —
+		/// a later <c>IEventBus</c> registration supersedes this one for
+		/// cross-module integration events.
+		/// </summary>
+		/// <returns>The service collection for chaining.</returns>
+		public IServiceCollection AddInProcessEventBus()
+		{
+			services.TryAddSingleton<EventMetrics>();
+			services.AddScoped<IEventBus, InProcessEventBus>();
 
-		return services;
+			return services;
+		}
 	}
 }

--- a/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
+++ b/src/Yumney.Shared.Events.InProcess/InProcessEventBus.cs
@@ -5,10 +5,8 @@ using Microsoft.Extensions.Logging;
 namespace SmartSolutionsLab.Yumney.Shared.Events;
 
 #pragma warning disable SA1601
-public sealed partial class InProcessEventBus(
-	IServiceProvider serviceProvider,
-	EventMetrics metrics,
-	ILogger<InProcessEventBus> logger) : IEventBus
+public sealed partial class InProcessEventBus(IServiceProvider serviceProvider, EventMetrics metrics, ILogger<InProcessEventBus> logger)
+	: IEventBus
 {
 	public async Task PublishAsync<TEvent>(TEvent busEvent, CancellationToken cancellationToken = default)
 		where TEvent : IBusEvent

--- a/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/IntegrationEventConsumer.cs
@@ -38,11 +38,7 @@ public sealed partial class IntegrationEventConsumer<TEvent>(
 		InboxOutcome outcome;
 		try
 		{
-			outcome = await inboxStore.TryProcessAsync(
-				message.EventIdentifier,
-				consumerName,
-				ct => handler.HandleAsync(message, ct),
-				cancellationToken);
+			outcome = await inboxStore.TryProcessAsync(message.EventIdentifier, consumerName, ct => handler.HandleAsync(message, ct), cancellationToken);
 		}
 		catch (Exception exception)
 		{

--- a/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
+++ b/src/Yumney.Shared.Events.Wolverine/WolverineEventBusExtensions.cs
@@ -131,11 +131,7 @@ public static class WolverineEventBusExtensions
 		return builder;
 	}
 
-	private static void RegisterBusEventConsumers(
-		WolverineOptions opts,
-		Assembly assembly,
-		Type openHandlerInterface,
-		Type openConsumerType)
+	private static void RegisterBusEventConsumers(WolverineOptions opts, Assembly assembly, Type openHandlerInterface, Type openConsumerType)
 	{
 		var eventTypes = assembly.GetTypes()
 			.SelectMany(type => type.GetInterfaces())

--- a/src/Yumney.Shared.Events/BusEventHandlerRegistration.cs
+++ b/src/Yumney.Shared.Events/BusEventHandlerRegistration.cs
@@ -7,8 +7,7 @@ public static class BusEventHandlerRegistration
 {
 	extension(IServiceCollection services)
 	{
-		public IServiceCollection AddBusEventHandlersFromAssemblyContaining<T>() =>
-			services.AddBusEventHandlers(typeof(T).Assembly);
+		public IServiceCollection AddBusEventHandlersFromAssemblyContaining<T>() => services.AddBusEventHandlers(typeof(T).Assembly);
 
 		public IServiceCollection AddBusEventHandlers(Assembly assembly)
 		{

--- a/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
@@ -33,8 +33,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 
 		var aggregateId = GetAggregateId(aggregate);
 
-		var existingMetadata = await Context.Set<TMetadata>()
-			.FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+		var existingMetadata = await Context.Set<TMetadata>().FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
 
 		if (existingMetadata is null)
 		{
@@ -45,7 +44,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 		for (var index = 0; index < uncommitted.Count; index++)
 		{
 			var @event = uncommitted[index];
-			Context.Set<TStoredEvent>().Add(new TStoredEvent
+			TStoredEvent storedEvent = new()
 			{
 				Id = Guid.CreateVersion7(),
 				AggregateId = aggregateId,
@@ -53,7 +52,8 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 				EventData = Serializer.Serialize(@event),
 				Version = baseVersion + index + 1,
 				OccurredAt = @event.OccurredOn,
-			});
+			};
+			Context.Set<TStoredEvent>().Add(storedEvent);
 		}
 
 		var busEvents = BuildBusEvents(aggregate, uncommitted);
@@ -86,8 +86,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 		new Dictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory>();
 #pragma warning restore SA1311
 
-	protected virtual IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> ModuleEventFactories =>
-		emptyModuleFactories;
+	protected virtual IReadOnlyDictionary<Type, ModuleEventConvention.ModuleEventFactory> ModuleEventFactories => emptyModuleFactories;
 
 	protected virtual IReadOnlyDictionary<Type, CrossModuleEventConvention.CrossModuleEventFactory> CrossModuleEventFactories =>
 		emptyCrossModuleFactories;

--- a/src/Yumney.Shared.Persistence/InboxStore.cs
+++ b/src/Yumney.Shared.Persistence/InboxStore.cs
@@ -18,11 +18,7 @@ namespace SmartSolutionsLab.Yumney.Shared.Persistence;
 public sealed class InboxStore<TContext>(TContext context) : IInboxStore
 	where TContext : DbContext
 {
-	public async Task<InboxOutcome> TryProcessAsync(
-		Guid messageId,
-		string consumerName,
-		Func<CancellationToken, Task> handler,
-		CancellationToken cancellationToken = default)
+	public async Task<InboxOutcome> TryProcessAsync(Guid messageId, string consumerName, Func<CancellationToken, Task> handler, CancellationToken cancellationToken = default)
 	{
 		var strategy = context.Database.CreateExecutionStrategy();
 
@@ -36,10 +32,7 @@ public sealed class InboxStore<TContext>(TContext context) : IInboxStore
 					.AsNoTracking()
 					.AnyAsync(message => message.MessageId == messageId && message.ConsumerName == consumerName, cancellationToken);
 
-				if (alreadyProcessed)
-				{
-					return InboxOutcome.AlreadyProcessed;
-				}
+				if (alreadyProcessed) return InboxOutcome.AlreadyProcessed;
 
 				context.Set<InboxMessage>().Add(new InboxMessage
 				{

--- a/src/Yumney.Shared.Persistence/NpgsqlDbContextRegistration.cs
+++ b/src/Yumney.Shared.Persistence/NpgsqlDbContextRegistration.cs
@@ -17,7 +17,7 @@ public static class NpgsqlDbContextRegistration
 	{
 		var connectionString = configuration.GetConnectionString(connectionName);
 
-		services.AddDbContext<TContext>((sp, options) =>
+		services.AddDbContext<TContext>((serviceProvider, options) =>
 		{
 			options.UseNpgsql(connectionString, npgsql => npgsql
 				.MigrationsHistoryTable(migrationsHistoryTable)
@@ -25,7 +25,7 @@ public static class NpgsqlDbContextRegistration
 
 			foreach (var interceptorType in interceptorTypes)
 			{
-				options.AddInterceptors((IInterceptor)sp.GetRequiredService(interceptorType));
+				options.AddInterceptors((IInterceptor)serviceProvider.GetRequiredService(interceptorType));
 			}
 		});
 

--- a/src/Yumney.Shared.Persistence/PagingExtensions.cs
+++ b/src/Yumney.Shared.Persistence/PagingExtensions.cs
@@ -5,16 +5,16 @@ namespace SmartSolutionsLab.Yumney.Shared.Persistence;
 
 public static class PagingExtensions
 {
-	public static async Task<(IReadOnlyList<T> Items, ItemCount TotalCount)> ToPagedListAsync<T>(
-		this IQueryable<T> query,
-		PagingOptions paging,
-		CancellationToken cancellationToken = default)
+	extension<T>(IQueryable<T> query)
 	{
-		var totalCount = await query.CountAsync(cancellationToken);
-		var items = await query
-			.Skip(paging.Skip)
-			.Take(paging.PageSize.Value)
-			.ToListAsync(cancellationToken);
-		return (items, ItemCount.From(totalCount));
+		public async Task<(IReadOnlyList<T> Items, ItemCount TotalCount)> ToPagedListAsync(PagingOptions paging, CancellationToken cancellationToken = default)
+		{
+			var totalCount = await query.CountAsync(cancellationToken);
+			var items = await query
+				.Skip(paging.Skip)
+				.Take(paging.PageSize.Value)
+				.ToListAsync(cancellationToken);
+			return (items, ItemCount.From(totalCount));
+		}
 	}
 }

--- a/src/Yumney.Shared.Quantities/FreshnessExtensions.cs
+++ b/src/Yumney.Shared.Quantities/FreshnessExtensions.cs
@@ -10,6 +10,5 @@ public static class FreshnessExtensions
 		_ => 0,
 	};
 
-	public static bool IsUrgent(this Freshness freshness)
-		=> freshness is Freshness.UseSoon or Freshness.CheckIt;
+	public static bool IsUrgent(this Freshness freshness) => freshness is Freshness.UseSoon or Freshness.CheckIt;
 }

--- a/src/Yumney.Shared.Quantities/IngredientCategory.cs
+++ b/src/Yumney.Shared.Quantities/IngredientCategory.cs
@@ -30,11 +30,7 @@ public sealed record IngredientCategory : IValueObject<string>
 
 	private IngredientCategory(string value)
 	{
-		Value = Ensure.That(value)
-			.IsNotNullOrWhiteSpace()
-			.HasMaxLength(MaxLength)
-			.IsOneOf(allowedValues)
-			.AndReturn();
+		Value = Ensure.That(value).IsNotNullOrWhiteSpace().HasMaxLength(MaxLength).IsOneOf(allowedValues).AndReturn();
 		DisplayOrder = Array.IndexOf(allowedValues, Value);
 	}
 

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -3,10 +3,8 @@ using System.Reflection;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -41,11 +39,9 @@ public static partial class HostBuilderExtensions
 		builder.AddRedisDistributedCache("redis");
 		builder.AddRedisClient("redis");
 
-		builder.Services.ConfigureHttpJsonOptions(options =>
-			options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+		builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
-		builder.Services.Configure<HostOptions>(options =>
-			options.ShutdownTimeout = TimeSpan.FromSeconds(30));
+		builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
 
 		builder.Services.AddHttpContextAccessor();
 		builder.Services.AddScoped<ICurrentUser, CurrentUserProvider>();
@@ -106,8 +102,7 @@ public static partial class HostBuilderExtensions
 
 		app.MapGet("/version", () => new
 		{
-			Version = typeof(HostBuilderExtensions).Assembly
-				.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
+			Version = typeof(HostBuilderExtensions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
 			Environment = app.Environment.EnvironmentName,
 		}).AllowAnonymous();
 

--- a/src/Yumney.Shared.Web/HostBuilderExtensions.cs
+++ b/src/Yumney.Shared.Web/HostBuilderExtensions.cs
@@ -128,6 +128,17 @@ public static partial class HostBuilderExtensions
 				{
 					options.TokenValidationParameters.ValidIssuer = KeycloakDefaults.RealmUrl(builder.Configuration);
 				}
+
+				// Aspire 13.3.3+ may publish Keycloak as HTTPS in dev with a self-signed
+				// cert. The OIDC discovery / JWKS fetch happens over this same URL, so
+				// skip backchannel TLS validation in Development.
+				if (isDevelopment)
+				{
+					options.BackchannelHttpHandler = new HttpClientHandler
+					{
+						ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+					};
+				}
 			});
 
 		builder.Services.AddAuthorization();

--- a/src/Yumney.Shared.Web/IModuleHttpClient.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClient.cs
@@ -2,43 +2,16 @@ namespace SmartSolutionsLab.Yumney.Shared.Web;
 
 public interface IModuleHttpClient
 {
-	Task<TResult> GetOrDefaultAsync<TResult>(
-		string url,
-		TResult fallback,
-		string operation,
-		CancellationToken cancellationToken = default);
+	Task<TResult> GetOrDefaultAsync<TResult>(string url, TResult fallback, string operation, CancellationToken cancellationToken = default);
 
-	Task<TResult?> FindAsync<TResult>(
-		string url,
-		string operation,
-		CancellationToken cancellationToken = default)
+	Task<TResult?> FindAsync<TResult>(string url, string operation, CancellationToken cancellationToken = default)
 		where TResult : class;
 
-	Task PostAsync<TBody>(
-		string url,
-		TBody body,
-		string operation,
-		CancellationToken cancellationToken = default);
+	Task PostAsync<TBody>(string url, TBody body, string operation, CancellationToken cancellationToken = default);
 
-	Task PutAsync<TBody>(
-		string url,
-		TBody body,
-		string operation,
-		CancellationToken cancellationToken = default);
+	Task PutAsync<TBody>(string url, TBody body, string operation, CancellationToken cancellationToken = default);
 
-	Task DeleteAsync(
-		string url,
-		string operation,
-		CancellationToken cancellationToken = default);
+	Task DeleteAsync(string url, string operation, CancellationToken cancellationToken = default);
 
-	Task DeleteAsync<TBody>(
-		string url,
-		TBody body,
-		string operation,
-		CancellationToken cancellationToken = default);
-}
-
-public interface IModuleHttpClientFactory
-{
-	IModuleHttpClient For(string upstreamName);
+	Task DeleteAsync<TBody>(string url, TBody body, string operation, CancellationToken cancellationToken = default);
 }

--- a/src/Yumney.Shared.Web/IModuleHttpClientFactory.cs
+++ b/src/Yumney.Shared.Web/IModuleHttpClientFactory.cs
@@ -1,0 +1,6 @@
+namespace SmartSolutionsLab.Yumney.Shared.Web;
+
+public interface IModuleHttpClientFactory
+{
+	IModuleHttpClient For(string upstreamName);
+}

--- a/src/Yumney.Shared.Web/KeycloakDefaults.cs
+++ b/src/Yumney.Shared.Web/KeycloakDefaults.cs
@@ -21,23 +21,11 @@ public static class KeycloakDefaults
 			?? DefaultUrl;
 	}
 
-	public static string GetRealm(IConfiguration configuration)
-	{
-		return configuration.GetValue<string>(RealmConfigKey) ?? DefaultRealm;
-	}
+	public static string GetRealm(IConfiguration configuration) => configuration.GetValue<string>(RealmConfigKey) ?? DefaultRealm;
 
-	public static string AuthorizationUrl(IConfiguration configuration)
-	{
-		return $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}/protocol/openid-connect/auth";
-	}
+	public static string AuthorizationUrl(IConfiguration configuration) => $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}/protocol/openid-connect/auth";
 
-	public static string TokenUrl(IConfiguration configuration)
-	{
-		return $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}/protocol/openid-connect/token";
-	}
+	public static string TokenUrl(IConfiguration configuration) => $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}/protocol/openid-connect/token";
 
-	public static string RealmUrl(IConfiguration configuration)
-	{
-		return $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}";
-	}
+	public static string RealmUrl(IConfiguration configuration) => $"{GetBaseUrl(configuration)}/realms/{GetRealm(configuration)}";
 }

--- a/src/Yumney.Shared.Web/KeycloakDefaults.cs
+++ b/src/Yumney.Shared.Web/KeycloakDefaults.cs
@@ -16,8 +16,11 @@ public static class KeycloakDefaults
 
 	public static string GetBaseUrl(IConfiguration configuration)
 	{
+		// Aspire 13.3.3 may publish Keycloak under services:keycloak:https:0
+		// (HTTPS upgrade for dev-cert scenarios) rather than :http:0; accept either.
 		return configuration.GetConnectionString(ConnectionStringName)
 			?? configuration[$"services:{ConnectionStringName}:http:0"]
+			?? configuration[$"services:{ConnectionStringName}:https:0"]
 			?? DefaultUrl;
 	}
 

--- a/src/Yumney.Shared.Web/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/CorrelationIdMiddleware.cs
@@ -9,8 +9,7 @@ public sealed class CorrelationIdMiddleware(RequestDelegate next)
 
 	public async Task InvokeAsync(HttpContext context)
 	{
-		var correlationId = context.Request.Headers[HeaderName].FirstOrDefault()
-			?? Guid.NewGuid().ToString("N");
+		var correlationId = context.Request.Headers[HeaderName].FirstOrDefault() ?? Guid.NewGuid().ToString("N");
 
 		context.Items[HeaderName] = correlationId;
 		context.Response.OnStarting(() =>

--- a/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -30,28 +30,16 @@ public sealed partial class GlobalExceptionHandlerMiddleware(RequestDelegate nex
 		catch (BusinessRuleValidationException ex)
 		{
 			LogBusinessRuleViolated(ex, ex.BrokenRule.GetType().Name);
-			await WriteProblemDetailsAsync(
-				context,
-				HttpStatusCode.UnprocessableEntity,
-				"Business Rule Violation",
-				ex.Message);
+			await WriteProblemDetailsAsync(context, HttpStatusCode.UnprocessableEntity, "Business Rule Violation", ex.Message);
 		}
 		catch (Exception ex)
 		{
 			LogUnhandledException(ex);
-			await WriteProblemDetailsAsync(
-				context,
-				HttpStatusCode.InternalServerError,
-				"Internal Server Error",
-				"An unexpected error occurred.");
+			await WriteProblemDetailsAsync(context, HttpStatusCode.InternalServerError, "Internal Server Error", "An unexpected error occurred.");
 		}
 	}
 
-	private static async Task WriteProblemDetailsAsync(
-		HttpContext context,
-		HttpStatusCode statusCode,
-		string title,
-		string detail)
+	private static async Task WriteProblemDetailsAsync(HttpContext context, HttpStatusCode statusCode, string title, string detail)
 	{
 		context.Response.StatusCode = (int)statusCode;
 

--- a/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
+++ b/src/Yumney.Shopping.Application/Commands/Handlers/CreateShoppingListFromRecipesCommandHandler.cs
@@ -14,13 +14,12 @@ public sealed class CreateShoppingListFromRecipesCommandHandler(
 	ICurrentUser currentUser)
 	: ICommandHandler<CreateShoppingListFromRecipesCommand, Result<ShoppingListDetailDto>>
 {
-	public async Task<Result<ShoppingListDetailDto>> HandleAsync(CreateShoppingListFromRecipesCommand command, CancellationToken cancellationToken = default)
+	public async Task<Result<ShoppingListDetailDto>> HandleAsync(
+		CreateShoppingListFromRecipesCommand command,
+		CancellationToken cancellationToken = default)
 	{
 		var (title, recipes) = command;
-		if (recipes.Count == 0)
-		{
-			return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoRecipesProvided);
-		}
+		if (recipes.Count == 0) return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoRecipesProvided);
 
 		List<IngredientMergeInput> inputs = new(recipes.Count);
 		foreach (var selection in recipes)
@@ -30,10 +29,7 @@ public sealed class CreateShoppingListFromRecipesCommandHandler(
 			inputs.Add(new IngredientMergeInput(ingredients, selection.DesiredServings));
 		}
 
-		if (inputs.Count == 0)
-		{
-			return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoIngredientsResolved);
-		}
+		if (inputs.Count == 0) return Result<ShoppingListDetailDto>.Failure(CreateShoppingListFromRecipesErrors.NoIngredientsResolved);
 
 		var merged = IngredientMerger.Merge(inputs);
 		var items = merged

--- a/src/Yumney.Shopping.Application/Queries/GetShoppingListByIdQuery.cs
+++ b/src/Yumney.Shopping.Application/Queries/GetShoppingListByIdQuery.cs
@@ -5,5 +5,4 @@ using SmartSolutionsLab.Yumney.Shopping.Domain.ShoppingList;
 
 namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries;
 
-public sealed record GetShoppingListByIdQuery(
-	ShoppingListIdentifier Identifier) : IQuery<Result<ShoppingListDetailDto>>;
+public sealed record GetShoppingListByIdQuery(ShoppingListIdentifier Identifier) : IQuery<Result<ShoppingListDetailDto>>;

--- a/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
+++ b/src/Yumney.Shopping.Application/Queries/Handlers/GetIngredientBalanceQueryHandler.cs
@@ -10,7 +10,8 @@ namespace SmartSolutionsLab.Yumney.Shopping.Application.Queries.Handlers;
 public sealed class GetIngredientBalanceQueryHandler(
 	IIngredientBalanceReadModelRepository readModel,
 	IStaplesProvider staplesProvider,
-	ICurrentUser currentUser) : IQueryHandler<GetIngredientBalanceQuery, Result<IngredientBalanceDto>>
+	ICurrentUser currentUser)
+	: IQueryHandler<GetIngredientBalanceQuery, Result<IngredientBalanceDto>>
 {
 	public async Task<Result<IngredientBalanceDto>> HandleAsync(GetIngredientBalanceQuery query, CancellationToken cancellationToken = default)
 	{

--- a/src/Yumney.Shopping.Client/ShoppingClient.cs
+++ b/src/Yumney.Shopping.Client/ShoppingClient.cs
@@ -7,17 +7,10 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 	private readonly IModuleHttpClient http = factory.For("shopping-api");
 
 	public Task<ShoppingBalanceResponse?> GetBalanceAsync(CancellationToken cancellationToken = default) =>
-		http.FindAsync<ShoppingBalanceResponse>(
-			"/api/v1/shopping-lists/balance",
-			"GetShoppingBalance",
-			cancellationToken);
+		http.FindAsync<ShoppingBalanceResponse>("/api/v1/shopping-lists/balance", "GetShoppingBalance", cancellationToken);
 
 	public Task AddItemAsync(AddShoppingItemRequest request, CancellationToken cancellationToken = default) =>
-		http.PostAsync(
-			"/api/v1/shopping-lists/items",
-			request,
-			"AddShoppingItem",
-			cancellationToken);
+		http.PostAsync("/api/v1/shopping-lists/items", request, "AddShoppingItem", cancellationToken);
 
 	public Task<MergedShoppingListResponse?> GetMergedListAsync(bool includePastBought = false, CancellationToken cancellationToken = default) =>
 		http.FindAsync<MergedShoppingListResponse>(
@@ -29,11 +22,7 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 	{
 		try
 		{
-			await http.PostAsync(
-				"/api/v1/shopping-lists/from-recipes",
-				body,
-				"CreateShoppingListFromRecipes",
-				cancellationToken);
+			await http.PostAsync("/api/v1/shopping-lists/from-recipes", body, "CreateShoppingListFromRecipes", cancellationToken);
 			return true;
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
@@ -46,11 +35,7 @@ internal sealed class ShoppingClient(IModuleHttpClientFactory factory) : IShoppi
 	{
 		try
 		{
-			await http.DeleteAsync(
-				"/api/v1/shopping-lists/items",
-				body,
-				"RemoveShoppingItem",
-				cancellationToken);
+			await http.DeleteAsync("/api/v1/shopping-lists/items", body, "RemoveShoppingItem", cancellationToken);
 			return true;
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Yumney.Shopping.Extraction/Services/StubShoppingItemCategorizer.cs
+++ b/src/Yumney.Shopping.Extraction/Services/StubShoppingItemCategorizer.cs
@@ -17,9 +17,7 @@ public sealed class StubShoppingItemCategorizer : IShoppingItemCategorizer
 		return Task.FromResult(category);
 	}
 
-	public Task<IReadOnlyDictionary<ItemName, IngredientCategory>> CategorizeManyAsync(
-		IReadOnlyCollection<ItemName> names,
-		CancellationToken cancellationToken = default)
+	public Task<IReadOnlyDictionary<ItemName, IngredientCategory>> CategorizeManyAsync(IReadOnlyCollection<ItemName> names, CancellationToken cancellationToken = default)
 	{
 		IReadOnlyDictionary<ItemName, IngredientCategory> map = names
 			.DistinctBy(name => name.Value)

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/HttpRecipeIngredientLookup.cs
@@ -7,19 +7,11 @@ namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
 
 public sealed class HttpRecipeIngredientLookup(IRecipesClient recipes) : IRecipeIngredientLookup
 {
-	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(
-		RecipeReference recipe,
-		CancellationToken cancellationToken = default)
+	public async Task<IReadOnlyList<RecipeIngredientLookupResult>> LookupAsync(RecipeReference recipe, CancellationToken cancellationToken = default)
 	{
 		var response = await recipes.GetRecipeAsync(recipe.Value, cancellationToken);
 		if (response is null) return [];
 
-		return response.Ingredients
-			.Select(ingredient => new RecipeIngredientLookupResult(
-				ingredient.Name,
-				ingredient.Amount,
-				ingredient.Unit,
-				response.Servings))
-			.ToList();
+		return response.Ingredients.Select(ingredient => ingredient.ToResult(response)).ToList();
 	}
 }

--- a/src/Yumney.Shopping.Infrastructure/ExternalServices/MappingExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ExternalServices/MappingExtensions.cs
@@ -1,0 +1,16 @@
+using SmartSolutionsLab.Yumney.Recipes.Client;
+using SmartSolutionsLab.Yumney.Shopping.Application.DTOs;
+
+namespace SmartSolutionsLab.Yumney.Shopping.Infrastructure.ExternalServices;
+
+public static class MappingExtensions
+{
+	public static RecipeIngredientLookupResult ToResult(this RecipeIngredientPayload ingredient, RecipeResponse response)
+	{
+		return new RecipeIngredientLookupResult(
+			ingredient.Name,
+			ingredient.Amount,
+			ingredient.Unit,
+			response.Servings);
+	}
+}

--- a/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingEventStore.cs
+++ b/src/Yumney.Shopping.Infrastructure/Persistence/EventStore/ShoppingEventStore.cs
@@ -28,8 +28,7 @@ public sealed partial class ShoppingEventStore(
 #pragma warning restore SA1311
 
 	public async Task<ShoppingLedger> LoadAsync(OwnerIdentifier ownerId, CancellationToken cancellationToken = default)
-		=> await FindAsync(ownerId, cancellationToken)
-			?? throw new EntityNotFoundException(nameof(ShoppingLedger), ownerId.Value);
+		=> await FindAsync(ownerId, cancellationToken) ?? throw new EntityNotFoundException(nameof(ShoppingLedger), ownerId.Value);
 
 	public async Task<ShoppingLedger?> FindAsync(OwnerIdentifier ownerId, CancellationToken cancellationToken = default)
 	{
@@ -63,10 +62,7 @@ public sealed partial class ShoppingEventStore(
 	// rows; FlushOutgoingMessagesAsync nudges Wolverine to deliver immediately
 	// — a delivery failure leaves the rows in the outbox table for the
 	// background relay to pick up on retry.
-	protected override async Task PersistAndPublishAsync(
-		ShoppingLedger aggregate,
-		IReadOnlyList<IBusEvent> busEvents,
-		CancellationToken cancellationToken)
+	protected override async Task PersistAndPublishAsync(ShoppingLedger aggregate, IReadOnlyList<IBusEvent> busEvents, CancellationToken cancellationToken)
 	{
 		foreach (var busEvent in busEvents)
 		{

--- a/src/Yumney.Users.Api/DangerZoneEndpoints.cs
+++ b/src/Yumney.Users.Api/DangerZoneEndpoints.cs
@@ -21,9 +21,7 @@ public static class DangerZoneEndpoints
 			.Produces(StatusCodes.Status204NoContent)
 			.ProducesProblem(StatusCodes.Status503ServiceUnavailable);
 
-		static async Task<IResult> DeleteAccount(
-			ICommandHandler<DeleteAccountCommand, Result> handler,
-			CancellationToken cancellationToken)
+		static async Task<IResult> DeleteAccount(ICommandHandler<DeleteAccountCommand, Result> handler, CancellationToken cancellationToken)
 		{
 			var result = await handler.HandleAsync(new DeleteAccountCommand(), cancellationToken);
 			return result.ToNoContent();

--- a/src/Yumney.Users.Api/StaplesEndpoints.cs
+++ b/src/Yumney.Users.Api/StaplesEndpoints.cs
@@ -17,10 +17,7 @@ public static class StaplesEndpoints
 
 		return app;
 
-		static async Task<IResult> GetStaples(
-			IStaplesProvider staplesProvider,
-			ICurrentUser currentUser,
-			CancellationToken cancellationToken)
+		static async Task<IResult> GetStaples(IStaplesProvider staplesProvider, ICurrentUser currentUser, CancellationToken cancellationToken)
 		{
 			var owner = OwnerIdentifier.From(currentUser.UserId);
 			var staples = await staplesProvider.GetStapleNamesAsync(owner, cancellationToken);

--- a/src/Yumney.Users.Api/UsersApiModule.cs
+++ b/src/Yumney.Users.Api/UsersApiModule.cs
@@ -24,8 +24,7 @@ public sealed class UsersApiModule : IEndpointModule
 
 	public WebApplication RegisterEndpoints(WebApplication app)
 	{
-		app
-			.UseYumneyDefaults()
+		app.UseYumneyDefaults()
 			.MapApiV1()
 			.MapUsersEndpoints();
 

--- a/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/DeleteAccountCommandHandler.cs
@@ -68,9 +68,7 @@ public sealed partial class DeleteAccountCommandHandler(
 		return Result.Success();
 	}
 
-	private async Task<AccountDeletionEmailPayload?> TryBuildEmailPayloadAsync(
-		KeycloakUserId keycloakId,
-		CancellationToken cancellationToken)
+	private async Task<AccountDeletionEmailPayload?> TryBuildEmailPayloadAsync(KeycloakUserId keycloakId, CancellationToken cancellationToken)
 	{
 		var profile = await unitOfWork.Profiles.FindByKeycloakUserIdAsync(keycloakId, cancellationToken);
 		if (profile is null)
@@ -86,7 +84,7 @@ public sealed partial class DeleteAccountCommandHandler(
 			return null;
 		}
 
-		return new AccountDeletionEmailPayload(emailResult.Value!, profile.DisplayName, profile.PreferredLanguage);
+		return new AccountDeletionEmailPayload(emailResult.Value, profile.DisplayName, profile.PreferredLanguage);
 	}
 
 	private async Task TrySendConfirmationAsync(AccountDeletionEmailPayload payload, CancellationToken cancellationToken)

--- a/src/Yumney.Users.Application/Commands/Handlers/EnsureUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/EnsureUserProfileCommandHandler.cs
@@ -18,8 +18,7 @@ public sealed class EnsureUserProfileCommandHandler(IUsersUnitOfWork unitOfWork,
 		// (realm-seeded test users, SSO providers, admin-created users) may
 		// not yet have an AppUserProfile row. Create one on first profile
 		// request so the app doesn't block on 404.
-		var displayName = DisplayName.From(
-			string.IsNullOrWhiteSpace(currentUser.DisplayName) ? currentUser.Email : currentUser.DisplayName);
+		var displayName = DisplayName.From(string.IsNullOrWhiteSpace(currentUser.DisplayName) ? currentUser.Email : currentUser.DisplayName);
 		var profile = AppUserProfile.Create(keycloakId, displayName);
 		await unitOfWork.Profiles.AddAsync(profile, cancellationToken);
 		await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
+++ b/src/Yumney.Users.Application/Commands/Handlers/UpdateUserProfileCommandHandler.cs
@@ -11,17 +11,19 @@ public sealed class UpdateUserProfileCommandHandler(IUsersUnitOfWork unitOfWork,
 {
 	public async Task<Result<UserProfileDto>> HandleAsync(UpdateUserProfileCommand command, CancellationToken cancellationToken = default)
 	{
+		var (displayName, preferredLanguage, preferredUnitSystem, defaultServings, theme, voiceSettings, notificationPreferences, dietaryProfile) = command;
+
 		var keycloakId = KeycloakUserId.From(currentUser.UserId);
 		var profile = await unitOfWork.Profiles.GetByKeycloakUserIdAsync(keycloakId, cancellationToken);
 
-		if (command.DisplayName is not null) profile.RenameAs(command.DisplayName);
-		if (command.PreferredLanguage is not null) profile.SwitchLanguageTo(command.PreferredLanguage);
-		if (command.PreferredUnitSystem is not null) profile.SwitchUnitSystemTo(command.PreferredUnitSystem);
-		if (command.Theme is not null) profile.SwitchThemeTo(command.Theme);
-		if (command.VoiceSettings is not null) profile.UpdateVoiceSettings(command.VoiceSettings);
-		if (command.NotificationPreferences is not null) profile.UpdateNotificationPreferences(command.NotificationPreferences);
-		profile.AdjustDefaultServingsTo(command.DefaultServings);
-		profile.UpdateDietaryProfile(command.DietaryProfile);
+		if (displayName is not null) profile.RenameAs(displayName);
+		if (preferredLanguage is not null) profile.SwitchLanguageTo(preferredLanguage);
+		if (preferredUnitSystem is not null) profile.SwitchUnitSystemTo(preferredUnitSystem);
+		if (theme is not null) profile.SwitchThemeTo(theme);
+		if (voiceSettings is not null) profile.UpdateVoiceSettings(voiceSettings);
+		if (notificationPreferences is not null) profile.UpdateNotificationPreferences(notificationPreferences);
+		profile.AdjustDefaultServingsTo(defaultServings);
+		profile.UpdateDietaryProfile(dietaryProfile);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecentActivityQueryHandler.cs
@@ -11,13 +11,14 @@ public sealed class GetRecentActivityQueryHandler(IUserActivityRepository activi
 {
 	public async Task<Result<UserActivityPageDto>> HandleAsync(GetRecentActivityQuery query, CancellationToken cancellationToken = default)
 	{
+		var (limit, type, cursor) = query;
 		var owner = currentUser.AsOwner();
 
-		var entries = query.Type is null
-			? await activities.GetRecentByCursorAsync(owner, query.Limit, query.Cursor, cancellationToken)
-			: await activities.GetRecentByTypeAndCursorAsync(owner, query.Type, query.Limit, query.Cursor, cancellationToken);
+		var entries = type is null
+			? await activities.GetRecentByCursorAsync(owner, limit, cursor, cancellationToken)
+			: await activities.GetRecentByTypeAndCursorAsync(owner, type, limit, cursor, cancellationToken);
 
-		var nextCursor = entries.Count == query.Limit.Value
+		var nextCursor = entries.Count == limit.Value
 			? ActivityCursor.From(entries[^1].OccurredAt, entries[^1].Id).Encode()
 			: null;
 

--- a/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
+++ b/src/Yumney.Users.Application/Queries/Handlers/GetRecipeActivityStatsQueryHandler.cs
@@ -11,11 +11,10 @@ public sealed class GetRecipeActivityStatsQueryHandler(IUserActivityRepository a
 {
 	public async Task<Result<RecipeActivityStatsDto>> HandleAsync(GetRecipeActivityStatsQuery query, CancellationToken cancellationToken = default)
 	{
+		var recipe = RecipeIdentifierSnapshot.From(query.RecipeIdentifier);
 		var owner = currentUser.AsOwner();
-		var stats = await activities.GetRecipeStatsAsync(
-			owner,
-			RecipeIdentifierSnapshot.From(query.RecipeIdentifier),
-			cancellationToken);
+
+		var stats = await activities.GetRecipeStatsAsync(owner, recipe, cancellationToken);
 		return Result.Success(stats.ToDto());
 	}
 }

--- a/src/Yumney.Users.Client/UsersClient.cs
+++ b/src/Yumney.Users.Client/UsersClient.cs
@@ -7,15 +7,8 @@ internal sealed class UsersClient(IModuleHttpClientFactory factory) : IUsersClie
 	private readonly IModuleHttpClient http = factory.For("users-api");
 
 	public Task<IReadOnlyList<string>> GetMyStaplesAsync(CancellationToken cancellationToken = default) =>
-		http.GetOrDefaultAsync<IReadOnlyList<string>>(
-			"/api/v1/users/staples",
-			[],
-			"GetStaples",
-			cancellationToken);
+		http.GetOrDefaultAsync<IReadOnlyList<string>>("/api/v1/users/staples", [], "GetStaples", cancellationToken);
 
 	public Task<UsersProfileResponse?> GetMyProfileAsync(CancellationToken cancellationToken = default) =>
-		http.FindAsync<UsersProfileResponse>(
-			"/api/v1/users/me/profile",
-			"GetUserProfile",
-			cancellationToken);
+		http.FindAsync<UsersProfileResponse>("/api/v1/users/me/profile", "GetUserProfile", cancellationToken);
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/AppUserProfileIdentifier.cs
@@ -16,8 +16,7 @@ public sealed record AppUserProfileIdentifier : IValueObject
 
 	public static AppUserProfileIdentifier From(Guid value) => new(value);
 
-	public static AppUserProfileIdentifier? FromNullable(Guid? value) =>
-		value.HasValue ? new AppUserProfileIdentifier(value.Value) : null;
+	public static AppUserProfileIdentifier? FromNullable(Guid? value) => value.HasValue ? new AppUserProfileIdentifier(value.Value) : null;
 
 	public override string ToString() => Value.ToString();
 }

--- a/src/Yumney.Users.Domain/AppUserProfile/CookingEffortPreference.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/CookingEffortPreference.cs
@@ -9,8 +9,7 @@ public sealed record CookingEffortPreference : IValueObject<string>
 	public const int MaxLength = 25;
 
 #pragma warning disable SA1202 // allowedValues must initialize before the public static instances
-	private static readonly string[] allowedValues =
-		["quick-weekdays", "balanced", "elaborate-weekends"];
+	private static readonly string[] allowedValues = ["quick-weekdays", "balanced", "elaborate-weekends"];
 
 	public static readonly CookingEffortPreference QuickWeekdays = new("quick-weekdays");
 	public static readonly CookingEffortPreference Balanced = new("balanced");

--- a/src/Yumney.Users.Domain/AppUserProfile/DefaultServings.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DefaultServings.cs
@@ -21,8 +21,7 @@ public sealed record DefaultServings : IValueObject<int>
 
 	public static DefaultServings From(int value) => new(value);
 
-	public static DefaultServings? FromNullable(int? value) =>
-		value.HasValue ? new DefaultServings(value.Value) : null;
+	public static DefaultServings? FromNullable(int? value) => value.HasValue ? new DefaultServings(value.Value) : null;
 
 	public static implicit operator int(DefaultServings obj) => obj.Value;
 

--- a/src/Yumney.Users.Domain/AppUserProfile/DietaryType.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/DietaryType.cs
@@ -9,8 +9,7 @@ public sealed record DietaryType : IValueObject<string>
 	public const int MaxLength = 20;
 
 #pragma warning disable SA1202 // allowedValues must initialize before the public static instances
-	private static readonly string[] allowedValues =
-		["omnivore", "vegetarian", "vegan", "pescatarian", "flexitarian"];
+	private static readonly string[] allowedValues = ["omnivore", "vegetarian", "vegan", "pescatarian", "flexitarian"];
 
 	public static readonly DietaryType Omnivore = new("omnivore");
 	public static readonly DietaryType Vegetarian = new("vegetarian");

--- a/src/Yumney.Users.Domain/AppUserProfile/WeeklyBalanceGoals.cs
+++ b/src/Yumney.Users.Domain/AppUserProfile/WeeklyBalanceGoals.cs
@@ -32,8 +32,7 @@ public sealed record WeeklyBalanceGoals : IValueObject
 		MaxRedMeatMeals = maxRedMeatMeals;
 	}
 
-	public static WeeklyBalanceGoals From(int? minVeggieMeals, int? maxRedMeatMeals) =>
-		new(minVeggieMeals, maxRedMeatMeals);
+	public static WeeklyBalanceGoals From(int? minVeggieMeals, int? maxRedMeatMeals) => new(minVeggieMeals, maxRedMeatMeals);
 
 	public static readonly WeeklyBalanceGoals None = new(null, null);
 

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.Delete.cs
@@ -17,7 +17,8 @@ public sealed partial class KeycloakAdminService
 
 		var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}";
 
-		var response = await SendAuthenticatedAsync(HttpMethod.Delete, url, null, "delete_user", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
+		var response = await SendAuthenticatedAsync(
+			HttpMethod.Delete, url, null, "delete_user", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
 		if (response.IsFailure)
 		{
 			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.GetEmail.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.GetEmail.cs
@@ -19,7 +19,8 @@ public sealed partial class KeycloakAdminService
 
 		var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}";
 
-		var response = await SendAuthenticatedAsync(HttpMethod.Get, url, null, "get_email", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
+		var response = await SendAuthenticatedAsync(
+			HttpMethod.Get, url, null, "get_email", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
 		if (response.IsFailure)
 		{
 			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);

--- a/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
+++ b/src/Yumney.Users.Infrastructure/Services/KeycloakAdminService.cs
@@ -38,7 +38,11 @@ public sealed partial class KeycloakAdminService(
 	private static readonly SemaphoreSlim tokenRefreshGate = new(1, 1);
 	private static readonly string[] verifyEmailActions = ["VERIFY_EMAIL"];
 
-	public async Task<Result<KeycloakUserId>> CreateUserAsync(Email email, Password password, DisplayName displayName, CancellationToken cancellationToken = default)
+	public async Task<Result<KeycloakUserId>> CreateUserAsync(
+		Email email,
+		Password password,
+		DisplayName displayName,
+		CancellationToken cancellationToken = default)
 	{
 		using var activity = UsersDiagnostics.ActivitySource.StartActivity("keycloak.create_user");
 		activity?.SetTag("keycloak.email", email.Value);
@@ -46,7 +50,8 @@ public sealed partial class KeycloakAdminService(
 		var url = $"/admin/realms/{options.Value.Realm}/users";
 		var content = JsonContent.Create(BuildUserPayload(email, password, displayName), options: jsonOptions);
 
-		var response = await SendAuthenticatedAsync(HttpMethod.Post, url, content, "create_user", RegistrationErrors.IdentityProviderUnavailable, cancellationToken);
+		var response = await SendAuthenticatedAsync(
+			HttpMethod.Post, url, content, "create_user", RegistrationErrors.IdentityProviderUnavailable, cancellationToken);
 		if (response.IsFailure)
 		{
 			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);
@@ -66,7 +71,8 @@ public sealed partial class KeycloakAdminService(
 		var encodedEmail = Uri.EscapeDataString(email.Value);
 		var url = $"/admin/realms/{options.Value.Realm}/users?email={encodedEmail}&exact=true";
 
-		var response = await SendAuthenticatedAsync(HttpMethod.Get, url, null, "search_users", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
+		var response = await SendAuthenticatedAsync(
+			HttpMethod.Get, url, null, "search_users", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
 		if (response.IsFailure)
 		{
 			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);
@@ -98,7 +104,8 @@ public sealed partial class KeycloakAdminService(
 		var url = $"/admin/realms/{options.Value.Realm}/users/{keycloakUserId.Value}/execute-actions-email";
 		var content = JsonContent.Create(verifyEmailActions, options: jsonOptions);
 
-		var response = await SendAuthenticatedAsync(HttpMethod.Put, url, content, "send_verification", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
+		var response = await SendAuthenticatedAsync(
+			HttpMethod.Put, url, content, "send_verification", VerificationErrors.IdentityProviderUnavailable, cancellationToken);
 		if (response.IsFailure)
 		{
 			activity?.SetStatus(ActivityStatusCode.Error, response.Error!.Message);

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using SmartSolutionsLab.Yumney.Shared.Events;
 using SmartSolutionsLab.Yumney.Shared.Events.Wolverine;
 using SmartSolutionsLab.Yumney.Shared.Persistence;
@@ -50,10 +51,26 @@ public static class UsersInfrastructureServiceCollectionExtensions
 		services.AddScoped<IStaplesListRepository>(sp => sp.GetRequiredService<UsersUnitOfWork>().StaplesLists);
 		services.AddScoped<IStaplesProvider, StaplesProvider>();
 
+		// Drop the _http endpoint-name prefix: Aspire 13.3.3 may publish Keycloak
+		// under the "https" endpoint name in dev (HTTPS upgrade), and the prefix
+		// would only match an "http"-named endpoint. The bare service name lets
+		// service discovery pick whichever scheme is published.
 		services.AddHttpClient<IKeycloakAdminService, KeycloakAdminService>(client =>
 		{
-			client.BaseAddress = new Uri("https+http://_http.keycloak");
-		}).AddStandardResilienceHandler();
+			client.BaseAddress = new Uri("https+http://keycloak");
+		})
+			.ConfigurePrimaryHttpMessageHandler(sp =>
+			{
+				var handler = new HttpClientHandler();
+				if (sp.GetRequiredService<IHostEnvironment>().IsDevelopment())
+				{
+					// Aspire dev cert is self-signed; admin calls would otherwise fail TLS.
+					handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+				}
+
+				return handler;
+			})
+			.AddStandardResilienceHandler();
 
 		services.AddHealthChecks().AddDbContextCheck<UsersDbContext>("usersdb");
 


### PR DESCRIPTION
## Summary

- **Style cleanup** across handlers, endpoints, value objects, and shared infrastructure: short guard clauses collapsed to single-line returns, multi-line signatures collapsed (or split back when over 140-char limit), command/query Deconstruct used over repeated `command.X` access, integration-event publishes inlined.
- **AppHost simplification**: early-return on `DatabaseOnly` removes a 200-line wrapper indent; `ConfigureContainerApp` local function extracted to a `PublishAsScaledContainerApp(min, max, concurrentRequests?)` extension (Project + Container overloads); `else if (!isRunMode)` collapsed to `else`; `AddShoppingAndMealPlanResetEntries` renamed to honest `AddResetEntries`.
- **Solution layout**: `/src/Host/` split — `Yumney.AppHost` + `Yumney.ServiceDefaults` stay there; `Yumney.Gateway`, `Yumney.Mcp.Server`, `Yumney.MigrationRunner` move to a new `/src/Common/` folder.
- **NuGet upgrades**: Aspire 13.3.0 → 13.3.3 (preview packages → matching 13.3.3-preview.1.26264.13); Microsoft.* patches 10.0.7 → 10.0.8 across EF Core, ASP.NET extensions, configuration, DI, hosting, logging, test host; Resilience/ServiceDiscovery 10.5.0 → 10.6.0; OpenTelemetry instrumentation patches; SemanticKernel 1.74 → 1.76; Wolverine 5.31.1 → 5.39.2; Scalar 2.14.1 → 2.14.14; Test.Sdk 18.4 → 18.5.1; FluentAssertions 8.9 → 8.10; coverlet.collector 8 → 10; TimeProvider.Testing 9 → 10. CommunityToolkit.Ollama pinned to 13.3.0 (no newer release); StyleCop.Analyzers stays on its existing pin.
- **Keycloak resolver fix** for Aspire 13.3.3: the new HTTPS-endpoint upgrade publishes Keycloak under `services:keycloak:https:0` instead of (or in addition to) `:http:0`. Without adapting, every API rejected JWTs (`SecurityTokenSignatureKeyNotFoundException` because JWKS discovery hit a dead URL) and the `KeycloakAdminService` HttpClient hung for 30s on DNS for a name-prefixed endpoint that no longer exists. `KeycloakDefaults.GetBaseUrl` (+ MCP's local copy) now falls back to `:https:0`, JwtBearer wiring adds a Development-only `BackchannelHttpHandler` that skips TLS validation against the self-signed dev cert, and the admin HttpClient drops the `_http` endpoint-name prefix and gains the same dev cert bypass.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] Full local test suite — **3127 / 3127 pass** across all 22 test projects, including the 295-test Aspire integration suite (was 143 failing on the bare Aspire bump before the resolver fix landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)