### PR TITLE
fix(infra): add yumney-api client scope so DCR clients get audience claim

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -35,6 +35,32 @@
     ]
   },
   "defaultRoles": ["user"],
+  "clientScopes": [
+    {
+      "name": "yumney-api",
+      "description": "Adds the yumney-api audience claim to access tokens so the per-module APIs and the MCP server accept the bearer.",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "yumney-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "yumney-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": ["yumney-api", "role_list", "profile", "email", "roles", "web-origins", "acr", "basic"],
   "clients": [
     {
       "clientId": "yumney-api",


### PR DESCRIPTION
## Why

After #806 unblocked DCR for Claude / ChatGPT, the next step still failed: every API host (and the MCP server) validates that the bearer token has `aud: yumney-api`, but that claim was added by a protocolMapper sitting on the `yumney-web` client only. DCR-registered clients got tokens without the audience → MCP returned 401 the moment Claude tried to call a tool.

Also: the protected-resource metadata advertises `yumney-api` as a supported scope, but no client scope by that name actually existed in the realm. Keycloak's discovery doc confirmed it — `scopes_supported` only listed the OIDC standards. So Claude's OAuth request for `scope=yumney-api` would have been rejected with `invalid_scope` even if it had gotten further.

## Fix

Two realm changes:

- **Define a `yumney-api` client scope** under `realm.clientScopes` with an `oidc-audience-mapper` pinned to `included.custom.audience: yumney-api`. The mapper writes the audience into access tokens and introspection responses.
- **Add `yumney-api` to `defaultDefaultClientScopes`** so every newly-registered client — including ones created via anonymous DCR — auto-inherits the scope.

The existing client-level audience-mapper on `yumney-web` stays in place as belt-and-suspenders; both produce the same `aud` claim and JWT audience is a unique set, so the duplication is harmless.

## Required manual follow-up

Realm-import is one-shot — Keycloak won't re-import the JSON on next deploy because the realm already exists in Postgres. **Staging Keycloak needs the same change applied manually via the admin UI:**

1. Realm `yumney` → **Client scopes** → **Create client scope** named `yumney-api`, protocol `openid-connect`, "Include in token scope" on.
2. On the new scope → **Mappers** → **Add mapper** "By configuration" → **Audience** → name `yumney-api-audience`, custom audience `yumney-api`, "Add to access token" on, "Add to introspection token" on.
3. Realm `yumney` → **Client scopes** tab at top (above the per-client one) → make `yumney-api` a **Default** assigned scope (so it auto-attaches to new clients including DCR).
4. Then delete the existing DCR-registered Claude/ChatGPT clients (if any test-runs registered them) so the next connector setup gets a fresh client with the new scope.

After the manual fix, `curl -X POST .../clients-registrations/openid-connect ...` should still return 201, and the registered client's `defaultClientScopes` should include `yumney-api`. Claude's connector flow should then complete past the OAuth step and hit the MCP tool list.

## Test plan

- [x] JSON validates.
- [ ] Manual staging fix applied per the steps above.
- [ ] Verify by registering a probe client: response's `client_secret` is returned + `scope` field includes `yumney-api`.
- [ ] Adding `https://yumney-gateway.../mcp` as a Claude custom connector completes OAuth and reaches tool discovery.