### PR TITLE
fix(recipes): persist SSE eventType across reader.read() calls

### DIFF
--- a/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
+++ b/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
@@ -1,3 +1,4 @@
+import { ReadableStream } from 'node:stream/web';
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
@@ -54,7 +55,11 @@ describe('RecipeApiService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AuthService, useValue: { gatewayUrl: () => '' } }],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { gatewayUrl: () => '', getAccessToken: () => 'test-token' } },
+      ],
     });
 
     service = TestBed.inject(RecipeApiService);
@@ -274,6 +279,87 @@ describe('RecipeApiService', () => {
       const req = httpTesting.expectOne('/api/v1/recipes/recipe-abc/notes');
       expect(req.request.body).toEqual({ notes: null });
       req.flush(null);
+    });
+  });
+
+  describe('importRecipeStream', () => {
+    // SSE parser regression: the eventType accumulator must persist across
+    // ReadableStream.read() calls. The chefkoch JSON-LD fast-path on 2026-05-24
+    // emitted a ~1.5 KB chunk event whose `event: chunk\n` line landed in one
+    // network frame and the `data: {...}` line in the next — losing the type
+    // (function-local variable) and dropping the event entirely. Verified end-
+    // to-end against staging: extraction returned 200 + JSON-LD success, but
+    // the UI never displayed the Review-Extracted-Recipe form because the
+    // chunk + done events were silently swallowed.
+    function makeFakeFetchResponse(chunks: string[]): Response {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(chunk));
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('emits all events when each one arrives in its own chunk (happy path)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        makeFakeFetchResponse([
+          'event: status\ndata: Fetching page...\n\n',
+          'event: status\ndata: Extracting recipe...\n\n',
+          'event: chunk\ndata: {"title":"Carbonara"}\n\n',
+          'event: done\ndata: {"title":"Carbonara"}\n\n',
+        ]),
+      );
+
+      const received: { type: string; data: string }[] = [];
+      await new Promise<void>((resolve, reject) => {
+        service.importRecipeStream('https://example.com/recipe').subscribe({
+          next: (evt) => received.push(evt),
+          error: reject,
+          complete: resolve,
+        });
+      });
+
+      expect(received.map((evt) => evt.type)).toEqual(['status', 'status', 'chunk', 'done']);
+      expect(received[2].data).toBe('{"title":"Carbonara"}');
+    });
+
+    it('emits the chunk event even when event: and data: lines arrive in separate reads', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        makeFakeFetchResponse([
+          // First read: only the event-type line — the data line is in the next frame.
+          'event: chunk\n',
+          // Second read: the data line + blank-line terminator.
+          'data: {"title":"Bolognese","ingredients":[]}\n\n',
+          // Plus the terminal event so the stream completes.
+          'event: done\ndata: {"title":"Bolognese"}\n\n',
+        ]),
+      );
+
+      const received: { type: string; data: string }[] = [];
+      await new Promise<void>((resolve, reject) => {
+        service.importRecipeStream('https://example.com/recipe').subscribe({
+          next: (evt) => received.push(evt),
+          error: reject,
+          complete: resolve,
+        });
+      });
+
+      // The chunk event MUST be present even though its event: and data: lines
+      // arrived in different network frames. The pre-fix parser dropped it.
+      const chunkEvent = received.find((evt) => evt.type === 'chunk');
+      expect(chunkEvent).toBeDefined();
+      expect(chunkEvent!.data).toBe('{"title":"Bolognese","ingredients":[]}');
+
+      const doneEvent = received.find((evt) => evt.type === 'done');
+      expect(doneEvent).toBeDefined();
     });
   });
 });

--- a/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
+++ b/client/libs/shared/api-recipes/src/lib/recipe-api.service.spec.ts
@@ -301,7 +301,13 @@ describe('RecipeApiService', () => {
           controller.close();
         },
       });
