### PR TITLE
fix(test): point Playwright login flow at dynamic Keycloak HTTPS port

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -255,6 +255,39 @@ jobs:
           done
           test -s /tmp/e2e-tokens.json
 
+      - name: Rewrite app-config.json with dynamic Keycloak URL
+        # The shell's `assets/config/app-config.json` hard-codes
+        # `http://localhost:8080` for keycloakUrl. Aspire 13.3.3 only
+        # publishes Keycloak on a random host port for the 8443/tcp HTTPS
+        # endpoint, so any in-browser OIDC redirect (login.spec, account
+        # deletion) lands at an unbound port and Chromium reports
+        # ERR_EMPTY_RESPONSE. Resolve the actual mapped HTTPS port and
+        # patch the config before Playwright opens the app — the Angular
+        # config service fetches this file at bootstrap, so the rewrite
+        # is picked up on every fresh page navigation.
+        run: |
+          set -e
+          kc=$(docker ps -q -f name=keycloak | head -1)
+          test -n "$kc" || { echo "keycloak container not found"; exit 1; }
+          kc_port=$(docker port "$kc" 8443/tcp 2>/dev/null | head -1 | sed -E 's/.*:([0-9]+)$/\1/')
+          scheme=https
+          if [ -z "$kc_port" ]; then
+            kc_port=$(docker port "$kc" 8080/tcp 2>/dev/null | head -1 | sed -E 's/.*:([0-9]+)$/\1/')
+            scheme=http
+          fi
+          test -n "$kc_port" || { echo "could not resolve keycloak host port"; exit 1; }
+          target="${scheme}://localhost:${kc_port}"
+          echo "patching app-config.json keycloakUrl -> ${target}"
+
+          for config in \
+            client/dist/apps/shell/browser/assets/config/app-config.json \
+            client/apps/shell/src/assets/config/app-config.json; do
+            if [ -f "$config" ]; then
+              python3 -c 'import json,sys; path=sys.argv[1]; cfg=json.load(open(path)); cfg["keycloakUrl"]=sys.argv[2]; json.dump(cfg, open(path,"w"), indent=2)' "$config" "$target"
+              echo "  patched $config"
+            fi
+          done
+
       - name: Warm up API endpoints
         # First call to each *.Api after Aspire startup pays a 5-15s JIT +
         # EF-model-build cost. Playwright toBeVisible timeouts are 10s, so

--- a/client/apps/shell-e2e/playwright.config.ts
+++ b/client/apps/shell-e2e/playwright.config.ts
@@ -65,6 +65,11 @@ export default defineConfig({
     // like the confirm-dialog overlay render at static opacity:1 instead of
     // racing through a fade-in that Playwright sometimes catches at opacity:0.
     reducedMotion: 'reduce',
+    // OIDC redirects go to Aspire's Keycloak container on a dynamically-mapped
+    // HTTPS port with a self-signed dev cert. Without this, Chromium aborts
+    // the navigation with net::ERR_EMPTY_RESPONSE and the login flow tests
+    // time out. The flag is scoped to the e2e config; production is untouched.
+    ignoreHTTPSErrors: true,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

The Playwright in-browser auth tests (`auth/login.spec.ts`, `account/account-deletion.spec.ts`) have been failing on every PR since the Aspire 13.3.3 upgrade with `net::ERR_EMPTY_RESPONSE` during the OIDC redirect. Root cause: Aspire 13.3.3 publishes Keycloak only on the 8443/tcp HTTPS endpoint at a randomly-allocated host port, while the Angular shell's `assets/config/app-config.json` still hard-codes `http://localhost:8080`. The browser tries to redirect there, finds no listener, and aborts.

Two changes:

- **New `Rewrite app-config.json with dynamic Keycloak URL` step in `e2e.yml`** — runs after Keycloak is up, discovers the container's mapped 8443/tcp port (8080/tcp fallback for older Aspire), and patches the shipped `keycloakUrl` to `https://localhost:${port}`. The Angular config service fetches this file at bootstrap so every fresh page load picks up the rewritten value.
- **`ignoreHTTPSErrors: true`** in `playwright.config.ts` — the Aspire dev cert is self-signed, so without this Chromium would still reject the navigation.

## Test plan

- [ ] CI run on this PR: `auth/login.spec` (`should redirect to Keycloak on sign in click`, `should complete full login flow and reach dashboard`) and `account/account-deletion` should pass instead of timing out.
- [ ] Other E2E tests (authenticated via `auth.setup.ts`'s pre-fetched token) should still pass.