### PR TITLE
build(client): fix per-lib typecheck for shared libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Lint
         run: yarn nx run-many -t lint
 
+      - name: Typecheck
+        run: yarn nx run-many -t typecheck
+
       - name: Check formatting
         run: yarn prettier --check "**/*.{ts,html,scss,json}"
 

--- a/client/libs/shared/api-auth/src/lib/auth-api.service.spec.ts
+++ b/client/libs/shared/api-auth/src/lib/auth-api.service.spec.ts
@@ -1,7 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { AuthApiService, RegisterRequest, ResendVerificationRequest } from './auth-api.service';
+import { AuthApiService } from './auth-api.service';
+import type { RegisterRequest } from './register-request';
+import type { ResendVerificationRequest } from './resend-verification-request';
 
 describe('AuthApiService', () => {
   let service: AuthApiService;

--- a/client/libs/shared/api-auth/tsconfig.spec.json
+++ b/client/libs/shared/api-auth/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-common/tsconfig.spec.json
+++ b/client/libs/shared/api-common/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-dashboard/src/lib/dashboard-api.service.spec.ts
+++ b/client/libs/shared/api-dashboard/src/lib/dashboard-api.service.spec.ts
@@ -8,13 +8,13 @@ import type { SuggestionsResponse } from './suggestion';
 
 const mockActivity: UserActivityItem[] = [
   {
-    type: 'RecipeImported',
+    type: 'recipe_imported',
     recipeIdentifier: 'recipe-abc',
     recipeTitle: 'Pasta Carbonara',
     occurredAt: '2026-04-15T10:00:00Z',
   },
   {
-    type: 'RecipeCooked',
+    type: 'recipe_cooked',
     recipeIdentifier: 'recipe-def',
     recipeTitle: 'Caesar Salad',
     occurredAt: '2026-04-14T18:30:00Z',

--- a/client/libs/shared/api-dashboard/tsconfig.spec.json
+++ b/client/libs/shared/api-dashboard/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-meal-plan/tsconfig.spec.json
+++ b/client/libs/shared/api-meal-plan/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
+++ b/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
@@ -2,16 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AuthService } from '@yumney/shared/auth';
-import {
-  RecipeApiService,
-  ImportRecipeRequest,
-  ImportRecipeResponse,
-  SaveRecipeRequest,
-  SavedRecipeResponse,
-  UpdateRecipeRequest,
-  RecipeDetail,
-  RecipeListResponse,
-} from './recipe-api.service';
+import { RecipeApiService } from './recipe-api.service';
+import type { ImportRecipeRequest } from './import-recipe-request';
+import type { ImportRecipeResponse } from './import-recipe-response';
+import type { SaveRecipeRequest } from './save-recipe-request';
+import type { SavedRecipeResponse } from './saved-recipe-response';
+import type { UpdateRecipeRequest } from './update-recipe-request';
+import type { RecipeDetail } from './recipe-detail';
+import type { RecipeListResponse } from './recipe-list-response';
 
 const mockImportResponse: ImportRecipeResponse = {
   title: 'Pasta Carbonara',
@@ -38,6 +36,10 @@ const mockRecipeDetail: RecipeDetail = {
   createdAt: '2026-03-10T00:00:00Z',
   ingredients: [{ name: 'Spaghetti', amount: 400, unit: 'g' }],
   steps: [{ number: 1, description: 'Cook pasta' }],
+  tags: [],
+  isFavorite: false,
+  rating: null,
+  notes: null,
 };
 
 const mockSavedResponse: SavedRecipeResponse = {
@@ -190,12 +192,15 @@ describe('RecipeApiService', () => {
           difficulty: 'medium',
           imageUrl: null,
           createdAt: '2026-03-10T00:00:00Z',
+          tags: [],
+          isFavorite: false,
+          rating: null,
+          hasNotes: false,
         },
       ],
       page: 1,
       pageSize: 20,
       totalCount: 1,
-      totalPages: 1,
     };
 
     it('should GET /api/v1/recipes with no params by default', () => {

--- a/client/libs/shared/api-recipes/tsconfig.spec.json
+++ b/client/libs/shared/api-recipes/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-shopping/src/lib/shopping-api.service.spec.ts
+++ b/client/libs/shared/api-shopping/src/lib/shopping-api.service.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ShoppingApiService, CreateShoppingListRequest, ShoppingListDetail, ShoppingListSummary } from './shopping-api.service';
+import { ShoppingApiService } from './shopping-api.service';
+import type { CreateShoppingListRequest } from './create-shopping-list-request';
+import type { ShoppingListDetail } from './shopping-list-detail';
+import type { ShoppingListSummary } from './shopping-list-summary';
 
 const mockDetail: ShoppingListDetail = {
   identifier: 'list-123',
@@ -9,8 +12,8 @@ const mockDetail: ShoppingListDetail = {
   recipeIdentifier: 'recipe-abc',
   createdAt: '2026-03-10T00:00:00Z',
   items: [
-    { name: 'Spaghetti', amount: 400, unit: 'g' },
-    { name: 'Eggs', amount: 4, unit: null },
+    { identifier: 'item-1', name: 'Spaghetti', amount: 400, unit: 'g', category: 'pantry', isChecked: false },
+    { identifier: 'item-2', name: 'Eggs', amount: 4, unit: null, category: 'dairy', isChecked: false },
   ],
 };
 

--- a/client/libs/shared/api-shopping/tsconfig.spec.json
+++ b/client/libs/shared/api-shopping/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/api-user-profile/tsconfig.spec.json
+++ b/client/libs/shared/api-user-profile/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/chat-api/src/lib/chat-api.service.spec.ts
+++ b/client/libs/shared/chat-api/src/lib/chat-api.service.spec.ts
@@ -14,6 +14,7 @@ const mockChatResponse: ChatResponse = {
       reason: 'Quick and classic',
     },
   ],
+  actions: [],
 };
 
 describe('ChatApiService', () => {

--- a/client/libs/shared/chat-api/tsconfig.spec.json
+++ b/client/libs/shared/chat-api/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],

--- a/client/libs/shared/models/src/lib/async-state.spec.ts
+++ b/client/libs/shared/models/src/lib/async-state.spec.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 import { createAsyncState } from './async-state';
 
-const noopDestroyRef: DestroyRef = { onDestroy: () => () => undefined };
+const noopDestroyRef: DestroyRef = { destroyed: false, onDestroy: () => () => undefined };
 
 describe('createAsyncState', () => {
   it('flips isLoading while an observable is in flight', () => {

--- a/client/libs/shared/models/src/lib/camera.service.spec.ts
+++ b/client/libs/shared/models/src/lib/camera.service.spec.ts
@@ -69,7 +69,7 @@ describe('CameraService', () => {
       const stopSpy1 = vi.fn();
       const stopSpy2 = vi.fn();
       const fakeStream = {
-        getTracks: () => [{ stop: stopSpy1 } as MediaStreamTrack, { stop: stopSpy2 } as MediaStreamTrack],
+        getTracks: () => [{ stop: stopSpy1 } as unknown as MediaStreamTrack, { stop: stopSpy2 } as unknown as MediaStreamTrack],
       } as MediaStream;
 
       mockGetUserMedia(fakeStream);
@@ -122,7 +122,7 @@ describe('CameraService', () => {
     it('should stop previous stream when opening a new one', async () => {
       const stopSpy = vi.fn();
       const firstStream = {
-        getTracks: () => [{ stop: stopSpy } as MediaStreamTrack],
+        getTracks: () => [{ stop: stopSpy } as unknown as MediaStreamTrack],
       } as MediaStream;
       const secondStream = { getTracks: () => [] } as MediaStream;
 

--- a/client/libs/shared/models/src/lib/favorite-toggle.spec.ts
+++ b/client/libs/shared/models/src/lib/favorite-toggle.spec.ts
@@ -2,7 +2,7 @@ import { DestroyRef, signal } from '@angular/core';
 import { of, Subject, throwError } from 'rxjs';
 import { toggleFavoriteInList, toggleFavoriteOnItem } from './favorite-toggle';
 
-const noopDestroyRef: DestroyRef = { onDestroy: () => () => undefined };
+const noopDestroyRef: DestroyRef = { destroyed: false, onDestroy: () => () => undefined };
 
 interface Item {
   identifier: string;

--- a/client/libs/shared/models/src/lib/optimistic-update.spec.ts
+++ b/client/libs/shared/models/src/lib/optimistic-update.spec.ts
@@ -6,7 +6,7 @@ interface TestState {
   count: number;
 }
 
-const noopDestroyRef: DestroyRef = { onDestroy: () => () => undefined };
+const noopDestroyRef: DestroyRef = { destroyed: false, onDestroy: () => () => undefined };
 
 describe('optimisticSignalUpdate', () => {
   it('applies the mutation immediately before the API call resolves', () => {

--- a/client/libs/shared/models/src/lib/recipe-mapping.spec.ts
+++ b/client/libs/shared/models/src/lib/recipe-mapping.spec.ts
@@ -5,12 +5,12 @@ const imported: ImportRecipeResponse = {
   title: 'Pasta Carbonara',
   description: 'Classic',
   ingredients: [
-    { name: 'spaghetti', amount: 400, unit: 'g', confidence: 0.9 },
-    { name: 'pancetta', amount: 150, unit: 'g', confidence: 0.95 },
+    { name: 'spaghetti', amount: 400, unit: 'g' },
+    { name: 'pancetta', amount: 150, unit: 'g' },
   ],
   steps: [
-    { number: 1, description: 'boil water', confidence: 1 },
-    { number: 2, description: 'cook pasta', confidence: 1 },
+    { number: 1, description: 'boil water' },
+    { number: 2, description: 'cook pasta' },
   ],
   servings: 4,
   prepTimeMinutes: 10,
@@ -32,18 +32,16 @@ describe('mapToSaveRecipeRequest', () => {
     expect(result.imageUrl).toBe('https://example.com/img.jpg');
   });
 
-  it('strips the extraction-confidence field from ingredients', () => {
+  it('copies ingredients through to the request', () => {
     const result = mapToSaveRecipeRequest(imported);
 
     expect(result.ingredients[0]).toEqual({ name: 'spaghetti', amount: 400, unit: 'g' });
-    expect(result.ingredients[0]).not.toHaveProperty('confidence');
   });
 
-  it('strips the extraction-confidence field from steps', () => {
+  it('copies steps through to the request', () => {
     const result = mapToSaveRecipeRequest(imported);
 
     expect(result.steps[0]).toEqual({ number: 1, description: 'boil water' });
-    expect(result.steps[0]).not.toHaveProperty('confidence');
   });
 
   it('includes sourceUrl when provided', () => {
@@ -86,6 +84,8 @@ describe('mapDetailToImportResponse', () => {
       tags: [],
       createdAt: '2026-04-22T00:00:00Z',
       isFavorite: false,
+      rating: null,
+      notes: null,
     };
 
     const result = mapDetailToImportResponse(detail);

--- a/client/libs/shared/models/tsconfig.spec.json
+++ b/client/libs/shared/models/tsconfig.spec.json
@@ -2,6 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
+    "module": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": ["vite.config.mts", "src/**/*.ts", "src/**/*.spec.ts"],


### PR DESCRIPTION
## Summary

- **Fix `nx typecheck` for all shared libs.** `yarn nx run-many -t typecheck` was failing on 9 projects (`shared-models`, `shared-chat-api`, `shared-api-*`) because their `tsconfig.spec.json` inherits `moduleResolution: \"node\"` from the base config, which can't resolve Angular subpath imports (`@angular/common/http`). Override `moduleResolution: \"bundler\"` + `module: \"preserve\"` + modern `target`/`lib` in each spec config.
- **Surface real type drift.** Once Angular imports resolved, tsc found a batch of stale specs:
  - `recipe-mapping.spec.ts` referenced removed `confidence` field on extracted ingredient/step types
  - `recipe-api.service.spec.ts` was missing required fields (`tags`, `isFavorite`, `rating`, `notes`/`hasNotes`) on `RecipeDetail` / `RecipeListItem` mocks, and referenced a non-existent `totalPages` paging field
  - `shopping-api.service.spec.ts` items were missing the new `identifier`, `category`, `isChecked` fields
  - `dashboard-api.service.spec.ts` activity types were stale (`RecipeImported` → `recipe_imported`, etc.)
  - `chat-api.service.spec.ts` was missing the required `actions` field on `ChatResponse`
  - DestroyRef mocks across three spec files were missing the `destroyed` property added in Angular 19
- **Fix spec-side import drift.** `recipe-api.service.spec.ts`, `shopping-api.service.spec.ts`, and `auth-api.service.spec.ts` imported types from `./service` files; after the api-* split those types live in per-file modules and need direct imports.
- **Wire `nx typecheck` into CI** so this doesn't silently rot again.

## Test plan

- [x] `yarn nx run-many -t typecheck` — 14/14 pass (was failing on 9)
- [x] `yarn nx run-many -t lint -p shared-*` — 0 errors
- [x] `yarn nx run-many -t test -p shared-*` — all pass
- [x] `yarn prettier --check` on touched files — clean