### PR TITLE
fix(recipes): import_recipe_from_url now persists, not just extracts (closes #820)

### DIFF
--- a/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
+++ b/src/Yumney.Recipes.Api/RecipesEndpoints.Streaming.cs
@@ -138,11 +138,12 @@ public static partial class RecipesEndpoints
 			.WithValidation<Requests.ImportRecipe>()
 			.WithCapability(
 				name: "import_recipe_from_url",
-				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the parsed recipe (title, ingredients, steps). Use for 'save this recipe' / 'add this to my collection' / 'speicher das Rezept'.",
+				description: "Extract a recipe from a URL (recipe site, blog, or video page) and add it to the user's collection. Returns the saved recipe identifier so it can be referenced in follow-up tool calls. Use for 'save this recipe' / 'add this to my collection' / 'speicher das Rezept'.",
 				surfaces: CapabilitySurface.Mcp | CapabilitySurface.Voice)
-			.Produces<ExtractedRecipeDto>()
+			.Produces<SavedRecipeDto>()
 			.ProducesValidationProblem()
 			.ProducesProblem(StatusCodes.Status404NotFound)
+			.ProducesProblem(StatusCodes.Status409Conflict)
 			.ProducesProblem(StatusCodes.Status413PayloadTooLarge)
 			.ProducesProblem(StatusCodes.Status429TooManyRequests)
 			.ProducesProblem(StatusCodes.Status500InternalServerError)
@@ -152,7 +153,7 @@ public static partial class RecipesEndpoints
 
 		static async Task<IResult> Import(
 			Requests.ImportRecipe request,
-			ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>> handler,
+			ICommandHandler<ImportRecipeCommand, Result<SavedRecipeDto>> handler,
 			CancellationToken cancellationToken)
 		{
 			var command = new ImportRecipeCommand(RecipeUrl.From(request.Url));

--- a/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeCommandHandler.cs
+++ b/src/Yumney.Recipes.Application/Commands/Handlers/ImportRecipeCommandHandler.cs
@@ -1,25 +1,64 @@
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
+using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
 using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 
-public sealed class ImportRecipeCommandHandler(IWebScraper scraper, IRecipeExtractionService extraction)
-	: ICommandHandler<ImportRecipeCommand, Result<ExtractedRecipeDto>>
+// MCP / Voice clients call this via POST /api/v1/recipes/import — there's no
+// user-review step in the LLM flow, so the handler extracts AND persists.
+// Earlier shape (extract-only, returning ExtractedRecipeDto) was a #820 bug:
+// the capability description promised "add it to the user's collection" but
+// the implementation just parsed and threw the result away. The UI uses the
+// SSE-streaming endpoint for the review-and-save pattern; this command is
+// specifically the headless import-and-save path.
+public sealed class ImportRecipeCommandHandler(
+	IWebScraper scraper,
+	IRecipeExtractionService extraction,
+	ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>> saveHandler)
+	: ICommandHandler<ImportRecipeCommand, Result<SavedRecipeDto>>
 {
-	public async Task<Result<ExtractedRecipeDto>> HandleAsync(ImportRecipeCommand command, CancellationToken cancellationToken = default)
+	public async Task<Result<SavedRecipeDto>> HandleAsync(ImportRecipeCommand command, CancellationToken cancellationToken = default)
 	{
 		var url = command.Url;
 
 		var scrapeResult = await scraper.ScrapeAsync(url, cancellationToken);
-
 		if (scrapeResult.IsFailure) return scrapeResult.Error!;
 
 		var extractResult = await extraction.ExtractAsync(scrapeResult.Value, cancellationToken);
-
 		if (extractResult.IsFailure) return extractResult.Error!;
 
-		return extractResult;
+		var saveCommand = BuildSaveCommand(extractResult.Value, url);
+		return await saveHandler.HandleAsync(saveCommand, cancellationToken);
+	}
+
+	private static SaveRecipeCommand BuildSaveCommand(ExtractedRecipeDto extracted, RecipeUrl sourceUrl)
+	{
+		var ingredients = extracted.Ingredients
+			.Select(item => new SaveRecipeIngredientItem(
+				IngredientName.From(item.Name),
+				Quantity.FromNullable(
+					Amount.FromNullable(item.Amount),
+					Unit.FromNullable(item.Unit))))
+			.ToList();
+
+		var steps = extracted.Steps
+			.Select(step => new SaveRecipeStepItem(StepNumber.From(step.Number), StepDescription.From(step.Description)))
+			.ToList();
+
+		return new SaveRecipeCommand(
+			RecipeTitle.From(extracted.Title),
+			ingredients,
+			steps,
+			RecipeDescription.FromNullable(extracted.Description),
+			Domain.Recipe.Servings.FromNullable(extracted.Servings),
+			TimingInfo.FromNullable(
+				PreparationTime.FromNullable(extracted.PrepTimeMinutes),
+				CookingTime.FromNullable(extracted.CookTimeMinutes)),
+			Domain.Recipe.Difficulty.FromNullable(extracted.Difficulty),
+			Domain.Recipe.ImageUrl.FromNullable(extracted.ImageUrl),
+			RecipeLanguage.FromNullable(extracted.Language),
+			sourceUrl);
 	}
 }

--- a/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
+++ b/src/Yumney.Recipes.Application/Commands/ImportRecipeCommand.cs
@@ -5,4 +5,4 @@ using SmartSolutionsLab.Yumney.Shared.Outcomes;
 
 namespace SmartSolutionsLab.Yumney.Recipes.Application.Commands;
 
-public sealed record ImportRecipeCommand(RecipeUrl Url) : ICommand<Result<ExtractedRecipeDto>>;
+public sealed record ImportRecipeCommand(RecipeUrl Url) : ICommand<Result<SavedRecipeDto>>;

--- a/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeContractTests.cs
+++ b/tests/Yumney.Integration.Tests/Recipes/Contract/ImportRecipeContractTests.cs
@@ -15,17 +15,22 @@ public class ImportRecipeContractTests(AspireFixture fixture)
 	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
 	[Fact]
-	public async Task Import_ValidUrl_Returns200WithExtractedRecipe()
+	public async Task Import_ValidUrl_Returns200WithSavedRecipe()
 	{
+		// Shape changed in #820: the endpoint now extracts AND persists, so the
+		// response carries the saved recipe identifier (SavedRecipeDto) instead
+		// of the full extracted shape with ingredients/steps. The stub-recipe
+		// E2E mode still drives the title. Unique URL per run avoids the
+		// AlreadyImported guard if this test re-runs against the same fixture.
 		using var client = await fixture.CreateAuthenticatedClientAsync("recipes-api");
 
-		var response = await client.PostAsJsonAsync(Endpoint, new { url = "https://example.com/recipe" });
+		var response = await client.PostAsJsonAsync(Endpoint, new { url = $"https://example.com/recipe-{Guid.NewGuid():N}" });
 
 		response.StatusCode.Should().Be(HttpStatusCode.OK);
 		var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
 		body.GetProperty("title").GetString().Should().Be("Stub Recipe");
-		body.GetProperty("ingredients").GetArrayLength().Should().BeGreaterThan(0);
-		body.GetProperty("steps").GetArrayLength().Should().BeGreaterThan(0);
+		body.GetProperty("identifier").GetGuid().Should().NotBe(Guid.Empty);
+		body.GetProperty("createdAt").GetDateTime().Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
 	}
 
 	[Fact]

--- a/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
+++ b/tests/Yumney.Recipes.Application.Tests/Commands/ImportRecipeCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using SmartSolutionsLab.Yumney.Recipes.Application.Commands.Handlers;
 using SmartSolutionsLab.Yumney.Recipes.Application.DTOs;
 using SmartSolutionsLab.Yumney.Recipes.Application.Interfaces;
 using SmartSolutionsLab.Yumney.Recipes.Domain.Recipe;
+using SmartSolutionsLab.Yumney.Shared.CQRS;
 using SmartSolutionsLab.Yumney.Shared.Outcomes;
 using Xunit;
 
@@ -14,28 +15,79 @@ public class ImportRecipeCommandHandlerTests
 {
 	private readonly IWebScraper scraper = Substitute.For<IWebScraper>();
 	private readonly IRecipeExtractionService extraction = Substitute.For<IRecipeExtractionService>();
+	private readonly ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>> saveHandler = Substitute.For<ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>>>();
+
+	public ImportRecipeCommandHandlerTests()
+	{
+		// Default: save succeeds. Individual tests can override.
+		saveHandler.HandleAsync(Arg.Any<SaveRecipeCommand>(), Arg.Any<CancellationToken>())
+			.Returns(Result<SavedRecipeDto>.Success(new SavedRecipeDto(Guid.NewGuid(), "Pasta Carbonara", DateTime.UtcNow)));
+	}
 
 	[Fact]
-	public async Task HandleAsync_ValidUrl_ReturnsExtractedRecipe()
+	public async Task HandleAsync_ValidUrl_ReturnsSavedRecipe()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
 		var scrapedContent = new ScrapedContent("Recipe content", url);
-		var expectedRecipe = CreateExtractedRecipe("Pasta Carbonara");
+		var extracted = CreateExtractedRecipe("Pasta Carbonara");
 
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Success(scrapedContent));
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
-			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+			.Returns(Result<ExtractedRecipeDto>.Success(extracted));
 
 		var handler = CreateHandler();
 		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
 		result.IsSuccess.Should().BeTrue();
 		result.Value.Title.Should().Be("Pasta Carbonara");
+		result.Value.Identifier.Should().NotBe(Guid.Empty);
 	}
 
 	[Fact]
-	public async Task HandleAsync_ScrapeFailure_ReturnsFailure()
+	public async Task HandleAsync_ValidUrl_InvokesSaveHandlerWithExtractedFields()
+	{
+		// Regression test for #820. The handler used to return ExtractedRecipeDto
+		// without persisting — MCP / Voice clients then saw "IsError=False" but
+		// nothing landed in the user's collection.
+		var url = RecipeUrl.From("https://example.com/banana-bread");
+		var scrapedContent = new ScrapedContent("banana bread content", url);
+		var extracted = new ExtractedRecipeDto(
+			"Banana Bread",
+			[new ExtractedIngredientDto("Banana", 3, null), new ExtractedIngredientDto("Flour", 250, "g")],
+			[new ExtractedStepDto(1, "Mash bananas"), new ExtractedStepDto(2, "Mix and bake")],
+			Description: "Classic banana bread",
+			Servings: 8,
+			PrepTimeMinutes: 15,
+			CookTimeMinutes: 60,
+			ImageUrl: "https://example.com/banana.jpg");
+
+		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+			.Returns(Result<ScrapedContent>.Success(scrapedContent));
+		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
+			.Returns(Result<ExtractedRecipeDto>.Success(extracted));
+
+		SaveRecipeCommand? captured = null;
+		saveHandler
+			.HandleAsync(Arg.Do<SaveRecipeCommand>(command => captured = command), Arg.Any<CancellationToken>())
+			.Returns(Result<SavedRecipeDto>.Success(new SavedRecipeDto(Guid.NewGuid(), "Banana Bread", DateTime.UtcNow)));
+
+		var handler = CreateHandler();
+		await handler.HandleAsync(new ImportRecipeCommand(url));
+
+		await saveHandler.Received(1).HandleAsync(Arg.Any<SaveRecipeCommand>(), Arg.Any<CancellationToken>());
+		captured.Should().NotBeNull();
+		captured!.Title.Value.Should().Be("Banana Bread");
+		captured.Ingredients.Should().HaveCount(2);
+		captured.Steps.Should().HaveCount(2);
+		captured.Servings!.Value.Should().Be(8);
+		captured.Timing!.Preparation!.Value.Should().Be(15);
+		captured.Timing.Cooking!.Value.Should().Be(60);
+		captured.SourceUrl.Should().Be(url);
+	}
+
+	[Fact]
+	public async Task HandleAsync_ScrapeFailure_DoesNotInvokeSave()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
 
@@ -47,10 +99,11 @@ public class ImportRecipeCommandHandlerTests
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.PageUnreachable);
+		await saveHandler.DidNotReceive().HandleAsync(Arg.Any<SaveRecipeCommand>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
-	public async Task HandleAsync_NoRecipeFound_ReturnsFailure()
+	public async Task HandleAsync_ExtractionFailure_DoesNotInvokeSave()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
 		var scrapedContent = new ScrapedContent("Some content", url);
@@ -65,24 +118,27 @@ public class ImportRecipeCommandHandlerTests
 
 		result.IsFailure.Should().BeTrue();
 		result.Error.Should().Be(ImportRecipeErrors.NoRecipeFound);
+		await saveHandler.DidNotReceive().HandleAsync(Arg.Any<SaveRecipeCommand>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
-	public async Task HandleAsync_ScrapeSucceeds_CallsExtraction()
+	public async Task HandleAsync_SaveFailure_PropagatesError()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
-		var scrapedContent = new ScrapedContent("Recipe content", url);
-		var expectedRecipe = CreateExtractedRecipe();
+		var scrapedContent = new ScrapedContent("Content", url);
 
 		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
 			.Returns(Result<ScrapedContent>.Success(scrapedContent));
 		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
-			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+			.Returns(Result<ExtractedRecipeDto>.Success(CreateExtractedRecipe()));
+		saveHandler.HandleAsync(Arg.Any<SaveRecipeCommand>(), Arg.Any<CancellationToken>())
+			.Returns(Result<SavedRecipeDto>.Failure(SaveRecipeErrors.AlreadyImported));
 
 		var handler = CreateHandler();
-		await handler.HandleAsync(new ImportRecipeCommand(url));
+		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
 
-		await extraction.Received(1).ExtractAsync(scrapedContent, Arg.Any<CancellationToken>());
+		result.IsFailure.Should().BeTrue();
+		result.Error.Should().Be(SaveRecipeErrors.AlreadyImported);
 	}
 
 	[Fact]
@@ -96,8 +152,7 @@ public class ImportRecipeCommandHandlerTests
 		var handler = CreateHandler();
 		await handler.HandleAsync(new ImportRecipeCommand(url));
 
-		await extraction.DidNotReceive().ExtractAsync(
-			Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>());
+		await extraction.DidNotReceive().ExtractAsync(Arg.Any<ScrapedContent>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
@@ -116,35 +171,16 @@ public class ImportRecipeCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task HandleAsync_ExtractionFailed_PropagatesExtractionError()
-	{
-		var url = RecipeUrl.From("https://example.com/recipe");
-		var scrapedContent = new ScrapedContent("Some content", url);
-
-		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
-			.Returns(Result<ScrapedContent>.Success(scrapedContent));
-		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
-			.Returns(Result<ExtractedRecipeDto>.Failure(ImportRecipeErrors.ExtractionFailed));
-
-		var handler = CreateHandler();
-		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
-
-		result.IsFailure.Should().BeTrue();
-		result.Error.Should().Be(ImportRecipeErrors.ExtractionFailed);
-	}
-
-	[Fact]
 	public async Task HandleAsync_ValidUrl_PassesCancellationTokenToScraper()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
 		var cts = new CancellationTokenSource();
 		var scrapedContent = new ScrapedContent("Content", url);
-		var expectedRecipe = CreateExtractedRecipe();
 
 		scraper.ScrapeAsync(url, cts.Token)
 			.Returns(Result<ScrapedContent>.Success(scrapedContent));
 		extraction.ExtractAsync(scrapedContent, cts.Token)
-			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+			.Returns(Result<ExtractedRecipeDto>.Success(CreateExtractedRecipe()));
 
 		var handler = CreateHandler();
 		await handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
@@ -158,12 +194,11 @@ public class ImportRecipeCommandHandlerTests
 		var url = RecipeUrl.From("https://example.com/recipe");
 		var cts = new CancellationTokenSource();
 		var scrapedContent = new ScrapedContent("Content", url);
-		var expectedRecipe = CreateExtractedRecipe();
 
 		scraper.ScrapeAsync(url, cts.Token)
 			.Returns(Result<ScrapedContent>.Success(scrapedContent));
 		extraction.ExtractAsync(scrapedContent, cts.Token)
-			.Returns(Result<ExtractedRecipeDto>.Success(expectedRecipe));
+			.Returns(Result<ExtractedRecipeDto>.Success(CreateExtractedRecipe()));
 
 		var handler = CreateHandler();
 		await handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
@@ -172,24 +207,21 @@ public class ImportRecipeCommandHandlerTests
 	}
 
 	[Fact]
-	public async Task HandleAsync_MinimalRecipeData_ReturnsSuccess()
+	public async Task HandleAsync_ValidUrl_PassesCancellationTokenToSave()
 	{
 		var url = RecipeUrl.From("https://example.com/recipe");
+		var cts = new CancellationTokenSource();
 		var scrapedContent = new ScrapedContent("Content", url);
-		var minimalRecipe = new ExtractedRecipeDto("Simple Dish", [], []);
 
-		scraper.ScrapeAsync(url, Arg.Any<CancellationToken>())
+		scraper.ScrapeAsync(url, cts.Token)
 			.Returns(Result<ScrapedContent>.Success(scrapedContent));
-		extraction.ExtractAsync(scrapedContent, Arg.Any<CancellationToken>())
-			.Returns(Result<ExtractedRecipeDto>.Success(minimalRecipe));
+		extraction.ExtractAsync(scrapedContent, cts.Token)
+			.Returns(Result<ExtractedRecipeDto>.Success(CreateExtractedRecipe()));
 
 		var handler = CreateHandler();
-		var result = await handler.HandleAsync(new ImportRecipeCommand(url));
+		await handler.HandleAsync(new ImportRecipeCommand(url), cts.Token);
 
-		result.IsSuccess.Should().BeTrue();
-		result.Value.Title.Should().Be("Simple Dish");
-		result.Value.Description.Should().BeNull();
-		result.Value.Servings.Should().BeNull();
+		await saveHandler.Received(1).HandleAsync(Arg.Any<SaveRecipeCommand>(), cts.Token);
 	}
 
 	[Fact]
@@ -246,5 +278,5 @@ public class ImportRecipeCommandHandlerTests
 	private static ExtractedRecipeDto CreateExtractedRecipe(string title = "Test Recipe") =>
 		new(title, [new ExtractedIngredientDto("Flour", 500, "g")], [new ExtractedStepDto(1, "Mix ingredients")], Servings: 4);
 
-	private ImportRecipeCommandHandler CreateHandler() => new(scraper, extraction);
+	private ImportRecipeCommandHandler CreateHandler() => new(scraper, extraction, saveHandler);
 }


