### PR TITLE
refactor(frontend): modern Angular APIs + VoiceService dedup

### DIFF
--- a/client/apps/shell/src/app/docs-mcp/docs-mcp.component.ts
+++ b/client/apps/shell/src/app/docs-mcp/docs-mcp.component.ts
@@ -1,4 +1,5 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslocoModule } from '@jsverse/transloco';
 import { DiscoveredCapabilitiesService } from './discovered-capabilities.service';
 import { DiscoveredCapability } from './discovered-capability';
@@ -37,9 +38,13 @@ export class DocsMcpComponent implements OnInit {
   protected readonly toolsLoading = computed(() => this.tools() === null);
 
   private readonly capabilitiesService = inject(DiscoveredCapabilitiesService);
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.capabilitiesService.fetchMcpTools().subscribe((tools) => this.tools.set(tools));
+    this.capabilitiesService
+      .fetchMcpTools()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((tools) => this.tools.set(tools));
   }
 
   copyDesktopConfig(): void {

--- a/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-suggestion-panel/meal-suggestion-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
 import { concat, last, toArray } from 'rxjs';
@@ -8,7 +8,6 @@ import { AsyncStateComponent } from '@yumney/ui';
 
 @Component({
   selector: 'yn-meal-suggestion-panel',
-  standalone: true,
   imports: [TranslocoModule, LucideAngularModule, AsyncStateComponent],
   templateUrl: './meal-suggestion-panel.component.html',
   styleUrl: './meal-suggestion-panel.component.scss',
@@ -19,10 +18,10 @@ export class MealSuggestionPanelComponent {
   private suggestState = createAsyncState();
   private acceptState = createAsyncState();
 
-  @Input({ required: true }) year = 0;
-  @Input({ required: true }) week = 0;
+  readonly year = input.required<number>();
+  readonly week = input.required<number>();
 
-  @Output() planAccepted = new EventEmitter<void>();
+  readonly planAccepted = output<void>();
 
   protected suggestion = signal<WeekSuggestion | null>(null);
   protected loading = this.suggestState.isLoading;
@@ -32,7 +31,7 @@ export class MealSuggestionPanelComponent {
 
   protected onSuggest(): void {
     this.suggestion.set(null);
-    this.suggestState.execute(this.api.suggestWeekPlan(this.year, this.week), ERROR_MAPS.mealPlanner.suggestWeek, (result) =>
+    this.suggestState.execute(this.api.suggestWeekPlan(this.year(), this.week()), ERROR_MAPS.mealPlanner.suggestWeek, (result) =>
       this.suggestion.set(result),
     );
   }
@@ -50,7 +49,7 @@ export class MealSuggestionPanelComponent {
     // ConcurrencyConflictException on all but the first write. `concat`
     // chains the assigns in order; `last` waits for the final response.
     const assignments = entries.map((entry) =>
-      this.api.assignRecipe(this.year, this.week, {
+      this.api.assignRecipe(this.year(), this.week(), {
         day: entry.day,
         recipeIdentifier: entry.recipeIdentifier,
         recipeTitle: entry.recipeTitle,

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -108,33 +108,13 @@ export class VoiceService {
   }
 
   startListening(onCommand: (command: VoiceCommand) => void): void {
-    if (!this.sttSupported() || this.isListening()) {
-      return;
-    }
-    const recognition = this.createRecognition();
-    if (!recognition) return;
-
-    recognition.lang = this.currentLang;
-    recognition.continuous = true;
-    recognition.interimResults = false;
-    recognition.onresult = (event) => {
-      const last = event.results[event.results.length - 1];
-      const transcript = last[0]?.transcript?.trim() ?? '';
-      const command = VoiceService.parseCommand(transcript);
-      if (command) {
-        onCommand(command);
-      }
-    };
-    recognition.onerror = () => {
-      this.isListening.set(false);
-    };
-    recognition.onend = () => {
-      this.isListening.set(false);
-    };
-
-    this.recognition = recognition;
-    recognition.start();
-    this.isListening.set(true);
+    this.beginSession({
+      continuous: true,
+      onTranscript: (transcript) => {
+        const command = VoiceService.parseCommand(transcript);
+        if (command) onCommand(command);
+      },
+    });
   }
 
   stopListening(): void {
@@ -158,36 +138,18 @@ export class VoiceService {
    * fire the local timer, not a chat round-trip.
    */
   startListeningWithFallback(onCommand: (command: VoiceCommand) => void, onTranscript: (transcript: string) => void): void {
-    if (!this.sttSupported() || this.isListening()) {
-      return;
-    }
-    const recognition = this.createRecognition();
-    if (!recognition) return;
-
-    recognition.lang = this.currentLang;
-    recognition.continuous = true;
-    recognition.interimResults = false;
-    recognition.onresult = (event) => {
-      const last = event.results[event.results.length - 1];
-      const transcript = last[0]?.transcript?.trim() ?? '';
-      if (transcript === '') return;
-      const command = VoiceService.parseCommand(transcript);
-      if (command) {
-        onCommand(command);
-        return;
-      }
-      onTranscript(transcript);
-    };
-    recognition.onerror = () => {
-      this.isListening.set(false);
-    };
-    recognition.onend = () => {
-      this.isListening.set(false);
-    };
-
-    this.recognition = recognition;
-    recognition.start();
-    this.isListening.set(true);
+    this.beginSession({
+      continuous: true,
+      onTranscript: (transcript) => {
+        if (transcript === '') return;
+        const command = VoiceService.parseCommand(transcript);
+        if (command) {
+          onCommand(command);
+          return;
+        }
+        onTranscript(transcript);
+      },
+    });
   }
 
   /**
@@ -207,43 +169,58 @@ export class VoiceService {
    * a "didn't catch that" hint to the user — AC TC-360-05.
    */
   startListeningForTranscript(onTranscript: (transcript: string) => void, onNoSpeech?: () => void): void {
-    if (!this.sttSupported() || this.isListening()) {
-      return;
-    }
+    let gotTranscript = false;
+    this.beginSession({
+      continuous: false,
+      onTranscript: (transcript) => {
+        if (transcript !== '') {
+          gotTranscript = true;
+          onTranscript(transcript);
+        }
+      },
+      // 'no-speech' is the browser's "silence timeout" signal; surface it
+      // to the caller so the UI can prompt "didn't catch that". Other
+      // errors (aborted, audio-capture, not-allowed, network) are not
+      // no-speech — leave them to the silent failure path the chat panel
+      // already handles via lastInputWasVoice reset.
+      onError: (event) => {
+        if (event.error === 'no-speech' && !gotTranscript) onNoSpeech?.();
+      },
+      // Some browsers (Chromium on Android) fire onend without an explicit
+      // 'no-speech' onerror when the silence timeout elapses. Cover that
+      // path too.
+      onEnd: () => {
+        if (!gotTranscript) onNoSpeech?.();
+      },
+    });
+  }
+
+  private beginSession(config: {
+    continuous: boolean;
+    onTranscript: (transcript: string) => void;
+    onError?: (event: { error: string }) => void;
+    onEnd?: () => void;
+  }): void {
+    if (!this.sttSupported() || this.isListening()) return;
+
     const recognition = this.createRecognition();
     if (!recognition) return;
 
-    let gotTranscript = false;
     recognition.lang = this.currentLang;
-    recognition.continuous = false;
+    recognition.continuous = config.continuous;
     recognition.interimResults = false;
     recognition.onresult = (event) => {
       const last = event.results[event.results.length - 1];
       const transcript = last[0]?.transcript?.trim() ?? '';
-      if (transcript !== '') {
-        gotTranscript = true;
-        onTranscript(transcript);
-      }
+      config.onTranscript(transcript);
     };
     recognition.onerror = (event) => {
       this.isListening.set(false);
-      // 'no-speech' is the browser's "silence timeout" signal; surface it
-      // to the caller so the UI can prompt "didn't catch that".
-      // Other errors (aborted, audio-capture, not-allowed, network) are
-      // not no-speech — leave them to the silent failure path the chat
-      // panel already handles via lastInputWasVoice reset.
-      if (event.error === 'no-speech' && !gotTranscript) {
-        onNoSpeech?.();
-      }
+      config.onError?.(event);
     };
     recognition.onend = () => {
       this.isListening.set(false);
-      // Some browsers (Chromium on Android) fire onend without an explicit
-      // 'no-speech' onerror when the silence timeout elapses. Cover that
-      // path too.
-      if (!gotTranscript) {
-        onNoSpeech?.();
-      }
+      config.onEnd?.();
     };
 
     this.recognition = recognition;


### PR DESCRIPTION
## Summary

Two small frontend cleanups, both verified end-to-end with the existing test suites:

- **`MealSuggestionPanelComponent` migrated to the modern signal-based author API.** `@Input({required:true})` → `input.required<number>()`, `@Output() planAccepted = new EventEmitter<void>()` → `output<void>()`. This was the last decorator-based `@Output()` in `apps/shell` — the rest of the shell is now uniformly on the new APIs. The component's spec already used `componentRef.setInput()` and `componentInstance.planAccepted.subscribe()`, both of which continue to work unchanged.
- **`DocsMcpComponent` adds `takeUntilDestroyed` to the MCP-tools fetch.** HTTP auto-completes so there's no leak today, but the subscription was the only callsite in the production frontend that didn't follow the project's "always pipe to `takeUntilDestroyed`" pattern, and a fast nav-away would still `.set()` on a destroyed signal.
- **`VoiceService` extracts a private `beginSession(config)`.** Three public `startListening*` entry points each repeated ~22 lines of `SpeechRecognition` wiring (sttSupported guard, lang, continuous/interimResults, onresult/onerror/onend boilerplate, recognition.start, `isListening` flip). Pulled into one place; the public methods now each express only their own behaviour. **281 → 258 lines, ~30 lines of triplicated boilerplate gone.**

## Audit notes

I scanned every `.subscribe()` callsite in `client/apps/**` and `client/libs/**`. After the `DocsMcpComponent` fix, every remaining production subscribe is either:

- already piped through `takeUntilDestroyed(this.destroyRef)`, or
- in a `@Injectable({ providedIn: 'root' })` singleton (no destroy event, no leak)

I also checked: 341 frontend `.ts`/`.html` files, **zero** over the 300-line cap; **zero** `@Input()` left in apps; **one** `@Output()` (this PR removes it); **zero** `@ViewChild()` (all migrated); **zero** TODO/FIXME, console.log debris, or direct `document.querySelector` access in production code.

## Test plan

- [x] `yarn nx test shared-models` — 237 / 237 pass
- [x] `yarn nx test shell` — 268 / 268 pass
- [x] `yarn nx test ui` — 318 / 318 pass
- [x] `yarn nx test recipes` — 213 / 213 pass (cook-mode exercises `startListeningWithFallback`)
- [x] `yarn nx lint shell` — pre-existing 1 warning, zero new

🤖 Generated with [Claude Code](https://claude.com/claude-code)