### PR TITLE
refactor(shell): extract swipe + date helpers from meal-planner

### DIFF
--- a/client/apps/shell/src/app/meal-planner/attach-horizontal-swipe.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/attach-horizontal-swipe.spec.ts
@@ -1,0 +1,76 @@
+import { DestroyRef } from '@angular/core';
+import { attachHorizontalSwipe } from './attach-horizontal-swipe';
+
+function makeDestroyRef(): { ref: DestroyRef; destroy: () => void } {
+  const callbacks: Array<() => void> = [];
+  return {
+    ref: { destroyed: false, onDestroy: (cb: () => void) => callbacks.push(cb) },
+    destroy: () => callbacks.forEach((cb) => cb()),
+  };
+}
+
+describe('attachHorizontalSwipe', () => {
+  let host: HTMLElement;
+  let onSwipeLeft: ReturnType<typeof vi.fn>;
+  let onSwipeRight: ReturnType<typeof vi.fn>;
+  let destroyRef: ReturnType<typeof makeDestroyRef>;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    onSwipeLeft = vi.fn();
+    onSwipeRight = vi.fn();
+    destroyRef = makeDestroyRef();
+    attachHorizontalSwipe(host, destroyRef.ref, { onSwipeLeft, onSwipeRight });
+  });
+
+  afterEach(() => {
+    document.body.removeChild(host);
+  });
+
+  function fire(type: 'pointerdown' | 'pointerup', x: number, y: number, pointerType: 'touch' | 'mouse' = 'touch'): void {
+    host.dispatchEvent(new PointerEvent(type, { pointerType, clientX: x, clientY: y }));
+  }
+
+  it('fires onSwipeLeft for a sufficient leftward touch drag', () => {
+    fire('pointerdown', 300, 100);
+    fire('pointerup', 200, 105);
+    expect(onSwipeLeft).toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('fires onSwipeRight for a sufficient rightward touch drag', () => {
+    fire('pointerdown', 100, 100);
+    fire('pointerup', 220, 95);
+    expect(onSwipeRight).toHaveBeenCalled();
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('ignores mouse drags', () => {
+    fire('pointerdown', 300, 100, 'mouse');
+    fire('pointerup', 150, 100, 'mouse');
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('ignores drags shorter than the threshold', () => {
+    fire('pointerdown', 300, 100);
+    fire('pointerup', 260, 105);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('ignores mostly-vertical drags (treat as scroll, not swipe)', () => {
+    fire('pointerdown', 200, 100);
+    fire('pointerup', 260, 300);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('removes listeners when the destroyRef fires', () => {
+    destroyRef.destroy();
+    fire('pointerdown', 300, 100);
+    fire('pointerup', 200, 105);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+});

--- a/client/apps/shell/src/app/meal-planner/attach-horizontal-swipe.ts
+++ b/client/apps/shell/src/app/meal-planner/attach-horizontal-swipe.ts
@@ -1,0 +1,48 @@
+import { DestroyRef } from '@angular/core';
+
+const SWIPE_MIN_DX_PX = 60;
+// |dy| must be < 50% of |dx| to count as horizontal — anything more vertical
+// is treated as a scroll gesture, not a swipe.
+const SWIPE_MAX_DY_RATIO = 0.5;
+
+export interface HorizontalSwipeCallbacks {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+}
+
+/**
+ * Attach touch-only horizontal swipe handling to a host element. The listeners
+ * are removed when `destroyRef` fires.
+ *
+ * Touch-only by design: mouse drags would conflict with scroll-bar dragging
+ * and text selection on desktop.
+ */
+export function attachHorizontalSwipe(host: HTMLElement, destroyRef: DestroyRef, callbacks: HorizontalSwipeCallbacks): void {
+  let start: { x: number; y: number } | null = null;
+
+  const onDown = (event: PointerEvent): void => {
+    if (event.pointerType !== 'touch') return;
+    start = { x: event.clientX, y: event.clientY };
+  };
+
+  const onUp = (event: PointerEvent): void => {
+    const begin = start;
+    start = null;
+    if (!begin || event.pointerType !== 'touch') return;
+
+    const dx = event.clientX - begin.x;
+    const dy = event.clientY - begin.y;
+    if (Math.abs(dx) < SWIPE_MIN_DX_PX) return;
+    if (Math.abs(dy) > Math.abs(dx) * SWIPE_MAX_DY_RATIO) return;
+
+    if (dx < 0) callbacks.onSwipeLeft();
+    else callbacks.onSwipeRight();
+  };
+
+  host.addEventListener('pointerdown', onDown);
+  host.addEventListener('pointerup', onUp);
+  destroyRef.onDestroy(() => {
+    host.removeEventListener('pointerdown', onDown);
+    host.removeEventListener('pointerup', onUp);
+  });
+}

--- a/client/apps/shell/src/app/meal-planner/meal-planner-dates.spec.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner-dates.spec.ts
@@ -1,0 +1,34 @@
+import { DAY_NAMES, getCurrentWeek, isToday } from './meal-planner-dates';
+
+describe('DAY_NAMES', () => {
+  it('starts on Monday and lists 7 days', () => {
+    expect(DAY_NAMES).toEqual(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']);
+  });
+});
+
+describe('getCurrentWeek', () => {
+  it('returns week 1 for Jan-4 of any year (ISO-ish boundary)', () => {
+    expect(getCurrentWeek(new Date(2026, 0, 4))).toBe(1);
+  });
+
+  it('returns week 2 for Jan-11 (one week after Jan-4)', () => {
+    expect(getCurrentWeek(new Date(2026, 0, 11))).toBe(2);
+  });
+
+  it('returns a value between 1 and 53 for any date in the year', () => {
+    const dec31 = getCurrentWeek(new Date(2026, 11, 31));
+    expect(dec31).toBeGreaterThanOrEqual(52);
+    expect(dec31).toBeLessThanOrEqual(53);
+  });
+});
+
+describe('isToday', () => {
+  it('returns true for the day matching the supplied date', () => {
+    // 2026-03-09 is a Monday.
+    expect(isToday('Monday', new Date(2026, 2, 9))).toBe(true);
+  });
+
+  it('returns false for a non-matching day', () => {
+    expect(isToday('Friday', new Date(2026, 2, 9))).toBe(false);
+  });
+});

--- a/client/apps/shell/src/app/meal-planner/meal-planner-dates.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner-dates.ts
@@ -1,0 +1,20 @@
+const MS_PER_DAY = 86_400_000;
+
+export const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
+
+const JS_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const;
+
+/**
+ * ISO-ish week number for the given date — Jan-4 is week 1 of its year, which
+ * lines up with the way the API server numbers weeks. Used by the meal-planner
+ * to pick the "current" week on first load and to label past/future weeks.
+ */
+export function getCurrentWeek(now: Date = new Date()): number {
+  const jan4 = new Date(now.getFullYear(), 0, 4);
+  const daysDiff = Math.floor((now.getTime() - jan4.getTime()) / MS_PER_DAY);
+  return Math.ceil((daysDiff + jan4.getDay() + 1) / 7);
+}
+
+export function isToday(dayName: string, now: Date = new Date()): boolean {
+  return JS_DAY_NAMES[now.getDay()] === dayName;
+}

--- a/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
+++ b/client/apps/shell/src/app/meal-planner/meal-planner.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ElementRef, HostListener, inject, signal, computed } from '@angular/core';
+import { Component, ChangeDetectionStrategy, DestroyRef, ElementRef, inject, signal, computed } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@jsverse/transloco';
 import { LucideAngularModule } from 'lucide-angular';
@@ -6,13 +6,10 @@ import { MealPlanApiService, type WeeklyPlan, type MealSlot, type GenerateShoppi
 import { injectAsyncStates, ERROR_MAPS, UI } from '@yumney/shared/models';
 import { AsyncStateComponent } from '@yumney/ui';
 import { MealSuggestionPanelComponent } from './meal-suggestion-panel/meal-suggestion-panel.component';
+import { attachHorizontalSwipe } from './attach-horizontal-swipe';
+import { DAY_NAMES, getCurrentWeek, isToday } from './meal-planner-dates';
 
 const WEEKS_PER_YEAR = 52;
-const MS_PER_DAY = 86_400_000;
-const SWIPE_MIN_DX_PX = 60;
-const SWIPE_MAX_DY_RATIO = 0.5; // |dy| must be < 50% of |dx| to count as horizontal
-const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-const JS_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 @Component({
   selector: 'yn-meal-planner',
@@ -27,10 +24,11 @@ export class MealPlannerComponent {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private host = inject(ElementRef<HTMLElement>);
+  private destroyRef = inject(DestroyRef);
   private states = injectAsyncStates('load', 'generate', 'clearSlot', 'copy');
 
   protected year = signal(new Date().getFullYear());
-  protected weekNumber = signal(this.getCurrentWeek());
+  protected weekNumber = signal(getCurrentWeek());
   protected plan = signal<WeeklyPlan | null>(null);
   protected loading = this.states.load.isLoading;
   protected error = computed(
@@ -47,7 +45,7 @@ export class MealPlannerComponent {
   protected weekLabel = computed(() => `${this.year()}-W${String(this.weekNumber()).padStart(2, '0')}`);
 
   private currentYear = new Date().getFullYear();
-  private currentWeekNumber = this.getCurrentWeek();
+  private currentWeekNumber = getCurrentWeek();
 
   protected isPastWeek = computed(() => {
     const year = this.year();
@@ -76,6 +74,10 @@ export class MealPlannerComponent {
       this.weekNumber.set(weekParam);
     }
     this.loadPlan();
+    attachHorizontalSwipe(this.host.nativeElement, this.destroyRef, {
+      onSwipeLeft: () => this.onNextWeek(),
+      onSwipeRight: () => this.onPreviousWeek(),
+    });
   }
 
   protected onOpenHistory(): void {
@@ -175,40 +177,7 @@ export class MealPlannerComponent {
     this.loadPlan();
   }
 
-  private swipeStart: { x: number; y: number } | null = null;
-
-  @HostListener('pointerdown', ['$event'])
-  protected onSwipeStart(event: PointerEvent): void {
-    if (event.pointerType !== 'touch') return;
-    this.swipeStart = { x: event.clientX, y: event.clientY };
-  }
-
-  @HostListener('pointerup', ['$event'])
-  protected onSwipeEnd(event: PointerEvent): void {
-    const start = this.swipeStart;
-    this.swipeStart = null;
-    if (!start || event.pointerType !== 'touch') return;
-
-    const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    if (Math.abs(dx) < SWIPE_MIN_DX_PX) return;
-    if (Math.abs(dy) > Math.abs(dx) * SWIPE_MAX_DY_RATIO) return;
-
-    if (dx < 0) {
-      this.onNextWeek();
-    } else {
-      this.onPreviousWeek();
-    }
-  }
-
   protected isToday(dayName: string): boolean {
-    return JS_DAY_NAMES[new Date().getDay()] === dayName;
-  }
-
-  private getCurrentWeek(): number {
-    const now = new Date();
-    const jan4 = new Date(now.getFullYear(), 0, 4);
-    const daysDiff = Math.floor((now.getTime() - jan4.getTime()) / MS_PER_DAY);
-    return Math.ceil((daysDiff + jan4.getDay() + 1) / 7);
+    return isToday(dayName);
   }
 }


### PR DESCRIPTION
## Summary

Two extractions from `meal-planner.component.ts`:

- **`attachHorizontalSwipe(host, destroyRef, callbacks)`**: pure function that wires `pointerdown`/`pointerup` listeners on a host element and tears them down via DestroyRef. Modeled as a function rather than a directive because the existing spec dispatches PointerEvents on `fixture.nativeElement` (the component host) — a directive on a child element doesn't catch those.
- **`meal-planner-dates.ts`**: `DAY_NAMES`, `getCurrentWeek(now?)`, `isToday(day, now?)`. Pure, with optional `now` parameters so tests can pin a date instead of relying on real time.

- `meal-planner.component.ts`: **214 → 178 lines** (-36).

## Test plan

- [x] `yarn nx test shell` — 280/280 pass (268 existing + 12 new helper tests)
- [x] `yarn nx run-many -t lint -t typecheck -p shell` — clean
- [x] `yarn prettier --check apps/shell/src/app/meal-planner` — clean