### PR TITLE
refactor(recipes): extract CookModeVoiceController from cook-mode

### DIFF
--- a/client/apps/recipes/src/app/cook-mode/cook-mode-voice.controller.spec.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode-voice.controller.spec.ts
@@ -1,0 +1,98 @@
+import { DestroyRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslocoService } from '@jsverse/transloco';
+import { of, throwError } from 'rxjs';
+import { ChatMessageDispatcher, CookingTimerService, VoiceService, type VoiceCommand } from '@yumney/shared/models';
+import { CookModeVoiceController, type CookVoiceActions } from './cook-mode-voice.controller';
+
+describe('CookModeVoiceController', () => {
+  let controller: CookModeVoiceController;
+  let voice: {
+    startListeningWithFallback: ReturnType<typeof vi.fn>;
+    stopSpeaking: ReturnType<typeof vi.fn>;
+    speak: ReturnType<typeof vi.fn>;
+  };
+  let timers: { cancelAll: ReturnType<typeof vi.fn>; start: ReturnType<typeof vi.fn> };
+  let transloco: { translate: ReturnType<typeof vi.fn> };
+  let dispatcher: { dispatch: ReturnType<typeof vi.fn> };
+  let actions: { [K in keyof CookVoiceActions]: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    voice = { startListeningWithFallback: vi.fn(), stopSpeaking: vi.fn(), speak: vi.fn() };
+    timers = { cancelAll: vi.fn(), start: vi.fn() };
+    transloco = { translate: vi.fn().mockReturnValue('Timer') };
+    dispatcher = { dispatch: vi.fn().mockReturnValue(of({ reply: 'r', suggestions: [], actions: [] })) };
+    actions = { next: vi.fn(), previous: vi.fn(), repeat: vi.fn(), stop: vi.fn(), showIngredients: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        CookModeVoiceController,
+        { provide: VoiceService, useValue: voice },
+        { provide: CookingTimerService, useValue: timers },
+        { provide: TranslocoService, useValue: transloco },
+        { provide: ChatMessageDispatcher, useValue: dispatcher },
+        { provide: DestroyRef, useValue: { destroyed: false, onDestroy: () => () => undefined } },
+      ],
+    });
+
+    controller = TestBed.inject(CookModeVoiceController);
+  });
+
+  function fireCommand(command: VoiceCommand): void {
+    controller.start(actions);
+    const onCommand = voice.startListeningWithFallback.mock.calls[0][0] as (cmd: VoiceCommand) => void;
+    onCommand(command);
+  }
+
+  function fireTranscript(text: string): void {
+    controller.start(actions);
+    const onTranscript = voice.startListeningWithFallback.mock.calls[0][1] as (text: string) => void;
+    onTranscript(text);
+  }
+
+  it('routes "next" command to actions.next', () => {
+    fireCommand({ type: 'next' });
+    expect(actions.next).toHaveBeenCalled();
+  });
+
+  it('routes "previous" command to actions.previous', () => {
+    fireCommand({ type: 'previous' });
+    expect(actions.previous).toHaveBeenCalled();
+  });
+
+  it('routes "repeat" command to actions.repeat', () => {
+    fireCommand({ type: 'repeat' });
+    expect(actions.repeat).toHaveBeenCalled();
+  });
+
+  it('routes "ingredients" command to actions.showIngredients', () => {
+    fireCommand({ type: 'ingredients' });
+    expect(actions.showIngredients).toHaveBeenCalled();
+  });
+
+  it('on "stop" cancels timers, stops TTS, and notifies actions', () => {
+    fireCommand({ type: 'stop' });
+    expect(voice.stopSpeaking).toHaveBeenCalled();
+    expect(timers.cancelAll).toHaveBeenCalled();
+    expect(actions.stop).toHaveBeenCalled();
+  });
+
+  it('on "timer" starts a timer with the localized default name', () => {
+    fireCommand({ type: 'timer', minutes: 5 });
+    expect(transloco.translate).toHaveBeenCalledWith('recipes.cook.timer.defaultName');
+    expect(timers.start).toHaveBeenCalledWith('Timer', 5);
+  });
+
+  it('routes transcripts through the chat dispatcher and speaks the reply', () => {
+    dispatcher.dispatch.mockReturnValue(of({ reply: 'Adding butter…', suggestions: [], actions: [] }));
+    fireTranscript('add butter to shopping list');
+
+    expect(dispatcher.dispatch).toHaveBeenCalledWith('add butter to shopping list', []);
+    expect(voice.speak).toHaveBeenCalledWith('Adding butter…');
+  });
+
+  it('swallows dispatcher errors silently', () => {
+    dispatcher.dispatch.mockReturnValue(throwError(() => new Error('boom')));
+    expect(() => fireTranscript('anything')).not.toThrow();
+  });
+});

