### PR TITLE
fix(gateway): allow claude.ai/chatgpt.com CORS + route MCP discovery endpoints

### DIFF
--- a/src/Yumney.Gateway/appsettings.json
+++ b/src/Yumney.Gateway/appsettings.json
@@ -1,6 +1,10 @@
 {
   "Cors": {
-    "AllowedOrigins": ["http://localhost:4200"]
+    "AllowedOrigins": [
+      "http://localhost:4200",
+      "https://claude.ai",
+      "https://chatgpt.com"
+    ]
   },
   "Logging": {
     "LogLevel": {
@@ -51,6 +55,18 @@
         "ClusterId": "mcp-server",
         "Match": {
           "Path": "/.well-known/oauth-protected-resource"
+        }
+      },
+      "mcp-discovered-capabilities": {
+        "ClusterId": "mcp-server",
+        "Match": {
+          "Path": "/discovered-capabilities"
+        }
+      },
+      "mcp-openapi": {
+        "ClusterId": "mcp-server",
+        "Match": {
+          "Path": "/openapi/v1.json"
         }
       },
       "keycloak-route": {


### PR DESCRIPTION
## Summary

Two YARP/CORS fixes that block external MCP client setup against any deployed environment:

1. **CORS origins for MCP clients** — `https://claude.ai` and `https://chatgpt.com` weren't in `Cors:AllowedOrigins`. The browser CORS preflight (`OPTIONS /mcp`) returned 405, silently breaking the Claude.ai connector handshake. The existing manual preflight middleware in `Program.cs` already reads from this list and serves 204 on match — config-only fix, no code change.
2. **MCP discovery endpoints** — `/discovered-capabilities` and `/openapi/v1.json` (both `AllowAnonymous()` on the MCP server) were falling through the gateway's `{**catch-all}` to the frontend SPA, returning the HTML index instead of the JSON manifest. Added explicit YARP routes mapping them to the `mcp-server` cluster.

## Why now

Discovered while debugging a failed Claude.ai connector setup against staging (`yumney-gateway.wittyglacier-27fd5013.canadacentral.azurecontainerapps.io`). The handshake never completed; gateway access logs showed the preflight 405 followed by no further activity from the claude.ai origin.

`/mcp/{**remainder}` already covers the actual protocol traffic, so this is purely an unblock for the connector preflight + discovery endpoints.

## Test plan

- [ ] After merge + deploy: `curl -X OPTIONS -H "Origin: https://claude.ai" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: authorization, content-type" -D - https://<gateway>/mcp` returns **204** with `Access-Control-Allow-Origin: https://claude.ai`
- [ ] `curl https://<gateway>/discovered-capabilities | jq .` returns the MCP capability JSON (not the SPA HTML)
- [ ] `curl https://<gateway>/openapi/v1.json | jq '.info.title'` returns the OpenAPI doc title
- [ ] Connecting Claude.ai → `Settings → Connectors → Add custom connector` with the gateway URL completes the OAuth handshake (assumes a valid IAT for DCR)