### PR TITLE
fix(ci): upload Keycloak realm to file share after aspire deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,6 +296,47 @@ jobs:
           Parameters__RedisPassword: ${{ secrets.REDIS_PASSWORD }}
           Parameters__KeycloakDbHost: ${{ vars.POSTGRES_HOST }}
 
+      - name: Seed Keycloak realm to file share
+        # Aspire's `WithRealmImport("Realms")` provisions the Azure File
+        # volume mount at /opt/keycloak/data/import but does NOT upload
+        # the local realm JSON into the share. On a from-scratch deploy
+        # (RG wiped), Keycloak boots with an empty import dir and never
+        # sees the yumney realm — only `master` gets initialized.
+        # Upload the (already gateway-URL-injected) realm here, then
+        # restart Keycloak so `--import-realm` runs against it.
+        #
+        # Idempotent on subsequent deploys: Keycloak's import strategy is
+        # IGNORE_EXISTING, so re-uploading the same realm (or an updated
+        # one) won't overwrite an existing realm. Realm-schema changes
+        # still need to go through the Keycloak admin API or a manual
+        # realm-delete + redeploy.
+        env:
+          RG: ${{ vars.AZURE_RESOURCE_GROUP }}
+        run: |
+          set -e
+          sa=$(az storage account list -g "$RG" --query "[?starts_with(name,'caestoragevolume')] | [0].name" -o tsv)
+          if [ -z "$sa" ]; then
+            echo "::warning::no caestoragevolume* storage account found in $RG — skipping realm upload"
+            exit 0
+          fi
+          key=$(az storage account keys list -g "$RG" -n "$sa" --query "[0].value" -o tsv)
+          share=$(az storage share list --account-name "$sa" --account-key "$key" --query "[?contains(name,'keycloak')] | [0].name" -o tsv)
+          if [ -z "$share" ]; then
+            echo "::warning::no keycloak file share found on $sa — skipping realm upload"
+            exit 0
+          fi
+          echo "Uploading realm to share=$share (account=$sa)"
+          az storage file upload \
+            --share-name "$share" \
+            --account-name "$sa" \
+            --account-key "$key" \
+            --source src/Yumney.AppHost/Realms/yumney-realm.json \
+            --path yumney-realm.json
+
+          echo "Restarting Keycloak so --import-realm picks up the file"
+          rev=$(az containerapp show -g "$RG" -n keycloak --query "properties.latestRevisionName" -o tsv)
+          az containerapp revision restart -g "$RG" -n keycloak --revision "$rev"
+
       - name: Run EF migrations
         # yumney-migrations is published as a Container Apps Job (manual
         # trigger). aspire deploy creates/updates the Job resource but does


### PR DESCRIPTION
## Summary

- Adds a Deploy-workflow step that uploads `src/Yumney.AppHost/Realms/yumney-realm.json` to the Azure File share backing `/opt/keycloak/data/import`, then restarts the Keycloak Container App revision so `--import-realm` runs.
- Fills a real gap exposed by a from-scratch staging redeploy on 2026-05-23: Aspire's `WithRealmImport("Realms")` provisions the volume but never uploads the JSON, so on a fresh share Keycloak boots with only the `master` realm and every `/realms/yumney/...` URL 404s.
- Idempotent for normal deploys — Keycloak's import strategy is `IGNORE_EXISTING`.

## Background

The change was originally pushed straight to develop as `8686e18b` while resetting staging end-to-end. Reverted as `9f216603` and reopening here for review per the project's no-direct-push convention.

End-to-end-verified on the previous direct push (deploy run [26330218523](https://github.com/smartsolutionslab/yumney/actions/runs/26330218523)): realm import succeeded, OIDC discovery returned 200, `testuser`/`admin` logged in via the UI, recipe import + save worked.

## Test plan

- [ ] CI workflow runs through the new `Seed Keycloak realm to file share` step on this branch with no failure
- [ ] On staging merge, confirm `/realms/yumney/.well-known/openid-configuration` returns 200
- [ ] Confirm the step gracefully no-ops when the storage account / share isn't found (warnings, not failures)