### PR TITLE
fix(ci): make yarn cache step robust to Corepack download banner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,21 +81,36 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Yarn
-        run: corepack enable
-
-      - name: Get yarn cache directory
-        id: yarn-cache-dir
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+        # Pre-activate the pinned Yarn before any later step shells out to
+        # `yarn`. Newer Corepack versions print a "Corepack is about to
+        # download..." banner on first invocation that races with the
+        # cacheFolder lookup, returning an empty value and tripping the
+        # downstream actions/cache `Input required and not supplied: path`
+        # error. Setting COREPACK_ENABLE_DOWNLOAD_PROMPT=0 suppresses the
+        # banner; explicitly preparing yarn here guarantees subsequent
+        # `yarn` calls are warm.
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+        run: |
+          corepack enable
+          corepack prepare --activate
+          yarn --version
 
       - name: Cache Yarn
+        # The cache folder is Yarn 4's default (`.yarn/cache` next to the
+        # lockfile) — pin it directly instead of fishing it out of
+        # `yarn config get cacheFolder`, which has been intermittently
+        # empty under newer Corepack.
         uses: actions/cache@v4
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          path: client/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('client/yarn.lock') }}
           restore-keys: |
             yarn-${{ runner.os }}-
 
       - name: Install dependencies
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         run: yarn install --immutable
 
       - name: Verify i18n in sync

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,22 +63,27 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Install Yarn
-        run: corepack enable
-
-      - name: Get yarn cache directory
-        id: yarn-cache-dir
+        # See ci.yml for context — Corepack's first-run download banner can
+        # race with `yarn config get cacheFolder` and yield an empty path.
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         working-directory: client
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+        run: |
+          corepack enable
+          corepack prepare --activate
+          yarn --version
 
       - name: Cache Yarn
         uses: actions/cache@v4
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          path: client/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('client/yarn.lock') }}
           restore-keys: |
             yarn-${{ runner.os }}-
 
       - name: Install frontend dependencies
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         working-directory: client
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

The frontend job has been failing for two recent PRs at the "Cache Yarn" step:
```
##[error]Input required and not supplied: path
```

Root cause: newer Corepack versions print a banner on first run —
```
! Corepack is about to download https://repo.yarnpkg.com/4.6.0/packages/yarnpkg-cli/bin/yarn.js
```
— that races with the `yarn config get cacheFolder` step capturing yarn's stdout. When the race goes the wrong way the captured value is empty, and `actions/cache@v4` errors out because `path` is required.

Two changes in both `ci.yml` and `e2e.yml`:
- Suppress the Corepack banner via `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` and pre-activate yarn with `corepack prepare --activate` + a probe `yarn --version` before any later step shells out.
- Replace the dynamic `yarn config get cacheFolder` lookup with the literal `client/.yarn/cache` path — that's Yarn 4's documented default and matches what the working tree already produces locally. One fewer race, one fewer step that can be empty.

## Test plan

- [ ] Frontend (Build + Test) job reaches its Lint/Typecheck/Test steps on this PR.