### PR TITLE
refactor(frontend): extract ImportPanel sub-component from dashboard

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,9 +53,9 @@
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="RedisRateLimiting" Version="1.2.1" />
-    <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.39.2" />
-    <PackageVersion Include="WolverineFx.Postgresql" Version="5.39.2" />
-    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.39.2" />
+    <PackageVersion Include="WolverineFx.RabbitMQ" Version="5.39.3" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.39.3" />
+    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.39.3" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />

--- a/client/apps/shell/src/app/dashboard/dashboard.component.html
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.html
@@ -15,10 +15,6 @@
     <lucide-icon name="chevron-right" [size]="20" class="cookable-shortcut-chevron" />
   </a>
 
-  @if (serverError(); as error) {
-    <yn-message-banner tone="error" [message]="error" />
-  }
-
   @if (quickActions().length > 0) {
     <yn-quick-actions [actions]="quickActions()" (actionClicked)="onQuickAction($event)" />
   }
@@ -46,117 +42,9 @@
     </section>
   }
 
-  <section class="import-section" data-testid="import-section" [class.expanded]="importSectionExpanded()">
-    <button
-      class="import-toggle"
-      data-testid="import-toggle"
-      [attr.data-expanded]="importSectionExpanded()"
-      (click)="toggleImportSection()"
-    >
-      <h2>{{ t('dashboard.import.sectionTitle') }}</h2>
-      <span class="toggle-chevron" [class.open]="importSectionExpanded()">
-        <lucide-icon name="chevron-down" [size]="18" />
-      </span>
-    </button>
-
-    @if (importSectionExpanded()) {
-      <div class="import-content">
-        <yn-url-import
-          [isSaving]="isSaving()"
-          (importStarted)="onUrlImportStarted()"
-          (extracted)="onUrlExtracted($event)"
-          (failed)="onUrlImportFailed($event)"
-        />
-
-        <section class="photo-import">
-          <h3>{{ t('dashboard.photoImport.title') }}</h3>
-          <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
-          <div class="photo-import-actions">
-            @if (camera.cameraSupported()) {
-              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
-                {{ t('dashboard.photoImport.scanRecipe') }}
-              </yn-button>
-              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
-                {{ t('dashboard.photoImport.scanIngredients') }}
-              </yn-button>
-            }
-            <label class="btn-dashed" data-testid="photo-upload-btn" [class.disabled]="isLoading() || isSaving()">
-              <input
-                type="file"
-                data-testid="photo-upload-input"
-                accept="image/jpeg,image/png,image/webp"
-                multiple
-                [disabled]="isLoading() || isSaving()"
-                (change)="onImportFromPhotos($event)"
-                hidden
-              />
-              @if (isLoading()) {
-                <span class="btn-spinner"></span>
-                <span>{{ t('dashboard.photoImport.extracting') }}</span>
-              } @else {
-                <span>{{ t('dashboard.photoImport.submit') }}</span>
-              }
-            </label>
-          </div>
-          <p class="hint">{{ t('dashboard.photoImport.hint') }}</p>
-        </section>
-
-        <section class="manual-create">
-          <h3>{{ t('dashboard.create.title') }}</h3>
-          <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
-          <yn-button
-            variant="dashed"
-            extraClass="create-btn"
-            testId="create-recipe-btn"
-            [disabled]="isLoading() || isSaving() || !!extractedRecipe()"
-            (click)="onCreateManually()"
-          >
-            {{ t('dashboard.create.submit') }}
-          </yn-button>
-        </section>
-      </div>
-    }
-  </section>
-
-  @if (saveSuccess(); as savedTitle) {
-    <div class="save-success">
-      <yn-message-banner tone="success" message="dashboard.save.success" [params]="{ title: savedTitle }" testId="success-banner" />
-      <yn-button variant="ghost" extraClass="import-another" (click)="onImportAnother()">
-        {{ t('dashboard.save.importAnother') }}
-      </yn-button>
-    </div>
-  }
-  @if (extractedRecipe()) {
-    <yn-recipe-preview
-      [recipe]="extractedRecipe()!"
-      [isSaving]="isSaving()"
-      [previewTitle]="isManualEntry() ? t('dashboard.create.previewTitle') : undefined"
-      (save)="onSaveRecipe($event)"
-      (discard)="onDiscardRecipe()"
-    />
-  }
+  <yn-import-panel [sharedUrl]="sharedUrl()" (recipeSaved)="onRecipeSaved($event)" />
 
   @if (recentActivity().length > 0) {
     <yn-recent-activity [activities]="recentActivity()" />
-  }
-
-  @if (cameraActive()) {
-    @defer {
-      <yn-camera-capture
-        (capturedReady)="onCameraCaptured($event)"
-        (cancelled)="onCameraCancelled()"
-        (fallbackRequested)="onCameraFallback()"
-      />
-    }
-  }
-
-  @if (scannerActive()) {
-    @defer {
-      <yn-ingredient-scanner (ingredientsConfirmed)="onIngredientsConfirmed($event)" (cancelled)="onScannerCancelled()" />
-    }
-  }
-
-  @if (recognizedIngredients(); as ingredients) {
-    <yn-ingredients-toast [ingredients]="ingredients" (dismissed)="dismissRecognizedIngredients()" />
   }
 </div>

--- a/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.spec.ts
@@ -1,9 +1,11 @@
 import { provideYumneyIcons } from '@yumney/ui';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
+import { ImportPanelComponent } from '../integrations/recipes/import-panel/import-panel.component';
 import { setupTranslocoTesting, UI } from '@yumney/shared/models';
 import { DashboardApiService } from '@yumney/shared/api-dashboard';
 import { RecipeApiService, ImportRecipeResponse, SavedRecipeResponse } from '@yumney/shared/api-recipes';
