### PR TITLE
refactor(shared): extract voice command parser from VoiceService

### DIFF
--- a/client/libs/shared/models/src/index.ts
+++ b/client/libs/shared/models/src/index.ts
@@ -39,7 +39,8 @@ export { IngredientRecognitionService } from './lib/ingredient-recognition.servi
 export { ChatStateService } from './lib/chat-state.service';
 export { ChatHintService } from './lib/chat-hint.service';
 export { ChatMessageDispatcher, type ChatDispatchResult } from './lib/chat-message-dispatcher.service';
-export { VoiceService, type VoiceCommand } from './lib/voice.service';
+export { VoiceService } from './lib/voice.service';
+export { parseVoiceCommand, type VoiceCommand } from './lib/voice-command-parser';
 export { WakeLockService } from './lib/wake-lock.service';
 export { CookingTimerService, type CookingTimer } from './lib/cooking-timer.service';
 export { ToastService, type Toast, type ToastKind, type ShowToastOptions } from './lib/toast.service';

--- a/client/libs/shared/models/src/lib/voice-command-parser.ts
+++ b/client/libs/shared/models/src/lib/voice-command-parser.ts
@@ -1,0 +1,36 @@
+export type VoiceCommand =
+  | { type: 'next' }
+  | { type: 'previous' }
+  | { type: 'repeat' }
+  | { type: 'stop' }
+  | { type: 'ingredients' }
+  | { type: 'timer'; minutes: number };
+
+const COMMAND_PATTERNS: Array<{
+  match: RegExp;
+  build: (groups: RegExpMatchArray) => VoiceCommand;
+}> = [
+  { match: /^(next step|next|nächster schritt|weiter)$/i, build: () => ({ type: 'next' }) },
+  { match: /^(previous step|previous|back|vorheriger schritt|zurück)$/i, build: () => ({ type: 'previous' }) },
+  { match: /^(repeat|wiederhole|wiederholen)$/i, build: () => ({ type: 'repeat' }) },
+  { match: /^(stop|stopp|stop it|halt)$/i, build: () => ({ type: 'stop' }) },
+  { match: /^(ingredients|zutaten)$/i, build: () => ({ type: 'ingredients' }) },
+  {
+    match: /^timer\s+(\d{1,3})\s*(?:minutes?|min|minuten|minute)$/i,
+    build: (match) => ({ type: 'timer', minutes: Number(match[1]) }),
+  },
+  {
+    match: /^(\d{1,3})\s*(?:minute|minuten|min)\s+timer$/i,
+    build: (match) => ({ type: 'timer', minutes: Number(match[1]) }),
+  },
+];
+
+export function parseVoiceCommand(transcript: string): VoiceCommand | null {
+  const normalized = transcript.trim().toLowerCase();
+  if (normalized === '') return null;
+  for (const pattern of COMMAND_PATTERNS) {
+    const match = normalized.match(pattern.match);
+    if (match) return pattern.build(match);
+  }
+  return null;
+}

--- a/client/libs/shared/models/src/lib/voice.service.spec.ts
+++ b/client/libs/shared/models/src/lib/voice.service.spec.ts
@@ -2,70 +2,71 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { UserPreferencesService } from './user-preferences.service';
 import { VoiceService } from './voice.service';
+import { parseVoiceCommand } from './voice-command-parser';
 
