### PR TITLE
refactor(shared): enforce ConfigureAwait(false) across shared libs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,6 +29,21 @@ dotnet_diagnostic.SA1027.severity = none
 dotnet_diagnostic.CA1000.severity = suggestion
 dotnet_diagnostic.CA1716.severity = none
 dotnet_diagnostic.CA1848.severity = suggestion
+
+# Shared libraries must use ConfigureAwait(false) on every awaited task so
+# they remain safe to reuse outside an ASP.NET Core host (e.g. a console
+# tool, desktop app, or any other SynchronizationContext-bearing caller).
+# Scoped to Yumney.Shared.* + Yumney.ServiceDefaults only — module-specific
+# host code stays opt-out since it always runs in an ASP.NET Core SyncContext.
+
+[src/Yumney.Shared/**/*.cs]
+dotnet_diagnostic.CA2007.severity = error
+
+[src/Yumney.Shared.*/**/*.cs]
+dotnet_diagnostic.CA2007.severity = error
+
+[src/Yumney.ServiceDefaults/**/*.cs]
+dotnet_diagnostic.CA2007.severity = error
 dotnet_sort_system_directives_first = true
 csharp_using_directive_placement = outside_namespace
 csharp_new_line_before_open_brace = all

--- a/src/Yumney.Shared.CQRS/Decorators/LoggingCommandHandlerDecorator.cs
+++ b/src/Yumney.Shared.CQRS/Decorators/LoggingCommandHandlerDecorator.cs
@@ -27,7 +27,7 @@ public sealed partial class LoggingCommandHandlerDecorator<TCommand, TResult>(
 
 		try
 		{
-			var result = await inner.HandleAsync(command, cancellationToken);
+			var result = await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
 			var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
 
 			if (ResultInspector.IsFailure(result, out var errorCode, out var errorMessage))

--- a/src/Yumney.Shared.CQRS/Decorators/LoggingQueryHandlerDecorator.cs
+++ b/src/Yumney.Shared.CQRS/Decorators/LoggingQueryHandlerDecorator.cs
@@ -27,7 +27,7 @@ public sealed partial class LoggingQueryHandlerDecorator<TQuery, TResult>(
 
 		try
 		{
-			var result = await inner.HandleAsync(query, cancellationToken);
+			var result = await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
 			var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
 
 			if (ResultInspector.IsFailure(result, out var errorCode, out var errorMessage))

--- a/src/Yumney.Shared.Persistence/EventStore/EventSourcedAggregateDraining.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EventSourcedAggregateDraining.cs
@@ -23,17 +23,17 @@ public static class EventSourcedAggregateDraining
 		var aggregateIds = await metadataSet
 			.Where(metadata => metadata.OwnerId == ownerValue)
 			.Select(metadata => metadata.AggregateId)
-			.ToListAsync(cancellationToken);
+			.ToListAsync(cancellationToken).ConfigureAwait(false);
 
 		if (aggregateIds.Count > 0)
 		{
 			await eventsSet
 				.Where(stored => aggregateIds.Contains(stored.AggregateId))
-				.ExecuteDeleteAsync(cancellationToken);
+				.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		await metadataSet
 			.Where(metadata => metadata.OwnerId == ownerValue)
-			.ExecuteDeleteAsync(cancellationToken);
+			.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
+++ b/src/Yumney.Shared.Persistence/EventStore/EventStoreBase.cs
@@ -33,7 +33,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 
 		var aggregateId = GetAggregateId(aggregate);
 
-		var existingMetadata = await Context.Set<TMetadata>().FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken);
+		var existingMetadata = await Context.Set<TMetadata>().FirstOrDefaultAsync(m => m.AggregateId == aggregateId, cancellationToken).ConfigureAwait(false);
 
 		if (existingMetadata is null)
 		{
@@ -60,7 +60,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 
 		try
 		{
-			await PersistAndPublishAsync(aggregate, busEvents, cancellationToken);
+			await PersistAndPublishAsync(aggregate, busEvents, cancellationToken).ConfigureAwait(false);
 		}
 		catch (DbUpdateException ex) when (ex.IsUniqueViolation())
 		{
@@ -116,13 +116,13 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 		IReadOnlyList<IBusEvent> busEvents,
 		CancellationToken cancellationToken)
 	{
-		await Context.SaveChangesAsync(cancellationToken);
+		await Context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
 		aggregate.MarkCommitted();
 
 		foreach (var busEvent in busEvents)
 		{
-			await EventBus.PublishAsync(busEvent, cancellationToken);
+			await EventBus.PublishAsync(busEvent, cancellationToken).ConfigureAwait(false);
 		}
 	}
 
@@ -132,7 +132,7 @@ public abstract class EventStoreBase<TAggregate, TIdentifier, TMetadata, TStored
 			.AsNoTracking()
 			.Where(row => row.AggregateId == aggregateId)
 			.OrderBy(row => row.Version)
-			.ToListAsync(cancellationToken);
+			.ToListAsync(cancellationToken).ConfigureAwait(false);
 
 		List<IDomainEvent> events = new(stored.Count);
 		HashSet<string>? unknownTypes = null;

--- a/src/Yumney.Shared.Web/HealthChecks/KeycloakHealthCheck.cs
+++ b/src/Yumney.Shared.Web/HealthChecks/KeycloakHealthCheck.cs
@@ -15,7 +15,7 @@ public sealed class KeycloakHealthCheck(IHttpClientFactory httpClientFactory, IC
 			using var client = httpClientFactory.CreateClient();
 			client.Timeout = TimeSpan.FromSeconds(5);
 
-			var response = await client.GetAsync(discoveryUrl, cancellationToken);
+			var response = await client.GetAsync(discoveryUrl, cancellationToken).ConfigureAwait(false);
 
 			return response.IsSuccessStatusCode
 				? HealthCheckResult.Healthy("Keycloak realm discovery is reachable")

--- a/src/Yumney.Shared.Web/HealthChecks/RedisHealthCheck.cs
+++ b/src/Yumney.Shared.Web/HealthChecks/RedisHealthCheck.cs
@@ -10,7 +10,7 @@ public sealed class RedisHealthCheck(IConnectionMultiplexer redis) : IHealthChec
 		try
 		{
 			var db = redis.GetDatabase();
-			var latency = await db.PingAsync();
+			var latency = await db.PingAsync().ConfigureAwait(false);
 
 			return latency.TotalMilliseconds < 1000
 				? HealthCheckResult.Healthy($"Redis ping: {latency.TotalMilliseconds:F0}ms")

--- a/src/Yumney.Shared.Web/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/CorrelationIdMiddleware.cs
@@ -20,6 +20,6 @@ public sealed class CorrelationIdMiddleware(RequestDelegate next)
 
 		Activity.Current?.SetBaggage("correlation.id", correlationId);
 
-		await next(context);
+		await next(context).ConfigureAwait(false);
 	}
 }

--- a/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -15,27 +15,27 @@ public sealed partial class GlobalExceptionHandlerMiddleware(RequestDelegate nex
 	{
 		try
 		{
-			await next(context);
+			await next(context).ConfigureAwait(false);
 		}
 		catch (EntityNotFoundException ex)
 		{
 			LogEntityNotFound(ex, ex.EntityName, ex.Identifier.ToString()!);
-			await WriteProblemDetailsAsync(context, HttpStatusCode.NotFound, "Not Found", ex.Message);
+			await WriteProblemDetailsAsync(context, HttpStatusCode.NotFound, "Not Found", ex.Message).ConfigureAwait(false);
 		}
 		catch (GuardException ex)
 		{
 			LogValidationFailed(ex, ex.ParameterName);
-			await WriteProblemDetailsAsync(context, HttpStatusCode.BadRequest, "Validation Error", ex.Message);
+			await WriteProblemDetailsAsync(context, HttpStatusCode.BadRequest, "Validation Error", ex.Message).ConfigureAwait(false);
 		}
 		catch (BusinessRuleValidationException ex)
 		{
 			LogBusinessRuleViolated(ex, ex.BrokenRule.GetType().Name);
-			await WriteProblemDetailsAsync(context, HttpStatusCode.UnprocessableEntity, "Business Rule Violation", ex.Message);
+			await WriteProblemDetailsAsync(context, HttpStatusCode.UnprocessableEntity, "Business Rule Violation", ex.Message).ConfigureAwait(false);
 		}
 		catch (Exception ex)
 		{
 			LogUnhandledException(ex);
-			await WriteProblemDetailsAsync(context, HttpStatusCode.InternalServerError, "Internal Server Error", "An unexpected error occurred.");
+			await WriteProblemDetailsAsync(context, HttpStatusCode.InternalServerError, "Internal Server Error", "An unexpected error occurred.").ConfigureAwait(false);
 		}
 	}
 
@@ -58,7 +58,7 @@ public sealed partial class GlobalExceptionHandlerMiddleware(RequestDelegate nex
 			problemDetails.Extensions["correlationId"] = correlationId;
 		}
 
-		await context.Response.WriteAsJsonAsync(problemDetails);
+		await context.Response.WriteAsJsonAsync(problemDetails).ConfigureAwait(false);
 	}
 
 	[LoggerMessage(Level = LogLevel.Warning, Message = "{EntityName} with identifier '{Identifier}' not found")]

--- a/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/RequestContextMiddleware.cs
@@ -24,7 +24,7 @@ public sealed class RequestContextMiddleware(RequestDelegate next, ILogger<Reque
 
 		using (logger.BeginScope(state))
 		{
-			await next(context);
+			await next(context).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Yumney.Shared.Web/Middleware/RequestLoggingMiddleware.cs
+++ b/src/Yumney.Shared.Web/Middleware/RequestLoggingMiddleware.cs
@@ -21,14 +21,14 @@ public sealed partial class RequestLoggingMiddleware(RequestDelegate next, ILogg
 
 		if (excludedPaths.Contains(path))
 		{
-			await next(context);
+			await next(context).ConfigureAwait(false);
 			return;
 		}
 
 		var method = context.Request.Method;
 		var start = Stopwatch.GetTimestamp();
 
-		await next(context);
+		await next(context).ConfigureAwait(false);
 
 		var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
 		var statusCode = context.Response.StatusCode;


### PR DESCRIPTION
## Summary

Shared libraries are reusable by definition, but the rest of the Yumney solution always runs in ASP.NET Core where `SynchronizationContext` is null — so a missing `ConfigureAwait(false)` is invisible until someone reuses one of these libs from a caller with a real sync context (desktop app, console tool, etc.), where it can deadlock.

- **Enable CA2007 as an error** scoped to `Yumney.Shared.*` + `Yumney.ServiceDefaults` via the root `.editorconfig`. Module-specific host code (Recipes.Api, Shopping.*, MealPlan.*, etc.) stays opt-out since it's intrinsically host-bound and the rule would just be visual noise there.
- **Auto-fix the 10 violations** with `dotnet format analyzers --diagnostics CA2007`:
  - `Shared.CQRS`: `LoggingCommandHandlerDecorator`, `LoggingQueryHandlerDecorator`
  - `Shared.Persistence`: `EventStoreBase`, `EventSourcedAggregateDraining`
  - `Shared.Web`: `CorrelationIdMiddleware`, `GlobalExceptionHandlerMiddleware`, `RequestContextMiddleware`, `RequestLoggingMiddleware`, `RedisHealthCheck`, `KeycloakHealthCheck`

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors)
- [x] `dotnet test tests/Yumney.Shared.Tests` — 455/455 pass
- [x] `dotnet format --verify-no-changes` — clean