### PR TITLE
style(frontend): three UI fixes (dashboard import + chat panel + recipes import link)

### DIFF
--- a/client/apps/recipes/public/assets/i18n/recipes/de.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/de.json
@@ -4,6 +4,7 @@
     "assignTitle": "Rezept auswählen",
     "back": "Zurück",
     "assign": "Zum Essensplan hinzufügen",
+    "import": "Rezept importieren",
     "sortLabel": "Rezepte sortieren",
     "sort": {
       "dateDesc": "Neueste zuerst",

--- a/client/apps/recipes/public/assets/i18n/recipes/en.json
+++ b/client/apps/recipes/public/assets/i18n/recipes/en.json
@@ -4,6 +4,7 @@
     "assignTitle": "Select a recipe",
     "back": "Back",
     "assign": "Assign to meal plan",
+    "import": "Import recipe",
     "sortLabel": "Sort recipes",
     "sort": {
       "dateDesc": "Newest first",

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.html
@@ -9,6 +9,16 @@
       </div>
     } @else {
       <h1>{{ t('recipes.list.title') }}</h1>
+      <a
+        class="btn-import"
+        data-testid="recipe-list-import"
+        [routerLink]="ROUTES.dashboard"
+        [queryParams]="{ openImport: 'true' }"
+        [attr.aria-label]="t('recipes.list.import')"
+      >
+        <lucide-icon name="plus" [size]="18" />
+        <span>{{ t('recipes.list.import') }}</span>
+      </a>
     }
     <yn-sort-menu
       [currentValue]="currentSort()"

--- a/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
+++ b/client/apps/recipes/src/app/recipe-list/recipe-list.component.scss
@@ -12,12 +12,32 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--yn-space-3);
   margin-bottom: var(--yn-space-7);
 
   h1 {
     margin: 0;
+    margin-right: auto;
     font-size: var(--yn-text-4xl);
     font-weight: var(--yn-font-semibold);
+  }
+}
+
+.btn-import {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--yn-space-2);
+  padding: var(--yn-space-2) var(--yn-space-4);
+  border-radius: var(--yn-radius-input);
+  background: var(--yn-primary);
+  color: var(--yn-text-inverse);
+  font-weight: var(--yn-font-semibold);
+  text-decoration: none;
+  transition: filter var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &:hover,
+  &:focus-visible {
+    filter: brightness(1.05);
   }
 }
 

--- a/client/apps/shell/public/assets/i18n/recipes/de.json
+++ b/client/apps/shell/public/assets/i18n/recipes/de.json
@@ -4,6 +4,7 @@
     "assignTitle": "Rezept auswählen",
     "back": "Zurück",
     "assign": "Zum Essensplan hinzufügen",
+    "import": "Rezept importieren",
     "sortLabel": "Rezepte sortieren",
     "sort": {
       "dateDesc": "Neueste zuerst",

--- a/client/apps/shell/public/assets/i18n/recipes/en.json
+++ b/client/apps/shell/public/assets/i18n/recipes/en.json
@@ -4,6 +4,7 @@
     "assignTitle": "Select a recipe",
     "back": "Back",
     "assign": "Assign to meal plan",
+    "import": "Import recipe",
     "sortLabel": "Sort recipes",
     "sort": {
       "dateDesc": "Newest first",

--- a/client/apps/shell/src/app/dashboard/dashboard.component.scss
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.scss
@@ -258,74 +258,10 @@
   }
 }
 