### PR DESCRIPTION
## Summary

The MCP capability description on `POST /api/v1/recipes/import` promised _"extract a recipe from a URL ... and add it to the user's collection"_, but `ImportRecipeCommandHandler` only ran scraper + LLM extraction and returned an `ExtractedRecipeDto` without saving. Claude.ai (and any Voice client) saw `IsError=False`, told the user "saved", but the recipe never landed in the database.

Verified the bug today against staging: `admin@yumney.dev` has 2 recipes — both from manual UI/curl smokes; zero from yesterday's Claude.ai-driven imports (logs show several `import_recipe_from_url completed. IsError = False` calls).

## Change

- `ImportRecipeCommand` now returns `Result<SavedRecipeDto>` (was `Result<ExtractedRecipeDto>`).
- `ImportRecipeCommandHandler` grows a `ICommandHandler<SaveRecipeCommand, Result<SavedRecipeDto>>` dependency and dispatches to it after a successful extraction. Save errors propagate to the caller (`SaveRecipeErrors.AlreadyImported` already maps to 409 via the existing problem-details pipeline).
- Endpoint: `.Produces<SavedRecipeDto>()` + `.ProducesProblem(409)`.
- Capability description tweaked: _"Returns the saved recipe identifier so it can be referenced in follow-up tool calls"_ — accurate to the new shape.

