### PR TITLE
refactor(recipes): extract RecipeCreateShoppingListService from recipe-detail

### DIFF
--- a/client/apps/recipes/src/app/integrations/shopping/recipe-create-shopping-list.service.spec.ts
+++ b/client/apps/recipes/src/app/integrations/shopping/recipe-create-shopping-list.service.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { of, Subject, throwError } from 'rxjs';
+import { ShoppingApiService, type RecipeDetail } from '../../api';
+import { RecipeCreateShoppingListService } from './recipe-create-shopping-list.service';
+
+const mockRecipe: RecipeDetail = {
+  identifier: 'recipe-abc',
+  title: 'Pasta Carbonara',
+  description: null,
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  difficulty: 'medium',
+  imageUrl: null,
+  sourceUrl: null,
+  createdAt: '2026-03-10T00:00:00Z',
+  ingredients: [],
+  steps: [],
+  tags: [],
+  isFavorite: false,
+  rating: null,
+  notes: null,
+};
+
+describe('RecipeCreateShoppingListService', () => {
+  let service: RecipeCreateShoppingListService;
+  let shoppingApiMock: { createShoppingList: ReturnType<typeof vi.fn> };
+  let router: Router;
+
+  beforeEach(() => {
+    shoppingApiMock = {
+      createShoppingList: vi.fn().mockReturnValue(of({ identifier: 'list-123' })),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [RecipeCreateShoppingListService, provideRouter([]), { provide: ShoppingApiService, useValue: shoppingApiMock }],
+    });
+
+    service = TestBed.inject(RecipeCreateShoppingListService);
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+  });
+
+  describe('open', () => {
+    it('clears the prior server error and opens the dialog', () => {
+      service.serverError.set('previous.error');
+      service.open();
+      expect(service.showConfirm()).toBe(true);
+      expect(service.serverError()).toBeNull();
+    });
+  });
+
+  describe('cancel', () => {
+    it('closes the dialog when not in flight', () => {
+      service.open();
+      service.cancel();
+      expect(service.showConfirm()).toBe(false);
+    });
+
+    it('keeps the dialog open while a create is in flight', () => {
+      const pending = new Subject<{ identifier: string }>();
+      shoppingApiMock.createShoppingList.mockReturnValue(pending);
+
+      service.open();
+      service.confirm({ recipe: mockRecipe, desiredServings: 4, ingredients: [] });
+      service.cancel();
+
+      expect(service.showConfirm()).toBe(true);
+      pending.next({ identifier: 'list-123' });
+      pending.complete();
+    });
+  });
+
+  describe('confirm', () => {
+    it('forwards items to the shopping API verbatim', () => {
+      service.confirm({
+        recipe: mockRecipe,
+        desiredServings: 4,
+        ingredients: [
+          { name: 'Spaghetti', amount: 400, unit: 'g' },
+          { name: 'Pancetta', amount: 200, unit: 'g' },
+        ],
+      });
+
+      expect(shoppingApiMock.createShoppingList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipeIdentifier: 'recipe-abc',
+          items: [
+            { name: 'Spaghetti', amount: 400, unit: 'g' },
+            { name: 'Pancetta', amount: 200, unit: 'g' },
+          ],
+        }),
+      );
+    });
+
+    it('appends (xN) to the title whenever both servings are known', () => {
+      service.confirm({ recipe: mockRecipe, desiredServings: 6, ingredients: [] });
+
+      expect(shoppingApiMock.createShoppingList).toHaveBeenCalledWith(expect.objectContaining({ title: 'Pasta Carbonara (x6)' }));
+    });
+
+    it('omits the scaling suffix when the recipe has no native servings', () => {
+      service.confirm({ recipe: { ...mockRecipe, servings: null }, desiredServings: 4, ingredients: [] });
+
+      expect(shoppingApiMock.createShoppingList).toHaveBeenCalledWith(expect.objectContaining({ title: 'Pasta Carbonara' }));
+    });
+
+    it('navigates to the created list and closes the dialog on success', () => {
+      service.open();
+      service.confirm({ recipe: mockRecipe, desiredServings: null, ingredients: [] });
+
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/shopping/lists/list-123');
+      expect(service.showConfirm()).toBe(false);
+    });
+
+    it('surfaces the mapped error and closes the dialog on failure', () => {
+      shoppingApiMock.createShoppingList.mockReturnValue(throwError(() => ({ status: 500 })));
+      service.open();
+
+      service.confirm({ recipe: mockRecipe, desiredServings: null, ingredients: [] });
+
+      expect(service.serverError()).not.toBeNull();
+      expect(service.showConfirm()).toBe(false);
+    });
+  });
+});