-// ── Collapsible Import Section ──
-.import-section {
-  @include glass.glass-surface(1);
-  border-radius: var(--yn-radius-card-lg);
-  margin-bottom: var(--yn-space-6);
-}
-
-.import-toggle {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  padding: var(--yn-card-padding-sm);
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--yn-text);
-
-  h2 {
-    margin: 0;
-    font-size: var(--yn-text-xl);
-    font-weight: var(--yn-font-bold);
-  }
-}
-
-.toggle-chevron {
-  font-size: var(--yn-text-sm);
-  color: var(--yn-text-muted);
-  transition: transform var(--yn-duration-fast) var(--yn-ease-glass);
-
-  &.open {
-    transform: rotate(180deg);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
-  }
-}
-
-.import-content {
-  padding: 0 var(--yn-card-padding-sm) var(--yn-card-padding-sm);
-  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
-
-  .url-import,
-  .photo-import,
-  .manual-create {
-    // Reset glass surface — already inside glass parent
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    background: var(--yn-background-subtle);
-    border: 1px solid var(--yn-border-light);
-    box-shadow: none;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
-}
-
-@include bp.respond-to('md') {
-  .import-toggle {
-    padding: var(--yn-space-7);
-  }
-
-  .import-content {
-    padding: 0 var(--yn-space-7) var(--yn-space-7);
-  }
-}
+// .import-section / .import-toggle / .import-content moved to
+// integrations/recipes/import-panel/import-panel.component.scss after the
+// component extraction — Angular's view-encapsulation kept them from
+// reaching the new component's template.
 
 // ── Extraction Progress (US-261) ──
 .extraction-progress {

--- a/client/apps/shell/src/app/dashboard/dashboard.component.ts
+++ b/client/apps/shell/src/app/dashboard/dashboard.component.ts
@@ -56,7 +56,14 @@ export class DashboardComponent implements OnInit {
       const params = this.queryParams();
       const urlParam = params['url'] as string | undefined;
       const textParam = params['text'] as string | undefined;
+      const openImport = params['openImport'] === 'true';
       const sharedText = urlParam || textParam;
+
+      // `openImport` is the "Rezept importieren" deep-link from the
+      // recipe-list page — opens the import panel without prefilling a URL.
+      if (openImport) {
+        this.shouldExpandImport.set(true);
+      }
 
       if (!sharedText) return;
 

--- a/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.scss
+++ b/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.scss
@@ -1,0 +1,75 @@
+@use '@yumney/ui/styles/glass' as glass;
+@use '@yumney/ui/styles/breakpoints' as bp;
+
+// Container styles match the surrounding dashboard cards. Pre-extraction
+// these rules lived in dashboard.component.scss, but Angular's view-
+// encapsulation kept them from reaching the import-panel template — the
+// header rendered unstyled (default browser button: white-on-grey) until
+// they moved here.
+.import-section {
+  @include glass.glass-surface(1);
+  border-radius: var(--yn-radius-card-lg);
+  margin-bottom: var(--yn-space-6);
+}
+
+.import-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: var(--yn-card-padding-sm);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--yn-text);
+
+  h2 {
+    margin: 0;
+    font-size: var(--yn-text-xl);
+    font-weight: var(--yn-font-bold);
+  }
+}
+
+.toggle-chevron {
+  font-size: var(--yn-text-sm);
+  color: var(--yn-text-muted);
+  transition: transform var(--yn-duration-fast) var(--yn-ease-glass);
+
+  &.open {
+    transform: rotate(180deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.import-content {
+  padding: 0 var(--yn-card-padding-sm) var(--yn-card-padding-sm);
+  animation: yn-fade-in var(--yn-duration-fast) var(--yn-ease-glass) both;
+
+  .url-import,
+  .photo-import,
+  .manual-create {
+    // Reset glass surface — already inside glass parent.
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: var(--yn-background-subtle);
+    border: 1px solid var(--yn-border-light);
+    box-shadow: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@include bp.respond-to('md') {
+  .import-toggle {
+    padding: var(--yn-space-7);
+  }
+
+  .import-content {
+    padding: 0 var(--yn-space-7) var(--yn-space-7);
+  }
+}

--- a/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.scss
+++ b/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.scss
@@ -1,5 +1,5 @@
-@use '@yumney/ui/styles/glass' as glass;
-@use '@yumney/ui/styles/breakpoints' as bp;
+@use 'glass';
+@use 'breakpoints' as bp;
 
 // Container styles match the surrounding dashboard cards. Pre-extraction
 // these rules lived in dashboard.component.scss, but Angular's view-

--- a/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.ts
+++ b/client/apps/shell/src/app/integrations/recipes/import-panel/import-panel.component.ts
@@ -35,6 +35,7 @@ import { UrlImportComponent } from '../url-import.component';
     IngredientsToastComponent,
   ],
   templateUrl: './import-panel.component.html',
+  styleUrl: './import-panel.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ImportPanelComponent implements OnDestroy {

--- a/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
+++ b/client/libs/ui/src/lib/chat-panel/chat-panel.component.scss
@@ -337,14 +337,19 @@
 }
 
 // ── Input ──
+// Two-row layout: textarea spans the full row so it has room to type;
+// mic / mute / replay sit on the row below with the send button pinned
+// to the right. Before the redesign, all five controls shared one flex
+// row and the textarea got squeezed to ~150px on narrow panels.
 .chat-input {
   display: flex;
-  gap: var(--yn-space-3);
+  flex-wrap: wrap;
+  gap: var(--yn-space-2);
   padding: var(--yn-space-5);
   border-top: 1px solid var(--yn-glass-border-subtle);
 
   textarea {
-    flex: 1;
+    flex: 1 0 100%;
     padding: var(--yn-space-3) var(--yn-space-4);
     border: 1px solid var(--yn-glass-border);
     border-radius: var(--yn-radius-input);
@@ -370,18 +375,17 @@
 }
 
 .chat-send {
-  align-self: flex-end;
+  margin-left: auto;
 }
 
 .chat-mic,
 .chat-mute,
 .chat-replay {
-  align-self: flex-end;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border-radius: var(--yn-radius-circle);
   border: 1px solid var(--yn-glass-border);
   background: var(--yn-glass-bg);


### PR DESCRIPTION
## Summary

Three UI fixes:

### 1. Dashboard `Rezept importieren oder erstellen` button — was off-theme
Rendered as a default white/grey browser button. Root cause: the `.import-section / .import-toggle` styles were left behind in `dashboard.component.scss` when `ImportPanelComponent` was extracted (PR #786). Angular's view-encapsulation kept them from reaching the new component's template, so the glass-surface + chevron toggle never applied.
- Move the rules to a new `import-panel.component.scss` next to the markup.
- `dashboard.component.scss` keeps a tombstone comment pointing at the move.

### 2. Chat panel input — textarea was cramped
`<textarea> + 4 buttons` all shared one flex row, leaving the textarea at ~150 px on narrow panels.
- Two-row layout: `textarea { flex: 1 0 100%; }` so it spans the full row; buttons sit below with `.chat-send { margin-left: auto; }`.
- Icon buttons shrink 44 → 40 px so the row stays compact (still ≥ Material's 40 px tap target).

### 3. Add `Rezept importieren` button on the recipes list
Currently recipe import only lives on the dashboard.
- Prominent button at the top of `recipe-list` that deep-links to `/dashboard?openImport=true`.
- New `openImport` query-param wired into the dashboard's existing `shouldExpandImport` effect so the import panel auto-opens on arrival.
- Translations: `recipes.list.import` (en: "Import recipe", de: "Rezept importieren").

**Follow-up:** inline recipe-import directly on the recipes page requires relocating `ImportPanelComponent` + `UrlImportComponent` out of `apps/shell/src/app/integrations/recipes/` into a shared lib that both `apps/shell` and `apps/recipes` can consume. Larger move; deferred.

## Test plan

- [x] `yarn nx run-many -t lint -t typecheck -t test -p shell,recipes,ui` — clean
- [x] `yarn prettier --check` on touched paths — clean
- [ ] Visual: import panel header now matches dashboard card style (glass surface, chevron toggle).
- [ ] Visual: chat panel textarea spans the full input row; mic/mute/replay sit below with the send button right-aligned.
- [ ] Click "Rezept importieren" on `/recipes`, land on `/dashboard?openImport=true`, import panel is expanded.