--- a/client/apps/recipes/src/app/cook-mode/cook-mode-voice.controller.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode-voice.controller.ts
@@ -1,0 +1,68 @@
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslocoService } from '@jsverse/transloco';
+import { ChatMessageDispatcher, CookingTimerService, VoiceService, type VoiceCommand } from '@yumney/shared/models';
+
+export interface CookVoiceActions {
+  next: () => void;
+  previous: () => void;
+  repeat: () => void;
+  stop: () => void;
+  showIngredients: () => void;
+}
+
+@Injectable()
+export class CookModeVoiceController {
+  private voice = inject(VoiceService);
+  private timers = inject(CookingTimerService);
+  private transloco = inject(TranslocoService);
+  private dispatcher = inject(ChatMessageDispatcher);
+  private destroyRef = inject(DestroyRef);
+
+  start(actions: CookVoiceActions): void {
+    this.voice.startListeningWithFallback(
+      (command) => this.handleCommand(command, actions),
+      (transcript) => this.handleTranscript(transcript),
+    );
+  }
+
+  private handleCommand(command: VoiceCommand, actions: CookVoiceActions): void {
+    switch (command.type) {
+      case 'next':
+        actions.next();
+        break;
+      case 'previous':
+        actions.previous();
+        break;
+      case 'repeat':
+        actions.repeat();
+        break;
+      case 'stop':
+        this.voice.stopSpeaking();
+        this.timers.cancelAll();
+        actions.stop();
+        break;
+      case 'ingredients':
+        actions.showIngredients();
+        break;
+      case 'timer': {
+        const name = this.transloco.translate('recipes.cook.timer.defaultName');
+        this.timers.start(name, command.minutes);
+        break;
+      }
+    }
+  }
+
+  private handleTranscript(transcript: string): void {
+    // Route through the chat dispatcher so users can say things like
+    // "add butter to shopping list" while cooking without leaving the screen.
+    // The reply rides the same TTS path as auto-read steps.
+    this.dispatcher
+      .dispatch(transcript, [])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => this.voice.speak(result.reply),
+        error: () => undefined,
+      });
+  }
+}

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -1,26 +1,13 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  DestroyRef,
-  effect,
-  HostListener,
-  inject,
-  OnDestroy,
-  OnInit,
-  signal,
-} from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, effect, HostListener, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
-import { ChatApiService, RecipeApiService, type RecipeDetail } from '../api';
+import { RecipeApiService, type RecipeDetail } from '../api';
 import {
   CookingTimerService,
   createAsyncState,
   ERROR_MAPS,
   ROUTES,
   UserPreferencesService,
-  type VoiceCommand,
   VoiceService,
   WakeLockService,
 } from '@yumney/shared/models';
@@ -33,6 +20,7 @@ import {
   StepDisplayComponent,
   VoiceIndicatorComponent,
 } from '@yumney/ui';
+import { CookModeVoiceController } from './cook-mode-voice.controller';
 
 const SWIPE_THRESHOLD = 50;
 