--- a/client/apps/recipes/src/app/integrations/shopping/recipe-create-shopping-list.service.ts
+++ b/client/apps/recipes/src/app/integrations/shopping/recipe-create-shopping-list.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { createAsyncState, ERROR_MAPS, ROUTES } from '@yumney/shared/models';
+import { CreateShoppingListItem, RecipeDetail, ShoppingApiService } from '../../api';
+
+export interface CreateFromRecipePayload {
+  recipe: RecipeDetail;
+  desiredServings: number | null;
+  ingredients: ReadonlyArray<{ name: string; amount: number | null; unit: string | null }>;
+}
+
+@Injectable()
+export class RecipeCreateShoppingListService {
+  private shoppingApi = inject(ShoppingApiService);
+  private router = inject(Router);
+  private createState = createAsyncState();
+
+  readonly isCreating = this.createState.isLoading;
+  readonly showConfirm = signal(false);
+  readonly serverError = signal<string | null>(null);
+
+  open(): void {
+    this.serverError.set(null);
+    this.showConfirm.set(true);
+  }
+
+  cancel(): void {
+    if (this.isCreating()) return;
+    this.showConfirm.set(false);
+  }
+
+  confirm(payload: CreateFromRecipePayload): void {
+    const items: CreateShoppingListItem[] = payload.ingredients.map(({ name, amount, unit }) => ({ name, amount, unit }));
+    const title =
+      payload.recipe.servings !== null && payload.desiredServings !== null
+        ? `${payload.recipe.title} (x${payload.desiredServings})`
+        : payload.recipe.title;
+
+    this.createState.execute(
+      this.shoppingApi.createShoppingList({ title, items, recipeIdentifier: payload.recipe.identifier }),
+      ERROR_MAPS.recipes.createShoppingList,
+      (created) => {
+        this.showConfirm.set(false);
+        void this.router.navigateByUrl(ROUTES.shopping.detail(created.identifier));
+      },
+      (error) => {
+        this.showConfirm.set(false);
+        this.serverError.set(error);
+      },
+    );
+  }
+}

--- a/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
+++ b/client/apps/recipes/src/app/recipe-detail/recipe-detail.component.ts
@@ -3,16 +3,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
-import {
-  ActivityApiService,
-  CreateShoppingListItem,
-  RecipeApiService,
-  RecipeActivityStats,
-  RecipeDetail,
-  ShoppingApiService,
-} from '../api';
+import { ActivityApiService, RecipeApiService, RecipeActivityStats, RecipeDetail } from '../api';
 import { RecipeNotesAutosaveService } from './recipe-notes-autosave.service';
 import { RecipeScalingService } from './recipe-scaling.service';
