### PR TITLE
fix(infra): publish public MCP URL so Claude/ChatGPT can connect

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,164 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+  schedule:
+    # Weekly Monday 06:00 UTC sweep so the vuln database stays fresh even on
+    # quiet branches. Catches advisories published against packages we shipped
+    # before they got flagged.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability Scan (Trivy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      # Trivy walks both .NET (project.assets.json / *.csproj) and Node
+      # (yarn.lock / package.json) dependency manifests, so one scan covers
+      # the whole repo. `ignore-unfixed: true` keeps the noise floor down —
+      # we only surface vulns that already have a published fix.
+      #
+      # Advisory-mode (`exit-code: 0`) initially: the existing transitive
+      # backlog (axios / node-forge / path-to-regexp / fast-uri / flatted
+      # via Angular build / esbuild / babel) would otherwise block every
+      # PR. SARIF still uploads to the Security tab so findings stay
+      # actionable. Flip to `1` once the backlog is cleared.
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-fs
+
+      # Re-run Trivy in advisory mode capturing table output so PR logs
+      # show the actual findings without the SARIF JSON noise.
+      - name: Trivy summary (advisory)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+  dotnet-vulnerable-packages:
+    name: .NET Vulnerable Packages (dotnet CLI)
+    # Belt + suspenders next to Trivy. The official `dotnet list package
+    # --vulnerable` resolves via NuGet's advisory feed, which sometimes
+    # catches CVEs faster than Trivy's vuln DB and gives package-context
+    # error messages that are easier to triage.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore Yumney.slnx
+
+      - name: List vulnerable packages
+        run: |
+          set -e
+          output=$(dotnet list Yumney.slnx package --vulnerable --include-transitive 2>&1)
+          echo "$output"
+          # `dotnet list` exits 0 even when vulnerable packages are found.
+          # Detect the "has the following vulnerable packages" marker and fail.
+          if echo "$output" | grep -q "has the following vulnerable packages"; then
+            echo "::error::Vulnerable NuGet packages detected"
+            exit 1
+          fi
+
+  yarn-audit:
+    name: Yarn Audit (frontend)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Yarn
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+        run: |
+          corepack enable
+          corepack prepare --activate
+          yarn --version
+
+      - name: Audit dependencies
+        # `yarn npm audit` exits non-zero on findings. Threshold is `critical`
+        # for the blocking check; the high-severity transitive backlog (axios,
+        # node-forge, path-to-regexp, fast-uri, flatted, etc. — all build-
+        # tooling or test-only deps pulled in by Angular / esbuild / babel)
+        # is real but each entry needs case-by-case triage and most are
+        # waiting on upstream releases. Trivy's SARIF still publishes those
+        # to the Security tab so they're visible without blocking PRs.
+        run: yarn npm audit --severity critical --recursive --all
+
+      - name: Audit dependencies (advisory — high severity)
+        # Non-blocking report so the high-severity backlog stays visible in
+        # PR logs without breaking the build. Flip the blocking threshold
+        # above from `critical` to `high` once the backlog is cleared.
+        continue-on-error: true
+        run: yarn npm audit --severity high --recursive --all
+
+  sbom:
+    name: Generate SBOM (CycloneDX)
+    # Software Bill of Materials, uploaded as a workflow artifact and (on
+    # main/develop pushes) attached to the GitHub dependency graph. Lets
+    # downstream consumers verify exactly which deps shipped in a build.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+          artifact-name: sbom-${{ github.sha }}.cyclonedx.json
+          # Skip dependency-graph upload from PRs — the GraphQL API rejects
+          # uploads from forks, which would noisy-fail every external PR.
+          # On develop / main pushes the action attaches the SBOM to the
+          # repo's dependency graph for downstream consumers.
+          dependency-snapshot: ${{ github.event_name == 'push' }}

--- a/src/Yumney.AppHost/Program.cs
+++ b/src/Yumney.AppHost/Program.cs
@@ -230,7 +230,7 @@ if (isRunMode)
 		shell = addMfe("shell", "serve:shell:dist", 4200);
 	}
 
-	builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
+	var gateway = builder.AddProject<Projects.Yumney_Gateway>("yumney-gateway")
 		.WithHttpEndpoint(port: 5100)
 		.WithReference(recipesApi)
 		.WithReference(shoppingApi)
@@ -240,6 +240,12 @@ if (isRunMode)
 		.WithReference(shell)
 		.WithReference(keycloak)
 		.WaitFor(keycloak);
