### PR TITLE
fix(infra): allowlist Claude + ChatGPT for anonymous DCR (MCP connectors)

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -92,12 +92,13 @@
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {
-        "name": "Trusted Hosts (anonymous DCR blocked)",
+        "name": "Trusted Hosts (anonymous DCR for known MCP clients)",
         "providerId": "trusted-hosts",
         "subType": "anonymous",
         "config": {
-          "host-sending-registration-request-must-match": ["true"],
-          "client-uris-must-match": ["true"]
+          "host-sending-registration-request-must-match": ["false"],
+          "client-uris-must-match": ["true"],
+          "trusted-hosts": ["claude.ai", "chatgpt.com"]
         }
       }
     ]


### PR DESCRIPTION
## Why

PR #804 fixed the `resource_metadata` advertising in MCP's `WWW-Authenticate` header — Claude can now find the OIDC discovery doc. But it still can't actually **connect** because the next step in the spec, Dynamic Client Registration against Keycloak, returns **403 Forbidden**.

Diagnosis chain against staging (yumney-gateway.calmsky-ae1ea5be...):
| Step | Result |
|---|---|
| `GET /mcp` | ✅ 401 + correct resource_metadata |
| `GET /.well-known/oauth-protected-resource` | ✅ RFC 9728 JSON |
| `GET {kc}/.well-known/openid-configuration` | ✅ OIDC config |
| `POST {kc}/clients-registrations/openid-connect` (anonymous DCR) | ❌ **403** |

Root cause: the realm's anonymous DCR policy has both `host-sending-registration-request-must-match: true` and `client-uris-must-match: true` with **no `trusted-hosts` list**. Every anonymous request fails the host match. State set in `b63fac72` / `e3e57df5` ("trim DCR policies to just trusted-hosts" / "drop bogus client-uris policy") which locked the policy down without configuring its allowlist.

## Fix

Two changes to the `trusted-hosts` policy in `yumney-realm.json`:

- **Flip `host-sending-registration-request-must-match` to `false`.** Claude's DCR call originates from Anthropic's backend, not from `claude.ai` itself, so matching the request-source host would require enumerating Anthropic IPs — impractical for SaaS clients.
- **Set `trusted-hosts: ["claude.ai", "chatgpt.com"]`** and keep `client-uris-must-match: true`. The registered client's redirect URIs must use one of those origins, which keeps abuse contained — someone registering with a redirect URI on a domain they don't control would have the OAuth flow fail at the redirect step anyway.

## Test plan

- [x] JSON validates.
- [ ] After merge + deploy: `curl -X POST {kc}/realms/yumney/clients-registrations/openid-connect -H 'Content-Type: application/json' -d '{"redirect_uris":["https://claude.ai/api/mcp/oauth/callback"],"client_name":"probe"}'` returns 201 with `client_id`.
- [ ] Adding `https://yumney-gateway.../mcp` as a Claude custom connector completes the OAuth flow and reaches tool discovery.