+import { RecipeCreateShoppingListService } from '../integrations/shopping/recipe-create-shopping-list.service';
 import { createAsyncState, type UnitSystem, ERROR_MAPS, ROUTES, UserPreferencesService, toggleFavoriteOnItem } from '@yumney/shared/models';
 import {
   BackLinkComponent,
@@ -45,30 +39,30 @@ import { CreateShoppingListDialogComponent } from '../integrations/shopping/crea
   templateUrl: './recipe-detail.component.html',
   styleUrl: './recipe-detail.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [RecipeNotesAutosaveService, RecipeScalingService],
+  providers: [RecipeNotesAutosaveService, RecipeScalingService, RecipeCreateShoppingListService],
 })
 export class RecipeDetailComponent implements OnInit {
   protected readonly ROUTES = ROUTES;
 
   private recipeApi = inject(RecipeApiService);
-  private shoppingApi = inject(ShoppingApiService);
   private activityApi = inject(ActivityApiService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private loadState = createAsyncState();
   private deleteState = createAsyncState();
-  private createShoppingListState = createAsyncState();
   private notesAutosave = inject(RecipeNotesAutosaveService);
   private scaling = inject(RecipeScalingService);
+  protected createShoppingList = inject(RecipeCreateShoppingListService);
   private preferences = inject(UserPreferencesService);
 
   recipe = signal<RecipeDetail | null>(null);
   recipeStats = signal<RecipeActivityStats | null>(null);
   isLoading = this.loadState.isLoading;
   isDeleting = this.deleteState.isLoading;
-  isCreatingShoppingList = this.createShoppingListState.isLoading;
-  serverError = signal<string | null>(null);
+  isCreatingShoppingList = this.createShoppingList.isCreating;
+  private localError = signal<string | null>(null);
+  serverError = computed(() => this.localError() ?? this.createShoppingList.serverError());
 
   desiredServings = this.scaling.desiredServings;
   scaledIngredients = this.scaling.scaledIngredients;
@@ -77,7 +71,7 @@ export class RecipeDetailComponent implements OnInit {
   unitSystem = this.scaling.unitSystem;
 
   showDeleteConfirm = signal(false);
-  showCreateShoppingListConfirm = signal(false);
+  showCreateShoppingListConfirm = this.createShoppingList.showConfirm;
 
   notesDraft = this.notesAutosave.draft;
   notesSaved = this.notesAutosave.saved;
@@ -106,7 +100,7 @@ export class RecipeDetailComponent implements OnInit {
   ngOnInit(): void {
     const identifier = this.route.snapshot.paramMap.get('identifier');
     if (!identifier) {
-      this.serverError.set('recipes.detail.notFound');
+      this.localError.set('recipes.detail.notFound');
       return;
     }
 
@@ -132,7 +126,7 @@ export class RecipeDetailComponent implements OnInit {
         this.scaling.initFor(recipe);
         this.notesAutosave.attach(this.recipe);
       },
-      (error) => this.serverError.set(error),
+      (error) => this.localError.set(error),
     );
   }
 
@@ -175,13 +169,13 @@ export class RecipeDetailComponent implements OnInit {
     if (!recipe) return;
 
     this.showDeleteConfirm.set(false);
-    this.serverError.set(null);
+    this.localError.set(null);
 
     this.deleteState.execute(
       this.recipeApi.deleteRecipe(recipe.identifier),
       ERROR_MAPS.recipes.delete,
       () => this.router.navigate([ROUTES.recipes.list]),
-      (error) => this.serverError.set(error),
+      (error) => this.localError.set(error),
     );
   }
 
@@ -199,42 +193,21 @@ export class RecipeDetailComponent implements OnInit {
 
   onCreateShoppingList(): void {
     if (!this.recipe()) return;
-    this.serverError.set(null);
-    this.showCreateShoppingListConfirm.set(true);
+    this.localError.set(null);
+    this.createShoppingList.open();
   }
 
   onCreateShoppingListCancelled(): void {
-    if (this.isCreatingShoppingList()) return;
-    this.showCreateShoppingListConfirm.set(false);
+    this.createShoppingList.cancel();
   }
 
   onCreateShoppingListConfirmed(): void {
     const recipe = this.recipe();
     if (!recipe) return;
-
-    const desired = this.desiredServings();
-    const items: CreateShoppingListItem[] = this.scaledIngredients().map(({ name, amount, unit }) => ({
-      name,
-      amount,
-      unit,
-    }));
-    const title = recipe.servings !== null && desired !== null ? `${recipe.title} (x${desired})` : recipe.title;
-
-    this.createShoppingListState.execute(
-      this.shoppingApi.createShoppingList({
-        title,
-        items,
-        recipeIdentifier: recipe.identifier,
-      }),
-      ERROR_MAPS.recipes.createShoppingList,
-      (created) => {
-        this.showCreateShoppingListConfirm.set(false);
-        void this.router.navigateByUrl(ROUTES.shopping.detail(created.identifier));
-      },
-      (error) => {
-        this.showCreateShoppingListConfirm.set(false);
-        this.serverError.set(error);
-      },
-    );
+    this.createShoppingList.confirm({
+      recipe,
+      desiredServings: this.desiredServings(),
+      ingredients: this.scaledIngredients(),
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Extract the ~40-line create-shopping-list dialog flow (state + handlers + title formatting + post-create navigation) out of `recipe-detail.component.ts` into a new component-scoped `RecipeCreateShoppingListService` under `apps/recipes/src/app/integrations/shopping/`.
- The integrations/ location matches the existing pattern: cross-module concerns (recipe → shopping) live alongside `MultiRecipeShoppingListService` rather than inside the recipe-detail component itself.
- `serverError` is now a `computed` that merges the component-owned local error (load/delete) with the service-owned create error, so the template banner still shows both sources from one signal.
- `recipe-detail.component.ts`: **240 → 213 lines** (-27).

## Test plan

- [x] `yarn nx test recipes` — 229/229 pass (221 existing + 8 new service tests)
- [x] `yarn nx run-many -t lint -t typecheck -p recipes` — clean
- [x] `yarn prettier --check` on touched paths — clean