### PR TITLE
refactor(ui): extract ChatMessageDispatcher from chat-panel

### DIFF
--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -38,6 +38,7 @@ export { CameraService, type FacingMode } from './lib/camera.service';
 export { IngredientRecognitionService } from './lib/ingredient-recognition.service';
 export { ChatStateService } from './lib/chat-state.service';
 export { ChatHintService } from './lib/chat-hint.service';
+export { ChatMessageDispatcher, type ChatDispatchResult } from './lib/chat-message-dispatcher.service';
 export { VoiceService, type VoiceCommand } from './lib/voice.service';
 export { WakeLockService } from './lib/wake-lock.service';
 export { CookingTimerService, type CookingTimer } from './lib/cooking-timer.service';

--- a/client/libs/shared/models/src/lib/chat-message-dispatcher.service.spec.ts
+++ b/client/libs/shared/models/src/lib/chat-message-dispatcher.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import { ChatApiService } from '@yumney/shared/chat-api';
+import { RecipeApiService } from '@yumney/shared/api-recipes';
+import { ChatMessageDispatcher } from './chat-message-dispatcher.service';
+
+describe('ChatMessageDispatcher', () => {
+  let dispatcher: ChatMessageDispatcher;
+  let chatApi: { send: ReturnType<typeof vi.fn> };
+  let recipeApi: { importRecipe: ReturnType<typeof vi.fn>; importFromText: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    chatApi = {
+      send: vi.fn().mockReturnValue(of({ reply: 'chat reply', suggestions: [], actions: [] })),
+    };
+    recipeApi = {
+      importRecipe: vi
+        .fn()
+        .mockReturnValue(of({ title: 'Imported Recipe', ingredients: [1, 2, 3], steps: [1, 2] })),
+      importFromText: vi
+        .fn()
+        .mockReturnValue(of({ title: 'Text Recipe', ingredients: [1], steps: [1, 2, 3] })),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ChatApiService, useValue: chatApi },
+        { provide: RecipeApiService, useValue: recipeApi },
+      ],
+    });
+
+    dispatcher = TestBed.inject(ChatMessageDispatcher);
+  });
+
+  it('routes plain text to chatApi.send', async () => {
+    const result = await firstValueFrom(dispatcher.dispatch('what is dinner?', []));
+
+    expect(chatApi.send).toHaveBeenCalledWith({ message: 'what is dinner?', history: [] });
+    expect(result.reply).toBe('chat reply');
+  });
+
+  it('routes a single URL to recipeApi.importRecipe', async () => {
+    const result = await firstValueFrom(dispatcher.dispatch('https://example.com/recipe', []));
+
+    expect(recipeApi.importRecipe).toHaveBeenCalledWith({ url: 'https://example.com/recipe' });
+    expect(result.suggestions[0]).toEqual({ recipeIdentifier: null, title: 'Imported Recipe', reason: 'Extracted from URL' });
+  });
+
+  it('routes long recipe text (3+ lines) to recipeApi.importFromText', async () => {
+    const text = 'Title\nIngredients\nSteps';
+    const result = await firstValueFrom(dispatcher.dispatch(text, []));
+
+    expect(recipeApi.importFromText).toHaveBeenCalledWith(text);
+    expect(result.suggestions[0].reason).toBe('Extracted from text');
+  });
+
+  it('routes long recipe text (30+ words) to recipeApi.importFromText', async () => {
+    const text = Array.from({ length: 30 }, (_, idx) => `word${idx}`).join(' ');
+    await firstValueFrom(dispatcher.dispatch(text, []));
+
+    expect(recipeApi.importFromText).toHaveBeenCalled();
+  });
+
+  it('builds a reply that names the imported recipe and counts', async () => {
+    const result = await firstValueFrom(dispatcher.dispatch('https://example.com/r', []));
+
+    expect(result.reply).toContain('Imported Recipe');
+    expect(result.reply).toContain('3 ingredients');
+    expect(result.reply).toContain('2 steps');
+  });
+
+  it('passes history through to chatApi.send for non-import messages', async () => {
+    const history = [{ role: 'user' as const, content: 'hi' }];
+    await firstValueFrom(dispatcher.dispatch('any reply', history));
+
+    expect(chatApi.send).toHaveBeenCalledWith({ message: 'any reply', history });
+  });
+
+  it('returns empty actions array when chatApi omits the field', async () => {
+    chatApi.send.mockReturnValue(of({ reply: 'r', suggestions: [] }));
+
+    const result = await firstValueFrom(dispatcher.dispatch('hi', []));
+
+    expect(result.actions).toEqual([]);
+  });
+});

