### PR TITLE
fix(test): cache Keycloak tokens per fixture to dodge brute-force lockout

### DIFF
--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.Auth.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.Auth.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -9,6 +10,17 @@ namespace SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
 public sealed partial class AspireFixture
 #pragma warning restore SA1601
 {
+	// Cache tokens across the whole xUnit collection. Without this, every
+	// test does InitializeAsync (cleanup -> token #1), Act (auth client ->
+	// token #2), DisposeAsync (cleanup -> token #3) = 3 password grants per
+	// test for the shared `testuser`. 295 tests therefore hammer Keycloak
+	// with ~885 grants, and the realm's bruteForceProtected + default
+	// quickLoginCheckMilliSeconds inevitably starts replying 401 invalid_grant
+	// on a random subset of runs. Tokens are valid for 1h (accessTokenLifespan
+	// in the realm json), well past the full-suite duration.
+	private static readonly TimeSpan ExpirySafetyMargin = TimeSpan.FromMinutes(1);
+	private readonly ConcurrentDictionary<string, CachedToken> _tokenCache = new();
+
 	public Task<HttpClient> CreateAuthenticatedClientAsync(string resourceName) =>
 		CreateAuthenticatedClientAsync(resourceName, "testuser", "Test1234");
 
@@ -36,6 +48,19 @@ public sealed partial class AspireFixture
 
 	public async Task<string> GetAccessTokenAsync(string username, string password)
 	{
+		var cacheKey = $"{username}|{password}";
+		if (_tokenCache.TryGetValue(cacheKey, out var cached) && cached.ExpiresAt > DateTimeOffset.UtcNow + ExpirySafetyMargin)
+		{
+			return cached.AccessToken;
+		}
+
+		var token = await FetchAccessTokenAsync(username, password);
+		_tokenCache[cacheKey] = token;
+		return token.AccessToken;
+	}
+
+	private async Task<CachedToken> FetchAccessTokenAsync(string username, string password)
+	{
 		var keycloakClient = App.CreateHttpClient("keycloak");
 		Dictionary<string, string> valueCollection = new()
 		{
@@ -53,9 +78,12 @@ public sealed partial class AspireFixture
 		}
 
 		var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
-
-		return tokenJson.GetProperty("access_token").GetString()!;
+		var accessToken = tokenJson.GetProperty("access_token").GetString()!;
+		var expiresIn = tokenJson.TryGetProperty("expires_in", out var expiresProperty) ? expiresProperty.GetInt32() : 60;
+		return new CachedToken(accessToken, DateTimeOffset.UtcNow.AddSeconds(expiresIn));
 	}
+
+	private sealed record CachedToken(string AccessToken, DateTimeOffset ExpiresAt);
 
 	/// <summary>
 	/// Provision a brand-new Keycloak user via the admin API with emailVerified=true


### PR DESCRIPTION
## Summary

The integration test suite has been showing random 401 `invalid_grant` failures during teardown — e.g., PR #794's `WhatCanICookContractTests.CleanupAsync` ran a passing test then failed on cleanup with `Keycloak password grant failed: invalid_grant`.

Root cause: every test does ~3 password-grant calls against the shared `testuser`:
1. `InitializeAsync` → cleanup → `GetTestUserIdAsync` → grant
2. test body → `CreateAuthenticatedClientAsync` → grant
3. `DisposeAsync` → cleanup → `GetTestUserIdAsync` → grant

Across 295 tests that's ~885 grants on a single user. The yumney realm has `bruteForceProtected: true` with the Keycloak defaults (`quickLoginCheckMilliSeconds: 1000`, `minimumQuickLoginWaitSeconds: 60`), which marks the user temporarily-disabled when many auths land inside the 1s window. The suite then sees random 401 invalid_grant cleanup failures — usually on whichever test runs through the lockout boundary.

Fix: cache the token on the `AspireFixture` for the full xUnit collection lifetime. The realm's `accessTokenLifespan` is 3600s, well past any realistic test-suite duration. Cache key is `(username, password)` so fixture-provisioned users (e.g. `CreateKeycloakUserAsync`) still get their own grants.

Brings the per-user grant count from ~3 per test to ~1 per fixture lifetime.

## Test plan

- [x] `dotnet build tests/Yumney.Integration.Tests -p:TreatWarningsAsErrors=true` — clean
- [ ] Integration suite passes in CI without the periodic `invalid_grant` flake

## Follow-up

The Playwright in-browser auth tests (`auth/login.spec.ts`, `account-deletion`) fail with `net::ERR_EMPTY_RESPONSE` because `app-config.json` still hard-codes `keycloakUrl: "http://localhost:8080"` while Aspire 13.3.3 only publishes Keycloak on a dynamic HTTPS port. That fix needs a runtime rewrite of `app-config.json` during the E2E workflow + `ignoreHTTPSErrors: true` in Playwright — separate PR.