### PR TITLE
fix(mcp): CORS at MCP server + missing gateway discovery routes

### DIFF
--- a/src/Yumney.AppHost/FrontendComposition.cs
+++ b/src/Yumney.AppHost/FrontendComposition.cs
@@ -84,6 +84,14 @@ internal static class FrontendComposition
 				// can fetch it through the public gateway (otherwise it falls
 				// through to the SPA catch-all below).
 				yarp.AddRoute("/.well-known/oauth-protected-resource", mcpCluster);
+
+				// MCP server's anonymous discovery endpoints — without these
+				// explicit routes both fall through to the SPA catch-all and
+				// return the frontend HTML instead of the JSON manifests that
+				// the MCP setup docs advertise (Claude.ai/ChatGPT custom-GPT
+				// setup fetch these to enumerate the tool surface).
+				yarp.AddRoute("/discovered-capabilities", mcpCluster);
+				yarp.AddRoute("/openapi/v1.json", mcpCluster);
 				yarp.AddRoute("/{**catch-all}", frontend.GetEndpoint("http"));
 			})
 			.WithExternalHttpEndpoints();

--- a/src/Yumney.Mcp.Server/Program.cs
+++ b/src/Yumney.Mcp.Server/Program.cs
@@ -21,6 +21,27 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddKeycloakBearerAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddHttpContextAccessor();
 
+// CORS for browser-originating MCP clients (Claude.ai, ChatGPT custom GPTs).
+// Registered on the MCP server itself — not the gateway — so the policy lives
+// next to the resource it protects and works under both `aspire run` (project-
+// based gateway) and `aspire deploy` (Aspire.Hosting.Yarp prebuilt container,
+// which has no CORS wrapper). The `UseCors` call below runs BEFORE
+// `UseAuthentication`, so preflight OPTIONS returns 204 with the headers
+// instead of being short-circuited to 401 by the bearer challenge.
+const string McpClientsCorsPolicy = "ExternalMcpClients";
+var corsAllowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+	?? ["http://localhost:4200"];
+builder.Services.AddCors(options =>
+{
+	options.AddPolicy(McpClientsCorsPolicy, policy =>
+	{
+		policy.WithOrigins(corsAllowedOrigins)
+			.AllowAnyHeader()
+			.AllowAnyMethod()
+			.AllowCredentials();
+	});
+});
+
 builder.AddRedisClient("redis");
 var isE2ETests = builder.Configuration.GetValue<bool>("E2ETests");
 builder.Services.AddRateLimiter(options => options.AddMcpPolicy(isE2ETests));
@@ -50,6 +71,7 @@ builder.Services.AddMcpServer()
 
 var app = builder.Build();
 
+app.UseCors(McpClientsCorsPolicy);
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();

--- a/src/Yumney.Mcp.Server/appsettings.json
+++ b/src/Yumney.Mcp.Server/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:4200",
+      "https://claude.ai",
+      "https://chatgpt.com"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Two coupled fixes that actually unblock Claude.ai / ChatGPT custom-GPT setup against deployed envs. Supersedes #814 — that PR modified `Yumney.Gateway/appsettings.json`, but that gateway only runs under `aspire run`. In publish mode the AppHost uses `builder.AddYarp(...)` which spins up the prebuilt `mcr.microsoft.com/dotnet/nightly/yarp:2.3-preview` container with no CORS surface in `Aspire.Hosting.Yarp`'s API.

### 1. CORS at the MCP server, not the gateway

Register a CORS policy on `Yumney.Mcp.Server` and `UseCors` **before** `UseAuthentication`. Preflight OPTIONS returns 204 with `Access-Control-Allow-*` headers instead of being short-circuited to 401 by the bearer challenge. Works in run mode (project-based gateway) and publish mode (Aspire.Hosting.Yarp prebuilt container) without touching the gateway layer.

Allow-list (in `src/Yumney.Mcp.Server/appsettings.json`):
- `http://localhost:4200` — dev shell
- `https://claude.ai` — Claude.ai connectors
- `https://chatgpt.com` — ChatGPT custom GPTs (per `docs/mcp/chatgpt-setup.md`)

### 2. Missing gateway routes for `/discovered-capabilities` and `/openapi/v1.json`

Both endpoints are `AllowAnonymous()` on the MCP server, but `AddPublishModeFrontend` had no explicit YARP route for them. They fell through `/{**catch-all}` to the frontend SPA, returning the index HTML instead of the JSON manifests the MCP setup docs advertise (used by Claude.ai/ChatGPT to enumerate the tool surface). Added two `yarp.AddRoute` calls.

## Test plan

After merge + staging deploy:

- [ ] `curl -X OPTIONS -H "Origin: https://claude.ai" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: authorization, content-type" -D - <gw>/mcp` returns **204** with `Access-Control-Allow-Origin: https://claude.ai`
- [ ] `curl <gw>/discovered-capabilities | jq .` returns the MCP capability JSON
- [ ] `curl <gw>/openapi/v1.json | jq '.info.title'` returns the OpenAPI doc title
- [ ] Claude.ai connector setup (`Settings → Connectors → Add custom connector` with `<gw>/mcp`) completes the OAuth handshake when supplied with a valid IAT

## Note on PR #814

#814 stays merged; its `appsettings.json` change is valid for `aspire run` (the local dev gateway). It just doesn't apply to staging because the deployed gateway isn't this project. The README in `Yumney.Gateway` doesn't make that clear — worth a follow-up doc PR if you want.