## UI flow unaffected

The Angular dashboard uses `GET /api/v1/recipes/import/stream` for SSE-streamed extraction with a Review-and-Save UI on top, then `POST /api/v1/recipes` for the explicit save. That path is untouched. Only the headless `POST /api/v1/recipes/import` (MCP / Voice / direct script) changes behavior, and the change matches what its capability description always promised.

## Tests

Updated `ImportRecipeCommandHandlerTests` with the inner-save mock. New + tightened tests:
- **`HandleAsync_ValidUrl_InvokesSaveHandlerWithExtractedFields`** — the regression test: captures the `SaveRecipeCommand` the handler dispatches and asserts title / ingredients / steps / servings / timing / sourceUrl all map correctly from the `ExtractedRecipeDto`. Fails to compile against the pre-fix constructor signature.
- `HandleAsync_ScrapeFailure_DoesNotInvokeSave` and `HandleAsync_ExtractionFailure_DoesNotInvokeSave` — short-circuit paths don't double-save.
- `HandleAsync_SaveFailure_PropagatesError` — `AlreadyImported` surfaces correctly.
- `HandleAsync_ValidUrl_PassesCancellationTokenToSave` — cancellation flows into the new dep.

All 210 application tests pass locally. Strict build (`-p:TreatWarningsAsErrors=true`) + `dotnet format --verify-no-changes` clean.

## Verification post-merge

After staging deploys, exercising the MCP tool against a known-importable URL (e.g. `https://en.wikipedia.org/wiki/Carbonara`) should:
1. Return `SavedRecipeDto` with a non-empty `identifier`.
2. Make the recipe queryable via `search_recipes` and `GET /api/v1/recipes`.
3. Surface as a row in the user's dashboard list.

Closes #820