### PR TITLE
fix(apphost): surface Scalar + OpenAPI URLs on each module API

### DIFF
--- a/src/Yumney.AppHost/AppHostExtensions.cs
+++ b/src/Yumney.AppHost/AppHostExtensions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.AppContainers;
 using SmartSolutionsLab.Yumney.AppHost.Options;
@@ -23,7 +24,7 @@ internal static class AppHostExtensions
 			.WithReference(keycloak)
 			.WithReference(redis)
 			.WithReference(messaging)
-			.WithUrl("/scalar/v1", "Scalar");
+			.WithUrls(AddScalarAndOpenApiUrls);
 
 		if (options.E2ETests) configured.WithEnvironment("E2ETests", "true");
 
@@ -107,4 +108,29 @@ internal static class AppHostExtensions
 				});
 			}
 		};
+
+	// The plain `.WithUrl("/scalar/v1", "Scalar")` overload takes a literal
+	// URL — Aspire has no endpoint context to resolve a leading slash, so
+	// the dashboard silently drops the entry. Per Aspire docs (define-
+	// custom-resource-urls), additive URLs that need to be joined to a
+	// runtime endpoint go through `WithUrls(callback)`: walk the existing
+	// URL set for the http endpoint, then append deep links on it.
+	private static void AddScalarAndOpenApiUrls(ResourceUrlsCallbackContext context)
+	{
+		var http = context.Urls.FirstOrDefault(url => url.Endpoint?.EndpointName == "http");
+		if (http is null) return;
+
+		context.Urls.Add(new ResourceUrlAnnotation
+		{
+			Url = $"{http.Url.TrimEnd('/')}/scalar/v1",
+			Endpoint = http.Endpoint,
+			DisplayText = "Scalar",
+		});
+		context.Urls.Add(new ResourceUrlAnnotation
+		{
+			Url = $"{http.Url.TrimEnd('/')}/openapi/v1.json",
+			Endpoint = http.Endpoint,
+			DisplayText = "OpenAPI",
+		});
+	}
 }


### PR DESCRIPTION
## Summary

The Aspire dashboard wasn't showing a Scalar link for any module API. Root cause: `AppHostExtensions.cs:26` called the wrong `WithUrl` overload.

```csharp
.WithUrl("/scalar/v1", "Scalar");
```

Per [Aspire docs (define-custom-resource-urls)](https://aspire.dev/define-custom-resource-urls/), the bare-string `WithUrl` overload expects a literal URL — Aspire has no endpoint context to resolve a leading-slash relative path against, so the dashboard silently dropped the annotation. The Scalar link never rendered.

## Fix

Replaced with the additive `WithUrls(callback)` shape:

```csharp
.WithUrls(AddScalarAndOpenApiUrls);

private static void AddScalarAndOpenApiUrls(ResourceUrlsCallbackContext context) {
    var http = context.Urls.FirstOrDefault(url => url.Endpoint?.EndpointName == "http");
    if (http is null) return;
    context.Urls.Add(new() { Url = $"{http.Url}/scalar/v1",       Endpoint = http.Endpoint, DisplayText = "Scalar"  });
    context.Urls.Add(new() { Url = $"{http.Url}/openapi/v1.json", Endpoint = http.Endpoint, DisplayText = "OpenAPI" });
}
```

This joins the runtime-resolved http endpoint URL with the two deep links the API hosts already publish (Scalar via `MapScalarApiReference()` in non-Production, OpenAPI doc via `MapOpenApi()`). Additive — doesn't replace the endpoint's default URL, so the dashboard shows root + Scalar + OpenAPI side-by-side on each API card.

## Test plan

- [ ] `aspire run` locally
- [ ] Dashboard's resource card for each module API (recipes-api, shopping-api, users-api, mealplan-api) shows three links: the http root, `Scalar`, and `OpenAPI`
- [ ] Clicking `Scalar` opens the Scalar UI; clicking `OpenAPI` returns the JSON doc

## Out of scope (also discussed)

The "no error bubbles on Aspire dashboard" question turned out to be by design: `GlobalExceptionHandlerMiddleware` logs `EntityNotFound` / `Guard` / `BusinessRule` violations at `LogLevel.Warning` (intentional — they're expected 4xx responses), and the dashboard's error counter only counts Error+ severities. Unhandled exceptions still log at Error and bubble correctly. No change in this PR.