### PR TITLE
fix(ci): pre-check Postgres state in deploy + auto-restart stuck servers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,51 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Diagnose Postgres health
+        # Five consecutive deploys (PRs after 2026-05-20) failed at the
+        # `provision-postgres` step with Azure InternalServerError after
+        # ~5-15 min. The all-or-nothing 500 from Azure swallows the real
+        # cause; the most common one is the Flexible Server stuck in a
+        # non-terminal state (Updating / Restarting / Stopped) from a
+        # prior failed deploy, which Aspire's idempotent PUT can't recover.
+        # Show state here and nudge any stuck server back to Ready so the
+        # subsequent `aspire deploy` succeeds.
+        env:
+          RG: ${{ vars.AZURE_RESOURCE_GROUP }}
+        run: |
+          set -e
+          echo "─── Postgres servers in $RG ───"
+          az postgres flexible-server list -g "$RG" -o table || true
+
+          servers=$(az postgres flexible-server list -g "$RG" --query "[].name" -o tsv)
+          if [ -z "$servers" ]; then
+            echo "No Postgres flexible servers found yet — first-time provisioning, skipping precheck."
+            exit 0
+          fi
+
+          for srv in $servers; do
+            state=$(az postgres flexible-server show -g "$RG" -n "$srv" --query "state" -o tsv)
+            echo "  $srv → state=$state"
+            if [ "$state" != "Ready" ] && [ "$state" != "Disabled" ]; then
+              echo "  ⚠ $srv is $state (not Ready) — attempting restart"
+              az postgres flexible-server restart -g "$RG" -n "$srv" --no-wait || true
+
+              deadline=$(( $(date +%s) + 900 ))
+              while [ "$(date +%s)" -lt "$deadline" ]; do
+                state=$(az postgres flexible-server show -g "$RG" -n "$srv" --query "state" -o tsv)
+                echo "    polling $srv state=$state"
+                if [ "$state" = "Ready" ]; then break; fi
+                sleep 20
+              done
+              if [ "$state" != "Ready" ]; then
+                echo "  ✗ $srv still $state after 15 min — failing precheck so the deploy doesn't waste 15 more min hitting Azure 500s"
+                az monitor activity-log list -g "$RG" --max-events 5 -o table || true
+                exit 1
+              fi
+              echo "  ✓ $srv back to Ready"
+            fi
+          done
+
       - name: Deploy to Azure
         working-directory: src/Yumney.AppHost
         run: aspire deploy


### PR DESCRIPTION
## Why

Five consecutive deploys since 2026-05-20 have failed at the `provision-postgres` step. Azure returns a generic `InternalServerError` after 5-15 min and Aspire surfaces nothing more specific. No code in those PRs touched Postgres, so the cause is almost certainly the Flexible Server stuck in a non-terminal state (Updating / Restarting / Stopping) from an earlier failed deploy — which Aspire's idempotent PUT can't recover from.

Without Azure portal access from the CI runner, we've been blind to *which* state the server is in. This PR adds the visibility + an auto-recovery attempt.

## What

A precheck step right before `aspire deploy` that:

- Lists every Postgres flexible server in the resource group and surfaces their state in the log — turning the "Azure 500 with no context" failure mode into something actionable.
- For any server not in `Ready` (and not the deliberately-disabled state), issues a `flexible-server restart` and polls for up to 15 min.
- If polling expires without reaching Ready, dumps the recent activity-log entries for the RG and fails the step so the subsequent `aspire deploy` doesn't waste another 15 min hitting the same 500.

First-time deploys (no servers in the RG yet) skip the precheck cleanly.

## Test plan

- [x] Workflow YAML parses (no other CI affected — this step is gated behind the existing `Azure login` step in the deploy job).
- [ ] On next push to develop, the precheck either: (a) finds the server `Ready` and proceeds straight to `aspire deploy` (no behaviour change in the happy path), or (b) finds it stuck, restarts it, and the deploy succeeds.
- [ ] If the server is genuinely broken (not just stuck), the precheck fails fast with the activity-log dump showing the underlying Azure error.