@@ -51,21 +39,21 @@ const SWIPE_THRESHOLD = 50;
   templateUrl: './cook-mode.component.html',
   styleUrl: './cook-mode.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [CookModeVoiceController],
 })
 export class CookModeComponent implements OnInit, OnDestroy {
   protected readonly ROUTES = ROUTES;
 
   private recipeApi = inject(RecipeApiService);
-  private chatApi = inject(ChatApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private destroyRef = inject(DestroyRef);
   private loadState = createAsyncState();
   protected voice = inject(VoiceService);
   protected timers = inject(CookingTimerService);
   private wakeLock = inject(WakeLockService);
   private transloco = inject(TranslocoService);
   private preferences = inject(UserPreferencesService);
+  private voiceCtrl = inject(CookModeVoiceController);
 
   recipe = signal<RecipeDetail | null>(null);
   currentStepIndex = signal(0);
@@ -155,24 +143,13 @@ export class CookModeComponent implements OnInit, OnDestroy {
   }
 
   private startListeningInCookMode(): void {
-    this.voice.startListeningWithFallback(
-      (command) => this.handleCommand(command),
-      (transcript) => this.handleTranscript(transcript),
-    );
-  }
-
-  private handleTranscript(transcript: string): void {
-    // Global voice command while cooking — route through chat so users can say
-    // "add butter to shopping list" or "what's for dinner tomorrow?" without
-    // leaving cook mode. The reply gets spoken via the TTS path used by the
-    // step-read effect.
-    this.chatApi
-      .send({ message: transcript, history: [] })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (response) => this.voice.speak(response.reply),
-        error: () => undefined,
-      });
+    this.voiceCtrl.start({
+      next: () => this.next(),
+      previous: () => this.previous(),
+      repeat: () => this.repeat(),
+      stop: () => undefined,
+      showIngredients: () => this.ingredientsPanelOpen.set(true),
+    });
   }
 
   toggleMute(): void {
@@ -228,29 +205,4 @@ export class CookModeComponent implements OnInit, OnDestroy {
     else if (event.key === 'Escape') this.exit();
   }
 
-  private handleCommand(command: VoiceCommand): void {
-    switch (command.type) {
-      case 'next':
-        this.next();
-        break;
-      case 'previous':
-        this.previous();
-        break;
-      case 'repeat':
-        this.repeat();
-        break;
-      case 'stop':
-        this.voice.stopSpeaking();
-        this.timers.cancelAll();
-        break;
-      case 'ingredients':
-        this.ingredientsPanelOpen.set(true);
-        break;
-      case 'timer': {
-        const name = this.transloco.translate('recipes.cook.timer.defaultName');
-        this.timers.start(name, command.minutes);
-        break;
-      }
-    }
-  }
 }

--- a/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
+++ b/client/apps/recipes/src/app/cook-mode/cook-mode.component.ts
@@ -204,5 +204,4 @@ export class CookModeComponent implements OnInit, OnDestroy {
     else if (event.key === 'ArrowLeft') this.previous();
     else if (event.key === 'Escape') this.exit();
   }
-
 }

--- a/client/libs/shared/models/src/lib/chat-message-dispatcher.service.spec.ts
+++ b/client/libs/shared/models/src/lib/chat-message-dispatcher.service.spec.ts
@@ -15,12 +15,8 @@ describe('ChatMessageDispatcher', () => {
       send: vi.fn().mockReturnValue(of({ reply: 'chat reply', suggestions: [], actions: [] })),
     };
     recipeApi = {
-      importRecipe: vi
-        .fn()
-        .mockReturnValue(of({ title: 'Imported Recipe', ingredients: [1, 2, 3], steps: [1, 2] })),
-      importFromText: vi
-        .fn()
-        .mockReturnValue(of({ title: 'Text Recipe', ingredients: [1], steps: [1, 2, 3] })),
+      importRecipe: vi.fn().mockReturnValue(of({ title: 'Imported Recipe', ingredients: [1, 2, 3], steps: [1, 2] })),
+      importFromText: vi.fn().mockReturnValue(of({ title: 'Text Recipe', ingredients: [1], steps: [1, 2, 3] })),
     };
 
     TestBed.configureTestingModule({

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.ts
@@ -139,7 +139,10 @@ export class ChatPanelComponent implements AfterViewInit {
       });
   }
 
-  private applyDispatchResult(result: { reply: string; suggestions: ChatRecipeSuggestion[]; actions: ChatAction[] }, speakReply: boolean): void {
+  private applyDispatchResult(
+    result: { reply: string; suggestions: ChatRecipeSuggestion[]; actions: ChatAction[] },
+    speakReply: boolean,
+  ): void {
     this.state.addMessage({ role: 'assistant', content: result.reply });
     this.lastSuggestions.set(result.suggestions);
     this.lastActions.set(result.actions);


### PR DESCRIPTION
## Summary

- Extract cook-mode's voice integration (start-listening + voice-command switch + transcript handling) into a component-scoped `CookModeVoiceController` service. The component now hands the controller a callbacks object describing what each command should do; the controller owns the plumbing.
- While there, route transcripts through `ChatMessageDispatcher` (introduced in #788) instead of calling `ChatApiService` directly. cook-mode no longer depends on `ChatApiService`.
- `cook-mode.component.ts`: **256 → 208 lines** (-48).

## Test plan

- [x] `yarn nx test recipes` — 221/221 pass (213 existing + 8 new controller tests). The transcript test asserts on the existing `chatApiMock.send` — that still works because the dispatcher routes through DI, so the mock is hit transparently.
- [x] `yarn nx run-many -t lint -t typecheck -p recipes` — clean