--- a/client/libs/shared/models/src/lib/chat-message-dispatcher.service.ts
+++ b/client/libs/shared/models/src/lib/chat-message-dispatcher.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { ChatApiService, type ChatAction, type ChatMessage, type ChatRecipeSuggestion } from '@yumney/shared/chat-api';
+import { RecipeApiService } from '@yumney/shared/api-recipes';
+
+export interface ChatDispatchResult {
+  reply: string;
+  suggestions: ChatRecipeSuggestion[];
+  actions: ChatAction[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class ChatMessageDispatcher {
+  private chatApi = inject(ChatApiService);
+  private recipeApi = inject(RecipeApiService);
+
+  dispatch(message: string, history: ChatMessage[]): Observable<ChatDispatchResult> {
+    if (this.looksLikeUrl(message)) return this.dispatchUrlImport(message);
+    if (this.looksLikeRecipeText(message)) return this.dispatchTextImport(message);
+    return this.dispatchChat(message, history);
+  }
+
+  private dispatchChat(message: string, history: ChatMessage[]): Observable<ChatDispatchResult> {
+    return this.chatApi.send({ message, history }).pipe(
+      map((response) => ({
+        reply: response.reply,
+        suggestions: response.suggestions,
+        actions: response.actions ?? [],
+      })),
+    );
+  }
+
+  private dispatchUrlImport(url: string): Observable<ChatDispatchResult> {
+    return this.recipeApi.importRecipe({ url }).pipe(
+      map((recipe) => ({
+        reply: this.buildRecipeReply(recipe),
+        suggestions: [{ recipeIdentifier: null, title: recipe.title, reason: 'Extracted from URL' }],
+        actions: [],
+      })),
+    );
+  }
+
+  private dispatchTextImport(text: string): Observable<ChatDispatchResult> {
+    return this.recipeApi.importFromText(text).pipe(
+      map((recipe) => ({
+        reply: this.buildRecipeReply(recipe),
+        suggestions: [{ recipeIdentifier: null, title: recipe.title, reason: 'Extracted from text' }],
+        actions: [],
+      })),
+    );
+  }
+
+  private buildRecipeReply(recipe: { title: string; ingredients: unknown[]; steps: unknown[] }): string {
+    return `I found a recipe: **${recipe.title}**\n${recipe.ingredients.length} ingredients, ${recipe.steps.length} steps.`;
+  }
+
+  private looksLikeUrl(text: string): boolean {
+    return /^https?:\/\/\S+$/i.test(text);
+  }
+
+  private looksLikeRecipeText(text: string): boolean {
+    const lines = text.split('\n').length;
+    const words = text.split(/\s+/).length;
+    return lines >= 3 || words >= 30;
+  }
+}

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.spec.ts
@@ -336,18 +336,8 @@ describe('ChatPanelComponent', () => {
     expect(recipeApiMock.importFromText).not.toHaveBeenCalled();
   });
 
-  it('should detect URL correctly', () => {
-    expect(fixture.componentInstance['looksLikeUrl']('https://example.com/recipe')).toBe(true);
-    expect(fixture.componentInstance['looksLikeUrl']('http://food.com/pasta')).toBe(true);
-    expect(fixture.componentInstance['looksLikeUrl']('not a url')).toBe(false);
-    expect(fixture.componentInstance['looksLikeUrl']('Check https://example.com')).toBe(false);
-  });
-
-  it('should detect recipe text correctly', () => {
-    expect(fixture.componentInstance['looksLikeRecipeText']('line1\nline2\nline3')).toBe(true);
-    expect(fixture.componentInstance['looksLikeRecipeText']('a '.repeat(30))).toBe(true);
-    expect(fixture.componentInstance['looksLikeRecipeText']('short text')).toBe(false);
-  });
+  // URL / recipe-text detection lives in `ChatMessageDispatcher` and is covered
+  // by chat-message-dispatcher.service.spec.ts.
 
   // ── Actions ──
 

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -14,9 +14,8 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { RecipeApiService } from '@yumney/shared/api-recipes';
-import { ChatApiService, type ChatAction, type ChatRecipeSuggestion } from '@yumney/shared/chat-api';
-import { ChatHintService, ChatStateService, ROUTES, VoiceService } from '@yumney/shared/models';
+import { type ChatAction, type ChatRecipeSuggestion } from '@yumney/shared/chat-api';
+import { ChatHintService, ChatMessageDispatcher, ChatStateService, ROUTES, VoiceService } from '@yumney/shared/models';
 
 @Component({
   selector: 'yn-chat-panel',
@@ -31,8 +30,7 @@ export class ChatPanelComponent implements AfterViewInit {
 
   protected state = inject(ChatStateService);
   protected hints = inject(ChatHintService);
-  private chatApi = inject(ChatApiService);
-  private recipeApi = inject(RecipeApiService);
+  private dispatcher = inject(ChatMessageDispatcher);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   protected voice = inject(VoiceService);
@@ -129,87 +127,29 @@ export class ChatPanelComponent implements AfterViewInit {
     this.state.addMessage({ role: 'user', content: message });
     this.state.setThinking(true);
 
-    if (this.looksLikeUrl(message)) {
-      this.handleUrlImport(message);
-    } else if (this.looksLikeRecipeText(message)) {
-      this.handleTextImport(message);
-    } else {
-      this.handleChat(message);
-    }
-  }
-
-  private handleChat(message: string): void {
     const history = this.state.messages().slice(0, -1);
     const speakReply = this.lastInputWasVoice();
 
-    this.chatApi
-      .send({ message, history })
+    this.dispatcher
+      .dispatch(message, history)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (response) => {
-          this.state.addMessage({ role: 'assistant', content: response.reply });
-          this.lastSuggestions.set(response.suggestions);
-          this.lastActions.set(response.actions ?? []);
-          this.lastAssistantMessage.set(response.reply);
-          this.state.setThinking(false);
-          if (speakReply) {
-            this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
-            this.voice.speak(response.reply);
-          }
-          this.lastInputWasVoice.set(false);
-        },
+        next: (result) => this.applyDispatchResult(result, speakReply),
         error: (err) => this.handleError(err),
       });
   }
 
-  private handleUrlImport(url: string): void {
-    this.recipeApi
-      .importRecipe({ url })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (recipe) => {
-          const reply = this.buildRecipeReply(recipe);
-          this.state.addMessage({ role: 'assistant', content: reply });
-          this.lastSuggestions.set([
-            {
-              recipeIdentifier: null,
-              title: recipe.title,
-              reason: 'Extracted from URL',
-            },
-          ]);
-          this.lastAssistantMessage.set(reply);
-          this.state.setThinking(false);
-        },
-        error: (err) => this.handleError(err),
-      });
-  }
-
-  private handleTextImport(text: string): void {
-    this.recipeApi
-      .importFromText(text)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (recipe) => {
-          const reply = this.buildRecipeReply(recipe);
-          this.state.addMessage({ role: 'assistant', content: reply });
-          this.lastSuggestions.set([
-            {
-              recipeIdentifier: null,
-              title: recipe.title,
-              reason: 'Extracted from text',
-            },
-          ]);
-          this.lastAssistantMessage.set(reply);
-          this.state.setThinking(false);
-        },
-        error: (err) => this.handleError(err),
-      });
-  }
-
-  private buildRecipeReply(recipe: { title: string; ingredients: unknown[]; steps: unknown[] }): string {
-    const count = recipe.ingredients.length;
-    const steps = recipe.steps.length;
-    return `I found a recipe: **${recipe.title}**\n` + `${count} ingredients, ${steps} steps.`;
+  private applyDispatchResult(result: { reply: string; suggestions: ChatRecipeSuggestion[]; actions: ChatAction[] }, speakReply: boolean): void {
+    this.state.addMessage({ role: 'assistant', content: result.reply });
+    this.lastSuggestions.set(result.suggestions);
+    this.lastActions.set(result.actions);
+    this.lastAssistantMessage.set(result.reply);
+    this.state.setThinking(false);
+    if (speakReply) {
+      this.voice.setLanguage(this.transloco.getActiveLang() as 'en' | 'de');
+      this.voice.speak(result.reply);
+    }
+    this.lastInputWasVoice.set(false);
   }
 
   private handleError(err: { status?: number }): void {
@@ -219,16 +159,6 @@ export class ChatPanelComponent implements AfterViewInit {
     } else {
       this.error.set('chat.errors.failed');
     }
-  }
-
-  private looksLikeUrl(text: string): boolean {
-    return /^https?:\/\/\S+$/i.test(text);
-  }
-
-  private looksLikeRecipeText(text: string): boolean {
-    const lines = text.split('\n').length;
-    const words = text.split(/\s+/).length;
-    return lines >= 3 || words >= 30;
   }
 
   protected onClear(): void {


### PR DESCRIPTION
## Summary

- Extract the chat-panel's send-dispatch logic into a `ChatMessageDispatcher` service in `@yumney/shared/models`. The panel previously hand-rolled three near-identical observable chains (chat / URL-import / text-import) plus the routing predicates (`looksLikeUrl`, `looksLikeRecipeText`) and the canned recipe-reply formatter — none of which touched view state. The new service exposes one `dispatch(message, history)` that picks the right backend call and normalizes the response shape, and is unit-tested in isolation.
- `chat-panel.component.ts`: **291 → 221 lines** (-70). The panel now subscribes once, calls `applyDispatchResult`, and is done.

## Test plan

- [x] `yarn nx test ui` — 244/244 pass (chat-panel tests cover the orchestration; routing rules removed since `ChatMessageDispatcher` owns them)
- [x] `yarn nx test shared-models` — 316/316 pass (7 new dispatcher tests)
- [x] `yarn nx run-many -t lint -t typecheck` — clean (16 projects)