-describe('VoiceService.parseCommand', () => {
+describe('parseVoiceCommand', () => {
   it('should parse "next step" as next command', () => {
-    expect(VoiceService.parseCommand('next step')).toEqual({ type: 'next' });
+    expect(parseVoiceCommand('next step')).toEqual({ type: 'next' });
   });
 
   it('should parse German "nächster schritt" as next command', () => {
-    expect(VoiceService.parseCommand('nächster schritt')).toEqual({ type: 'next' });
+    expect(parseVoiceCommand('nächster schritt')).toEqual({ type: 'next' });
   });
 
   it('should parse "previous step" as previous command', () => {
-    expect(VoiceService.parseCommand('previous step')).toEqual({ type: 'previous' });
+    expect(parseVoiceCommand('previous step')).toEqual({ type: 'previous' });
   });
 
   it('should parse German "vorheriger schritt" as previous command', () => {
-    expect(VoiceService.parseCommand('vorheriger schritt')).toEqual({ type: 'previous' });
+    expect(parseVoiceCommand('vorheriger schritt')).toEqual({ type: 'previous' });
   });
 
   it('should parse "repeat" as repeat command', () => {
-    expect(VoiceService.parseCommand('repeat')).toEqual({ type: 'repeat' });
+    expect(parseVoiceCommand('repeat')).toEqual({ type: 'repeat' });
   });
 
   it('should parse "stop" as stop command', () => {
-    expect(VoiceService.parseCommand('stop')).toEqual({ type: 'stop' });
+    expect(parseVoiceCommand('stop')).toEqual({ type: 'stop' });
   });
 
   it('should parse German "stopp" as stop command', () => {
-    expect(VoiceService.parseCommand('stopp')).toEqual({ type: 'stop' });
+    expect(parseVoiceCommand('stopp')).toEqual({ type: 'stop' });
   });
 
   it('should parse "ingredients" as ingredients command', () => {
-    expect(VoiceService.parseCommand('ingredients')).toEqual({ type: 'ingredients' });
+    expect(parseVoiceCommand('ingredients')).toEqual({ type: 'ingredients' });
   });
 
   it('should parse German "zutaten" as ingredients command', () => {
-    expect(VoiceService.parseCommand('zutaten')).toEqual({ type: 'ingredients' });
+    expect(parseVoiceCommand('zutaten')).toEqual({ type: 'ingredients' });
   });
 
   it('should parse "timer 5 minutes" as timer command with minutes', () => {
-    expect(VoiceService.parseCommand('timer 5 minutes')).toEqual({ type: 'timer', minutes: 5 });
+    expect(parseVoiceCommand('timer 5 minutes')).toEqual({ type: 'timer', minutes: 5 });
   });
 
   it('should parse German "timer 10 minuten" as timer command with minutes', () => {
-    expect(VoiceService.parseCommand('timer 10 minuten')).toEqual({ type: 'timer', minutes: 10 });
+    expect(parseVoiceCommand('timer 10 minuten')).toEqual({ type: 'timer', minutes: 10 });
   });
 
   it('should parse "5 minute timer" as timer command', () => {
-    expect(VoiceService.parseCommand('5 minute timer')).toEqual({ type: 'timer', minutes: 5 });
+    expect(parseVoiceCommand('5 minute timer')).toEqual({ type: 'timer', minutes: 5 });
   });
 
   it('should be case-insensitive', () => {
-    expect(VoiceService.parseCommand('NEXT STEP')).toEqual({ type: 'next' });
+    expect(parseVoiceCommand('NEXT STEP')).toEqual({ type: 'next' });
   });
 
   it('should ignore surrounding whitespace', () => {
-    expect(VoiceService.parseCommand('  next step  ')).toEqual({ type: 'next' });
+    expect(parseVoiceCommand('  next step  ')).toEqual({ type: 'next' });
   });
 
   it('should return null for unknown phrases', () => {
-    expect(VoiceService.parseCommand('do something random')).toBeNull();
+    expect(parseVoiceCommand('do something random')).toBeNull();
   });
 
   it('should return null for empty input', () => {
-    expect(VoiceService.parseCommand('')).toBeNull();
+    expect(parseVoiceCommand('')).toBeNull();
   });
 });
 

--- a/client/libs/shared/models/src/lib/voice.service.ts
+++ b/client/libs/shared/models/src/lib/voice.service.ts
@@ -1,35 +1,8 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { UserPreferencesService } from './user-preferences.service';
+import { parseVoiceCommand, type VoiceCommand } from './voice-command-parser';
 
-export type VoiceCommand =
-  | { type: 'next' }
-  | { type: 'previous' }
-  | { type: 'repeat' }
-  | { type: 'stop' }
-  | { type: 'ingredients' }
-  | { type: 'timer'; minutes: number };
-
-const COMMAND_PATTERNS: Array<{
-  match: RegExp;
-  build: (groups: RegExpMatchArray) => VoiceCommand;
-}> = [
-  { match: /^(next step|next|nächster schritt|weiter)$/i, build: () => ({ type: 'next' }) },
-  {
-    match: /^(previous step|previous|back|vorheriger schritt|zurück)$/i,
-    build: () => ({ type: 'previous' }),
-  },
-  { match: /^(repeat|wiederhole|wiederholen)$/i, build: () => ({ type: 'repeat' }) },
-  { match: /^(stop|stopp|stop it|halt)$/i, build: () => ({ type: 'stop' }) },
-  { match: /^(ingredients|zutaten)$/i, build: () => ({ type: 'ingredients' }) },
-  {
-    match: /^timer\s+(\d{1,3})\s*(?:minutes?|min|minuten|minute)$/i,
-    build: (match) => ({ type: 'timer', minutes: Number(match[1]) }),
-  },
-  {
-    match: /^(\d{1,3})\s*(?:minute|minuten|min)\s+timer$/i,
-    build: (match) => ({ type: 'timer', minutes: Number(match[1]) }),
-  },
-];
+export { type VoiceCommand };
 
 interface SpeechRecognitionLike {
   lang: string;
@@ -111,7 +84,7 @@ export class VoiceService {
     this.beginSession({
       continuous: true,
       onTranscript: (transcript) => {
-        const command = VoiceService.parseCommand(transcript);
+        const command = parseVoiceCommand(transcript);
         if (command) onCommand(command);
       },
     });
@@ -142,7 +115,7 @@ export class VoiceService {
       continuous: true,
       onTranscript: (transcript) => {
         if (transcript === '') return;
-        const command = VoiceService.parseCommand(transcript);
+        const command = parseVoiceCommand(transcript);
         if (command) {
           onCommand(command);
           return;
@@ -226,18 +199,6 @@ export class VoiceService {
     this.recognition = recognition;
     recognition.start();
     this.isListening.set(true);
-  }
-
-  static parseCommand(transcript: string): VoiceCommand | null {
-    const normalized = transcript.trim().toLowerCase();
-    if (normalized === '') return null;
-    for (const pattern of COMMAND_PATTERNS) {
-      const match = normalized.match(pattern.match);
-      if (match) {
-        return pattern.build(match);
-      }
-    }
-    return null;
   }
 
   private createRecognition(): SpeechRecognitionLike | null {


### PR DESCRIPTION
## Summary

- Extract `COMMAND_PATTERNS` + `parseCommand` into a new `voice-command-parser.ts` as `parseVoiceCommand`. The `VoiceCommand` type moves with it (and is re-exported from `@yumney/shared/models` so consumers don't need to update imports). `VoiceService.parseCommand` becomes a plain function call.
- `voice.service.ts`: **258 → 219 lines** (-39).
- Tests in `voice.service.spec.ts` (16 cases) now import `parseVoiceCommand` directly. The TTS / STT tests are untouched.

This is the easiest peel out of the three concerns living in VoiceService (TTS, STT, parsing) — the parser has no Angular deps. STT/TTS split is a bigger surgery and can wait for a follow-up.

## Test plan

- [x] `yarn nx test shared-models` — 244/244 pass
- [x] `yarn nx run-many -t typecheck` — 14/14 pass (no consumer path break)
- [x] `yarn nx run-many -t lint -p shared-models` — clean
- [x] `yarn prettier --check libs/shared/models/src` — clean