### PR TITLE
feat(infra): add /ready readiness probe (US-140)

### DIFF
--- a/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.MealPlan.Infrastructure/MealPlanInfrastructureServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ public static class MealPlanInfrastructureServiceCollectionExtensions
 		services.AddRecipesClient();
 		services.AddShoppingClient();
 		services.AddUsersClient();
-		services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb");
+		services.AddHealthChecks().AddDbContextCheck<MealPlanDbContext>("mealplandb", tags: ["ready"]);
 
 		return services;
 	}

--- a/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Recipes.Infrastructure/RecipesInfrastructureServiceCollectionExtensions.cs
@@ -54,7 +54,7 @@ public static class RecipesInfrastructureServiceCollectionExtensions
 		services.AddShoppingClient();
 		services.AddUsersClient();
 		services.AddMealPlanClient();
-		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb");
+		services.AddHealthChecks().AddDbContextCheck<RecipesDbContext>("recipesdb", tags: ["ready"]);
 
 		return services;
 	}

--- a/src/Yumney.ServiceDefaults/Extensions.cs
+++ b/src/Yumney.ServiceDefaults/Extensions.cs
@@ -74,6 +74,16 @@ public static class Extensions
 			Predicate = r => r.Tags.Contains("live"),
 		});
 
+		// Readiness probe — runs only the checks that exercise real
+		// dependencies (DbContext, Redis, Keycloak), so a load balancer
+		// can hold off traffic until the host can actually serve it.
+		// Liveness ("/alive") is intentionally minimal; restarting on a
+		// downed dependency would just cycle the host without recovering.
+		app.MapHealthChecks("/ready", new HealthCheckOptions
+		{
+			Predicate = r => r.Tags.Contains("ready"),
+		});
+
 		return app;
 	}
 

--- a/src/Yumney.Shared.Web/Middleware/RequestLoggingMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/RequestLoggingMiddleware.cs
@@ -12,6 +12,7 @@ public sealed partial class RequestLoggingMiddleware(RequestDelegate next, ILogg
 	{
 		"/health",
 		"/alive",
+		"/ready",
 	};
 
 	public async Task InvokeAsync(HttpContext context)

--- a/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Shopping.Infrastructure/ShoppingInfrastructureServiceCollectionExtensions.cs
@@ -43,7 +43,9 @@ public static class ShoppingInfrastructureServiceCollectionExtensions
 		services.AddBusEventHandlersFromAssemblyContaining<ShoppingListProjection>();
 		services.AddUsersClient();
 		services.AddScoped<IShoppingUserDataPurger, ShoppingUserDataPurger>();
-		services.AddHealthChecks().AddDbContextCheck<ShoppingDbContext>("shoppingdb");
+		services.AddHealthChecks()
+			.AddDbContextCheck<ShoppingDbContext>("shoppingdb", tags: ["ready"])
+			.AddDbContextCheck<ShoppingReadDbContext>("shopping-readdb", tags: ["ready"]);
 
 		return services;
 	}

--- a/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
+++ b/src/Yumney.Users.Infrastructure/UsersInfrastructureServiceCollectionExtensions.cs
@@ -72,7 +72,7 @@ public static class UsersInfrastructureServiceCollectionExtensions
 			})
 			.AddStandardResilienceHandler();
 
-		services.AddHealthChecks().AddDbContextCheck<UsersDbContext>("usersdb");
+		services.AddHealthChecks().AddDbContextCheck<UsersDbContext>("usersdb", tags: ["ready"]);
 
 		return services;
 	}

--- a/tests/Yumney.Shared.Tests/Web/RequestLoggingMiddlewareTests.cs
+++ b/tests/Yumney.Shared.Tests/Web/RequestLoggingMiddlewareTests.cs
@@ -68,6 +68,26 @@ public class RequestLoggingMiddlewareTests
 	}
 
 	[Fact]
+	public async Task InvokeAsync_ReadyEndpoint_SkipsLogging()
+	{
+		var wasCalled = false;
+		var logger = Substitute.For<ILogger<RequestLoggingMiddleware>>();
+		RequestDelegate next = _ =>
+		{
+			wasCalled = true;
+			return Task.CompletedTask;
+		};
+		var middleware = new RequestLoggingMiddleware(next, logger);
+
+		var context = new DefaultHttpContext();
+		context.Request.Path = "/ready";
+
+		await middleware.InvokeAsync(context);
+
+		wasCalled.Should().BeTrue();
+	}
+
+	[Fact]
 	public async Task InvokeAsync_404Response_DelegatesDownstream()
 	{
 		var logger = Substitute.For<ILogger<RequestLoggingMiddleware>>();


### PR DESCRIPTION
## Summary

Closes the last remaining sub-task of US-140 (Make Backend Services Horizontally Scalable). The other five sub-tasks have already shipped to develop:

| Sub-task | Status |
|---|---|
| FA-140-1 Distributed Rate Limiting | ✅ `RedisRateLimitPartition` in `HostBuilderExtensions.RateLimiting.cs` |
| FA-140-2 Safe Concurrent DB Migrations | ✅ `pg_advisory_lock` in `MigrationWorker` |
| FA-140-3 Distributed Event Bus | ✅ Wolverine + RabbitMQ via `AddWolverineEventBus` |
| FA-140-4 Distributed Keycloak Token Cache | ✅ `IDistributedCache` in `KeycloakAdminService.GetServiceAccountTokenAsync` |
| FA-140-5 SSE Sticky Sessions | ✅ `SessionAffinity.Policy=Cookie` on `recipes-api` cluster |
| **FA-140-6 Readiness Health Checks** | **This PR** |

This PR adds `/ready` alongside the existing `/health` (all checks) and `/alive` (live tag only) endpoints. `/ready` runs only checks tagged `"ready"` — the ones that exercise real dependencies a load balancer should honour before routing traffic in:

- **Per-module DbContext checks** (Recipes, Shopping × 2, MealPlan, Users) now register with `tags: ["ready"]` so each Api host's `/ready` fails until its database is reachable.
- **Redis and Keycloak** readiness checks in `Shared.Web` were already tagged `"ready"` — they just had no endpoint exposing them.
- `/ready` joins the `RequestLoggingMiddleware` excluded paths so probe traffic doesn't flood the logs.

Liveness stays minimal on purpose: restarting on a downed dependency would cycle the host without recovering. `/ready` is for the LB; `/alive` is for the container runtime.

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet test Yumney.Shared.Tests` — `InvokeAsync_ReadyEndpoint_SkipsLogging` passes alongside the existing `_HealthEndpoint_` / `_AliveEndpoint_` tests
- [x] `dotnet format --verify-no-changes` — clean
- [ ] End-to-end: hit `/ready` on each Api host with deps down → expect 503; with deps up → expect 200 (manual)