-      return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      // Cast through unknown: node:stream/web's ReadableStream type differs
+      // from the DOM ReadableStream the Response constructor expects, even
+      // though they're runtime-compatible.
+      return new Response(stream as unknown as BodyInit, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
     }
 
     afterEach(() => {

--- a/client/libs/shared/api-recipes/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-recipes/src/lib/recipe-api.service.ts
@@ -146,11 +146,7 @@ export class RecipeApiService {
     }
   }
 
-  private parseSseBuffer(
-    lines: string[],
-    state: SseParserState,
-    subscriber: import('rxjs').Subscriber<ImportStreamEvent>,
-  ): boolean {
+  private parseSseBuffer(lines: string[], state: SseParserState, subscriber: import('rxjs').Subscriber<ImportStreamEvent>): boolean {
     for (const line of lines) {
       if (line.startsWith('event: ')) {
         state.eventType = line.slice(7).trim();

--- a/client/libs/shared/api-recipes/src/lib/recipe-api.service.ts
+++ b/client/libs/shared/api-recipes/src/lib/recipe-api.service.ts
@@ -17,6 +17,10 @@ import type { CookableRecipeListResponse, GetCookableRecipesParams } from './coo
 import type { RecognizedIngredientsResponse } from './recognized-ingredient';
 import type { FavoriteState } from './favorite-state';
 
+interface SseParserState {
+  eventType: string | null;
+}
+
 @Injectable({ providedIn: 'root' })
 export class RecipeApiService {
   private http = inject(HttpClient);
@@ -105,6 +109,12 @@ export class RecipeApiService {
     const reader = body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
+    // Persists across reader.read() calls. Without this, an event whose
+    // `event:` line lands in one network chunk and its `data:` line in the
+    // next gets dropped — local-scoped parseSseBuffer state (#bug
+    // surfaced on chefkoch's ~1.5 KB chunk JSON, 2026-05-24) loses the
+    // type between calls.
+    const parserState: SseParserState = { eventType: null };
 
     try {
       while (true) {
@@ -115,7 +125,7 @@ export class RecipeApiService {
         const lines = buffer.split('\n');
         buffer = lines.pop() ?? '';
 
-        const terminal = this.parseSseBuffer(lines, subscriber);
+        const terminal = this.parseSseBuffer(lines, parserState, subscriber);
         if (terminal) {
           await reader.cancel();
           abortController.abort();
@@ -136,18 +146,25 @@ export class RecipeApiService {
     }
   }
 
-  private parseSseBuffer(lines: string[], subscriber: import('rxjs').Subscriber<ImportStreamEvent>): boolean {
-    let eventType: string | null = null;
-
+  private parseSseBuffer(
+    lines: string[],
+    state: SseParserState,
+    subscriber: import('rxjs').Subscriber<ImportStreamEvent>,
+  ): boolean {
     for (const line of lines) {
       if (line.startsWith('event: ')) {
-        eventType = line.slice(7).trim();
-      } else if (line.startsWith('data: ') && eventType) {
-        const type = eventType as ImportStreamEvent['type'];
+        state.eventType = line.slice(7).trim();
+      } else if (line.startsWith('data: ') && state.eventType) {
+        const type = state.eventType as ImportStreamEvent['type'];
         subscriber.next({ type, data: line.slice(6) });
 
         if (type === 'done' || type === 'fail') return true;
-        eventType = null;
+        state.eventType = null;
+      } else if (line === '') {
+        // SSE spec: blank line dispatches/terminates the current event.
+        // We dispatch on the data: line above (single-data-line shape used
+        // by the server), so a blank line just resets the type accumulator.
+        state.eventType = null;
       }
     }
 


### PR DESCRIPTION
## Summary

The recipe-import SSE parser declared `eventType` as a function-local in `parseSseBuffer`, so when fetch's ReadableStream split an event such that the `event:` line landed in one network frame and the `data:` line in the next, the type was lost and the event was silently dropped.

## Symptom (staging, 2026-05-24)

User reports "cannot import / create new recipes." On chefkoch.de URLs:
- `GET /api/v1/recipes/import/stream` returns 200 with full SSE payload (verified via curl — all 7 events present including `chunk` and `done`).
- The frontend Review-Extracted-Recipe form **never appears**.

Why it slipped past tests: smaller recipes (e.g. Wikipedia Carbonara, verified yesterday) fit in a single network frame and worked by luck. The `shared-api-recipes` package had zero tests around the SSE parser before this PR.

## Fix

- Hoist `eventType` into a per-stream `SseParserState` object owned by `readSseBody`, pass it into `parseSseBuffer` so state survives across read boundaries.
- Reset the accumulator on blank lines (per SSE spec §9.2.6) so a stray `event:` with no following `data:` doesn't poison the next event.

## Tests

Two new unit tests in `recipe-api.service.spec.ts > importRecipeStream`:

1. **Happy path**: each event in its own chunk — guards against regressions in the normal contract.
2. **Regression case**: a `event: chunk\n` frame followed by a separate `data: {...}\n\n` frame — reproduces the production bug. Confirmed both tests fail when the parser is reverted to the local-scoped form.

## Manual verification

After deploy, importing `https://www.chefkoch.de/rezepte/393031127655461/Spaghetti-Bolognese.html` via the dashboard's Import card will display the Review-Extracted-Recipe form populated with title, ingredients, and steps (all in German from the JSON-LD source).