### PR TITLE
refactor(recipes): extract RecipeListLoaderService from recipe-list

### DIFF
--- a/client/apps/recipes/src/app/recipe-list/recipe-list-loader.service.spec.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list-loader.service.spec.ts
@@ -1,0 +1,137 @@
+import { TestBed } from '@angular/core/testing';
+import { of, Subject, throwError } from 'rxjs';
+import { RecipeApiService, type RecipeListItem } from '../api';
+import { RecipeChatSearchService } from '../integrations/chat/recipe-chat-search.service';
+import { RecipeListLoaderService } from './recipe-list-loader.service';
+
+const mockItems: RecipeListItem[] = [
+  {
+    identifier: 'r1',
+    title: 'Carbonara',
+    description: null,
+    servings: 4,
+    prepTimeMinutes: 10,
+    cookTimeMinutes: 20,
+    difficulty: 'medium',
+    imageUrl: null,
+    createdAt: '2026-04-10T00:00:00Z',
+    tags: ['pasta', 'italian'],
+    isFavorite: false,
+    rating: null,
+    hasNotes: false,
+  },
+  {
+    identifier: 'r2',
+    title: 'Salad',
+    description: null,
+    servings: 2,
+    prepTimeMinutes: 5,
+    cookTimeMinutes: null,
+    difficulty: 'easy',
+    imageUrl: null,
+    createdAt: '2026-04-11T00:00:00Z',
+    tags: ['vegetarian'],
+    isFavorite: false,
+    rating: null,
+    hasNotes: false,
+  },
+];
+
+describe('RecipeListLoaderService', () => {
+  let loader: RecipeListLoaderService;
+  let recipeApi: { getRecipes: ReturnType<typeof vi.fn> };
+  let chatSearch: { search: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    recipeApi = { getRecipes: vi.fn().mockReturnValue(of({ items: mockItems, totalCount: 2 })) };
+    chatSearch = { search: vi.fn().mockReturnValue(of({ items: mockItems.slice(0, 1), fellBack: false })) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        RecipeListLoaderService,
+        { provide: RecipeApiService, useValue: recipeApi },
+        { provide: RecipeChatSearchService, useValue: chatSearch },
+      ],
+    });
+
+    loader = TestBed.inject(RecipeListLoaderService);
+  });
+
+  describe('load', () => {
+    it('populates recipes + totalCount on success', () => {
+      loader.load({ page: 1, pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' }, false);
+
+      expect(loader.recipes()).toEqual(mockItems);
+      expect(loader.totalCount()).toBe(2);
+    });
+
+    it('appends results when append=true', () => {
+      loader.recipes.set(mockItems.slice(0, 1));
+      recipeApi.getRecipes.mockReturnValue(of({ items: mockItems.slice(1), totalCount: 2 }));
+
+      loader.load({ page: 2, pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' }, true);
+
+      expect(loader.recipes()).toHaveLength(2);
+    });
+
+    it('collects unique tags sorted alphabetically', () => {
+      loader.load({ page: 1, pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' }, false);
+
+      expect(loader.availableTags()).toEqual(['italian', 'pasta', 'vegetarian']);
+    });
+
+    it('discards stale responses from earlier load calls', () => {
+      const firstSubject = new Subject<{ items: RecipeListItem[]; totalCount: number }>();
+      recipeApi.getRecipes.mockReturnValueOnce(firstSubject);
+
+      loader.load({ page: 1, pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' }, false);
+      // Second load runs synchronously via `of(...)`, bumping the requestId.
+      loader.load({ page: 2, pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' }, false);
+
+      firstSubject.next({ items: [mockItems[0]], totalCount: 99 });
+      firstSubject.complete();
+
+      expect(loader.totalCount()).toBe(2);
+    });
+  });
+
+  describe('loadFromChat', () => {
+    it('flips isAiPowered on and replaces the list with chat results', () => {
+      loader.loadFromChat('quick dinner', { pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' });
+
+      expect(loader.isAiPowered()).toBe(true);
+      expect(loader.recipes()).toEqual(mockItems.slice(0, 1));
+      expect(loader.totalCount()).toBe(1);
+    });
+
+    it('falls back to non-AI mode when chat reports fellBack', () => {
+      chatSearch.search.mockReturnValue(of({ items: mockItems, fellBack: true }));
+
+      loader.loadFromChat('anything', { pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' });
+
+      expect(loader.isAiPowered()).toBe(false);
+    });
+
+    it('surfaces the chat error via serverError', () => {
+      chatSearch.search.mockReturnValue(throwError(() => ({ status: 500 })));
+
+      loader.loadFromChat('anything', { pageSize: 20, sortBy: 'Date', sortDirection: 'Descending' });
+
+      expect(loader.serverError()).not.toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears recipes, totalCount, and resets currentPage to 1', () => {
+      loader.recipes.set(mockItems);
+      loader.totalCount.set(99);
+      loader.currentPage.set(3);
+
+      loader.reset();
+
+      expect(loader.recipes()).toEqual([]);
+      expect(loader.totalCount()).toBe(0);
+      expect(loader.currentPage()).toBe(1);
+    });
+  });
+});

--- a/client/apps/recipes/src/app/recipe-list/recipe-list-loader.service.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list-loader.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { createAsyncState, ERROR_MAPS } from '@yumney/shared/models';
+import { GetRecipesParams, RecipeApiService, RecipeListItem } from '../api';
+import { RecipeChatSearchService } from '../integrations/chat/recipe-chat-search.service';
+
+export interface ChatSearchOptions {
+  pageSize: number;
+  sortBy: 'Name' | 'Date' | 'Rating';
+  sortDirection: 'Ascending' | 'Descending';
+}
+
+@Injectable()
+export class RecipeListLoaderService {
+  private recipeApi = inject(RecipeApiService);
+  private chatSearch = inject(RecipeChatSearchService);
+  private asyncState = createAsyncState();
+  private loadRequestId = 0;
+
+  readonly recipes = signal<RecipeListItem[]>([]);
+  readonly totalCount = signal(0);
+  readonly currentPage = signal(1);
+  readonly availableTags = signal<string[]>([]);
+  readonly isAiPowered = signal(false);
+  readonly isLoading = this.asyncState.isLoading;
+  readonly serverError = this.asyncState.serverError;
+
+  reset(): void {
+    this.currentPage.set(1);
+    this.recipes.set([]);
+    this.totalCount.set(0);
+  }
+
+  setAiPowered(value: boolean): void {
+    this.isAiPowered.set(value);
+  }
+
+  load(params: GetRecipesParams, append: boolean): void {
+    const requestId = ++this.loadRequestId;
+    this.asyncState.execute(this.recipeApi.getRecipes(params), ERROR_MAPS.recipes.list, (response) => {
+      if (requestId !== this.loadRequestId) return;
+      this.totalCount.set(response.totalCount);
+      if (append) {
+        this.recipes.update((existing) => [...existing, ...response.items]);
+      } else {
+        this.recipes.set(response.items);
+      }
+      this.collectAvailableTags(response.items);
+    });
+  }
+
+  loadFromChat(query: string, options: ChatSearchOptions): void {
+    const requestId = ++this.loadRequestId;
+    this.isAiPowered.set(true);
+    this.currentPage.set(1);
+    this.recipes.set([]);
+    this.totalCount.set(0);
+
+    this.asyncState.execute(this.chatSearch.search(query, options), ERROR_MAPS.recipes.list, ({ items, fellBack }) => {
+      if (requestId !== this.loadRequestId) return;
+      if (fellBack) this.isAiPowered.set(false);
+      this.recipes.set(items);
+      this.totalCount.set(items.length);
+      this.collectAvailableTags(items);
+    });
+  }
+
+  private collectAvailableTags(items: RecipeListItem[]): void {
+    const existing = new Set(this.availableTags());
+    for (const item of items) {
+      if (Array.isArray(item.tags)) {
+        for (const tag of item.tags) existing.add(tag);
+      }
+    }
+    this.availableTags.set([...existing].sort((a, b) => a.localeCompare(b)));
+  }
+}

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.ts
@@ -1,8 +1,8 @@
 import { Component, ChangeDetectionStrategy, computed, inject, OnInit, DestroyRef, signal } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
-import { RecipeApiService, RecipeListItem, GetRecipesParams } from '../api';
-import { createAsyncState, debouncedEffect, ERROR_MAPS, ROUTES, UI, toggleFavoriteInList } from '@yumney/shared/models';
+import { RecipeApiService, GetRecipesParams } from '../api';
+import { debouncedEffect, ROUTES, UI, toggleFavoriteInList } from '@yumney/shared/models';
 import { RouterLink } from '@angular/router';
 import {
   ButtonComponent,
@@ -16,6 +16,7 @@ import {
 } from '@yumney/ui';
 import { RecipeCardComponent } from './recipe-card/recipe-card.component';
 import { SortMenuComponent, SortMenuOption } from './sort-menu/sort-menu.component';
+import { RecipeListLoaderService } from './recipe-list-loader.service';
 import { RecipeAssignmentService } from '../integrations/meal-plan/recipe-assignment.service';
 import { MultiRecipePreviewDialogComponent } from '../integrations/shopping/multi-recipe-preview-dialog/multi-recipe-preview-dialog.component';
 import { MultiRecipeShoppingListService } from '../integrations/shopping/multi-recipe-shopping-list.service';
@@ -42,7 +43,7 @@ interface SortOption extends SortMenuOption {
     SortMenuComponent,
     MultiRecipePreviewDialogComponent,
   ],
-  providers: [RecipeAssignmentService, MultiRecipeShoppingListService, RecipeChatSearchService],
+  providers: [RecipeAssignmentService, MultiRecipeShoppingListService, RecipeChatSearchService, RecipeListLoaderService],
   templateUrl: './recipe-list.component.html',
   styleUrl: './recipe-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -62,41 +63,45 @@ export class RecipeListComponent implements OnInit {
   private recipeApi = inject(RecipeApiService);
   private chatSearch = inject(RecipeChatSearchService);
   private destroyRef = inject(DestroyRef);
-  private asyncState = createAsyncState();
+  private loader = inject(RecipeListLoaderService);
   private searchInput = signal('');
-  private loadRequestId = 0;
 
   constructor() {
     debouncedEffect(this.searchInput, UI.SEARCH_DEBOUNCE_MS, (value) => {
       const trimmed = value.trim();
       this.activeSearch.set(trimmed);
       if (trimmed === '' || !this.chatSearch.isConversational(trimmed)) {
-        this.isAiPowered.set(false);
+        this.loader.setAiPowered(false);
         this.resetAndReload();
         return;
       }
 
-      this.searchViaChat(trimmed);
+      this.multiSelect.clearSelection();
+      this.loader.loadFromChat(trimmed, {
+        pageSize: this.pageSize(),
+        sortBy: this.sortBy(),
+        sortDirection: this.sortDirection(),
+      });
     });
   }
 
   protected assignment = inject(RecipeAssignmentService);
   protected multiSelect = inject(MultiRecipeShoppingListService);
 
-  recipes = signal<RecipeListItem[]>([]);
-  totalCount = signal(0);
-  currentPage = signal(1);
+  recipes = this.loader.recipes;
+  totalCount = this.loader.totalCount;
+  currentPage = this.loader.currentPage;
+  availableTags = this.loader.availableTags;
+  isAiPowered = this.loader.isAiPowered;
+  isLoading = this.loader.isLoading;
   pageSize = signal(UI.DEFAULT_PAGE_SIZE);
   sortBy = signal<'Name' | 'Date' | 'Rating'>('Date');
   sortDirection = signal<'Ascending' | 'Descending'>('Descending');
-  isLoading = this.asyncState.isLoading;
-  serverError = computed(() => this.multiSelect.serverError() ?? this.asyncState.serverError());
+  serverError = computed(() => this.multiSelect.serverError() ?? this.loader.serverError());
   searchQuery = signal('');
   activeSearch = signal('');
-  isAiPowered = signal(false);
   filter = signal<RecipeFilterValue>({ ...EMPTY_FILTER });
   filterPanelOpen = signal(false);
-  availableTags = signal<string[]>([]);
 
   // Pagination + load-more disabled in AI mode: chat returns a small fixed
   // set (top-N suggestions), there's no concept of "next page" to ask for.
@@ -123,7 +128,7 @@ export class RecipeListComponent implements OnInit {
   ngOnInit(): void {
     this.assignment.initFromRoute();
     this.multiSelect.initFromRoute();
-    this.loadRecipes(false);
+    this.loader.load(this.buildParams(), false);
   }
 
   onSearchInput(event: Event): void {
@@ -135,7 +140,7 @@ export class RecipeListComponent implements OnInit {
   onSearchClear(): void {
     this.searchQuery.set('');
     this.activeSearch.set('');
-    this.isAiPowered.set(false);
+    this.loader.setAiPowered(false);
     this.resetAndReload();
   }
 
@@ -149,7 +154,7 @@ export class RecipeListComponent implements OnInit {
 
   onLoadMore(): void {
     this.currentPage.update((page) => page + 1);
-    this.loadRecipes(true);
+    this.loader.load(this.buildParams(), true);
   }
 
   toggleFilterPanel(): void {
@@ -166,43 +171,15 @@ export class RecipeListComponent implements OnInit {
   }
 
   private resetAndReload(): void {
-    this.currentPage.set(1);
-    this.recipes.set([]);
-    this.totalCount.set(0);
+    this.loader.reset();
     this.multiSelect.clearSelection();
-    this.loadRecipes(false);
+    this.loader.load(this.buildParams(), false);
   }
 
-  private searchViaChat(query: string): void {
-    const requestId = ++this.loadRequestId;
-    this.isAiPowered.set(true);
-    this.currentPage.set(1);
-    this.recipes.set([]);
-    this.totalCount.set(0);
-    this.multiSelect.clearSelection();
-
-    this.asyncState.execute(
-      this.chatSearch.search(query, {
-        pageSize: this.pageSize(),
-        sortBy: this.sortBy(),
-        sortDirection: this.sortDirection(),
-      }),
-      ERROR_MAPS.recipes.list,
-      ({ items, fellBack }) => {
-        if (requestId !== this.loadRequestId) return;
-        if (fellBack) this.isAiPowered.set(false);
-        this.recipes.set(items);
-        this.totalCount.set(items.length);
-        this.collectAvailableTags(items);
-      },
-    );
-  }
-
-  private loadRecipes(append: boolean): void {
-    const requestId = ++this.loadRequestId;
+  private buildParams(): GetRecipesParams {
     const search = this.activeSearch();
     const filter = this.filter();
-    const params: GetRecipesParams = {
+    return {
       page: this.currentPage(),
       pageSize: this.pageSize(),
       sortBy: this.sortBy(),
@@ -214,26 +191,5 @@ export class RecipeListComponent implements OnInit {
       ...(filter.maxCookTime !== null && { maxCookTime: filter.maxCookTime }),
       ...(filter.favoritesOnly && { favorites: true }),
     };
-
-    this.asyncState.execute(this.recipeApi.getRecipes(params), ERROR_MAPS.recipes.list, (response) => {
-      if (requestId !== this.loadRequestId) return;
-      this.totalCount.set(response.totalCount);
-      if (append) {
-        this.recipes.update((existing) => [...existing, ...response.items]);
-      } else {
-        this.recipes.set(response.items);
-      }
-      this.collectAvailableTags(response.items);
-    });
-  }
-
-  private collectAvailableTags(items: RecipeListItem[]): void {
-    const existing = new Set(this.availableTags());
-    for (const item of items) {
-      if (Array.isArray(item.tags)) {
-        for (const tag of item.tags) existing.add(tag);
-      }
-    }
-    this.availableTags.set([...existing].sort((a, b) => a.localeCompare(b)));
   }
 }


### PR DESCRIPTION
## Summary

- Extract list-loading orchestration out of `recipe-list.component.ts` into a new component-scoped `RecipeListLoaderService`. The loader owns: `recipes`, `totalCount`, `availableTags`, `currentPage`, `isAiPowered`, `isLoading`, `serverError`, the race-cancellation `loadRequestId`, and the two load entry points (`load(params, append)` for paged HTTP, `loadFromChat(query, opts)` for one-shot AI search).
- Component keeps the UI state (search input, sort, filter, filter-panel open) and now reads as a sequence of thin handlers that build a `GetRecipesParams` snapshot via `buildParams()` and delegate to the loader.
- Signals are **re-exposed** on the component (`recipes = this.loader.recipes`, etc.) so the existing 60-case spec file that pokes `component.recipes / component.totalCount / component.isAiPowered / component.isLoading / component.serverError` works **without a single edit**.
- `recipe-list.component.ts`: **239 → 195 lines** (-44).

## Test plan

- [x] `yarn nx test recipes` — 237/237 pass (229 existing + 8 new loader tests)
- [x] `yarn nx run-many -t lint -t typecheck -p recipes` — clean
- [x] `yarn prettier --check apps/recipes/src/app/recipe-list` — clean