+
+	// MCP's OAuth challenge advertises the public discovery URL via
+	// resource_metadata. Without this env var it would build the URL from the
+	// inbound request's Host header — which YARP rewrites to the MCP
+	// container's internal DNS name, so Claude/ChatGPT can't reach it.
+	mcpServer.WithEnvironment("McpServer__PublicUrl", ReferenceExpression.Create($"{gateway.GetEndpoint("http")}/mcp"));
 }
 else
 {
@@ -247,7 +253,7 @@ else
 		.AddDockerfile("yumney-frontend", "../../client", "docker/Dockerfile")
 		.WithHttpEndpoint(targetPort: 80);
 
-	builder
+	var gateway = builder
 		.AddYarp("yumney-gateway")
 		.WithConfiguration(yarp =>
 		{
@@ -264,9 +270,20 @@ else
 				AllowResponseBuffering = false,
 			});
 			yarp.AddRoute("/mcp/{**catch-all}", mcpCluster);
+
+			// RFC 9728 mandates the protected-resource metadata document lives
+			// at the origin's well-known path. Route it to MCP so Claude/ChatGPT
+			// can fetch it through the public gateway (otherwise it falls
+			// through to the SPA catch-all below).
+			yarp.AddRoute("/.well-known/oauth-protected-resource", mcpCluster);
 			yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
 		})
 		.WithExternalHttpEndpoints();
+
+	// See run-mode comment above. In publish mode the gateway endpoint
+	// resolves to the externally-published Container Apps URL, so MCP's
+	// OAuth discovery advertises a URL Claude can actually fetch.
+	mcpServer.WithEnvironment("McpServer__PublicUrl", ReferenceExpression.Create($"{gateway.GetEndpoint("http")}/mcp"));
 
 	frontend.PublishAsScaledContainerApp(min: 1, max: 5, concurrentRequests: 100);
 }

--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -47,6 +47,12 @@
           "Path": "/mcp/{**remainder}"
         }
       },
