### PR TITLE
refactor(frontend): tighten MFE api facades

### DIFF
--- a/client/apps/account/src/app/api.ts
+++ b/client/apps/account/src/app/api.ts
@@ -1,6 +1,11 @@
 // MFE facade. This is the only place the account MFE imports from the
 // per-backend api libs. Grow this list as the MFE needs more; the
 // no-restricted-imports rule in the root ESLint config keeps direct
-// imports out of account/**.
+// imports out of account/**. Group new exports under the originating
+// backend so the cross-MFE coupling stays visible at a glance.
+
+// --- User profile (primary surface) ---
 export { UserProfileApiService, type UserProfile, type UpdateProfileRequest } from '@yumney/shared/api-user-profile';
+
+// --- Dashboard (paged user activity log) ---
 export { ActivityApiService, type UserActivityItem, type UserActivityPage, type ActivityTypeKey } from '@yumney/shared/api-dashboard';

--- a/client/apps/recipes/src/app/api.ts
+++ b/client/apps/recipes/src/app/api.ts
@@ -1,7 +1,10 @@
 // MFE facade. This is the only place the recipes MFE imports from the
 // per-backend api libs. Grow this list as the MFE needs more; the
 // no-restricted-imports rule in the root ESLint config keeps direct
-// imports out of recipes/**.
+// imports out of recipes/**. Group new exports under the originating
+// backend so the cross-MFE coupling stays visible at a glance.
+
+// --- Recipes (primary surface) ---
 export {
   RecipeApiService,
   type RecipeListItem,
@@ -14,7 +17,15 @@ export {
   type CookableRecipeMatchTier,
   type GetCookableRecipesParams,
 } from '@yumney/shared/api-recipes';
+
+// --- MealPlan (assignment from recipe list) ---
 export { MealPlanApiService } from '@yumney/shared/api-meal-plan';
+
+// --- Shopping (create-shopping-list-from-recipes flow) ---
 export { ShoppingApiService, type CreateShoppingListItem, type ShoppingListDetail } from '@yumney/shared/api-shopping';
+
+// --- Dashboard (per-recipe activity stats on detail page) ---
 export { ActivityApiService, type RecipeActivityStats } from '@yumney/shared/api-dashboard';
-export { ChatApiService, type ChatResponse, type ChatRecipeSuggestion } from '@yumney/shared/chat-api';
+
+// --- Chat (conversational recipe search) ---
+export { ChatApiService, type ChatRecipeSuggestion } from '@yumney/shared/chat-api';

--- a/client/apps/shopping/src/app/api.ts
+++ b/client/apps/shopping/src/app/api.ts
@@ -1,8 +1,10 @@
 // MFE facade. This is the only place the shopping MFE imports from the
 // per-backend api libs. Grow this list as the MFE needs more; the
 // no-restricted-imports rule in the root ESLint config keeps direct
-// imports out of shopping/**.
-export { RecipeApiService, type RecipeDetail } from '@yumney/shared/api-recipes';
+// imports out of shopping/**. Group new exports under the originating
+// backend so the cross-MFE coupling stays visible at a glance.
+
+// --- Shopping (primary surface) ---
 export {
   ShoppingApiService,
   type ShoppingListDetail,
@@ -19,3 +21,6 @@ export {
   type IngredientBalanceSource,
   type MarkAsFrozenRequest,
 } from '@yumney/shared/api-shopping';
+
+// --- Recipes (source recipe for the create-from-recipe flow) ---
+export { RecipeApiService, type RecipeDetail } from '@yumney/shared/api-recipes';

--- a/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
+++ b/client/apps/shopping/src/app/shopping-create/shopping-create.component.ts
@@ -1,8 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { RecipeApiService, RecipeDetail } from '../api';
-import { ShoppingApiService, CreateShoppingListItem } from '../api';
+import { CreateShoppingListItem, RecipeApiService, RecipeDetail, ShoppingApiService } from '../api';
 import { createAsyncState, ERROR_MAPS, ROUTES, VALIDATION } from '@yumney/shared/models';
 import { BackLinkComponent, LoadingSpinnerComponent, MessageBannerComponent } from '@yumney/ui';
 


### PR DESCRIPTION
## Summary

Follow-up to the per-backend api-lib split (#782). Each MFE's `app/api.ts` now re-exports from multiple shared libs; group the re-exports by originating backend with a one-line section header per group so the cross-MFE coupling is visible at a glance:

- **Recipes MFE**: primary recipes surface + (MealPlan, Shopping, Dashboard, Chat) as four labelled groups
- **Shopping MFE**: primary shopping surface + Recipes (source recipe for the create-from-recipe flow)
- **Account MFE**: primary user-profile surface + Dashboard activity log

Also two small cleanups:

- Dropped one **dead re-export** — `ChatResponse` was exported from the recipes facade but never imported anywhere in `apps/recipes/`. Only `ChatApiService` and `ChatRecipeSuggestion` are actually used.
- Combined the **two `from '../api'` imports** in `shopping-create.component.ts` (the only file in `apps/*` with that pattern) into one consolidated import.

Audit confirmed:

- 0 files in `apps/*` bypass the facade and import directly from `@yumney/shared/api-*`
- 0 files in `apps/*` have multiple `from '../api'` import statements
- All re-exports are used by at least one file in their owning MFE (shopping facade: every export has 1-11 usages; recipes facade: every export now used after dropping `ChatResponse`)

## Test plan

- [x] `yarn nx test recipes` — green
- [x] `yarn nx test shopping` — green
- [x] `yarn prettier --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)