### PR TITLE
fix(infra): ship yumney-api client scope in realm import (closes #817)

### DIFF
--- a/src/Yumney.AppHost/Realms/yumney-realm.json
+++ b/src/Yumney.AppHost/Realms/yumney-realm.json
@@ -89,6 +89,35 @@
       ]
     }
   ],
+  "clientScopes": [
+    {
+      "name": "yumney-api",
+      "description": "Grants the yumney-api audience to issued access tokens",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "Access Yumney recipe data"
+      },
+      "protocolMappers": [
+        {
+          "name": "yumney-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "yumney-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultOptionalClientScopes": [
+    "yumney-api"
+  ],
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {

--- a/tests/Yumney.Architecture.Tests/KeycloakRealmTests.cs
+++ b/tests/Yumney.Architecture.Tests/KeycloakRealmTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace SmartSolutionsLab.Yumney.Architecture.Tests;
+
+// Locks in the Keycloak realm config that external MCP clients depend on.
+// History: 2026-05-24 staging redeploy left Claude.ai unable to complete OAuth
+// because the realm had no `yumney-api` client scope — DCR-registered clients
+// (Claude.ai, ChatGPT custom GPTs) inherit realm defaults at registration, not
+// the per-client audience mapper on yumney-web, so they couldn't request a
+// token with the `yumney-api` audience. Runtime-patched via admin API; this
+// test fails if that fix isn't carried into the imported realm JSON, which
+// would re-break the connector on the next from-scratch RG wipe.
+public class KeycloakRealmTests
+{
+	private const string YumneyApiScope = "yumney-api";
+	private const string AudienceMapperProvider = "oidc-audience-mapper";
+
+	private static readonly Lazy<JsonDocument> Realm = new(() =>
+	{
+		var path = Path.Combine(SolutionRoot.Src, "Yumney.AppHost", "Realms", "yumney-realm.json");
+		var json = File.ReadAllText(path);
+		return JsonDocument.Parse(json);
+	});
+
+	[Fact]
+	public void Realm_DefinesYumneyApiClientScope()
+	{
+		var clientScopes = TryGetArray(Realm.Value.RootElement, "clientScopes");
+
+		clientScopes
+			.Should()
+			.NotBeNull("`clientScopes` is the only realm-level place to register the yumney-api scope so DCR-registered clients (Claude.ai, ChatGPT) can request it");
+
+		var scope = clientScopes!.Value
+			.EnumerateArray()
+			.FirstOrDefault(element => element.TryGetProperty("name", out var name) && name.GetString() == YumneyApiScope);
+
+		scope.ValueKind
+			.Should()
+			.NotBe(
+				JsonValueKind.Undefined,
+				"a client scope named '{0}' must exist so DCR clients can request `scope=yumney-api` without Keycloak rejecting it as Invalid scopes",
+				YumneyApiScope);
+	}
+
+	[Fact]
+	public void YumneyApiScope_HasAudienceProtocolMapper()
+	{
+		var scope = FindYumneyApiScope();
+
+		var mappers = TryGetArray(scope, "protocolMappers");
+		mappers.Should().NotBeNull("the yumney-api scope must include a protocol mapper that injects the audience into issued tokens");
+
+		var audienceMapper = mappers!.Value
+			.EnumerateArray()
+			.FirstOrDefault(mapper =>
+				mapper.TryGetProperty("protocolMapper", out var provider) && provider.GetString() == AudienceMapperProvider);
+
+		audienceMapper.ValueKind
+			.Should()
+			.NotBe(
+				JsonValueKind.Undefined,
+				"an `{0}` is required so tokens issued for this scope carry `aud=yumney-api`, which the module APIs validate",
+				AudienceMapperProvider);
+
+		audienceMapper.TryGetProperty("config", out var config).Should().BeTrue();
+		config.TryGetProperty("included.client.audience", out var audience).Should().BeTrue();
+		audience.GetString()
+			.Should()
+			.Be(YumneyApiScope, "the audience the mapper injects must match the API client ID");
+
+		config.TryGetProperty("access.token.claim", out var accessTokenClaim).Should().BeTrue();
+		accessTokenClaim.GetString()
+			.Should()
+			.Be("true", "the audience must land in the access token, which is the one the module APIs validate");
+	}
+
+	[Fact]
+	public void Realm_RegistersYumneyApiAsDefaultOptionalScope()
+	{
+		var optional = TryGetArray(Realm.Value.RootElement, "defaultOptionalClientScopes");
+		optional
+			.Should()
+			.NotBeNull("`defaultOptionalClientScopes` is what makes DCR-registered clients automatically inherit the yumney-api scope at registration time");
+
+		var present = optional!.Value
+			.EnumerateArray()
+			.Any(element => element.GetString() == YumneyApiScope);
+
+		present
+			.Should()
+			.BeTrue(
+				"yumney-api must be in defaultOptionalClientScopes so Claude.ai / ChatGPT can request it (current realm: [{0}])",
+				string.Join(", ", optional.Value.EnumerateArray().Select(element => element.GetString())));
+	}
+
+	private static JsonElement FindYumneyApiScope()
+	{
+		var clientScopes = TryGetArray(Realm.Value.RootElement, "clientScopes");
+		clientScopes.Should().NotBeNull("clientScopes array is required");
+
+		return clientScopes!.Value
+			.EnumerateArray()
+			.First(element => element.TryGetProperty("name", out var name) && name.GetString() == YumneyApiScope);
+	}
+
+	private static JsonElement? TryGetArray(JsonElement parent, string propertyName)
+	{
+		return parent.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.Array
+			? value
+			: null;
+	}
+}


### PR DESCRIPTION
## Summary

Closes #817. Moves the runtime Keycloak-admin patch from 2026-05-24 into source so the next from-scratch staging redeploy keeps Claude.ai / ChatGPT connector setup working.

## Realm changes (`src/Yumney.AppHost/Realms/yumney-realm.json`)

- New `clientScopes` array entry: `yumney-api` with an `oidc-audience-mapper` (matches the runtime patch — `included.client.audience = "yumney-api"`, access-token claim, introspection-token claim).
- New `defaultOptionalClientScopes: ["yumney-api"]` so DCR-registered clients inherit the scope at registration time.

## Test (`tests/Yumney.Architecture.Tests/KeycloakRealmTests.cs`)

Three asserts, each with a "why this matters" failure message:

1. `Realm_DefinesYumneyApiClientScope` — `clientScopes` array contains a `yumney-api` entry.
2. `YumneyApiScope_HasAudienceProtocolMapper` — the scope has an `oidc-audience-mapper` with `included.client.audience = yumney-api` and `access.token.claim = true`.
3. `Realm_RegistersYumneyApiAsDefaultOptionalScope` — `yumney-api` is in `defaultOptionalClientScopes`.

Confirmed all three fail when the realm changes are reverted, pass with the fix.

## Test plan

- [x] `dotnet test` on the 3 new tests — passes
- [x] `dotnet build -p:TreatWarningsAsErrors=true` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [ ] On merge + staging deploy, the auth flow continues to work (the runtime patch is already in place; the deploy is a no-op for this PR functionally, but a future RG wipe will pick up the new realm config)