+      "mcp-oauth-discovery": {
+        "ClusterId": "mcp-server",
+        "Match": {
+          "Path": "/.well-known/oauth-protected-resource"
+        }
+      },
       "keycloak-route": {
         "ClusterId": "keycloak",
         "Match": {

--- a/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
+++ b/tests/Yumney.Integration.Tests/Fixtures/AspireFixture.cs
@@ -62,6 +62,9 @@ public sealed partial class AspireFixture : IAsyncLifetime
 	/// <summary>Gets the pre-configured HttpClient targeting the MCP server.</summary>
 	public HttpClient McpServer { get; private set; } = null!;
 
+	/// <summary>Gets the pre-configured HttpClient targeting the YARP gateway.</summary>
+	public HttpClient Gateway { get; private set; } = null!;
+
 	public async Task InitializeAsync()
 	{
 		await CleanupStaleContainersAsync();
@@ -112,6 +115,7 @@ public sealed partial class AspireFixture : IAsyncLifetime
 		UsersApi = app.CreateHttpClient("users-api");
 		MealPlanApi = app.CreateHttpClient("mealplan-api");
 		McpServer = app.CreateHttpClient("mcp-server");
+		Gateway = app.CreateHttpClient("yumney-gateway");
 
 		async Task VerifyKeycloak()
 		{
@@ -140,6 +144,7 @@ public sealed partial class AspireFixture : IAsyncLifetime
 		UsersApi.Dispose();
 		MealPlanApi.Dispose();
 		McpServer.Dispose();
+		Gateway.Dispose();
 
 		if (app is not null)
 		{

--- a/tests/Yumney.Integration.Tests/Mcp/McpPublicUrlIntegrationTests.cs
+++ b/tests/Yumney.Integration.Tests/Mcp/McpPublicUrlIntegrationTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using SmartSolutionsLab.Yumney.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Integration.Tests.Mcp;
+
+/// <summary>
+/// Coverage for the fix in PR #804: the MCP server's <c>WWW-Authenticate</c>
+/// challenge MUST advertise a discovery URL on the public gateway origin,
+/// and that discovery URL MUST be routable through the gateway. Without
+/// either, external MCP clients (Claude, ChatGPT) can't complete the OAuth
+/// dance and connector setup fails before any tool call.
+/// </summary>
+[Collection(AspireCollection.Name)]
+public class McpPublicUrlIntegrationTests(AspireFixture fixture)
+{
+	[Fact]
+	public async Task GetMcp_ThroughGateway_AdvertisesDiscoveryUrlOnGatewayOrigin()
+	{
+		var response = await fixture.Gateway.GetAsync("/mcp");
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+		response.Headers.WwwAuthenticate.Should().NotBeEmpty();
+
+		var header = response.Headers.WwwAuthenticate.ToString();
+		header.Should().Contain("resource_metadata=");
+
+		// Extract the resource_metadata value and parse it.
+		var resourceMetadataUrl = ExtractResourceMetadata(header);
+		var resourceMetadataUri = new Uri(resourceMetadataUrl);
+
+		// The URL must share the gateway's authority (host + port), NOT the
+		// internal MCP container's. `fixture.Gateway.BaseAddress` is the URL
+		// Aspire allocated for the gateway resource — that's the public origin.
+		resourceMetadataUri.Authority.Should().Be(fixture.Gateway.BaseAddress!.Authority);
+		resourceMetadataUri.AbsolutePath.Should().Be("/.well-known/oauth-protected-resource");
+	}
+
+	[Fact]
+	public async Task GetDiscoveryDocument_ThroughGateway_ReturnsRfc9728Document()
+	{
+		var response = await fixture.Gateway.GetAsync("/.well-known/oauth-protected-resource");
+
+		// Specifically NOT routed to the SPA catch-all (which would return text/html).
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+		var document = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+		// RFC 9728 §2 required fields.
+		document.GetProperty("resource").GetString().Should().NotBeNullOrWhiteSpace();
+		document.GetProperty("authorization_servers").GetArrayLength().Should().BeGreaterThan(0);
+
+		// The resource URL in the document points at the public /mcp endpoint —
+		// the same origin Claude initially requested.
+		var resourceUrl = document.GetProperty("resource").GetString()!;
+		new Uri(resourceUrl).Authority.Should().Be(fixture.Gateway.BaseAddress!.Authority);
+		new Uri(resourceUrl).AbsolutePath.Should().Be("/mcp");
+	}
+
+	private static string ExtractResourceMetadata(string headerValue)
+	{
+		const string marker = "resource_metadata=\"";
+		var start = headerValue.IndexOf(marker, StringComparison.Ordinal);
+		start.Should().BeGreaterThan(-1, "the challenge header must include resource_metadata");
+		start += marker.Length;
+		var end = headerValue.IndexOf('"', start);
+		return headerValue[start..end];
+	}
+}


### PR DESCRIPTION
## Symptom

Claude can't connect to `https://yumney-gateway.calmsky-ae1ea5be.canadacentral.azurecontainerapps.io/mcp`. The endpoint returns 401 as expected, but the `WWW-Authenticate` header in that 401 advertises the wrong discovery URL:

```
www-authenticate: Bearer realm="yumney", resource_metadata="https://mcp-server.internal.calmsky-ae1ea5be.canadacentral.azurecontainerapps.io/.well-known/oauth-protected-resource"
```

That's the **internal** Container Apps DNS name — Claude can't resolve it, so the OAuth dance never starts and the connector errors out before any tool call.

## Root cause

`WwwAuthenticateChallenge.ResolveDiscoveryUrl` already supports overriding via `McpServer:PublicUrl` config, but the AppHost never sets it. It falls back to `request.Host`, which YARP rewrites to the MCP container's internal hostname.

## Fix

Two parts:

1. **Set `McpServer__PublicUrl` env var** on the MCP container to `{gateway-endpoint}/mcp` via `ReferenceExpression` in both run and publish mode. The MCP server's challenge code already honours this config and rebuilds the discovery URL on the public origin.
2. **Route `/.well-known/oauth-protected-resource`** through the gateway to the MCP cluster. RFC 9728 puts the metadata at the origin's well-known path, so once the challenge points at the public gateway, the discovery fetch must reach MCP through that same gateway — otherwise it falls through to the SPA catch-all and Claude gets HTML.

Both modes patched:
- `Yumney.Gateway/appsettings.json` — new `mcp-oauth-discovery` route for run mode
- `AppHost/Program.cs` — `yarp.AddRoute("/.well-known/oauth-protected-resource", mcpCluster)` in publish mode + `WithEnvironment(...)` on `mcpServer` in both modes

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [ ] After merge + deploy: `curl -i https://yumney-gateway.../mcp` returns `WWW-Authenticate` with `resource_metadata="https://yumney-gateway.../.well-known/oauth-protected-resource"` (public URL, not internal)
- [ ] `curl https://yumney-gateway.../.well-known/oauth-protected-resource` returns the JSON document (not the SPA HTML)
- [ ] Claude `Add custom connector` against `https://yumney-gateway.../mcp` completes OAuth and lands on tool list