@@ -79,6 +81,7 @@ const en = {
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
+  let importPanel: ImportPanelComponent;
   let fixture: ComponentFixture<DashboardComponent>;
   let recipeApiMock: {
     importRecipe: ReturnType<typeof vi.fn>;
@@ -121,6 +124,7 @@ describe('DashboardComponent', () => {
     fixture = TestBed.createComponent(DashboardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    importPanel = fixture.debugElement.query(By.directive(ImportPanelComponent)).componentInstance as ImportPanelComponent;
   });
 
   it('should create the component', () => {
@@ -143,14 +147,14 @@ describe('DashboardComponent', () => {
   // ── Extracted recipe orchestration ─────────────────────────────────────────
 
   it('should store extracted recipe and sourceUrl when child emits extracted', () => {
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
 
-    expect(component.extractedRecipe()).toEqual(mockRecipe);
-    expect(component.sourceUrl()).toBe('https://example.com/recipe');
+    expect(importPanel.extractedRecipe()).toEqual(mockRecipe);
+    expect(importPanel.sourceUrl()).toBe('https://example.com/recipe');
   });
 
   it('should show recipe preview after extraction', () => {
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('yn-recipe-preview')).toBeTruthy();
@@ -161,23 +165,23 @@ describe('DashboardComponent', () => {
   });
 
   it('should set serverError when child emits failed', () => {
-    component.onUrlImportFailed('dashboard.import.errors.generic');
+    importPanel.onUrlImportFailed('dashboard.import.errors.generic');
 
-    expect(component.serverError()).toBe('dashboard.import.errors.generic');
+    expect(importPanel.serverError()).toBe('dashboard.import.errors.generic');
   });
 
   it('should clear stale state when child emits importStarted', () => {
-    component.extractedRecipe.set(mockRecipe);
-    component.serverError.set('dashboard.import.errors.generic');
-    component.saveSuccess.set('Pasta');
-    component.isManualEntry.set(true);
+    importPanel.extractedRecipe.set(mockRecipe);
+    importPanel.serverError.set('dashboard.import.errors.generic');
+    importPanel.saveSuccess.set('Pasta');
+    importPanel.isManualEntry.set(true);
 
-    component.onUrlImportStarted();
+    importPanel.onUrlImportStarted();
 
-    expect(component.extractedRecipe()).toBeNull();
-    expect(component.serverError()).toBeNull();
-    expect(component.saveSuccess()).toBeNull();
-    expect(component.isManualEntry()).toBe(false);
+    expect(importPanel.extractedRecipe()).toBeNull();
+    expect(importPanel.serverError()).toBeNull();
+    expect(importPanel.saveSuccess()).toBeNull();
+    expect(importPanel.isManualEntry()).toBe(false);
   });
 
   // ── Save flow ──────────────────────────────────────────────────────────────
@@ -190,8 +194,8 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
     expect(recipeApiMock.saveRecipe).toHaveBeenCalled();
@@ -205,11 +209,11 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(component.saveSuccess()).toBe('Pasta Carbonara');
+    expect(importPanel.saveSuccess()).toBe('Pasta Carbonara');
     expect(routerMock.navigate).not.toHaveBeenCalled();
 
     tick(UI.SAVED_INDICATOR_MS);
@@ -223,8 +227,8 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick(UI.SAVED_INDICATOR_MS);
 
     expect(routerMock.navigate).toHaveBeenCalledWith(['/recipes/123']);
@@ -238,44 +242,44 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
-    component.onDiscardRecipe();
+    importPanel.onDiscardRecipe();
     tick(UI.SAVED_INDICATOR_MS);
 
     expect(routerMock.navigate).not.toHaveBeenCalled();
-    expect(component.saveSuccess()).toBeNull();
+    expect(importPanel.saveSuccess()).toBeNull();
   }));
 
   it('should show duplicate error on 409 response', fakeAsync(() => {
     recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 409 })));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(component.serverError()).toBe('dashboard.save.errors.duplicate');
+    expect(importPanel.serverError()).toBe('dashboard.save.errors.duplicate');
   }));
 
   it('should show generic save error on 500 response', fakeAsync(() => {
     recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(component.serverError()).toBe('dashboard.save.errors.generic');
+    expect(importPanel.serverError()).toBe('dashboard.save.errors.generic');
   }));
 
   it('should set isSaving during save operation', fakeAsync(() => {
     const subject = new Subject<SavedRecipeResponse>();
     recipeApiMock.saveRecipe.mockReturnValue(subject);
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
-    expect(component.isSaving()).toBe(true);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
+    expect(importPanel.isSaving()).toBe(true);
 
     subject.next({
       identifier: '123',
@@ -285,7 +289,7 @@ describe('DashboardComponent', () => {
     subject.complete();
     tick();
 
-    expect(component.isSaving()).toBe(false);
+    expect(importPanel.isSaving()).toBe(false);
   }));
 
   it('should call saveRecipe without sourceUrl when sourceUrl is null', fakeAsync(() => {
@@ -296,8 +300,8 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.extractedRecipe.set(mockRecipe);
-    component.onSaveRecipe(mockRecipe);
+    importPanel.extractedRecipe.set(mockRecipe);
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
     expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.not.objectContaining({ sourceUrl: expect.anything() }));
@@ -311,8 +315,8 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
     expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.objectContaining({ sourceUrl: 'https://example.com/recipe' }));
@@ -326,8 +330,8 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
     expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(
@@ -353,60 +357,60 @@ describe('DashboardComponent', () => {
   it('should set isSaving to false after save error', fakeAsync(() => {
     recipeApiMock.saveRecipe.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
     tick();
 
-    expect(component.isSaving()).toBe(false);
+    expect(importPanel.isSaving()).toBe(false);
   }));
 
   it('should clear serverError when starting a save', fakeAsync(() => {
-    component.serverError.set('previous error');
+    importPanel.serverError.set('previous error');
     recipeApiMock.saveRecipe.mockReturnValue(of({ identifier: '1', title: 'X', createdAt: '2026-03-10T00:00:00Z' } as SavedRecipeResponse));
 
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    component.onSaveRecipe(mockRecipe);
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onSaveRecipe(mockRecipe);
 
-    expect(component.serverError()).toBeNull();
+    expect(importPanel.serverError()).toBeNull();
     tick();
   }));
 
   // ── Discard flow ───────────────────────────────────────────────────────────
 
   it('should clear extracted recipe on discard', () => {
-    component.extractedRecipe.set(mockRecipe);
+    importPanel.extractedRecipe.set(mockRecipe);
 
-    component.onDiscardRecipe();
+    importPanel.onDiscardRecipe();
 
-    expect(component.extractedRecipe()).toBeNull();
+    expect(importPanel.extractedRecipe()).toBeNull();
   });
 
   it('should hide recipe preview after discard', () => {
-    component.extractedRecipe.set(mockRecipe);
+    importPanel.extractedRecipe.set(mockRecipe);
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('yn-recipe-preview')).toBeTruthy();
 
-    component.onDiscardRecipe();
+    importPanel.onDiscardRecipe();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('yn-recipe-preview')).toBeNull();
   });
 
   it('should clear serverError on discard', () => {
-    component.serverError.set('dashboard.save.errors.generic');
+    importPanel.serverError.set('dashboard.save.errors.generic');
 
-    component.onDiscardRecipe();
+    importPanel.onDiscardRecipe();
 
-    expect(component.serverError()).toBeNull();
+    expect(importPanel.serverError()).toBeNull();
   });
 
   it('should reset isManualEntry on discard', () => {
-    component.onCreateManually();
-    expect(component.isManualEntry()).toBe(true);
+    importPanel.onCreateManually();
+    expect(importPanel.isManualEntry()).toBe(true);
 
-    component.onDiscardRecipe();
+    importPanel.onDiscardRecipe();
 
-    expect(component.isManualEntry()).toBe(false);
+    expect(importPanel.isManualEntry()).toBe(false);
   });
 
   // ── Manual create ──────────────────────────────────────────────────────────
@@ -426,9 +430,9 @@ describe('DashboardComponent', () => {
   });
 
   it('should set empty recipe template on create manually', () => {
-    component.onCreateManually();
+    importPanel.onCreateManually();
 
-    const recipe = component.extractedRecipe();
+    const recipe = importPanel.extractedRecipe();
     if (!recipe) throw new Error('extractedRecipe should be set after onCreateManually');
     expect(recipe.title).toBe('');
     expect(recipe.ingredients).toHaveLength(1);
@@ -436,9 +440,9 @@ describe('DashboardComponent', () => {
   });
 
   it('should set isManualEntry on create manually', () => {
-    component.onCreateManually();
+    importPanel.onCreateManually();
 
-    expect(component.isManualEntry()).toBe(true);
+    expect(importPanel.isManualEntry()).toBe(true);
   });
 
   it('should navigate after saving manual recipe', fakeAsync(() => {
@@ -449,10 +453,10 @@ describe('DashboardComponent', () => {
     };
     recipeApiMock.saveRecipe.mockReturnValue(of(savedResponse));
 
-    component.onCreateManually();
-    const draft = component.extractedRecipe();
+    importPanel.onCreateManually();
+    const draft = importPanel.extractedRecipe();
     if (!draft) throw new Error('extractedRecipe should be set after onCreateManually');
-    component.onSaveRecipe({ ...draft, title: 'My Recipe' });
+    importPanel.onSaveRecipe({ ...draft, title: 'My Recipe' });
     tick(UI.SAVED_INDICATOR_MS);
 
     expect(recipeApiMock.saveRecipe).toHaveBeenCalledWith(expect.not.objectContaining({ sourceUrl: expect.anything() }));
@@ -460,7 +464,7 @@ describe('DashboardComponent', () => {
   }));
 
   it('should disable create button while loading', () => {
-    component.isLoading.set(true);
+    importPanel.isLoading.set(true);
     fixture.detectChanges();
 
     const btn = fixture.nativeElement.querySelector('.create-btn');
@@ -471,10 +475,10 @@ describe('DashboardComponent', () => {
     const subject = new Subject<SavedRecipeResponse>();
     recipeApiMock.saveRecipe.mockReturnValue(subject);
 
-    component.onCreateManually();
-    const draft = component.extractedRecipe();
+    importPanel.onCreateManually();
+    const draft = importPanel.extractedRecipe();
     if (!draft) throw new Error('extractedRecipe should be set after onCreateManually');
-    component.onSaveRecipe(draft);
+    importPanel.onSaveRecipe(draft);
     fixture.detectChanges();
 
     const btn = fixture.nativeElement.querySelector('.create-btn');
@@ -490,26 +494,26 @@ describe('DashboardComponent', () => {
   }));
 
   it('should clear sourceUrl when creating manually after import', () => {
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
-    expect(component.sourceUrl()).toBe('https://example.com/recipe');
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    expect(importPanel.sourceUrl()).toBe('https://example.com/recipe');
 
-    component.onCreateManually();
+    importPanel.onCreateManually();
 
-    expect(component.sourceUrl()).toBeNull();
+    expect(importPanel.sourceUrl()).toBeNull();
   });
 
   it('should clear serverError and saveSuccess on create manually', () => {
-    component.serverError.set('dashboard.save.errors.generic');
-    component.saveSuccess.set('Pasta');
+    importPanel.serverError.set('dashboard.save.errors.generic');
+    importPanel.saveSuccess.set('Pasta');
 
-    component.onCreateManually();
+    importPanel.onCreateManually();
 
-    expect(component.serverError()).toBeNull();
-    expect(component.saveSuccess()).toBeNull();
+    expect(importPanel.serverError()).toBeNull();
+    expect(importPanel.saveSuccess()).toBeNull();
   });
 
   it('should disable create button when recipe preview is shown', () => {
-    component.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
+    importPanel.onUrlExtracted({ recipe: mockRecipe, sourceUrl: 'https://example.com/recipe' });
     fixture.detectChanges();
 
     const btn = fixture.nativeElement.querySelector('.create-btn');
@@ -549,7 +553,7 @@ describe('DashboardComponent', () => {
   it('should expand the import section for any other quick action', () => {
     component.onQuickAction('try_something_new');
 
-    expect(component.importSectionExpanded()).toBe(true);
+    expect(importPanel.importSectionExpanded()).toBe(true);
     expect(routerMock.navigate).not.toHaveBeenCalled();
   });
 });
@@ -593,7 +597,9 @@ describe('DashboardComponent – Share Intent', () => {
     });
 
     const fixture = TestBed.createComponent(DashboardComponent);
-    return { fixture, component: fixture.componentInstance };
+    fixture.detectChanges();
+    const importPanelEl = fixture.debugElement.query(By.directive(ImportPanelComponent));
+    return { fixture, component: fixture.componentInstance, importPanel: importPanelEl?.componentInstance as ImportPanelComponent };
   }
 
   /**
@@ -610,7 +616,7 @@ describe('DashboardComponent – Share Intent', () => {
   }
 
   it('should auto-start import when ?url query param is provided', fakeAsync(() => {
-    const { fixture } = createComponentWithQueryParams({ url: 'https://example.com/recipe' });
+    const { fixture, importPanel } = createComponentWithQueryParams({ url: 'https://example.com/recipe' });
 
     runShareFlow(fixture);
 
@@ -618,17 +624,17 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should set extractedRecipe after share-import succeeds', fakeAsync(() => {
-    const { fixture, component } = createComponentWithQueryParams({
+    const { fixture, component, importPanel } = createComponentWithQueryParams({
       url: 'https://example.com/recipe',
     });
 
     runShareFlow(fixture);
 
-    expect(component.extractedRecipe()).toEqual(mockRecipe);
+    expect(importPanel.extractedRecipe()).toEqual(mockRecipe);
   }));
 
   it('should extract URL from ?text query param', fakeAsync(() => {
-    const { fixture } = createComponentWithQueryParams({
+    const { fixture, importPanel } = createComponentWithQueryParams({
       text: 'Check this out https://example.com/recipe',
     });
 
@@ -638,7 +644,7 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should prefer ?url over ?text when both are present', fakeAsync(() => {
-    const { fixture } = createComponentWithQueryParams({
+    const { fixture, importPanel } = createComponentWithQueryParams({
       url: 'https://example.com/from-url',
       text: 'Check this https://example.com/from-text',
     });
@@ -649,7 +655,7 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should not auto-import when no query params are present', () => {
-    const { fixture } = createComponentWithQueryParams({});
+    const { fixture, importPanel } = createComponentWithQueryParams({});
 
     fixture.detectChanges();
 
@@ -657,7 +663,7 @@ describe('DashboardComponent – Share Intent', () => {
   });
 
   it('should not auto-import when ?text has no URL', () => {
-    const { fixture } = createComponentWithQueryParams({
+    const { fixture, importPanel } = createComponentWithQueryParams({
       text: 'Just some text without a link',
     });
 
@@ -667,7 +673,7 @@ describe('DashboardComponent – Share Intent', () => {
   });
 
   it('should extract http URL from ?text', fakeAsync(() => {
-    const { fixture } = createComponentWithQueryParams({
+    const { fixture, importPanel } = createComponentWithQueryParams({
       text: 'Try this http://example.com/recipe',
     });
 
@@ -677,7 +683,7 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should extract first URL when ?text contains multiple URLs', fakeAsync(() => {
-    const { fixture } = createComponentWithQueryParams({
+    const { fixture, importPanel } = createComponentWithQueryParams({
       text: 'See https://first.com/recipe and https://second.com/recipe',
     });
 
@@ -687,7 +693,7 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should not auto-import when ?text is empty string', () => {
-    const { fixture } = createComponentWithQueryParams({ text: '' });
+    const { fixture, importPanel } = createComponentWithQueryParams({ text: '' });
 
     fixture.detectChanges();
 
@@ -695,7 +701,7 @@ describe('DashboardComponent – Share Intent', () => {
   });
 
   it('should show share toast when URL is shared', fakeAsync(() => {
-    const { fixture, component } = createComponentWithQueryParams({
+    const { fixture, component, importPanel } = createComponentWithQueryParams({
       url: 'https://example.com/recipe',
     });
 
@@ -705,29 +711,29 @@ describe('DashboardComponent – Share Intent', () => {
   }));
 
   it('should expand import section when URL is shared', fakeAsync(() => {
-    const { fixture, component } = createComponentWithQueryParams({
+    const { fixture, component, importPanel } = createComponentWithQueryParams({
       url: 'https://example.com/recipe',
     });
 
     runShareFlow(fixture);
 
-    expect(component.importSectionExpanded()).toBe(true);
+    expect(importPanel.importSectionExpanded()).toBe(true);
   }));
 
   it('should show error when shared text contains no URL', () => {
-    const { fixture, component } = createComponentWithQueryParams({
+    const { fixture, component, importPanel } = createComponentWithQueryParams({
       text: 'Just some text without a link',
     });
 
     fixture.detectChanges();
 
     expect(component.serverError()).toBe('dashboard.share.noUrlFound');
-    expect(component.importSectionExpanded()).toBe(true);
+    expect(importPanel.importSectionExpanded()).toBe(true);
     expect(recipeApiMock.importRecipeStream).not.toHaveBeenCalled();
   });
 
   it('should dismiss share toast when dismissShareToast is called', fakeAsync(() => {
-    const { fixture, component } = createComponentWithQueryParams({
+    const { fixture, component, importPanel } = createComponentWithQueryParams({
       url: 'https://example.com/recipe',
     });
 

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -1,25 +1,11 @@
-import { Component, ChangeDetectionStrategy, signal, inject, DestroyRef, OnInit, effect, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, effect, inject, signal, untracked, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import { RecipeApiService, ImportRecipeResponse } from '@yumney/shared/api-recipes';
-import { createAsyncState, mapToSaveRecipeRequest, ERROR_MAPS, ROUTES, UI } from '@yumney/shared/models';
+import { ROUTES } from '@yumney/shared/models';
 import { LucideAngularModule } from 'lucide-angular';
-import {
-  ButtonComponent,
-  CameraCaptureComponent,
-  IngredientScannerComponent,
-  IngredientsToastComponent,
-  MessageBannerComponent,
-  QuickActionsComponent,
-  RecentActivityComponent,
-  RecipePreviewComponent,
-  ShareToastComponent,
-  SuggestionCardComponent,
-} from '@yumney/ui';
-import { CameraService } from '@yumney/shared/models';
-import type { RecognizedIngredient } from '@yumney/shared/api-recipes';
-import { UrlImportComponent } from '../integrations/recipes/url-import.component';
+import { QuickActionsComponent, RecentActivityComponent, ShareToastComponent, SuggestionCardComponent } from '@yumney/ui';
+import { ImportPanelComponent } from '../integrations/recipes/import-panel/import-panel.component';
 import { DashboardSuggestionsService } from './dashboard-suggestions.service';
 
 @Component({
@@ -28,17 +14,11 @@ import { DashboardSuggestionsService } from './dashboard-suggestions.service';
     TranslocoModule,
     LucideAngularModule,
     RouterLink,
-    UrlImportComponent,
-    ButtonComponent,
-    MessageBannerComponent,
-    RecipePreviewComponent,
+    ImportPanelComponent,
     QuickActionsComponent,
     SuggestionCardComponent,
     RecentActivityComponent,
-    CameraCaptureComponent,
-    IngredientScannerComponent,
     ShareToastComponent,
-    IngredientsToastComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
@@ -50,28 +30,16 @@ export class DashboardComponent implements OnInit {
 
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private recipeApi = inject(RecipeApiService);
-  protected camera = inject(CameraService);
   private destroyRef = inject(DestroyRef);
-  private importState = createAsyncState();
-  private saveState = createAsyncState();
   private suggestionsState = inject(DashboardSuggestionsService);
-  private navigateAfterSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
-  protected urlImport = viewChild<UrlImportComponent>(UrlImportComponent);
+  protected readonly importPanel = viewChild<ImportPanelComponent>(ImportPanelComponent);
 
-  isLoading = this.importState.isLoading;
-  isSaving = this.saveState.isLoading;
-  serverError = signal<string | null>(null);
-  extractedRecipe = signal<ImportRecipeResponse | null>(null);
-  sourceUrl = signal<string | null>(null);
-  saveSuccess = signal<string | null>(null);
-  isManualEntry = signal(false);
-  importSectionExpanded = signal(false);
-  cameraActive = signal(false);
-  scannerActive = signal(false);
-  shareToast = signal<string | null>(null);
-  recognizedIngredients = signal<RecognizedIngredient[] | null>(null);
+  readonly serverError = signal<string | null>(null);
+  readonly shareToast = signal<string | null>(null);
+  readonly sharedUrl = signal<string | null>(null);
+  private readonly initialDataIsEmpty = signal(false);
+  private readonly shouldExpandImport = signal(false);
 
   // Re-exposed so the template (and existing tests) keep their flat access.
   quickActions = this.suggestionsState.quickActions;
@@ -92,13 +60,22 @@ export class DashboardComponent implements OnInit {
 
       if (!sharedText) return;
 
-      const sharedUrl = urlParam || this.extractUrl(textParam);
+      const url = urlParam || this.extractUrl(textParam);
 
-      if (sharedUrl) {
-        this.handleSharedUrl(sharedUrl);
+      if (url) {
+        this.shareToast.set(url);
+        this.sharedUrl.set(url);
       } else if (textParam) {
         this.serverError.set('dashboard.share.noUrlFound');
-        this.importSectionExpanded.set(true);
+        this.shouldExpandImport.set(true);
+      }
+    });
+
+    effect(() => {
+      const panel = this.importPanel();
+      if (!panel) return;
+      if (this.shouldExpandImport() || this.initialDataIsEmpty()) {
+        untracked(() => panel.expand());
       }
     });
   }
@@ -108,25 +85,12 @@ export class DashboardComponent implements OnInit {
       .load()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ initialDataIsEmpty }) => {
-        if (initialDataIsEmpty) this.importSectionExpanded.set(true);
+        this.initialDataIsEmpty.set(initialDataIsEmpty);
       });
-    this.destroyRef.onDestroy(() => this.cancelNavigateAfterSave());
-  }
-
-  private handleSharedUrl(sharedUrl: string): void {
-    this.importSectionExpanded.set(true);
-    this.shareToast.set(sharedUrl);
-    // Defer one microtask so the *@if (importSectionExpanded())* block renders
-    // and the UrlImportComponent ViewChild is available.
-    queueMicrotask(() => this.urlImport()?.importUrl(sharedUrl));
   }
 
   dismissShareToast(): void {
     this.shareToast.set(null);
-  }
-
-  toggleImportSection(): void {
-    this.importSectionExpanded.update((open) => !open);
   }
 
   onQuickAction(actionKey: string): void {
@@ -141,151 +105,16 @@ export class DashboardComponent implements OnInit {
       void this.router.navigate([ROUTES.recipes.list], { queryParams });
       return;
     }
-    this.importSectionExpanded.set(true);
+    this.shouldExpandImport.set(true);
   }
 
-  onUrlExtracted(payload: { recipe: ImportRecipeResponse; sourceUrl: string }): void {
-    this.extractedRecipe.set(payload.recipe);
-    this.sourceUrl.set(payload.sourceUrl);
-  }
-
-  onUrlImportFailed(errorKey: string): void {
-    this.serverError.set(errorKey);
-  }
-
-  onUrlImportStarted(): void {
-    this.resetImportState();
-  }
-
-  onImportFromPhotos(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const files = input.files;
-    if (!files || files.length === 0) return;
-
-    input.value = '';
-    this.importPhotos(Array.from(files));
-  }
-
-  onOpenCamera(): void {
-    this.cameraActive.set(true);
-  }
-
-  onCameraCaptured(files: File[]): void {
-    this.cameraActive.set(false);
-    this.importPhotos(files);
-  }
-
-  onCameraCancelled(): void {
-    this.cameraActive.set(false);
-  }
-
-  onCameraFallback(): void {
-    this.cameraActive.set(false);
-  }
-
-  onOpenScanner(): void {
-    this.scannerActive.set(true);
-  }
-
-  onIngredientsConfirmed(ingredients: RecognizedIngredient[]): void {
-    this.scannerActive.set(false);
-    this.recognizedIngredients.set(ingredients);
-  }
-
-  onScannerCancelled(): void {
-    this.scannerActive.set(false);
-  }
-
-  dismissRecognizedIngredients(): void {
-    this.recognizedIngredients.set(null);
-  }
-
-  private importPhotos(photos: File[]): void {
-    this.resetImportState();
-
-    this.importState.execute(
-      this.recipeApi.importFromPhotos(photos),
-      ERROR_MAPS.dashboard.import,
-      (response) => {
-        this.extractedRecipe.set(response);
-        this.sourceUrl.set(null);
-      },
-      (error) => this.serverError.set(error),
-    );
-  }
-
-  onCreateManually(): void {
-    this.resetImportState();
-    this.sourceUrl.set(null);
-    this.isManualEntry.set(true);
-    this.extractedRecipe.set({
-      title: '',
-      description: null,
-      ingredients: [{ name: '', amount: null, unit: null }],
-      steps: [{ number: 1, description: '' }],
-      servings: null,
-      prepTimeMinutes: null,
-      cookTimeMinutes: null,
-      difficulty: null,
-      imageUrl: null,
-    });
-  }
-
-  onSaveRecipe(recipe: ImportRecipeResponse): void {
-    const request = mapToSaveRecipeRequest(recipe, this.sourceUrl() ?? undefined);
-
-    this.serverError.set(null);
-    this.saveSuccess.set(null);
-    this.cancelNavigateAfterSave();
-
-    this.saveState.execute(
-      this.recipeApi.saveRecipe(request),
-      ERROR_MAPS.dashboard.save,
-      (saved) => {
-        // Show the success banner briefly so the user gets a confirmation
-        // beat before we navigate. Clicking "Import another" cancels the
-        // navigation by calling onDiscardRecipe().
-        this.saveSuccess.set(saved.title);
-        this.navigateAfterSaveTimer = setTimeout(() => {
-          this.navigateAfterSaveTimer = null;
-          void this.router.navigate([ROUTES.recipes.detail(saved.identifier)]);
-        }, UI.SAVED_INDICATOR_MS);
-      },
-      (error) => this.serverError.set(error),
-    );
-  }
-
-  onDiscardRecipe(): void {
-    this.cancelNavigateAfterSave();
-    this.extractedRecipe.set(null);
-    this.sourceUrl.set(null);
-    this.isManualEntry.set(false);
-    this.serverError.set(null);
-    this.saveSuccess.set(null);
-  }
-
-  onImportAnother(): void {
-    this.onDiscardRecipe();
-    this.importSectionExpanded.set(true);
-  }
-
-  private cancelNavigateAfterSave(): void {
-    if (this.navigateAfterSaveTimer !== null) {
-      clearTimeout(this.navigateAfterSaveTimer);
-      this.navigateAfterSaveTimer = null;
-    }
+  onRecipeSaved(payload: { identifier: string; title: string }): void {
+    void this.router.navigate([ROUTES.recipes.detail(payload.identifier)]);
   }
 
   private extractUrl(text: string | undefined): string | null {
     if (!text) return null;
     const [url] = text.match(/https?:\/\/\S+/i) ?? [];
     return url ?? null;
-  }
-
-  private resetImportState(): void {
-    this.serverError.set(null);
-    this.extractedRecipe.set(null);
-    this.saveSuccess.set(null);
-    this.isManualEntry.set(false);
   }
 }

--- a/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.html
+++ b/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.html
@@ -1,0 +1,116 @@
+<ng-container *transloco="let t">
+  <section class="import-section" data-testid="import-section" [class.expanded]="importSectionExpanded()">
+    <button
+      class="import-toggle"
+      data-testid="import-toggle"
+      [attr.data-expanded]="importSectionExpanded()"
+      (click)="toggleImportSection()"
+    >
+      <h2>{{ t('dashboard.import.sectionTitle') }}</h2>
+      <span class="toggle-chevron" [class.open]="importSectionExpanded()">
+        <lucide-icon name="chevron-down" [size]="18" />
+      </span>
+    </button>
+
+    @if (importSectionExpanded()) {
+      <div class="import-content">
+        <yn-url-import
+          [isSaving]="isSaving()"
+          (importStarted)="onUrlImportStarted()"
+          (extracted)="onUrlExtracted($event)"
+          (failed)="onUrlImportFailed($event)"
+        />
+
+        <section class="photo-import">
+          <h3>{{ t('dashboard.photoImport.title') }}</h3>
+          <p class="subtitle">{{ t('dashboard.photoImport.subtitle') }}</p>
+          <div class="photo-import-actions">
+            @if (camera.cameraSupported()) {
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenCamera()">
+                {{ t('dashboard.photoImport.scanRecipe') }}
+              </yn-button>
+              <yn-button variant="dashed" [disabled]="isLoading() || isSaving()" (click)="onOpenScanner()">
+                {{ t('dashboard.photoImport.scanIngredients') }}
+              </yn-button>
+            }
+            <label class="btn-dashed" data-testid="photo-upload-btn" [class.disabled]="isLoading() || isSaving()">
+              <input
+                type="file"
+                data-testid="photo-upload-input"
+                accept="image/jpeg,image/png,image/webp"
+                multiple
+                [disabled]="isLoading() || isSaving()"
+                (change)="onImportFromPhotos($event)"
+                hidden
+              />
+              @if (isLoading()) {
+                <span class="btn-spinner"></span>
+                <span>{{ t('dashboard.photoImport.extracting') }}</span>
+              } @else {
+                <span>{{ t('dashboard.photoImport.submit') }}</span>
+              }
+            </label>
+          </div>
+          <p class="hint">{{ t('dashboard.photoImport.hint') }}</p>
+        </section>
+
+        <section class="manual-create">
+          <h3>{{ t('dashboard.create.title') }}</h3>
+          <p class="subtitle">{{ t('dashboard.create.subtitle') }}</p>
+          <yn-button
+            variant="dashed"
+            extraClass="create-btn"
+            testId="create-recipe-btn"
+            [disabled]="isLoading() || isSaving() || !!extractedRecipe()"
+            (click)="onCreateManually()"
+          >
+            {{ t('dashboard.create.submit') }}
+          </yn-button>
+        </section>
+      </div>
+    }
+  </section>
+
+  @if (serverError(); as error) {
+    <yn-message-banner tone="error" [message]="error" />
+  }
+
+  @if (saveSuccess(); as savedTitle) {
+    <div class="save-success">
+      <yn-message-banner tone="success" message="dashboard.save.success" [params]="{ title: savedTitle }" testId="success-banner" />
+      <yn-button variant="ghost" extraClass="import-another" (click)="onImportAnother()">
+        {{ t('dashboard.save.importAnother') }}
+      </yn-button>
+    </div>
+  }
+
+  @if (extractedRecipe()) {
+    <yn-recipe-preview
+      [recipe]="extractedRecipe()!"
+      [isSaving]="isSaving()"
+      [previewTitle]="isManualEntry() ? t('dashboard.create.previewTitle') : undefined"
+      (save)="onSaveRecipe($event)"
+      (discard)="onDiscardRecipe()"
+    />
+  }
+
+  @if (cameraActive()) {
+    @defer {
+      <yn-camera-capture
+        (capturedReady)="onCameraCaptured($event)"
+        (cancelled)="onCameraCancelled()"
+        (fallbackRequested)="onCameraFallback()"
+      />
+    }
+  }
+
+  @if (scannerActive()) {
+    @defer {
+      <yn-ingredient-scanner (ingredientsConfirmed)="onIngredientsConfirmed($event)" (cancelled)="onScannerCancelled()" />
+    }
+  }
+
+  @if (recognizedIngredients(); as ingredients) {
+    <yn-ingredients-toast [ingredients]="ingredients" (dismissed)="dismissRecognizedIngredients()" />
+  }
+</ng-container>

--- a/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.ts
+++ b/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.ts
@@ -1,0 +1,229 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, effect, inject, input, output, signal, viewChild } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LucideAngularModule } from 'lucide-angular';
+import { ImportRecipeResponse, RecipeApiService } from '@yumney/shared/api-recipes';
+import type { RecognizedIngredient } from '@yumney/shared/api-recipes';
+import { CameraService, ERROR_MAPS, UI, createAsyncState, mapToSaveRecipeRequest } from '@yumney/shared/models';
+import {
+  ButtonComponent,
+  CameraCaptureComponent,
+  IngredientScannerComponent,
+  IngredientsToastComponent,
+  MessageBannerComponent,
+  RecipePreviewComponent,
+} from '@yumney/ui';
+import { UrlImportComponent } from '../url-import.component';
+
+/**
+ * Self-contained "import a recipe" widget — URL, photo, camera, scanner,
+ * manual entry — composed inside the dashboard. Owns its own state so the
+ * dashboard can stay focused on page-level concerns (suggestions, quick
+ * actions, share-URL detection). Emits `recipeSaved` so the parent owns
+ * the post-save navigation.
+ */
+@Component({
+  selector: 'yn-import-panel',
+  imports: [
+    TranslocoModule,
+    LucideAngularModule,
+    UrlImportComponent,
+    ButtonComponent,
+    MessageBannerComponent,
+    RecipePreviewComponent,
+    CameraCaptureComponent,
+    IngredientScannerComponent,
+    IngredientsToastComponent,
+  ],
+  templateUrl: './import-panel.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ImportPanelComponent implements OnDestroy {
+  /** When the dashboard receives an external share-intent URL, hand it down here. */
+  readonly sharedUrl = input<string | null>(null);
+
+  /** Emitted after a successful save so the parent can navigate to the saved recipe. */
+  readonly recipeSaved = output<{ identifier: string; title: string }>();
+
+  private readonly recipeApi = inject(RecipeApiService);
+  protected readonly camera = inject(CameraService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly importState = createAsyncState();
+  private readonly saveState = createAsyncState();
+  private readonly urlImport = viewChild<UrlImportComponent>(UrlImportComponent);
+
+  protected readonly importSectionExpanded = signal(false);
+  readonly isLoading = this.importState.isLoading;
+  readonly isSaving = this.saveState.isLoading;
+  readonly serverError = signal<string | null>(null);
+  readonly extractedRecipe = signal<ImportRecipeResponse | null>(null);
+  readonly sourceUrl = signal<string | null>(null);
+  readonly saveSuccess = signal<string | null>(null);
+  readonly isManualEntry = signal(false);
+  protected readonly cameraActive = signal(false);
+  protected readonly scannerActive = signal(false);
+  protected readonly recognizedIngredients = signal<RecognizedIngredient[] | null>(null);
+
+  private navigateAfterSaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    effect(() => {
+      const url = this.sharedUrl();
+      if (!url) return;
+      this.importSectionExpanded.set(true);
+      // Defer one microtask so the @if (importSectionExpanded()) block renders
+      // and the UrlImportComponent viewChild is available.
+      queueMicrotask(() => this.urlImport()?.importUrl(url));
+    });
+  }
+
+  /** Programmatic open used by the share-URL flow when the import section was collapsed. */
+  expand(): void {
+    this.importSectionExpanded.set(true);
+  }
+
+  ngOnDestroy(): void {
+    this.cancelNavigateAfterSave();
+  }
+
+  protected toggleImportSection(): void {
+    this.importSectionExpanded.update((open) => !open);
+  }
+
+  onUrlExtracted(payload: { recipe: ImportRecipeResponse; sourceUrl: string }): void {
+    this.extractedRecipe.set(payload.recipe);
+    this.sourceUrl.set(payload.sourceUrl);
+  }
+
+  onUrlImportFailed(errorKey: string): void {
+    this.serverError.set(errorKey);
+  }
+
+  onUrlImportStarted(): void {
+    this.resetImportState();
+  }
+
+  protected onImportFromPhotos(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files;
+    if (!files || files.length === 0) return;
+
+    input.value = '';
+    this.importPhotos(Array.from(files));
+  }
+
+  protected onOpenCamera(): void {
+    this.cameraActive.set(true);
+  }
+
+  protected onCameraCaptured(files: File[]): void {
+    this.cameraActive.set(false);
+    this.importPhotos(files);
+  }
+
+  protected onCameraCancelled(): void {
+    this.cameraActive.set(false);
+  }
+
+  protected onCameraFallback(): void {
+    this.cameraActive.set(false);
+  }
+
+  protected onOpenScanner(): void {
+    this.scannerActive.set(true);
+  }
+
+  protected onIngredientsConfirmed(ingredients: RecognizedIngredient[]): void {
+    this.scannerActive.set(false);
+    this.recognizedIngredients.set(ingredients);
+  }
+
+  protected onScannerCancelled(): void {
+    this.scannerActive.set(false);
+  }
+
+  protected dismissRecognizedIngredients(): void {
+    this.recognizedIngredients.set(null);
+  }
+
+  private importPhotos(photos: File[]): void {
+    this.resetImportState();
+
+    this.importState.execute(
+      this.recipeApi.importFromPhotos(photos),
+      ERROR_MAPS.dashboard.import,
+      (response) => {
+        this.extractedRecipe.set(response);
+        this.sourceUrl.set(null);
+      },
+      (error) => this.serverError.set(error),
+    );
+  }
+
+  onCreateManually(): void {
+    this.resetImportState();
+    this.sourceUrl.set(null);
+    this.isManualEntry.set(true);
+    this.extractedRecipe.set({
+      title: '',
+      description: null,
+      ingredients: [{ name: '', amount: null, unit: null }],
+      steps: [{ number: 1, description: '' }],
+      servings: null,
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      difficulty: null,
+      imageUrl: null,
+    });
+  }
+
+  onSaveRecipe(recipe: ImportRecipeResponse): void {
+    const request = mapToSaveRecipeRequest(recipe, this.sourceUrl() ?? undefined);
+
+    this.serverError.set(null);
+    this.saveSuccess.set(null);
+    this.cancelNavigateAfterSave();
+
+    this.saveState.execute(
+      this.recipeApi.saveRecipe(request),
+      ERROR_MAPS.dashboard.save,
+      (saved) => {
+        // Show the success banner briefly so the user gets a confirmation
+        // beat before the parent navigates. onImportAnother() cancels.
+        this.saveSuccess.set(saved.title);
+        this.navigateAfterSaveTimer = setTimeout(() => {
+          this.navigateAfterSaveTimer = null;
+          this.recipeSaved.emit({ identifier: saved.identifier, title: saved.title });
+        }, UI.SAVED_INDICATOR_MS);
+      },
+      (error) => this.serverError.set(error),
+    );
+  }
+
+  onDiscardRecipe(): void {
+    this.cancelNavigateAfterSave();
+    this.extractedRecipe.set(null);
+    this.sourceUrl.set(null);
+    this.isManualEntry.set(false);
+    this.serverError.set(null);
+    this.saveSuccess.set(null);
+  }
+
+  protected onImportAnother(): void {
+    this.onDiscardRecipe();
+    this.importSectionExpanded.set(true);
+  }
+
+  private cancelNavigateAfterSave(): void {
+    if (this.navigateAfterSaveTimer !== null) {
+      clearTimeout(this.navigateAfterSaveTimer);
+      this.navigateAfterSaveTimer = null;
+    }
+  }
+
+  private resetImportState(): void {
+    this.serverError.set(null);
+    this.extractedRecipe.set(null);
+    this.saveSuccess.set(null);
+    this.isManualEntry.set(false);
+  }
+}

--- a/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
+++ b/src/Yumney.Shared.Events.Wolverine/ModuleEventConsumer.cs
@@ -37,28 +37,25 @@ public sealed partial class ModuleEventConsumer<TEvent>(
 	{
 		LogHandlingEvent(typeof(TEvent).Name, handler.GetType().Name);
 
+		var eventIdentifier = message.EventIdentifier;
 		InboxOutcome outcome;
 		try
 		{
-			outcome = await inboxStore.TryProcessAsync(
-				message.EventIdentifier,
-				consumerName,
-				ct => handler.HandleAsync(message, ct),
-				cancellationToken);
+			outcome = await inboxStore.TryProcessAsync(eventIdentifier, consumerName, ct => handler.HandleAsync(message, ct), cancellationToken);
 		}
 		catch (Exception exception)
 		{
-			LogHandlerFailed(exception, typeof(TEvent).Name, handler.GetType().Name, message.EventIdentifier);
+			LogHandlerFailed(exception, typeof(TEvent).Name, handler.GetType().Name, eventIdentifier);
 			throw;
 		}
 
 		switch (outcome)
 		{
 			case InboxOutcome.AlreadyProcessed:
-				LogSkippingDuplicate(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+				LogSkippingDuplicate(typeof(TEvent).Name, consumerName, eventIdentifier);
 				break;
 			case InboxOutcome.DuplicateRace:
-				LogSkippingDuplicateRace(typeof(TEvent).Name, consumerName, message.EventIdentifier);
+				LogSkippingDuplicateRace(typeof(TEvent).Name, consumerName, eventIdentifier);
 				break;
 		}
 	}

--- a/src/Yumney.Shared.Persistence/InboxStore.cs
+++ b/src/Yumney.Shared.Persistence/InboxStore.cs
@@ -18,7 +18,11 @@ namespace SmartSolutionsLab.Yumney.Shared.Persistence;
 public sealed class InboxStore<TContext>(TContext context) : IInboxStore
 	where TContext : DbContext
 {
-	public async Task<InboxOutcome> TryProcessAsync(Guid messageId, string consumerName, Func<CancellationToken, Task> handler, CancellationToken cancellationToken = default)
+	public async Task<InboxOutcome> TryProcessAsync(
+		Guid messageId,
+		string consumerName,
+		Func<CancellationToken, Task> handler,
+		CancellationToken cancellationToken = default)
 	{
 		var strategy = context.Database.CreateExecutionStrategy();
 

--- a/src/Yumney.Shared.Persistence/PagingExtensions.cs
+++ b/src/Yumney.Shared.Persistence/PagingExtensions.cs
@@ -7,7 +7,9 @@ public static class PagingExtensions
 {
 	extension<T>(IQueryable<T> query)
 	{
-		public async Task<(IReadOnlyList<T> Items, ItemCount TotalCount)> ToPagedListAsync(PagingOptions paging, CancellationToken cancellationToken = default)
+		public async Task<(IReadOnlyList<T> Items, ItemCount TotalCount)> ToPagedListAsync(
+			PagingOptions paging,
+			CancellationToken cancellationToken = default)
 		{
 			var totalCount = await query.CountAsync(cancellationToken);
 			var items = await query


### PR DESCRIPTION
## Summary

- **ImportPanel extraction**: moves the URL/photo/camera/scanner/manual-entry/preview flow out of `DashboardComponent` into a self-contained `ImportPanelComponent` under `integrations/recipes/import-panel/`. Dashboard drops from ~340 to ~120 lines and becomes a thin coordinator: share-intent handling, suggestions widget, recent-activity widget, and recipe-saved navigation.
- **Reactive expand**: dashboard expands the import panel via an effect on a `viewChild` signal (the previous direct `panel.expand()` call from inside the load subscription fired before the view was initialized).
- **WolverineFx 5.39.2 → 5.39.3** (centralized package management).
- Picks up dotnet-format long-line wrapping in three pre-existing files (`ModuleEventConsumer`, `InboxStore`, `PagingExtensions`).

## Test plan

- [x] `yarn nx test shell` — 268/268 pass (including 52 dashboard.component tests, fully migrated to query `ImportPanelComponent` via `By.directive`)
- [x] `yarn nx lint shell` — 0 errors
- [x] `dotnet build -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] `yarn prettier --check` on touched files — clean
- [ ] E2E to confirm the dashboard import flow still works end-to-end via the new sub-component