### PR TITLE
fix(ci): dump Postgres deployment-operation error in precheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,22 @@ jobs:
           for srv in $servers; do
             state=$(az postgres flexible-server show -g "$RG" -n "$srv" --query "state" -o tsv)
             echo "  $srv → state=$state"
+
+            echo "─── Last 10 RG-level deployment operations (Postgres-relevant) ───"
+            az deployment group list -g "$RG" --query "[?contains(name,'postgres')||contains(name,'PostgreSQL')]|[0:10].{name:name,state:properties.provisioningState,ts:properties.timestamp}" -o table || true
+
+            echo "─── Last 5 failed deployments in the RG ───"
+            az deployment group list -g "$RG" --query "[?properties.provisioningState=='Failed']|[0:5].{name:name,state:properties.provisioningState,ts:properties.timestamp,err:properties.error.message}" -o table || true
+
+            # For the most recent failed deployment touching postgres, dump its
+            # operation-level error — that's where Azure surfaces the actual
+            # cause behind the InternalServerError.
+            last_failed=$(az deployment group list -g "$RG" --query "[?properties.provisioningState=='Failed']|[?contains(name,'postgres')||contains(name,'PostgreSQL')]|[0].name" -o tsv 2>/dev/null || true)
+            if [ -n "$last_failed" ]; then
+              echo "─── Operation-level error for failed deployment '$last_failed' ───"
+              az deployment operation group list -g "$RG" --name "$last_failed" --query "[?properties.provisioningState=='Failed'].{target:properties.targetResource.resourceType,name:properties.targetResource.resourceName,code:properties.statusMessage.error.code,msg:properties.statusMessage.error.message}" -o json || true
+            fi
+
             if [ "$state" != "Ready" ] && [ "$state" != "Disabled" ]; then
               echo "  ⚠ $srv is $state (not Ready) — attempting restart"
               az postgres flexible-server restart -g "$RG" -n "$srv" --no-wait || true


### PR DESCRIPTION
## Why

The first precheck PR (#810) confirmed something important: the Postgres server is in `state=Ready`, not stuck. Yet `provision-postgres` still fails with Azure `InternalServerError` after ~12 min. So the bug isn't a stuck server — it's that Aspire's PUT to update the already-Ready server is being rejected by Azure for a reason hidden behind the generic 500.

To find out *why*, enrich the precheck to dump:

- Recent Postgres-related deployment operations in the RG.
- Last 5 failed deployments with their top-level error messages.
- **Operation-level errors** for the most recent failed Postgres-targeting deployment — this is where Azure surfaces the actual root cause (e.g. `Cannot change storage size after server is created`, `Sku change not supported on this server tier`, `Property X is read-only`).

No behaviour change for happy-path deploys; just more diagnostic output on every run so the next failure tells us the real reason.

## Test plan

- [ ] Merge → push triggers deploy.
- [ ] Precheck step's logs include the operation-level error message from the previous failed deployment, revealing the actual Aspire/Azure incompatibility we then need to fix in the AppHost or by manually updating the resource.